### PR TITLE
Do not report Security Hotspots as external rules when analyzing PRs and short-living branches

### DIFF
--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/SarifParserCallbackImpl.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/SarifParserCallbackImpl.java
@@ -254,7 +254,7 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
   }
 
   private boolean shouldCreateExternalIssue(String ruleId) {
-    return !ignoreThirdPartyIssues && !ruleId.matches("^S\\d{3,5}$");
+    return !ignoreThirdPartyIssues && !ruleId.matches("^S\\d{3,4}$");
   }
 
   private RuleType mapRuleType(@Nullable String category, String defaultLevel) {

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/SarifParserCallbackImpl.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/SarifParserCallbackImpl.java
@@ -111,7 +111,7 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
     String repositoryKey = repositoryKeyByRoslynRuleKey.get(ruleId);
     if (repositoryKey != null) {
       createFileLevelIssue(ruleId, message, repositoryKey, inputFile);
-    } else if (!ignoreThirdPartyIssues) {
+    } else if (shouldCreateExternalIssue(ruleId)) {
       createFileLevelExternalIssue(ruleId, level, message, inputFile);
     }
   }
@@ -152,7 +152,7 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
     String repositoryKey = repositoryKeyByRoslynRuleKey.get(ruleId);
     if (repositoryKey != null) {
       createIssue(inputFile, ruleId, primaryLocation, secondaryLocations, repositoryKey);
-    } else if (!ignoreThirdPartyIssues) {
+    } else if (shouldCreateExternalIssue(ruleId)) {
       createExternalIssue(inputFile, ruleId, level, primaryLocation, secondaryLocations);
     }
   }
@@ -236,7 +236,7 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
 
   @Override
   public void onRule(String ruleId, @Nullable String shortDescription, @Nullable String fullDescription, String defaultLevel, @Nullable String category) {
-    if (ignoreThirdPartyIssues || repositoryKeyByRoslynRuleKey.containsKey(ruleId)) {
+    if (repositoryKeyByRoslynRuleKey.containsKey(ruleId) || !shouldCreateExternalIssue(ruleId)) {
       // This is not an external rule
       return;
     }
@@ -248,9 +248,13 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
       .ruleId(ruleId)
       .severity(mapSeverity(defaultLevel))
       .name(shortDescription != null ? shortDescription : ruleId)
-      .description(fullDescription != null ? fullDescription : null)
+      .description(fullDescription)
       .type(ruleType)
       .save();
+  }
+
+  private boolean shouldCreateExternalIssue(String ruleId) {
+    return !ignoreThirdPartyIssues && !ruleId.matches("^S\\d{3,5}$");
   }
 
   private RuleType mapRuleType(@Nullable String category, String defaultLevel) {

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/sarif/SarifParserCallbackImplTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/sarif/SarifParserCallbackImplTest.java
@@ -215,7 +215,7 @@ public class SarifParserCallbackImplTest {
     callback = new SarifParserCallbackImpl(ctx, repositoryKeyByRoslynRuleKey, false, emptySet(), emptySet(), emptySet());
     callback.onRule("SS1234", "My rule", "Rule description", "Error", "Foo"); // does not start with single S
     callback.onRule("S123456", "My rule", "Rule description", "Error", "Foo"); // too long
-    callback.onRule("S12345", "My rule", "Rule description", "Error", "Foo"); // sonar rule
+    callback.onRule("S12345", "My rule", "Rule description", "Error", "Foo"); // too long
     callback.onRule("S1234", "My rule", "Rule description", "Error", "Foo"); // sonar rule
     callback.onRule("S123", "My rule", "Rule description", "Error", "Foo"); // sonar rule
     callback.onRule("S12", "My rule", "Rule description", "Error", "Foo"); // too short
@@ -226,6 +226,7 @@ public class SarifParserCallbackImplTest {
       .containsExactlyInAnyOrder(
         tuple("roslyn", "SS1234", "My rule", "Rule description", Severity.CRITICAL, RuleType.BUG),
         tuple("roslyn", "S123456", "My rule", "Rule description", Severity.CRITICAL, RuleType.BUG),
+        tuple("roslyn", "S12345", "My rule", "Rule description", Severity.CRITICAL, RuleType.BUG),
         tuple("roslyn", "S12", "My rule", "Rule description", Severity.CRITICAL, RuleType.BUG),
         tuple("roslyn", "S123x", "My rule", "Rule description", Severity.CRITICAL, RuleType.BUG));
   }


### PR DESCRIPTION
Fix #2131