### PR TITLE
Remove PS Unrestricted requirement from Rspec2Resx.targets

### DIFF
--- a/sonaranalyzer-dotnet/src/Rspec2Resx.targets
+++ b/sonaranalyzer-dotnet/src/Rspec2Resx.targets
@@ -18,7 +18,6 @@
     <PropertyGroup>
       <PowerShellExe Condition="'$(PowerShellExe)'==''">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>
     </PropertyGroup>
-    <Exec Command="$(PowerShellExe) -command &quot;if ((Get-ExecutionPolicy) -ne &apos;Unrestricted&apos;) {echo &apos;Powershell: error 0000: You have to run Set-ExecutionPolicy Unrestricted (In powershell32)&apos;} &quot; " />
     <Exec ConsoleToMsBuild="true"
       Command="$(PowerShellExe) -NonInteractive -ExecutionPolicy Unrestricted -command &quot;  &amp; { ..\..\..\scripts\rspec\rspec2resx.ps1 $(Rspec2Resx)  $(ProjectDir)../../rspec/$(Rspec2Resx) $(ProjectDir)RspecStrings.resx } &quot;"/>
   </Target>


### PR DESCRIPTION
I don't understand why this is necessary.
It's also breaking my local env