### PR TITLE
Ignore functions that contain a poisonous construct

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -257,7 +257,25 @@ private int ForLoopContinue(int i)
             ValidateCodeGeneration(code);
 
         }
-
+        [TestMethod]
+        public void ForEachLoops()
+        {
+            var code = @"
+int ForEachLoop()
+{
+    var a = new int [10];
+    foreach(var i in a)
+    {
+        if (i == 0)
+        {
+            return i;
+        }
+    }
+    return 0;
+}
+";
+            ValidateCodeGeneration(code);
+        }
     }
 }
 


### PR DESCRIPTION
Poisonous construct are constructs that have an impact on the CFG and make it invalid until we write specific code to handle them.