### PR TITLE
SONARNTEST-6: Added NUnit test results import settings

### DIFF
--- a/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/core/CSharpUnitTestResultsProvider.java
+++ b/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/core/CSharpUnitTestResultsProvider.java
@@ -35,8 +35,9 @@ public class CSharpUnitTestResultsProvider {
   private static final String SUBCATEGORY = "Unit Tests";
 
   private static final String VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY = "sonar.cs.vstest.reportsPaths";
+  private static final String NUNIT_TEST_RESULTS_PROPERTY_KEY = "sonar.cs.nunit.reportsPaths";
 
-  private static final UnitTestConfiguration UNIT_TEST_CONF = new UnitTestConfiguration(VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY);
+  private static final UnitTestConfiguration UNIT_TEST_CONF = new UnitTestConfiguration(VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY, NUNIT_TEST_RESULTS_PROPERTY_KEY);
 
   private CSharpUnitTestResultsProvider() {
   }
@@ -48,6 +49,13 @@ public class CSharpUnitTestResultsProvider {
       PropertyDefinition.builder(VISUAL_STUDIO_TEST_RESULTS_PROPERTY_KEY)
         .name("Visual Studio Test Reports Paths")
         .description("Example: \"report.trx\", \"report1.trx,report2.trx\" or \"C:/report.trx\"")
+        .category(CATEGORY)
+        .subCategory(SUBCATEGORY)
+        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .build(),
+      PropertyDefinition.builder(NUNIT_TEST_RESULTS_PROPERTY_KEY)
+        .name("NUnit Test Reports Paths")
+        .description("Example: \"TestResult.xml\", \"TestResult1.xml,TestResult2.xml\" or \"C:/TestResult.xml\"")
         .category(CATEGORY)
         .subCategory(SUBCATEGORY)
         .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)

--- a/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/core/CSharpUnitTestResultsProviderTest.java
+++ b/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/core/CSharpUnitTestResultsProviderTest.java
@@ -38,7 +38,8 @@ public class CSharpUnitTestResultsProviderTest {
       CSharpUnitTestResultsAggregator.class,
       CSharpUnitTestResultsImportSensor.class);
     assertThat(propertyKeys(CSharpUnitTestResultsProvider.extensions())).containsOnly(
-      "sonar.cs.vstest.reportsPaths");
+      "sonar.cs.vstest.reportsPaths",
+      "sonar.cs.nunit.reportsPaths");
   }
 
   private static Set<String> nonProperties(List extensions) {


### PR DESCRIPTION
Added the new NUnit test report import setting from the pull request to the tests plugin:

https://github.com/SonarCommunity/sonar-dotnet-tests-library/pull/3

I've tested this on a Sonar 4.4 instance and it works correctly with the new NUnit test import on some C# projects I have.
