### PR TITLE
Handle names not encodable in ASCII

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/MLIRExporter.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/MLIRExporter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -52,7 +53,7 @@ namespace SonarAnalyzer
             var returnType = HasNoReturn(method) ?
                 "()" :
                 MLIRType(method.ReturnType);
-            writer.WriteLine($"func @{method.Identifier.ValueText}{GetAnonymousArgumentsString(method)} -> {returnType} {GetLocation(method)} {{");
+            writer.WriteLine($"func @{EncodeName(method.Identifier.ValueText)}{GetAnonymousArgumentsString(method)} -> {returnType} {GetLocation(method)} {{");
             CreateEntryBlock(method);
 
             var cfg = CSharpControlFlowGraph.Create(method.Body, semanticModel);
@@ -95,7 +96,7 @@ namespace SonarAnalyzer
                 }
                 var id = OpId(param);
                 writer.WriteLine($"%{id} = cbde.alloca {MLIRType(param)} {GetLocation(param)}");
-                writer.WriteLine($"cbde.store %{param.Identifier.ValueText}, %{id} : memref<{MLIRType(param)}> {GetLocation(param)}");
+                writer.WriteLine($"cbde.store %{EncodeName(param.Identifier.ValueText)}, %{id} : memref<{MLIRType(param)}> {GetLocation(param)}");
             }
             writer.WriteLine("br ^0");
             writer.WriteLine();
@@ -235,7 +236,7 @@ namespace SonarAnalyzer
                     ++paramCount;
                     var paramName = string.IsNullOrEmpty(p.Identifier.ValueText) ?
                         ".param" + paramCount.ToString() :
-                        p.Identifier.ValueText;
+                        EncodeName(p.Identifier.ValueText);
                     return $"%{paramName} : {MLIRType(p)}";
                 }
                 );
@@ -501,6 +502,7 @@ namespace SonarAnalyzer
         private int blockCounter = 0;
         private readonly Dictionary<SyntaxNode, int> opMap = new Dictionary<SyntaxNode, int>();
         private int opCounter = 0;
+        private readonly Encoding encoder = System.Text.Encoding.GetEncoding("ASCII", new PreservingEncodingFallback(), DecoderFallback.ExceptionFallback);
 
         public int BlockId(Block cfgBlock) =>
             this.blockMap.GetOrAdd(cfgBlock, b => this.blockCounter++);
@@ -511,6 +513,13 @@ namespace SonarAnalyzer
         public string UniqueOpId()
         {
             return (opCounter++).ToString();
+        }
+
+        public string EncodeName(string name)
+        {
+            Byte[] encodedBytes = encoder.GetBytes(name);
+            return '_' + encoder.GetString(encodedBytes);
+
         }
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/PreservingEncodingFallback.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/PreservingEncodingFallback.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SonarAnalyzer
+{
+    internal class PreservingEncodingBuffer : EncoderFallbackBuffer
+    {
+        public override int Remaining => buffer.Length - currentChar;
+
+        public override bool Fallback(char charUnknown, int index)
+        {
+            buffer = String.Format(".{0:X}", (int)charUnknown);
+            currentChar = 0;
+            return true;
+        }
+
+        public override bool Fallback(char charUnknownHigh, char charUnknownLow, int index)
+        {
+            buffer = String.Format(".{0:X}{1:X}", (int)charUnknownHigh, (int)charUnknownLow);
+            currentChar = 0;
+            return true;
+        }
+
+        public override char GetNextChar()
+        {
+            return currentChar < buffer.Length ? buffer[currentChar++] : '\u0000';
+        }
+
+        public override bool MovePrevious()
+        {
+            return false;
+        }
+        private string buffer;
+        private int currentChar;
+    }
+
+    internal class PreservingEncodingFallback : EncoderFallback
+    {
+        public override int MaxCharCount => 4;
+
+        public override EncoderFallbackBuffer CreateFallbackBuffer()
+        {
+            return new PreservingEncodingBuffer();
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -714,6 +714,22 @@ int f(int i)
             ValidateCodeGeneration(code);
         }
 
+        [TestMethod]
+        public void NonASCIIEncodings()
+        {
+            var code = @"
+public void 你好() { }
+
+public void Łódź() { }
+
+public void AsciiThen你好ThenAsciiAgain() { }
+
+public int Łódźअनुلمرadım(int 你好) { return 2 * 你好; }
+
+";
+            ValidateCodeGeneration(code);
+        }
+
 
     } // Class
 } // Namespace


### PR DESCRIPTION
MLIR is pretty restrictive in term of names it accepts. So converting non-compatible character into compatible ones with a bijection that preserves name readability in case of simple names