### PR TITLE
Fix S1144: Do not keep references to all type symbols

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
@@ -686,13 +686,13 @@ public class FieldUsages
 
         [TestMethod]
         [TestCategory("Rule")]
-        public void Assembly_Level_Attributes_FalsePositive()
+        public void Assembly_Level_Attributes()
         {
             Verifier.VerifyCSharpAnalyzer(@"
 [assembly: System.Reflection.AssemblyCompany(Foo.Constants.AppCompany)]
 public static class Foo
 {
-    internal static class Constants // Noncompliant, False Positive; we cannot detect usages from assembly level attributes.
+    internal static class Constants // Compliant, detect usages from assembly level attributes.
     {
         public const string AppCompany = ""foo"";
     }


### PR DESCRIPTION
Fix #2203, Fix #2154  

## Note

I did not go with the additional optimizations because reporting for property accessors would become much more difficult.