### PR TITLE
Update S1200: Rule should ignore 'nameof()' references

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/Automapper/AutoMapper-025B9F93-7953-454B-AF29-E6A55B2AA58F-S1200.json
+++ b/sonaranalyzer-dotnet/its/expected/Automapper/AutoMapper-025B9F93-7953-454B-AF29-E6A55B2AA58F-S1200.json
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S1200",
-"message":  "Split this class into smaller and more specialized ones to reduce its dependencies on other classes from 38 to the maximum authorized 30 or less.",
+"message":  "Split this class into smaller and more specialized ones to reduce its dependencies on other classes from 37 to the maximum authorized 30 or less.",
 "location":  {
 "uri":  "sources\Automapper\src\AutoMapper\Execution\TypeMapPlanBuilder.cs",
 "region":  {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveClassCoupling.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveClassCoupling.cs
@@ -257,6 +257,20 @@ namespace SonarAnalyzer.Rules.CSharp
                 AddDependentType(node);
                 base.VisitIdentifierName(node);
             }
+
+            public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+            {
+                // We don't use the helper method CSharpSyntaxHelper.IsNameof because it will do some extra
+                // semantic checks to ensure this is the real `nameof` and not a user made method.
+                // Here we prefer to favor fast results over accuracy (at worst we have FNs not FPs).
+                var isNameof = node.Expression.IsKind(SyntaxKind.IdentifierName) &&
+                    ((IdentifierNameSyntax)node.Expression).Identifier.ToString() == CSharpSyntaxHelper.NameOfKeywordText;
+
+                if (!isNameof)
+                {
+                    base.VisitInvocationExpression(node);
+                }
+            }
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AvoidExcessiveClassCouplingTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AvoidExcessiveClassCouplingTest.cs
@@ -468,7 +468,7 @@ public class Self // Compliant, attributes are not counted
         public void AvoidExcessiveClassCoupling_Nameof()
         {
             Verifier.VerifyCSharpAnalyzer(@"
-public class A // Compliant, attributes are not counted
+public class A // Compliant, types referenced by the nameof expression are not counted
 {
     public A()
     {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AvoidExcessiveClassCouplingTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AvoidExcessiveClassCouplingTest.cs
@@ -444,6 +444,7 @@ public class Self // Noncompliant {{Split this class into smaller and more speci
 ",
                 new AvoidExcessiveClassCoupling { Threshold = 0 });
         }
+
         [TestMethod]
         [TestCategory("Rule")]
         public void AvoidExcessiveClassCoupling_Attributes()
@@ -456,6 +457,23 @@ public class Self // Compliant, attributes are not counted
     [Obsolete]
     void M1()
     {
+    }
+}
+",
+                new AvoidExcessiveClassCoupling { Threshold = 0 });
+        }
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void AvoidExcessiveClassCoupling_Nameof()
+        {
+            Verifier.VerifyCSharpAnalyzer(@"
+public class A // Compliant, attributes are not counted
+{
+    public A()
+    {
+        var s1 = nameof(System.Type);
+        var s2 = nameof(System.Action);
     }
 }
 ",


### PR DESCRIPTION
Fix #2123 