### PR TITLE
SONARFXCOP-2 support custom rules in fxcop

### DIFF
--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -42,6 +42,7 @@
     <dependency>
       <groupId>org.codehaus.sonar.dotnet.fxcop</groupId>
       <artifactId>sonar-fxcop-library</artifactId>
+      <version>1.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.sonar.dotnet.tests</groupId>

--- a/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/core/CSharpFxCopProvider.java
+++ b/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/core/CSharpFxCopProvider.java
@@ -43,6 +43,7 @@ public class CSharpFxCopProvider {
   private static final String FXCOP_ASSEMBLIES_PROPERTY_KEY = "sonar.cs.fxcop.assembly";
   private static final String FXCOP_FXCOPCMD_PATH_PROPERTY_KEY = "sonar.cs.fxcop.fxCopCmdPath";
   private static final String FXCOP_TIMEOUT_PROPERTY_KEY = "sonar.cs.fxcop.timeoutMinutes";
+  private static final String FXCOP_CUSTOM_RULES_PROPERTY_KEY = "sonar.cs.fxcop.customRules";
 
   private static final FxCopConfiguration FXCOP_CONF = new FxCopConfiguration(
     CSharpConstants.LANGUAGE_KEY,
@@ -78,13 +79,22 @@ public class CSharpFxCopProvider {
         .category(CATEGORY)
         .subCategory(SUBCATEGORY)
         .onQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
-        .build());
+        .build(),
+      PropertyDefinition.builder(FXCOP_CUSTOM_RULES_PROPERTY_KEY)
+        .name("FxCop custom rules")
+        .description("XML definitions of custom FxCop rules, which are'nt builtin into the plugin."
+                   + " The used format is described <a href='http://docs.codehaus.org/display/SONAR/C%23+Plugin'>here</a>.")
+        .type(PropertyType.TEXT)
+        .category(CATEGORY)              
+        .subCategory(SUBCATEGORY)
+        .build()
+      );
   }
 
   public static class CSharpFxCopRuleRepository extends FxCopRuleRepository {
 
-    public CSharpFxCopRuleRepository(XMLRuleParser xmlRuleParser) {
-      super(FXCOP_CONF, xmlRuleParser);
+    public CSharpFxCopRuleRepository(XMLRuleParser xmlRuleParser, Settings settings) {
+      super(FXCOP_CONF, FXCOP_CUSTOM_RULES_PROPERTY_KEY, xmlRuleParser, settings);
     }
 
   }

--- a/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/core/CSharpFxCopProviderTest.java
+++ b/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/core/CSharpFxCopProviderTest.java
@@ -40,7 +40,8 @@ public class CSharpFxCopProviderTest {
     assertThat(propertyKeys(new CSharpFxCopProvider().extensions())).containsOnly(
       "sonar.cs.fxcop.assembly",
       "sonar.cs.fxcop.timeoutMinutes",
-      "sonar.cs.fxcop.fxCopCmdPath");
+      "sonar.cs.fxcop.fxCopCmdPath",
+      "sonar.cs.fxcop.customRules");
   }
 
   private static Set<String> nonProperties(List extensions) {


### PR DESCRIPTION
Did not notice i wasnt in my fork. This is 2 pull request one in the library in the other in the core. Creating a plugin for fxcop should really be considered

related with
https://github.com/SonarCommunity/sonar-fxcop-library/pull/1
