### PR TITLE
Add integration test for counting header comments

### DIFF
--- a/its/projects/MetricsTest/foo/Class1.cs
+++ b/its/projects/MetricsTest/foo/Class1.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿/**
+ * This is a header comment line 1
+ * Header comment line 2
+ */
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/its/src/test/java/com/sonar/it/csharp/MetricsIncludeHeaderCommentTest.java
+++ b/its/src/test/java/com/sonar/it/csharp/MetricsIncludeHeaderCommentTest.java
@@ -1,0 +1,201 @@
+/*
+ * SonarSource :: C# :: ITs :: Plugin
+ * Copyright (C) 2011-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.it.csharp;
+
+import com.sonar.it.shared.TestUtils;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.SystemUtils;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.sonarqube.ws.WsMeasures.Measure;
+
+import static com.sonar.it.csharp.Tests.ORCHESTRATOR;
+import static com.sonar.it.csharp.Tests.getComponent;
+import static com.sonar.it.csharp.Tests.getMeasure;
+import static com.sonar.it.csharp.Tests.getMeasureAsInt;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This is copy pasted from MetricsTest. It does not re-test everything, it just makes sure
+ * that when 'ignoreHeaderComments' is set to False, it counts the header comments as well
+ * and it does not modify the LOC metrics.
+ */
+public class MetricsIncludeHeaderCommentTest {
+
+  public static TemporaryFolder temp = new TemporaryFolder();
+
+  private static final String PROJECT = "MetricsTest";
+  private static final String DIRECTORY = TestUtils.hasModules(ORCHESTRATOR) ? "MetricsTest:MetricsTest:1F026ECA-900A-488D-9D07-AD23216FA32B:foo" : "MetricsTest:foo";
+  private static final String FILE = TestUtils.hasModules(ORCHESTRATOR) ? "MetricsTest:MetricsTest:1F026ECA-900A-488D-9D07-AD23216FA32B:foo/Class1.cs" : "MetricsTest:foo/Class1.cs";
+  private static final int NUMBER_OF_HEADER_COMMENT_LINES = 2;
+
+  @ClassRule
+  public static RuleChain chain = getRuleChain();
+
+  private static RuleChain getRuleChain() {
+    assertThat(SystemUtils.IS_OS_WINDOWS).withFailMessage("OS should be Windows.").isTrue();
+
+    // Scanner for MSBuild caches the analyzer, so running the test twice in a row means the old binary is used.
+    // This code deletes the cache, but there should be a way to run without cache.
+    // Ticket: https://jira.sonarsource.com/browse/SONARMSBRU-346
+    String localAppData = System.getenv("LOCALAPPDATA") + "\\Temp\\.sonarqube";
+    try {
+      FileUtils.deleteDirectory(new File(localAppData));
+    }
+    catch (IOException ioe) {
+      throw new IllegalStateException("could not delete Scanner for MSBuild cache folder", ioe);
+    }
+
+    return RuleChain
+      .outerRule(ORCHESTRATOR)
+      .around(temp)
+      .around(new ExternalResource() {
+        @Override
+        protected void before() throws Throwable {
+          ORCHESTRATOR.resetData();
+
+          Path projectDir = Tests.projectDir(temp, "MetricsTest");
+          ORCHESTRATOR.executeBuild(TestUtils.newScanner(projectDir)
+            .addArgument("begin")
+            .setProjectKey("MetricsTest")
+            .setProjectName("MetricsTest")
+            .setProjectVersion("1.0")
+            .setProfile("no_rule")
+            // Without that, the MetricsTest project is considered as a Test project :)
+            .setProperty("sonar.msbuild.testProjectPattern", "noTests"));
+
+          setIgnoreHeaderCommentsToFalse(projectDir);
+
+          TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild");
+
+          ORCHESTRATOR.executeBuild(TestUtils.newScanner(projectDir)
+            .addArgument("end"));
+        }
+      });
+  }
+
+  @Test
+  public void projectIsAnalyzed() {
+    assertThat(getComponent(PROJECT).getName()).isEqualTo("MetricsTest");
+    assertThat(getComponent(DIRECTORY).getName()).isEqualTo("foo");
+    assertThat(getComponent(FILE).getName()).isEqualTo("Class1.cs");
+  }
+
+  /* Lines - must be the same */
+
+  @Test
+  public void linesAtProjectLevel() {
+    assertThat(getProjectMeasureAsInt("lines")).isEqualTo(117);
+  }
+
+  @Test
+  public void linesAtDirectoryLevel() {
+    assertThat(getDirectoryMeasureAsInt("lines")).isEqualTo(79);
+  }
+
+  @Test
+  public void linesAtFileLevel() {
+    assertThat(getFileMeasureAsInt("lines")).isEqualTo(41);
+  }
+
+  /* Lines of code - must be the same */
+
+  @Test
+  public void linesOfCodeAtProjectLevel() {
+    assertThat(getProjectMeasureAsInt("ncloc")).isEqualTo(90);
+  }
+
+  @Test
+  public void linesOfCodeAtDirectoryLevel() {
+    assertThat(getDirectoryMeasureAsInt("ncloc")).isEqualTo(60);
+  }
+
+  @Test
+  public void linesOfCodeAtFileLevel() {
+    assertThat(getFileMeasureAsInt("ncloc")).isEqualTo(30);
+  }
+
+  /* Comment lines - these are actually modified */
+
+  @Test
+  public void commentLinesAtProjectLevel() {
+    assertThat(getProjectMeasureAsInt("comment_lines")).isEqualTo(12 + NUMBER_OF_HEADER_COMMENT_LINES);
+  }
+
+  @Test
+  public void commentLinesAtDirectoryLevel() {
+    assertThat(getDirectoryMeasureAsInt("comment_lines")).isEqualTo(8 + NUMBER_OF_HEADER_COMMENT_LINES);
+  }
+
+  @Test
+  public void commentLinesAtFileLevel() {
+    assertThat(getFileMeasureAsInt("comment_lines")).isEqualTo(4 + NUMBER_OF_HEADER_COMMENT_LINES);
+  }
+
+  /* Helper methods */
+
+  private Integer getProjectMeasureAsInt(String metricKey) {
+    return getMeasureAsInt(PROJECT, metricKey);
+  }
+
+  private Integer getDirectoryMeasureAsInt(String metricKey) {
+    return getMeasureAsInt(DIRECTORY, metricKey);
+  }
+
+  private Integer getFileMeasureAsInt(String metricKey) {
+    return getMeasureAsInt(FILE, metricKey);
+  }
+
+  private static void setIgnoreHeaderCommentsToFalse(Path projectDir) throws IOException {
+    StringBuilder sb = new StringBuilder();
+    String sonarLintXml = projectDir + "\\.sonarqube\\conf\\cs\\SonarLint.xml";
+    try (BufferedReader reader = new BufferedReader(new FileReader(sonarLintXml)))
+    {
+      String currentLine;
+      while ((currentLine = reader.readLine()) != null) {
+        if (currentLine.contains("sonar.cs.ignoreHeaderComments")) {
+          sb.append(currentLine);
+          currentLine = reader.readLine();
+          currentLine = currentLine.replaceAll("true", "false");
+          sb.append(currentLine);
+        } else {
+          sb.append(currentLine);
+        }
+      }
+    }
+
+    String contents = sb.toString();
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(sonarLintXml))) {
+      if (contents.length() > 0) {
+        writer.write(contents);
+      }
+    }
+  }
+}

