### PR TITLE
Fix regression (Symbolic Execution exception which breaks cirrus QA) introduced in #2511

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/ControlFlowGraph/CSharpControlFlowGraphBuilder.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/ControlFlowGraph/CSharpControlFlowGraphBuilder.cs
@@ -773,7 +773,6 @@ namespace SonarAnalyzer.ControlFlowGraph.CSharp
                 var newSuccessors = possibleTryBlock.SuccessorBlocks.ToList();
                 newSuccessors.Add(target);
                 var branchBlock = CreateBranchBlock(possibleTryBlock.BranchingNode, newSuccessors);
-                branchBlock.ReversedInstructions.Add(breakStatement);
                 return branchBlock;
             }
             return CreateJumpBlock(breakStatement, target, currentBlock);

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharpExplodedGraph.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharpExplodedGraph.cs
@@ -393,6 +393,8 @@ namespace SonarAnalyzer.SymbolicExecution
 
                 case SyntaxKind.CheckedExpression:
                 case SyntaxKind.UncheckedExpression:
+
+                case SyntaxKind.BreakStatement:
                     // Do nothing
                     break;
 

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharpExplodedGraph.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharpExplodedGraph.cs
@@ -393,8 +393,6 @@ namespace SonarAnalyzer.SymbolicExecution
 
                 case SyntaxKind.CheckedExpression:
                 case SyntaxKind.UncheckedExpression:
-
-                case SyntaxKind.BreakStatement:
                     // Do nothing
                     break;
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/ControlFlowGraph/ControlFlowGraphTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/ControlFlowGraph/ControlFlowGraphTest.cs
@@ -2759,7 +2759,7 @@ namespace NS
             VerifyAllInstructions(doBlock, "cw0", "cw0()");
             doBlock.SuccessorBlocks.Should().OnlyContainInOrder(tryBody);
 
-            VerifyAllInstructions(tryBody, "attempts", "attempts++", "cw1", "cw1()", "break;");
+            VerifyAllInstructions(tryBody, "attempts", "attempts++", "cw1", "cw1()");
             // this is wrong, the tryBody should not have a connection with whileStmt, it can lead to FNs
             tryBody.SuccessorBlocks.Should().OnlyContainInOrder(catchBlock, whileStmt, afterDoWhile);
 
@@ -2826,7 +2826,7 @@ namespace NS
             VerifyAllInstructions(doBeforeTry, "cw0", "cw0()");
             doBeforeTry.SuccessorBlocks.Should().OnlyContainInOrder(tryStatement);
 
-            VerifyAllInstructions(tryStatement, "cw1", "cw1()", "break;");
+            VerifyAllInstructions(tryStatement, "cw1", "cw1()");
             tryStatement.SuccessorBlocks.Should().OnlyContainInOrder(catchBody, finallyBody_NormalFlow, finallyBlock_Exit, afterDoWhile);
 
             tryBody.SuccessorBlocks.Should().OnlyContainInOrder(catchBody, finallyBody_NormalFlow, finallyBlock_Exit);
@@ -2983,7 +2983,7 @@ namespace NS
             VerifyAllInstructions(insideDoBeforeTry, "cw0", "cw0()");
             insideDoBeforeTry.SuccessorBlocks.Should().OnlyContainInOrder(insideTry);
 
-            VerifyAllInstructions(insideTry, "attempts", "attempts++", "cw1", "cw1()", "break;");
+            VerifyAllInstructions(insideTry, "attempts", "attempts++", "cw1", "cw1()");
             insideTry.SuccessorBlocks.Should().OnlyContainInOrder(catchBodyWithIf, whileStmt, afterDoWhile);
 
             temporaryStrayBlock.ReversedInstructions.Should().BeEmpty();

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
@@ -117,4 +117,28 @@ namespace Tests.Diagnostics
             }
         }
     }
+
+    class TestLoopWithBreak
+    {
+        public static void LoopWithBreak(System.Collections.Generic.IEnumerable<string> list, bool condition)
+        {
+            int? i1 = null;
+            foreach (string x in list)
+            {
+                try
+                {
+                    if (condition)
+                    {
+                        Console.WriteLine(i1.Value); // Noncompliant
+                    }
+                    break;
+                }
+                catch (Exception)
+                {
+                    continue;
+                }
+            }
+        }
+    }
+
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
@@ -663,4 +663,46 @@ namespace Tests.Diagnostics
             s.ToString(); // Noncompliant
         }
     }
+
+    class TestLoopWithBreak
+    {
+        public static void LoopWithBreak(IEnumerable<string> list)
+        {
+            foreach (string x in list)
+            {
+                try
+                {
+                    if (x == null)
+                    {
+                        x.ToString(); // Noncompliant
+                    }
+                    break;
+                }
+                catch (Exception)
+                {
+                    continue;
+                }
+            }
+        }
+
+        public static IEnumerable<string> LoopWithYeildBreak(IEnumerable<string> list)
+        {
+            foreach (string x in list)
+            {
+                try
+                {
+                    if (x == null)
+                    {
+                        yield return x.ToString(); // Noncompliant
+                    }
+                    yield break;
+                }
+                finally
+                {
+                    // do stuff
+                }
+            }
+        }
+
+    }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ObjectsShouldNotBeDisposedMoreThanOnce.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ObjectsShouldNotBeDisposedMoreThanOnce.cs
@@ -182,4 +182,27 @@ namespace Tests.Diagnostics
 
         }
     }
+
+    class TestLoopWithBreak
+    {
+        public static void LoopWithBreak(System.Collections.Generic.IEnumerable<string> list, bool condition, IInterface1 instance1)
+        {
+            foreach (string x in list)
+            {
+                try
+                {
+                    if (condition)
+                    {
+                        instance1.Dispose(); // Noncompliant
+                    }
+                    break;
+                }
+                catch (Exception)
+                {
+                    continue;
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Note: this was making many rules fail: NullPointerDereference, ObjectsShouldNotBeDisposedMoreThanOnce, EmptyNullableValueAccess, ConditionEvaluatesToConstant, InvalidCastToInterface, EmptyCollectionsShouldNotBeEnumerated

I have added just some partial UTs that go over the exploded graph