### PR TITLE
S1940: FP with null-conditional operator

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/BooleanCheckInverted.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/BooleanCheckInverted.cs
@@ -71,7 +71,13 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override bool IsIgnoredNullableOperation(BinaryExpressionSyntax expression, SemanticModel semanticModel) =>
             expression.OperatorToken.IsAnyKind(ignoredNullableOperators) &&
-            (IsNullable(expression.Left, semanticModel) || IsNullable(expression.Right, semanticModel));
+            (IsNullable(expression.Left, semanticModel) || IsNullable(expression.Right, semanticModel) ||
+            IsConditionalAccessExpression(expression.Left) || IsConditionalAccessExpression(expression.Right));
+
+        private static bool IsConditionalAccessExpression(ExpressionSyntax expression)
+        {
+            return expression.RemoveParentheses().IsKind(SyntaxKind.ConditionalAccessExpression);
+        }
 
         protected override bool IsLogicalNot(BinaryExpressionSyntax expression, out SyntaxNode logicalNot)
         {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/BooleanCheckInverted.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/BooleanCheckInverted.cs
@@ -74,10 +74,8 @@ namespace SonarAnalyzer.Rules.CSharp
             (IsNullable(expression.Left, semanticModel) || IsNullable(expression.Right, semanticModel) ||
             IsConditionalAccessExpression(expression.Left) || IsConditionalAccessExpression(expression.Right));
 
-        private static bool IsConditionalAccessExpression(ExpressionSyntax expression)
-        {
-            return expression.RemoveParentheses().IsKind(SyntaxKind.ConditionalAccessExpression);
-        }
+        private static bool IsConditionalAccessExpression(ExpressionSyntax expression) =>
+            expression.RemoveParentheses().IsKind(SyntaxKind.ConditionalAccessExpression);
 
         protected override bool IsLogicalNot(BinaryExpressionSyntax expression, out SyntaxNode logicalNot)
         {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Rules/BooleanCheckInverted.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Rules/BooleanCheckInverted.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Rules/BooleanCheckInverted.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Rules/BooleanCheckInverted.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
@@ -72,7 +73,13 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         protected override bool IsIgnoredNullableOperation(BinaryExpressionSyntax expression, SemanticModel semanticModel) =>
             expression.OperatorToken.IsAnyKind(ignoredNullableOperators) &&
-            (IsNullable(expression.Left, semanticModel) || IsNullable(expression.Right, semanticModel));
+            (IsNullable(expression.Left, semanticModel) || IsNullable(expression.Right, semanticModel) ||
+            IsConditionalAccessExpression(expression.Left) || IsConditionalAccessExpression(expression.Right));
+
+        private static bool IsConditionalAccessExpression(ExpressionSyntax expression)
+        {
+            return expression.RemoveParentheses().IsKind(SyntaxKind.ConditionalAccessExpression);
+        }
 
         protected override bool IsLogicalNot(BinaryExpressionSyntax expression, out SyntaxNode logicalNot)
         {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Rules/BooleanCheckInverted.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Rules/BooleanCheckInverted.cs
@@ -75,10 +75,8 @@ namespace SonarAnalyzer.Rules.VisualBasic
             (IsNullable(expression.Left, semanticModel) || IsNullable(expression.Right, semanticModel) ||
             IsConditionalAccessExpression(expression.Left) || IsConditionalAccessExpression(expression.Right));
 
-        private static bool IsConditionalAccessExpression(ExpressionSyntax expression)
-        {
-            return expression.RemoveParentheses().IsKind(SyntaxKind.ConditionalAccessExpression);
-        }
+        private static bool IsConditionalAccessExpression(ExpressionSyntax expression) =>
+            expression.RemoveParentheses().IsKind(SyntaxKind.ConditionalAccessExpression);
 
         protected override bool IsLogicalNot(BinaryExpressionSyntax expression, out SyntaxNode logicalNot)
         {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.Fixed.Batch.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.Fixed.Batch.cs
@@ -58,7 +58,14 @@ namespace Tests.Diagnostics
         }
 
         // Note that this is not the same as "collection?.Count <= 0" because when null is compared to a number, the result will always be false
-        public static bool IsNullOrEmpty<T>(IList<T> collection)
-            => collection?.Count <= 0; // Fixed
+        public static bool IsNullOrEmpty<T>(IList<T> collection) => !(collection?.Count > 0); // Compliant
+
+        public static bool IsNullOrEmpty1(IList<int> collection) => !(collection?[0] > 0); // Compliant
+
+        public static bool IsNullOrEmpty2<T>(IList<T> collection) => !(0 < collection?.Count); // Compliant
+
+        public static bool IsNullOrEmpty3<T>(IList<T> collection) => !((0) < ((collection?.Count))); // Compliant
+
+        public static bool IsNullOrEmpty4<T>(IList<T> collection) => collection?.Count != 0; // Fixed
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.Fixed.cs
@@ -58,7 +58,14 @@ namespace Tests.Diagnostics
         }
 
         // Note that this is not the same as "collection?.Count <= 0" because when null is compared to a number, the result will always be false
-        public static bool IsNullOrEmpty<T>(IList<T> collection)
-            => collection?.Count <= 0; // Fixed
+        public static bool IsNullOrEmpty<T>(IList<T> collection) => !(collection?.Count > 0); // Compliant
+
+        public static bool IsNullOrEmpty1(IList<int> collection) => !(collection?[0] > 0); // Compliant
+
+        public static bool IsNullOrEmpty2<T>(IList<T> collection) => !(0 < collection?.Count); // Compliant
+
+        public static bool IsNullOrEmpty3<T>(IList<T> collection) => !((0) < ((collection?.Count))); // Compliant
+
+        public static bool IsNullOrEmpty4<T>(IList<T> collection) => collection?.Count != 0; // Fixed
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.cs
@@ -60,7 +60,14 @@ namespace Tests.Diagnostics
         }
 
         // Note that this is not the same as "collection?.Count <= 0" because when null is compared to a number, the result will always be false
-        public static bool IsNullOrEmpty<T>(IList<T> collection)
-            => !(collection?.Count > 0); // Noncompliant FP #2427
+        public static bool IsNullOrEmpty<T>(IList<T> collection) => !(collection?.Count > 0); // Compliant
+
+        public static bool IsNullOrEmpty1(IList<int> collection) => !(collection?[0] > 0); // Compliant
+
+        public static bool IsNullOrEmpty2<T>(IList<T> collection) => !(0 < collection?.Count); // Compliant
+
+        public static bool IsNullOrEmpty3<T>(IList<T> collection) => !((0) < ((collection?.Count))); // Compliant
+
+        public static bool IsNullOrEmpty4<T>(IList<T> collection) => !(collection?.Count == 0); // Noncompliant
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.vb
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/BooleanCheckInverted.vb
@@ -53,7 +53,23 @@ Namespace Tests.Diagnostics
         End Operator
 
         Public Shared Function IsNullOrEmpty(Of T)(ByVal collection As IList(Of T)) As Boolean
-            Return Not (collection?.Count > 0) 'Noncompliant FP #2427
+            Return Not (collection?.Count > 0) 'Compliant - not the same as "collection?.Count <= 0"
+        End Function
+
+        Public Shared Function IsNullOrEmpty1(ByVal collection As IList(Of Integer)) As Boolean
+            Return Not (collection?(0) > 0) 'Compliant - not the same as "collection?(0) <= 0"
+        End Function
+
+        Public Shared Function IsNullOrEmpty2(Of T)(ByVal collection As IList(Of T)) As Boolean
+            Return Not (0 < collection?.Count) 'Compliant - not the same as "collection?.Count <= 0"
+        End Function
+
+        Public Shared Function IsNullOrEmpty3(Of T)(ByVal collection As IList(Of T)) As Boolean
+            Return Not (((0)) < ((collection?.Count))) 'Compliant - not the same as "collection?.Count <= 0"
+        End Function
+
+        Public Shared Function IsNullOrEmpty4(Of T)(ByVal collection As IList(Of T)) As Boolean
+            Return Not (0 = collection?.Count) 'Noncompliant
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #2427.
Note that failure on SonarCloud is due to duplicated code. However, it is not possible to easily simplify that part, as both CSharp and VisualBasic analyzers use different objects for `SyntaxKind`