--- a/its/src/test/java/com/sonar/it/csharp/MetricsTest.java
+++ b/its/src/test/java/com/sonar/it/csharp/MetricsTest.java
@@ -37,7 +37,6 @@ import static com.sonar.it.csharp.Tests.ORCHESTRATOR;
 import static com.sonar.it.csharp.Tests.getComponent;
 import static com.sonar.it.csharp.Tests.getMeasure;
 import static com.sonar.it.csharp.Tests.getMeasureAsInt;
-import static org.apache.commons.lang.StringUtils.countMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MetricsTest {
@@ -180,17 +179,17 @@ public class MetricsTest {
 
   @Test
   public void linesAtProjectLevel() {
-    assertThat(getProjectMeasureAsInt("lines")).isEqualTo(114);
+    assertThat(getProjectMeasureAsInt("lines")).isEqualTo(118);
   }
 
   @Test
   public void linesAtDirectoryLevel() {
-    assertThat(getDirectoryMeasureAsInt("lines")).isEqualTo(76);
+    assertThat(getDirectoryMeasureAsInt("lines")).isEqualTo(80);
   }
 
   @Test
   public void linesAtFileLevel() {
-    assertThat(getFileMeasureAsInt("lines")).isEqualTo(38);
+    assertThat(getFileMeasureAsInt("lines")).isEqualTo(42);
   }
 
   /* Lines of code */
@@ -305,38 +304,38 @@ public class MetricsTest {
   public void linesOfCodeByLine() {
     String value = getFileMeasure("ncloc_data").getValue();
 
-    assertThat(value).contains("1=1");
-    assertThat(value).contains("2=1");
-    assertThat(value).contains("3=1");
-    assertThat(value).contains("4=1");
     assertThat(value).contains("5=1");
-
+    assertThat(value).contains("6=1");
+    assertThat(value).contains("7=1");
+    assertThat(value).contains("8=1");
     assertThat(value).contains("9=1");
-    assertThat(value).contains("10=1");
-    assertThat(value).contains("11=1");
-    assertThat(value).contains("12=1");
 
+    assertThat(value).contains("13=1");
+    assertThat(value).contains("14=1");
+    assertThat(value).contains("15=1");
     assertThat(value).contains("16=1");
-    assertThat(value).contains("17=1");
-    assertThat(value).contains("18=1");
-    assertThat(value).contains("19=1");
+
     assertThat(value).contains("20=1");
     assertThat(value).contains("21=1");
     assertThat(value).contains("22=1");
     assertThat(value).contains("23=1");
-
+    assertThat(value).contains("24=1");
     assertThat(value).contains("25=1");
     assertThat(value).contains("26=1");
     assertThat(value).contains("27=1");
-    assertThat(value).contains("28=1");
+
     assertThat(value).contains("29=1");
     assertThat(value).contains("30=1");
     assertThat(value).contains("31=1");
     assertThat(value).contains("32=1");
     assertThat(value).contains("33=1");
     assertThat(value).contains("34=1");
+    assertThat(value).contains("35=1");
+    assertThat(value).contains("36=1");
+    assertThat(value).contains("37=1");
+    assertThat(value).contains("38=1");
 
-    assertThat(value.length()).isEqualTo(143); // No other line
+    assertThat(value.length()).isEqualTo(144); // No other line
   }
 
   /* Executable lines */
@@ -346,10 +345,10 @@ public class MetricsTest {
 
     String value = getFileMeasure("executable_lines_data").getValue();
 
-    assertThat(value).contains("20=1");
-    assertThat(value).contains("30=1");
-    assertThat(value).contains("32=1");
-    assertThat(value).contains("33=1");
+    assertThat(value).contains("24=1");
+    assertThat(value).contains("34=1");
+    assertThat(value).contains("36=1");
+    assertThat(value).contains("37=1");
 
     assertThat(value.length()).isEqualTo(19); // No other lines
   }

--- a/its/src/test/java/com/sonar/it/shared/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/shared/TestUtils.java
@@ -79,8 +79,9 @@ public class TestUtils {
   }
 
   public static Build<ScannerForMSBuild> newScanner(Path projectDir) {
+    // We need to set the fallback version to run from inside the IDE when the property isn't set
     return ScannerForMSBuild.create(projectDir.toFile())
-      .setScannerVersion(System.getProperty("scannerMsbuild.version"));
+      .setScannerVersion(System.getProperty("scannerMsbuild.version", "4.6.1.2049"));
   }
 
   public static void runMSBuild(Orchestrator orch, Path projectDir, String... arguments) {


### PR DESCRIPTION
This is quite hard to test inside the C# analyzer, as the `SonarLint.xml` file is passed as _Additional file_ to roslyn by S4MSB, which is quite hard to mock.