### PR TITLE
Added Exclude by attribute functionality for open cover.

### DIFF
--- a/sonar/dotnet/sonar-dotnet-gallio-plugin/src/main/java/org/sonar/plugins/csharp/gallio/GallioConstants.java
+++ b/sonar/dotnet/sonar-dotnet-gallio-plugin/src/main/java/org/sonar/plugins/csharp/gallio/GallioConstants.java
@@ -53,6 +53,9 @@ public final class GallioConstants {
 
   public static final String COVERAGE_EXCLUDES_KEY = "sonar.gallio.coverage.excludes";
   public static final String COVERAGE_EXCLUDES_DEFVALUE = null;
+  
+  public static final String ABSOLUTE_BASE_DIRECTORY_KEY = "sonar.gallio.absoluteBaseDirectory";
+  public static final String ABSOLUTE_BASE_DIRECTORY_DEFVALUE = "C:/Program Files/Gallio/bin";
 
   public static final String TIMEOUT_MINUTES_KEY = "sonar.gallio.timeoutMinutes";
   public static final int TIMEOUT_MINUTES_DEFVALUE = 30;

--- a/sonar/dotnet/sonar-dotnet-gallio-plugin/src/main/java/org/sonar/plugins/csharp/gallio/GallioPlugin.java
+++ b/sonar/dotnet/sonar-dotnet-gallio-plugin/src/main/java/org/sonar/plugins/csharp/gallio/GallioPlugin.java
@@ -92,6 +92,9 @@ import java.util.List;
   @Property(key = GallioConstants.OPEN_COVER_ATTRIBUTE_EXCLUDES_KEY,
 	name = "OpenCover attribute excludes", description = "Exclude a class or method by filter(s) that match attributes that have been applied that have been applied. An * can be used as a wildcard. Example: *.ExcludeFromCoverage*",
 	global = false, project = false, defaultValue = GallioConstants.OPEN_COVER_ATTRIBUTE_EXCLUDES_DEFVALUE),
+  @Property(key = GallioConstants.ABSOLUTE_BASE_DIRECTORY_KEY,
+    name = "Gallio absolute base directory", description = "Set the base directory of the application that is being tested",
+    global = true, project = false, defaultValue = GallioConstants.ABSOLUTE_BASE_DIRECTORY_DEFVALUE),
   @Property(key = GallioConstants.IT_MODE_KEY, defaultValue = AbstractDotNetSensor.MODE_SKIP,
     name = "Gallio integration tests activation mode", description = "Possible values : Default (means 'skip'), " +
       "'active', 'skip' and 'reuseReport'.",

--- a/sonar/dotnet/sonar-dotnet-gallio-plugin/src/main/java/org/sonar/plugins/csharp/gallio/GallioSensor.java
+++ b/sonar/dotnet/sonar-dotnet-gallio-plugin/src/main/java/org/sonar/plugins/csharp/gallio/GallioSensor.java
@@ -222,6 +222,7 @@ public class GallioSensor extends AbstractDotNetSensor {
         .getStringArray(GallioConstants.COVERAGE_EXCLUDES_KEY, GallioConstants.COVERAGE_EXCLUDES_DEFVALUE));
     builder.setOpenCoverAttributeExcludes(configuration
     		.getString(GallioConstants.OPEN_COVER_ATTRIBUTE_EXCLUDES_KEY));
+    builder.setAbsoluteBaseDirectory(new File(configuration.getString(GallioConstants.ABSOLUTE_BASE_DIRECTORY_KEY)));
     builder.setPartCoverInstallDirectory(new File(configuration.getString(GallioConstants.PART_COVER_INSTALL_KEY)));
     builder.setOpenCoverInstallDirectory(new File(configuration.getString(GallioConstants.OPEN_COVER_INSTALL_KEY)));
     builder.setDotCoverInstallDirectory(new File(configuration.getString(GallioConstants.DOT_COVER_INSTALL_KEY)));

--- a/tools/gallio-runner/src/main/java/org/sonar/dotnet/tools/gallio/GallioCommandBuilder.java
+++ b/tools/gallio-runner/src/main/java/org/sonar/dotnet/tools/gallio/GallioCommandBuilder.java
@@ -59,6 +59,7 @@ public class GallioCommandBuilder { // NOSONAR class not final to allow mocking
   private File dotCoverInstallDirectory;
   private String[] coverageExcludes;
   private String attributeExcludes;
+  private File absoluteBaseDirectory;
   private File coverageReportFile;
 
   private List<File> testAssemblies;
@@ -204,6 +205,16 @@ public class GallioCommandBuilder { // NOSONAR class not final to allow mocking
   public void setOpenCoverAttributeExcludes(String attributeExclude) {
 	  this.attributeExcludes = attributeExclude;
   }
+  
+  /**
+   * Sets the abd parameter for Gallio
+   * 
+   * @param absoluteBaseDirectory
+   *        project directory
+   */
+  public void setAbsoluteBaseDirectory(File absoluteBaseDirectory) {
+	  this.absoluteBaseDirectory = absoluteBaseDirectory;
+  }
 
   /**
    * Sets the coverage report file to generate
@@ -286,6 +297,11 @@ public class GallioCommandBuilder { // NOSONAR class not final to allow mocking
     }
     LOG.debug("- Runner              : {}", runner);
     gallioArguments.add("/r:" + runner.getValue());
+    
+    if(absoluteBaseDirectory != null && absoluteBaseDirectory.length() > 0) {
+    	LOG.debug("- Absolute base directory : {}", absoluteBaseDirectory.getAbsolutePath());
+    	gallioArguments.add("/abd:" + absoluteBaseDirectory.getAbsolutePath());
+    }
 
     File reportDirectory = gallioReportFile.getParentFile();
     LOG.debug("- Report directory    : {}", reportDirectory.getAbsolutePath());


### PR DESCRIPTION
Exclude a class or method by filter(s) that match attributes that have been applied that have been applied. An \* can be used as a wildcard. Example: _.ExcludeFromCoverage_.

This would be great to have in the main repository so I don't have to modify newer versions as I upgrade. I have tested this on the sonar server in my development environment and it does work at excluding methods/classes/properties that have the attribute defined under sonar.opencover.attributeExcludes applied to them. I did also modify how sonar.gallio.coverage.excludes works for open cover. Not sure if it was intended to only allow exclusions at the assembly level but I modified it so I can exclude freely just as you can by calling command line.

Pulled from opencover wiki for how their filtering works. I also verified that my changes are working on our sonar server.

-filter:<filters> - filters to employ to limit the scope of the coverage. Using PartCover syntax, where (+|-)[Assembly-Filter]Type-Filter 
i.e. 
+[Open_]_ include all types in assemblies starting with Open, 
-[_]Core._ exclude all types in the Core namespace regardless of the assembly. If no filters are supplied then the default inclusive filter +[_]_ is applied automatically. 
NOTE: Multiple filters can be applied by separating them with spaces and enclosing them with quotes i.e. -filter:"+[_]_ -[A_]Name._" .
NOTE: Exclusion filters take precedence over inclusion filters.

If it was intended to only allow assembly filtering then it would still be nice to have the attribute exclusion at the very least added. This seems more helpful in sonar because it does effect the code coverage where filtering entire namespaces does not - would could be the reason for the original design.
