### PR TITLE
Remove waffle badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # SonarC\# and SonarVB
 
-[![Waffle.io - Columns and their card count](https://badge.waffle.io/SonarSource/sonar-dotnet.svg?columns=all)](https://waffle.io/SonarSource/sonar-dotnet?source=SonarSource%2Fsonar-dotnet)
-
 |Product|Quality Gate|Coverage|
 |:--:|:--:|:--:|
 |Analyzer|[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=sonaranalyzer-dotnet&metric=alert_status)](https://sonarcloud.io/dashboard?id=sonaranalyzer-dotnet)|[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=sonaranalyzer-dotnet&metric=coverage)](https://sonarcloud.io/component_measures?id=sonaranalyzer-dotnet&metric=coverage)|


### PR DESCRIPTION
Waffle is shutting down in 2 weeks. I removed all automation from the Waffle settings.