### PR TITLE
Make the MLIR valid when a function call is present

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -305,6 +305,27 @@ long withLong()
             ValidateCodeGeneration(code);
         }
 
+        [TestMethod]
+        public void FuncCall()
+        {
+            var code = @"
+class A {
+int triple(int i) { return 3*i; }
+void log(int i) {}
+
+int f(int i)
+{
+    var result = triple(triple(i));
+    log(result);
+    return result;
+}
+}
+";
+            var dot = GetCfgGraph(code, "f");
+
+            ValidateCodeGeneration(code);
+        }
+
     }
 }
 


### PR DESCRIPTION
The function call is modeled as `unknown`. Doing anything more elaborate is useless until we are cross functions.