### PR TITLE
Added support for directory assembly dependencies.  Related to SONARFXCOP-9

### DIFF
--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -42,6 +42,7 @@
     <dependency>
       <groupId>org.codehaus.sonar.dotnet.fxcop</groupId>
       <artifactId>sonar-fxcop-library</artifactId>
+      <version>1.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.sonar.dotnet.tests</groupId>

--- a/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/core/CSharpFxCopProvider.java
+++ b/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/core/CSharpFxCopProvider.java
@@ -41,6 +41,7 @@ public class CSharpFxCopProvider {
   private static final String SUBCATEGORY = "Code Analysis / FxCop";
 
   private static final String FXCOP_ASSEMBLIES_PROPERTY_KEY = "sonar.cs.fxcop.assembly";
+  private static final String FXCOP_DIRECTORY_PROPERTY_KEY = "sonar.cs.fxcop.directory";
   private static final String FXCOP_FXCOPCMD_PATH_PROPERTY_KEY = "sonar.cs.fxcop.fxCopCmdPath";
   private static final String FXCOP_TIMEOUT_PROPERTY_KEY = "sonar.cs.fxcop.timeoutMinutes";
 
@@ -48,6 +49,7 @@ public class CSharpFxCopProvider {
     CSharpConstants.LANGUAGE_KEY,
     "fxcop",
     FXCOP_ASSEMBLIES_PROPERTY_KEY,
+    FXCOP_DIRECTORY_PROPERTY_KEY,
     FXCOP_FXCOPCMD_PATH_PROPERTY_KEY,
     FXCOP_TIMEOUT_PROPERTY_KEY);
 
@@ -67,6 +69,14 @@ public class CSharpFxCopProvider {
       PropertyDefinition.builder(FXCOP_ASSEMBLIES_PROPERTY_KEY)
         .name("Assembly to analyze")
         .description("Example: bin/Debug/MyProject.dll")
+        .category(CATEGORY)
+        .subCategory(SUBCATEGORY)
+        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .build(),
+      PropertyDefinition.builder(FXCOP_DIRECTORY_PROPERTY_KEY)
+        .name("List of directories (seperated by ',') to scan for referenced assemblies")
+        .description("Example: s:/Binaries,d:/dev/builddrop")
+        .defaultValue(null)
         .category(CATEGORY)
         .subCategory(SUBCATEGORY)
         .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
@@ -98,3 +108,4 @@ public class CSharpFxCopProvider {
   }
 
 }
+

--- a/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/core/CSharpFxCopProviderTest.java
+++ b/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/core/CSharpFxCopProviderTest.java
@@ -40,7 +40,8 @@ public class CSharpFxCopProviderTest {
     assertThat(propertyKeys(new CSharpFxCopProvider().extensions())).containsOnly(
       "sonar.cs.fxcop.assembly",
       "sonar.cs.fxcop.timeoutMinutes",
-      "sonar.cs.fxcop.fxCopCmdPath");
+      "sonar.cs.fxcop.fxCopCmdPath",
+      "sonar.cs.fxcop.directory");
   }
 
   private static Set<String> nonProperties(List extensions) {


### PR DESCRIPTION
Added support for directory assembly dependencies.  Related to SONARFXCOP-9

These changes need to be applied together with the changes on the fx-cop plugin (I also created a pull request for these changes) https://github.com/SonarCommunity/sonar-fxcop-library/pull/2
