### PR TITLE
Use a mangling instead of a name to support overloaded functions

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -828,7 +828,31 @@ namespace Tests
 
             ValidateCodeGeneration(code);
         }
+        [TestMethod]
+        public void Overloads()
+        {
+            var code = @"
+namespace N
+{
+    class A {
+        int F(int i) {return 2*i;}
+    }
+}
 
+class A {
+    int F() {return 0;}
+    int F(int i) {return 2*i;}
+    int F(int i, int j) {return i*j;}
+    double F(double d) {return 2*d;}
+}
+
+class B {
+    int F(int i) {return 2*i;}
+}
+";
+
+            ValidateCodeGeneration(code);
+        }
     } // Class
 } // Namespace
 


### PR DESCRIPTION
The basic mangling is provided by Roslyn, then cleaned-up from characters not acceptable for a MLIR function name.