### PR TITLE
Handle functions with unnamed parameters

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -628,6 +628,17 @@ public class A
 ";
             ValidateCodeGeneration(code);
         }
+        [TestMethod]
+        public void UnnamedFunctionParameter()
+        {
+            var code = @"
+int Func(int, int, int i)
+{
+    return 2*i;
+}
+";
+            ValidateCodeGeneration(code);
+        }
 
     } // Class
 } // Namespace


### PR DESCRIPTION
Create dummy unique SSA name for unnamed parameters in entry block params
Ignore unnamed parameters in the entry block body