### PR TITLE
Fix S3440: FP on properties affectation.

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantConditionalAroundAssignment.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantConditionalAroundAssignment.cs
@@ -59,28 +59,14 @@ namespace Tests.Diagnostics
             {
                 y += 2;
             }
-        }
 
-        private static int? f;
-        // Properties are not checked
-        public static int Property
-        {
-            get
+            // Properties are not checked
+            if (Property != default(int))
             {
-                if (f != null)
-                {
-                    f = null;
-                }
-
-                return 1;
-            }
-            set
-            {
-                if (f != null)
-                {
-                    f = null;
-                }
+                Property = default(int);
             }
         }
+
+        public static int Property { get; set; }
     }
 }


### PR DESCRIPTION
The rule should ignore property checking before assignment because of possible side effect, but  it's not the case.
The test is wrong, the verification is made for a check and assignment inside a property and not for a check and assignment of a property.

Fix #2313