### PR TITLE
Fix S4158: Rule should consider .NetCore 2.0+ 'Dictionary.TryAdd' method

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -66,6 +66,7 @@ namespace SonarAnalyzer.Rules.CSharp
             nameof(Stack<object>.Push),
             nameof(HashSet<object>.Add),
             nameof(HashSet<object>.UnionWith),
+            "TryAdd" // This is a .NetCore 2.0+ method on Dictionary
         };
 
         private static readonly HashSet<string> IgnoredMethods = new HashSet<string>

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EmptyCollectionsShouldNotBeEnumeratedTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EmptyCollectionsShouldNotBeEnumeratedTest.cs
@@ -31,7 +31,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void EmptyCollectionsShouldNotBeEnumerated()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\EmptyCollectionsShouldNotBeEnumerated.cs",
+            Verifier.VerifyAnalyzer(
+                @"TestCases\EmptyCollectionsShouldNotBeEnumerated.cs",
                 new EmptyCollectionsShouldNotBeEnumerated());
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -609,6 +609,14 @@ namespace Tests.Diagnostics
             dictionary.Add(1, 1);
             dictionary.Clear(); // Compliant, will normally raise
         }
+
+        public void TryAdd()
+        {
+            var dictionary = new NetCoreDictionary<string, object>();
+            if (dictionary.TryAdd("foo", new object()))
+            {
+            }
+        }
     }
 
     class Flows
@@ -772,6 +780,15 @@ namespace Tests.Diagnostics
             {
                 // silently do nothing
             }
+        }
+    }
+
+    // This class is here to simulate how the Dictionary from .NetCore 2.0+ behaves.
+    public class NetCoreDictionary<TKey, TValue> : Dictionary<TKey, TValue>
+    {
+        public bool TryAdd(TKey key, TValue value)
+        {
+            return true;
         }
     }
 }


### PR DESCRIPTION
Fix #2341 