### PR TITLE
Request to pull changes for code coverage statistics please

### DIFF
--- a/sonar/dotnet/sonar-dotnet-gallio-plugin/src/main/java/org/sonar/plugins/csharp/gallio/results/coverage/model/FileCoverage.java
+++ b/sonar/dotnet/sonar-dotnet-gallio-plugin/src/main/java/org/sonar/plugins/csharp/gallio/results/coverage/model/FileCoverage.java
@@ -85,16 +85,12 @@ public class FileCoverage {
    */
   public void addPoint(CoveragePoint point) {
     int startLine = point.getStartLine();
-    int endLine = point.getEndLine();
-    for (int idx = startLine; idx <= endLine; idx++) {
-      // We add a point for each line
-      SourceLine line = lines.get(idx);
-      if (line == null) {
-        line = new SourceLine(idx);
-        lines.put(idx, line);
-      }
-      line.update(point);
+    SourceLine line = lines.get(startLine);
+    if (line == null) {
+      line = new SourceLine(startLine);
+      lines.put(startLine, line);
     }
+    line.update(point);
   }
 
   /**

--- a/sonar/dotnet/sonar-dotnet-gallio-plugin/src/test/java/org/sonar/plugins/csharp/gallio/results/coverage/CoverageResultParserTest.java
+++ b/sonar/dotnet/sonar-dotnet-gallio-plugin/src/test/java/org/sonar/plugins/csharp/gallio/results/coverage/CoverageResultParserTest.java
@@ -95,8 +95,8 @@ public class CoverageResultParserTest {
     params.assemblyName = "Example.Core";
     params.fileNumber = 4;
     params.fileName = "Money.cs";
-    params.coveredLines = 46;
-    params.lines = 48;
+    params.coveredLines = 45;
+    params.lines = 47;
     params.coverage = 0.96;
 
     checkParsing(params);
@@ -110,7 +110,7 @@ public class CoverageResultParserTest {
     params.fileNumber = 1;
     params.fileName = "Money.cs";
     params.coveredLines = 0;
-    params.lines = 4;
+    params.lines = 1;
     params.coverage = 0;
 
     checkParsing(params);
@@ -123,8 +123,8 @@ public class CoverageResultParserTest {
     params.assemblyName = "Example.Core";
     params.fileNumber = 1;
     params.fileName = "Money.cs";
-    params.coveredLines = 4;
-    params.lines = 4;
+    params.coveredLines = 1;
+    params.lines = 1;
     params.coverage = 1.0;
 
     checkParsing(params);
@@ -165,9 +165,9 @@ public class CoverageResultParserTest {
     params.assemblyName = "Example.Core";
     params.fileNumber = 2;
     params.fileName = "Money.cs";
-    params.coveredLines = 25;
-    params.lines = 27;
-    params.coverage = 0.93;
+    params.coveredLines = 24;
+    params.lines = 26;
+    params.coverage = 0.92;
 
     checkParsing(params);
   }
@@ -179,8 +179,8 @@ public class CoverageResultParserTest {
     params.assemblyName = "Example.Core";
     params.fileNumber = 3;
     params.fileName = "Money.cs";
-    params.coveredLines = 45;
-    params.lines = 215;
+    params.coveredLines = 44;
+    params.lines = 214;
     params.coverage = 0.21;
 
     checkParsing(params);
@@ -193,9 +193,9 @@ public class CoverageResultParserTest {
     params.assemblyName = "Example.Core";
     params.fileNumber = 3;
     params.fileName = "Money.cs";
-    params.coveredLines = 35;
-    params.lines = 37;
-    params.coverage = 0.95;
+    params.coveredLines = 34;
+    params.lines = 36;
+    params.coverage = 0.94;
 
     checkParsing(params);
   }
@@ -207,8 +207,8 @@ public class CoverageResultParserTest {
     params.assemblyName = "Example.Core";
     params.fileNumber = 3;
     params.fileName = "Money.cs";
-    params.coveredLines = 45;
-    params.lines = 47;
+    params.coveredLines = 44;
+    params.lines = 46;
     params.coverage = 0.96;
 
     checkParsing(params);
@@ -221,8 +221,8 @@ public class CoverageResultParserTest {
     params.assemblyName = "Example.Core";
     params.fileNumber = 5;
     params.fileName = "Money.cs";
-    params.coveredLines = 45;
-    params.lines = 48;
+    params.coveredLines = 44;
+    params.lines = 47;
     params.coverage = 0.94;
     mockIoFileForDotCover();
 
@@ -236,8 +236,8 @@ public class CoverageResultParserTest {
     params.assemblyName = "Example.Core";
     params.fileNumber = 4;
     params.fileName = "Money.cs";
-    params.coveredLines = 45;
-    params.lines = 59;
+    params.coveredLines = 44;
+    params.lines = 58;
     params.coverage = 0.76;
     mockIoFileForDotCover();
 

--- a/sonar/dotnet/sonar-dotnet-gallio-plugin/src/test/java/org/sonar/plugins/csharp/gallio/results/coverage/model/FileCoverageTest.java
+++ b/sonar/dotnet/sonar-dotnet-gallio-plugin/src/test/java/org/sonar/plugins/csharp/gallio/results/coverage/model/FileCoverageTest.java
@@ -31,7 +31,13 @@ public class FileCoverageTest {
   public void shouldMergeCoverage() {
     FileCoverage firstCoverage = new FileCoverage(new File("somesourcefile.cs"));
     CoveragePoint point = new CoveragePoint();
-    point.setCountVisits(2);
+    point.setCountVisits(1);
+    point.setStartLine(2);
+    point.setEndLine(2);
+    firstCoverage.addPoint(point);
+
+    point = new CoveragePoint();
+    point.setCountVisits(0);
     point.setStartLine(3);
     point.setEndLine(10);
     firstCoverage.addPoint(point);
@@ -39,25 +45,32 @@ public class FileCoverageTest {
     FileCoverage secondCoverage = new FileCoverage(new File("someotherfile.cs"));
     point = new CoveragePoint();
     point.setCountVisits(3);
-    point.setStartLine(7);
+    point.setStartLine(3);
     point.setEndLine(15);
     secondCoverage.addPoint(point);
+
     point = new CoveragePoint();
     point.setCountVisits(0);
     point.setStartLine(9);
     point.setEndLine(20);
     secondCoverage.addPoint(point);
 
+    point = new CoveragePoint();
+    point.setCountVisits(4);
+    point.setStartLine(21);
+    point.setEndLine(21);
+    secondCoverage.addPoint(point);
+
     firstCoverage.merge(secondCoverage);
 
-    assertEquals(18, firstCoverage.getCountLines());
-    assertEquals(13, firstCoverage.getCoveredLines());
-    assertEquals(13d / 18d, firstCoverage.getCoverage(), 0.01d);
+    assertEquals(4, firstCoverage.getCountLines());
+    assertEquals(3, firstCoverage.getCoveredLines());
+    assertEquals(3d / 4d, firstCoverage.getCoverage(), 0.01d);
 
-    SourceLine intersectionLine = firstCoverage.getLines().get(8);
-    assertEquals(5, intersectionLine.getCountVisits());
+    SourceLine intersectionLine = firstCoverage.getLines().get(3);
+    assertEquals(3, intersectionLine.getCountVisits());
 
-    SourceLine disjunctionLine = firstCoverage.getLines().get(4);
-    assertEquals(2, disjunctionLine.getCountVisits());
+    SourceLine newLine = firstCoverage.getLines().get(21);
+    assertEquals(4, newLine.getCountVisits());
   }
 }


### PR DESCRIPTION
Dear,

This is to request you to pull our team changes regarding code coverage in dotnet gallio plugin. 

In summary, the changes are to count one statement as one valid line of code when doing statistics , including coverage. 

Example:

13:    routes.MapHttpRoute(
14          name: "DefaultApi",
15           routeTemplate: "api/{controller}/{id}",
16           defaults: new { id = RouteParameter.Optional }
17     );

Those lines above, e.g. one statement,  will be consider as one line of code when calculating coverage and total line of code.

As we all know, a test method will cover the whole statement in source, it is not possible to cover some lines inside one statement.  Therefore we think one statement should be one valid line of code when we doing such statistics, the coverage will be more accurate in this way and we think it is the real coverage.

I will be happy to help if you need more information. Look forward to hearing from you.

Regards,
Xianjing
