### PR TITLE
Add missing MVN arguments to PR and main build

### DIFF
--- a/scripts/build/ci-build.ps1
+++ b/scripts/build/ci-build.ps1
@@ -340,8 +340,11 @@ function Invoke-JavaBuild() {
             "-Pdeploy-sonarsource,sonaranalyzer" `
             "-Dmaven.test.redirectTestOutputToFile=false" `
             "-Dsonar.projectName=${sonarqubePluginName}" `
-            "-Dsonar.analysis.prNumber=${githubPullRequest}" `
+            "-Dsonar.analysis.buildNumber=${buildNumber}" `
+            "-Dsonar.analysis.pipeline=${buildNumber}" `
             "-Dsonar.analysis.sha1=${githubSha1}" `
+            "-Dsonar.analysis.repository=${githubRepo}" `
+            "-Dsonar.analysis.prNumber=${githubPullRequest}" `
             "-Dsonar.host.url=${sonarCloudUrl}" `
             "-Dsonar.login=${sonarCloudToken}" `
             "-Dsonar.organization=sonarsource" `
@@ -365,7 +368,10 @@ function Invoke-JavaBuild() {
             "-Pcoverage-per-test,deploy-sonarsource,release,sonaranalyzer" `
             "-Dmaven.test.redirectTestOutputToFile=false" `
             "-Dsonar.projectName=${sonarqubePluginName}" `
+            "-Dsonar.analysis.buildNumber=${buildNumber}" `
+            "-Dsonar.analysis.pipeline=${buildNumber}" `
             "-Dsonar.analysis.sha1=${githubSha1}" `
+            "-Dsonar.analysis.repository=${githubRepo}" `
             "-Dsonar.host.url=${sonarCloudUrl}" `
             "-Dsonar.login=${sonarCloudToken}" `
             "-Dsonar.organization=sonarsource" `


### PR DESCRIPTION
In other projects that use the Jenkinsfile, the following are common args
```
  def commonArgs = "-Dsonar.host.url=$SONAR_HOST_URL \
    -Dsonar.login=$SONAR_TOKEN \
    -Dsonar.analysis.buildNumber=$BUILD_NUMBER \
    -Dsonar.analysis.pipeline=$BUILD_NUMBER \
    -Dsonar.analysis.sha1=$GIT_SHA1  \
    -Dsonar.analysis.repository=$GITHUB_REPO \
    -B -e -V "
```