### PR TITLE
NuGet packages should stop using deprecated licenseUrl tag

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.CSharp.nuspec
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.CSharp.nuspec
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SonarAnalyzer.CSharp</id>
     <version>7.10.0.0</version>
@@ -27,5 +27,6 @@
     <file src="$binPath$\SonarAnalyzer.CSharp.dll" target="analyzers" />
     <file src="$binPath$\Google.Protobuf.dll" target="analyzers" />
     <file src="tools-cs\*.ps1" target="tools\" />
+    <file src="License.txt" />
   </files>
 </package>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.CSharp.nuspec
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.CSharp.nuspec
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>SonarAnalyzer.CSharp</id>
     <version>7.10.0.0</version>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.CSharp.nuspec
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.CSharp.nuspec
@@ -6,7 +6,7 @@
     <title>SonarAnalyzer for C#</title>
     <authors>SonarSource</authors>
     <owners>SonarSource</owners>
-    <licenseUrl>https://raw.githubusercontent.com/SonarSource-VisualStudio/sonaranalyzer-dotnet/master/LICENSE</licenseUrl>
+    <license type="file">License.txt</license>
     <projectUrl>http://vs.sonarlint.org</projectUrl>
     <iconUrl>http://dist.sonarsource.com/csharp/download/ico-sonarlint-64.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.VisualBasic.nuspec
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.VisualBasic.nuspec
@@ -27,5 +27,6 @@
     <file src="$binPath$\SonarAnalyzer.VisualBasic.dll" target="analyzers" />
     <file src="$binPath$\Google.Protobuf.dll" target="analyzers" />
     <file src="tools-vbnet\*.ps1" target="tools\" />
+    <file src="License.txt" />
   </files>
 </package>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.VisualBasic.nuspec
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.VisualBasic.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>SonarAnalyzer.VisualBasic</id>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.VisualBasic.nuspec
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.VisualBasic.nuspec
@@ -6,7 +6,7 @@
     <title>SonarAnalyzer for Visual Basic</title>
     <authors>SonarSource</authors>
     <owners>SonarSource</owners>
-    <licenseUrl>https://raw.githubusercontent.com/SonarSource-VisualStudio/sonaranalyzer-dotnet/master/LICENSE</licenseUrl>
+    <license type="file">License.txt</license>
     <projectUrl>http://vs.sonarlint.org</projectUrl>
     <iconUrl>http://dist.sonarsource.com/csharp/download/ico-sonarlint-64.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
When trying to publish the NuGet package to nuget.org there was a warning to tell us we are using a deprecated element.