### PR TITLE
Geoffray/wip ternary operators

### DIFF
--- a/scripts/rspec/rspec2resx.ps1
+++ b/scripts/rspec/rspec2resx.ps1
@@ -32,7 +32,7 @@ Set-StrictMode -version 1.0
 $ErrorActionPreference = "Stop"
 $RuleTemplateFolder = "${PSScriptRoot}\\rspec-templates"
 
-$resgenPath = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.6.1 Tools\\ResGen.exe"
+$resgenPath = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.7.2 Tools\\ResGen.exe"
 if (-Not (Test-Path $resgenPath)) {
     throw "You need to install the Windows SDK before using this script."
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/MLIRExporter.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/MLIRExporter.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer
             var returnType = HasNoReturn(method) ?
                 "()" :
                 "i32";
-            writer.WriteLine($"func @{method.Identifier.ValueText}{GetAnonymousArgumentsString(method)} -> {returnType} {{");
+            writer.WriteLine($"func @{method.Identifier.ValueText}{GetAnonymousArgumentsString(method)} -> {returnType} {GetLocation(method)} {{");
             CreateEntryBlock(method);
 
             var cfg = CSharpControlFlowGraph.Create(method.Body, semanticModel);
@@ -58,8 +58,8 @@ namespace SonarAnalyzer
             foreach (var param in method.ParameterList.Parameters)
             {
                 var id = OpId(param);
-                writer.WriteLine($"%{id} = cbde.alloca i32 : () -> memref<i32>");
-                writer.WriteLine($"cbde.store %{param.Identifier.ValueText}, %{id} : memref<i32>");
+                writer.WriteLine($"%{id} = cbde.alloca i32 : () -> memref<i32> {GetLocation(param)}");
+                writer.WriteLine($"cbde.store %{param.Identifier.ValueText}, %{id} : memref<i32> {GetLocation(param)}");
             }
             writer.WriteLine("br ^0");
             writer.WriteLine();
@@ -74,7 +74,7 @@ namespace SonarAnalyzer
         {
             if (block is ExitBlock && !HasNoReturn(parentMethod))
             {
-                // If the method returns, it will have an explicit return, no need for this spurious block
+               // If the method returns, it will have an explicit return, no need for this spurious block
                 return;
             }
             else
@@ -94,13 +94,13 @@ namespace SonarAnalyzer
                     switch (jb.JumpNode)
                     {
                         case ReturnStatementSyntax ret:
-                            writer.WriteLine($"return %{OpId(ret.Expression)} : i32");
+                            writer.WriteLine($"return %{OpId(ret.Expression)} : i32 {GetLocation(ret)}");
                             break;
-                        case BreakStatementSyntax _:
-                            writer.WriteLine($"br ^{BlockId(jb.SuccessorBlock)} // break");
+                        case BreakStatementSyntax breakStmt:
+                            writer.WriteLine($"br ^{BlockId(jb.SuccessorBlock)} {GetLocation(breakStmt)} // break");
                             break;
-                        case ContinueStatementSyntax _:
-                            writer.WriteLine($"br ^{BlockId(jb.SuccessorBlock)} // continue");
+                        case ContinueStatementSyntax continueStmt:
+                            writer.WriteLine($"br ^{BlockId(jb.SuccessorBlock)} {GetLocation(continueStmt)} // continue");
                             break;
                         default:
                             Debug.Assert(false, "Unknown kind of JumpBlock");
@@ -113,7 +113,7 @@ namespace SonarAnalyzer
                     // For a for, bbb.BranchingNode represents the for. Since for is a statement, not an expression, if we
                     // see a for, we know it's at the top level of the expression tree, so it cannot be a for inside of a if condition
 
-                    writer.WriteLine($"cond_br %{OpId(cond)}, ^{BlockId(bbb.TrueSuccessorBlock)}, ^{BlockId(bbb.FalseSuccessorBlock)}");
+                    writer.WriteLine($"cond_br %{OpId(cond)}, ^{BlockId(bbb.TrueSuccessorBlock)}, ^{BlockId(bbb.FalseSuccessorBlock)} {GetLocation(cond)}");
                     /*
                      * Up to now, we do exactly the same for all cases that may have created a BinaryBranchBlock
                      * maybe later, depending on the reason (if vs for?) we'll do something different
@@ -195,37 +195,37 @@ namespace SonarAnalyzer
                 case SyntaxKind.AddExpression:
                     {
                         var binExpr = op as BinaryExpressionSyntax;
-                        writer.WriteLine($"%{OpId(op)} = addi %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32");
+                        writer.WriteLine($"%{OpId(op)} = addi %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32 {GetLocation(op)}");
                         break;
                     }
                 case SyntaxKind.SubtractExpression:
                     {
                         var binExpr = op as BinaryExpressionSyntax;
-                        writer.WriteLine($"%{OpId(op)} = subi %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32");
+                        writer.WriteLine($"%{OpId(op)} = subi %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32 {GetLocation(op)}");
                         break;
                     }
                 case SyntaxKind.MultiplyExpression:
                     {
                         var binExpr = op as BinaryExpressionSyntax;
-                        writer.WriteLine($"%{OpId(op)} = muli %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32");
+                        writer.WriteLine($"%{OpId(op)} = muli %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32 {GetLocation(op)}");
                         break;
                     }
                 case SyntaxKind.DivideExpression:
                     {
                         var binExpr = op as BinaryExpressionSyntax;
-                        writer.WriteLine($"%{OpId(op)} = divis %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32");
+                        writer.WriteLine($"%{OpId(op)} = divis %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32 {GetLocation(op)}");
                         break;
                     }
                 case SyntaxKind.ModuloExpression:
                     {
                         var binExpr = op as BinaryExpressionSyntax;
-                        writer.WriteLine($"%{OpId(op)} = remis %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32");
+                        writer.WriteLine($"%{OpId(op)} = remis %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32 {GetLocation(op)}");
                         break;
                     }
                 case SyntaxKind.NumericLiteralExpression:
                     {
                         var lit = op as LiteralExpressionSyntax;
-                        writer.WriteLine($"%{OpId(op)} = constant {lit.Token.ValueText} : i32");
+                        writer.WriteLine($"%{OpId(op)} = constant {lit.Token.ValueText} : i32 {GetLocation(op)}");
                         break;
                     }
                 case SyntaxKind.EqualsExpression:
@@ -250,17 +250,17 @@ namespace SonarAnalyzer
                     {
                         var id = op as IdentifierNameSyntax;
                         var decl = semanticModel.GetSymbolInfo(id).Symbol.DeclaringSyntaxReferences[0].GetSyntax();
-                        writer.WriteLine($"%{OpId(op)} = cbde.load %{OpId(decl)} : memref<i32>");
+                        writer.WriteLine($"%{OpId(op)} = cbde.load %{OpId(decl)} : memref<i32> {GetLocation(op)}");
                     }
                     break;
                 case SyntaxKind.VariableDeclarator:
                     {
                         var decl = op as VariableDeclaratorSyntax;
                         var id = OpId(decl);
-                        writer.WriteLine($"%{id} = cbde.alloca i32 : () -> memref<i32> // {decl.Identifier.ValueText}");
+                        writer.WriteLine($"%{id} = cbde.alloca i32 : () -> memref<i32> {GetLocation(decl)} // {decl.Identifier.ValueText}");
                         if (decl.Initializer != null)
                         {
-                            writer.WriteLine($"cbde.store %{OpId(decl.Initializer.Value)}, %{id} : memref<i32>");
+                            writer.WriteLine($"cbde.store %{OpId(decl.Initializer.Value)}, %{id} : memref<i32> {GetLocation(decl)}");
                         }
                     }
                     break;
@@ -268,11 +268,11 @@ namespace SonarAnalyzer
                     {
                         var assign = op as AssignmentExpressionSyntax;
                         var lhs = semanticModel.GetSymbolInfo(assign.Left).Symbol.DeclaringSyntaxReferences[0].GetSyntax();
-                        writer.WriteLine($"cbde.store %{OpId(assign.Right)}, %{OpId(lhs)} : memref<i32>");
+                        writer.WriteLine($"cbde.store %{OpId(assign.Right)}, %{OpId(lhs)} : memref<i32> {GetLocation(op)}");
                         break;
                     }
                 default:
-                    writer.WriteLine($"%{OpId(op)} = constant {OpId(op)} : i32 // {op.ToFullString()} ({op.Kind()})");
+                    writer.WriteLine($"%{OpId(op)} = constant {OpId(op)} : i32 {GetLocation(op)} // {op.ToFullString()} ({op.Kind()})");
                     break;
             }
         }
@@ -280,8 +280,18 @@ namespace SonarAnalyzer
         {
             var binExpr = op as BinaryExpressionSyntax;
             // The type is the type of the operands, not of the result, which is always i1
-            writer.WriteLine($"%{OpId(op)} = cmpi \"{compName}\", %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32");
+            writer.WriteLine($"%{OpId(op)} = cmpi \"{compName}\", %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32 {GetLocation(op)}");
+        }
 
+        private string GetLocation(SyntaxNode node)
+        {
+            // TODO: We should decide which of GetLineSpan or GetMappedLineSpan is better to use
+            var loc = node.GetLocation().GetLineSpan();
+            var location = $"loc(\"{loc.Path}\"" +
+                $" :{loc.StartLinePosition.Line}" +
+                $" :{loc.StartLinePosition.Character})";
+
+            return location;
         }
 
         private readonly TextWriter writer;

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/MLIRExporter.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/MLIRExporter.cs
@@ -1,0 +1,225 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SonarAnalyzer.ControlFlowGraph;
+using SonarAnalyzer.ControlFlowGraph.CSharp;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer
+{
+    public class MLIRExporter
+    {
+        public MLIRExporter(TextWriter w, SemanticModel model)
+        {
+            writer = w;
+            semanticModel = model;
+        }
+
+        public void ExportFunction(MethodDeclarationSyntax method)
+        {
+            blockCounter = 0;
+            var returnType = semanticModel.GetTypeInfo(method.ReturnType).Type.SpecialType == SpecialType.System_Void ?
+                "()" :
+                "i32";
+            writer.WriteLine($"func @{method.Identifier.ValueText}{GetAnonymousArgumentsString(method)} -> {returnType} {{");
+            var cfg = CSharpControlFlowGraph.Create(method.Body, semanticModel);
+            foreach (var block in cfg.Blocks)
+            {
+                ExportBlock(block, block == cfg.EntryBlock, method);
+            }
+            writer.WriteLine("}");
+        }
+
+
+
+        private void ExportBlock(Block block, bool isEntryBlock, MethodDeclarationSyntax parentMethod)
+        {
+            if (isEntryBlock)
+            {
+                writer.WriteLine($"^{BlockId(block)} {GetArgumentsString(parentMethod)}: // {block.GetType().Name}");
+                foreach(var param in parentMethod.ParameterList.Parameters)
+                {
+                    var id = OpId(param);
+                    writer.WriteLine($"%{id} = cbde.alloca i32 : () -> memref<i32>");
+                    writer.WriteLine($"cbde.store %{param.Identifier.ValueText}, %{id} : memref<i32>");
+                }
+            }
+            else if (block is ExitBlock)
+            {
+                return;
+            }
+            else
+            {
+                writer.WriteLine($"^{BlockId(block)}: // {block.GetType().Name}"); // TODO: Block arguments...
+            }
+            // MLIR encodes blocks relationships in operations, not in blocks themselves
+            foreach(var op in block.Instructions)
+            {
+                ExtractInstruction(op);
+            }
+            // MLIR encodes blocks relationships in operations, not in blocks themselves
+            // So we need to add the corresponding operations at the end...
+            switch (block)
+            {
+                case JumpBlock jb:
+                    Debug.Assert(jb.JumpNode is ReturnStatementSyntax);
+                    var ret = jb.JumpNode as ReturnStatementSyntax;
+                    writer.WriteLine($"return %{OpId(ret.Expression)} : i32");
+                    break;
+                case BinaryBranchBlock bbb:
+                    // bbb.BranchingNode represent the condition, not the statement that holds the condition
+                    writer.WriteLine($"cond_br %{OpId(bbb.BranchingNode)}, ^{BlockId(bbb.TrueSuccessorBlock)}, ^{BlockId(bbb.FalseSuccessorBlock)}");
+                    /*
+                     * Up to now, we do exactly the same for all cases that may have created a BinaryBranchBlock
+                     * maybe later, depending on the reason (if vs for?) we'll do something different
+                     * 
+                    var condStatement = bbb.BranchingNode.Parent;
+                    switch (condStatement.Kind())
+                    {
+                        case SyntaxKind.ConditionalExpression: // a ? b : c
+                            var cond = condStatement as ConditionalExpressionSyntax;
+                            writer.WriteLine($"cond_br %{OpId(cond.Condition)}, ^{BlockId(bbb.TrueSuccessorBlock)}, ^{BlockId(bbb.FalseSuccessorBlock)}");
+                            break;
+                        case SyntaxKind.IfStatement:
+                            var ifCond = condStatement as IfStatementSyntax;
+                            writer.WriteLine($"cond_br %{OpId(ifCond.Condition)}, ^{BlockId(bbb.TrueSuccessorBlock)}, ^{BlockId(bbb.FalseSuccessorBlock)}");
+                            break;
+                        case SyntaxKind.ForEachStatement:
+                        case SyntaxKind.CoalesceExpression:
+                        case SyntaxKind.ConditionalAccessExpression:
+                        case SyntaxKind.LogicalAndExpression:
+                        case SyntaxKind.LogicalOrExpression:
+                        case SyntaxKind.ForStatement:
+                        case SyntaxKind.CatchFilterClause:
+                        default:
+                            writer.WriteLine($"// Unhandled branch {bbb.BranchingNode.Kind().ToString()}");
+                            break;
+
+                    }*/
+                    break;
+                case SimpleBlock sb:
+                    writer.WriteLine("return");
+                    break;
+                case ExitBlock eb:
+                    writer.WriteLine("return");
+                    break;
+
+            }
+            writer.WriteLine();
+        }
+        private static string GetArgumentsString(MethodDeclarationSyntax method)
+        {
+            if (method.ParameterList.Parameters.Count == 0)
+            {
+                return string.Empty;
+            }
+            var args = method.ParameterList.Parameters.Select(p => $"%{p.Identifier.ValueText} : i32");
+            return '(' + string.Join(", ", args) + ')';
+        }
+
+        private static string GetAnonymousArgumentsString(MethodDeclarationSyntax method)
+        {
+            var args = method.ParameterList.Parameters.Select(p => $"i32");
+            return '(' + string.Join(", ", args) + ')';
+        }
+
+        private void ExtractInstruction(SyntaxNode op)
+        {
+            switch (op.Kind())
+            {
+                case SyntaxKind.AddExpression:
+                    {
+                        var binExpr = op as BinaryExpressionSyntax;
+                        writer.WriteLine($"%{OpId(op)} = addi %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32");
+                        break;
+                    }
+                case SyntaxKind.SubtractExpression:
+                    {
+                        var binExpr = op as BinaryExpressionSyntax;
+                        writer.WriteLine($"%{OpId(op)} = subi %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32");
+                        break;
+                    }
+                case SyntaxKind.MultiplyExpression:
+                    {
+                        var binExpr = op as BinaryExpressionSyntax;
+                        writer.WriteLine($"%{OpId(op)} = muli %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32");
+                        break;
+                    }
+                case SyntaxKind.DivideExpression:
+                    {
+                        var binExpr = op as BinaryExpressionSyntax;
+                        writer.WriteLine($"%{OpId(op)} = divis %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32");
+                        break;
+                    }
+                case SyntaxKind.ModuloExpression:
+                    {
+                        var binExpr = op as BinaryExpressionSyntax;
+                        writer.WriteLine($"%{OpId(op)} = remis %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32");
+                        break;
+                    }
+                case SyntaxKind.NumericLiteralExpression:
+                    {
+                        var lit = op as LiteralExpressionSyntax;
+                        writer.WriteLine($"%{OpId(op)} = constant {lit.Token.ValueText} : i32");
+                        break;
+                    }
+                case SyntaxKind.EqualsExpression:
+                    ExportComparison("eq", op);
+                    break;
+                case SyntaxKind.NotEqualsExpression:
+                    ExportComparison("ne", op);
+                    break;
+                case SyntaxKind.IdentifierName:
+                    {
+                        var id = op as IdentifierNameSyntax;
+                        var decl = semanticModel.GetSymbolInfo(id).Symbol.DeclaringSyntaxReferences[0].GetSyntax();
+                        writer.WriteLine($"%{OpId(op)} = cbde.load %{OpId(decl)} : memref<i32>");
+                    }
+                    break;
+                case SyntaxKind.VariableDeclarator:
+                    {
+                        var decl = op as VariableDeclaratorSyntax;
+                        var id = OpId(decl);
+                        writer.WriteLine($"%{id} = cbde.alloca i32 : () -> memref<i32> // {decl.Identifier.ValueText}");
+                        if (decl.Initializer != null)
+                        {
+                            writer.WriteLine($"cbde.store %{OpId(decl.Initializer.Value)}, %{id} : memref<i32>");
+                        }
+                    }
+                    break;
+                default:
+                    writer.WriteLine($"%{OpId(op)} = constant {OpId(op)} : i32 // {op.ToFullString()} ({op.Kind()})");
+                    break;
+            }
+        }
+        private void ExportComparison(string compName, SyntaxNode op)
+        {
+            var binExpr = op as BinaryExpressionSyntax;
+            // The type is the type of the operands, not of the result, which is always i1
+            writer.WriteLine($"%{OpId(op)} = cmpi \"{compName}\", %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32");
+
+        }
+
+
+        private TextWriter writer;
+        private SemanticModel semanticModel;
+        private readonly Dictionary<Block, int> blockMap = new Dictionary<Block, int>();
+        private int blockCounter = 0;
+        private readonly Dictionary<SyntaxNode, int> opMap = new Dictionary<SyntaxNode, int>();
+        private int opCounter = 0;
+
+        public int BlockId(Block cfgBlock) =>
+            this.blockMap.GetOrAdd(cfgBlock, b => this.blockCounter++);
+        public string OpId(SyntaxNode node)
+        {
+            return this.opMap.GetOrAdd(node, b => this.opCounter++).ToString();
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/MLIRExporter.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/MLIRExporter.cs
@@ -14,10 +14,11 @@ namespace SonarAnalyzer
 {
     public class MLIRExporter
     {
-        public MLIRExporter(TextWriter w, SemanticModel model)
+        public MLIRExporter(TextWriter w, SemanticModel model, bool withLoc)
         {
             writer = w;
             semanticModel = model;
+            exportsLocations = withLoc;
         }
 
         public void ExportFunction(MethodDeclarationSyntax method)
@@ -351,6 +352,10 @@ namespace SonarAnalyzer
 
         private string GetLocation(SyntaxNode node)
         {
+            if (!exportsLocations)
+            {
+                return string.Empty;
+            }
             // TODO: We should decide which of GetLineSpan or GetMappedLineSpan is better to use
             var loc = node.GetLocation().GetLineSpan();
             var location = $"loc(\"{loc.Path}\"" +
@@ -362,6 +367,7 @@ namespace SonarAnalyzer
 
         private readonly TextWriter writer;
         private readonly SemanticModel semanticModel;
+        private readonly bool exportsLocations;
         private readonly Dictionary<Block, int> blockMap = new Dictionary<Block, int>();
         private int blockCounter = 0;
         private readonly Dictionary<SyntaxNode, int> opMap = new Dictionary<SyntaxNode, int>();

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/MLIRExporter.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/MLIRExporter.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer
             foreach (var param in method.ParameterList.Parameters)
             {
                 var id = OpId(param);
-                writer.WriteLine($"%{id} = cbde.alloca {MLIRType(param)} : () -> memref<{MLIRType(param)}> {GetLocation(param)}");
+                writer.WriteLine($"%{id} = cbde.alloca {MLIRType(param)} {GetLocation(param)}");
                 writer.WriteLine($"cbde.store %{param.Identifier.ValueText}, %{id} : memref<{MLIRType(param)}> {GetLocation(param)}");
             }
             writer.WriteLine("br ^0");
@@ -281,7 +281,7 @@ namespace SonarAnalyzer
                             // No need to write the variable, all references to it will be replaced by "unknown"
                             return;
                         }
-                        writer.WriteLine($"%{id} = cbde.alloca {MLIRType(decl)} : () -> memref<{MLIRType(decl)}> {GetLocation(decl)} // {decl.Identifier.ValueText}");
+                        writer.WriteLine($"%{id} = cbde.alloca {MLIRType(decl)} {GetLocation(decl)} // {decl.Identifier.ValueText}");
                         if (decl.Initializer != null)
                         {
                             writer.WriteLine($"cbde.store %{OpId(decl.Initializer.Value)}, %{id} : memref<{MLIRType(decl)}> {GetLocation(decl)}");

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/MLIRExporter.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/MLIRExporter.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer
             blockCounter = 0;
             var returnType = HasNoReturn(method) ?
                 "()" :
-                "i32";
+                MLIRType(method.ReturnType);
             writer.WriteLine($"func @{method.Identifier.ValueText}{GetAnonymousArgumentsString(method)} -> {returnType} {GetLocation(method)} {{");
             CreateEntryBlock(method);
 
@@ -58,8 +58,8 @@ namespace SonarAnalyzer
             foreach (var param in method.ParameterList.Parameters)
             {
                 var id = OpId(param);
-                writer.WriteLine($"%{id} = cbde.alloca i32 : () -> memref<i32> {GetLocation(param)}");
-                writer.WriteLine($"cbde.store %{param.Identifier.ValueText}, %{id} : memref<i32> {GetLocation(param)}");
+                writer.WriteLine($"%{id} = cbde.alloca {MLIRType(param)} : () -> memref<{MLIRType(param)}> {GetLocation(param)}");
+                writer.WriteLine($"cbde.store %{param.Identifier.ValueText}, %{id} : memref<{MLIRType(param)}> {GetLocation(param)}");
             }
             writer.WriteLine("br ^0");
             writer.WriteLine();
@@ -94,7 +94,14 @@ namespace SonarAnalyzer
                     switch (jb.JumpNode)
                     {
                         case ReturnStatementSyntax ret:
-                            writer.WriteLine($"return %{OpId(ret.Expression)} : i32 {GetLocation(ret)}");
+                            if (ret.Expression == null)
+                            {
+                                writer.WriteLine($"return {GetLocation(ret)}");
+                            }
+                            else
+                            {
+                                writer.WriteLine($"return %{OpId(ret.Expression)} : {MLIRType(ret.Expression)} {GetLocation(ret)}");
+                            }
                             break;
                         case BreakStatementSyntax breakStmt:
                             writer.WriteLine($"br ^{BlockId(jb.SuccessorBlock)} {GetLocation(breakStmt)} // break");
@@ -172,20 +179,50 @@ namespace SonarAnalyzer
             }
         }
 
-        private static string GetArgumentsString(MethodDeclarationSyntax method)
+        private string GetArgumentsString(MethodDeclarationSyntax method)
         {
             if (method.ParameterList.Parameters.Count == 0)
             {
                 return string.Empty;
             }
-            var args = method.ParameterList.Parameters.Select(p => $"%{p.Identifier.ValueText} : i32");
+            var args = method.ParameterList.Parameters.Select(
+                p => $"%{p.Identifier.ValueText} : {MLIRType(p)}");
             return '(' + string.Join(", ", args) + ')';
         }
 
-        private static string GetAnonymousArgumentsString(MethodDeclarationSyntax method)
+        private string GetAnonymousArgumentsString(MethodDeclarationSyntax method)
         {
-            var args = method.ParameterList.Parameters.Select(p => $"i32");
+            var args = method.ParameterList.Parameters.Select(p => MLIRType(p));
             return '(' + string.Join(", ", args) + ')';
+        }
+
+        private string MLIRType(ParameterSyntax p) => MLIRType(semanticModel.GetDeclaredSymbol(p).GetSymbolType());
+
+        private string MLIRType(ExpressionSyntax e) => MLIRType(semanticModel.GetTypeInfo(e).Type);
+
+        private string MLIRType(VariableDeclaratorSyntax v) => MLIRType(semanticModel.GetDeclaredSymbol(v).GetSymbolType());
+
+        private string MLIRType(ITypeSymbol csType)
+        {
+            Debug.Assert(csType != null);
+            if (csType.SpecialType == SpecialType.System_Boolean)
+            {
+                return "i1";
+            }
+            else if (csType.SpecialType == SpecialType.System_Int32)
+            {
+                return "i32";
+            }
+            else
+            {
+                return "none";
+            }
+        }
+
+        private bool IsTypeKnown(ITypeSymbol csType)
+        {
+            return csType.SpecialType == SpecialType.System_Boolean ||
+                csType.SpecialType == SpecialType.System_Int32;
         }
 
         private void ExtractInstruction(SyntaxNode op)
@@ -193,39 +230,16 @@ namespace SonarAnalyzer
             switch (op.Kind())
             {
                 case SyntaxKind.AddExpression:
-                    {
-                        var binExpr = op as BinaryExpressionSyntax;
-                        writer.WriteLine($"%{OpId(op)} = addi %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32 {GetLocation(op)}");
-                        break;
-                    }
                 case SyntaxKind.SubtractExpression:
-                    {
-                        var binExpr = op as BinaryExpressionSyntax;
-                        writer.WriteLine($"%{OpId(op)} = subi %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32 {GetLocation(op)}");
-                        break;
-                    }
                 case SyntaxKind.MultiplyExpression:
-                    {
-                        var binExpr = op as BinaryExpressionSyntax;
-                        writer.WriteLine($"%{OpId(op)} = muli %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32 {GetLocation(op)}");
-                        break;
-                    }
                 case SyntaxKind.DivideExpression:
-                    {
-                        var binExpr = op as BinaryExpressionSyntax;
-                        writer.WriteLine($"%{OpId(op)} = divis %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32 {GetLocation(op)}");
-                        break;
-                    }
                 case SyntaxKind.ModuloExpression:
-                    {
-                        var binExpr = op as BinaryExpressionSyntax;
-                        writer.WriteLine($"%{OpId(op)} = remis %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32 {GetLocation(op)}");
-                        break;
-                    }
+                    ExtractBinaryExpression(op);
+                    break;
                 case SyntaxKind.NumericLiteralExpression:
                     {
                         var lit = op as LiteralExpressionSyntax;
-                        writer.WriteLine($"%{OpId(op)} = constant {lit.Token.ValueText} : i32 {GetLocation(op)}");
+                        writer.WriteLine($"%{OpId(op)} = constant {lit.Token.ValueText} : {MLIRType(lit)} {GetLocation(op)}");
                         break;
                     }
                 case SyntaxKind.EqualsExpression:
@@ -250,37 +264,89 @@ namespace SonarAnalyzer
                     {
                         var id = op as IdentifierNameSyntax;
                         var decl = semanticModel.GetSymbolInfo(id).Symbol.DeclaringSyntaxReferences[0].GetSyntax();
-                        writer.WriteLine($"%{OpId(op)} = cbde.load %{OpId(decl)} : memref<i32> {GetLocation(op)}");
+                        if (!SupportedTypes(id))
+                        {
+                            writer.WriteLine($"%{OpId(op)} = cbde.unknown : {MLIRType(id)} {GetLocation(op)} // Variable of unknown type {id.Identifier.ValueText}");
+                            return;
+                        }
+                        writer.WriteLine($"%{OpId(op)} = cbde.load %{OpId(decl)} : memref<{MLIRType(id)}> {GetLocation(op)}");
                     }
                     break;
                 case SyntaxKind.VariableDeclarator:
                     {
                         var decl = op as VariableDeclaratorSyntax;
                         var id = OpId(decl);
-                        writer.WriteLine($"%{id} = cbde.alloca i32 : () -> memref<i32> {GetLocation(decl)} // {decl.Identifier.ValueText}");
+                        if (!IsTypeKnown(semanticModel.GetDeclaredSymbol(decl).GetSymbolType()))
+                        {
+                            // No need to write the variable, all references to it will be replaced by "unknown"
+                            return;
+                        }
+                        writer.WriteLine($"%{id} = cbde.alloca {MLIRType(decl)} : () -> memref<{MLIRType(decl)}> {GetLocation(decl)} // {decl.Identifier.ValueText}");
                         if (decl.Initializer != null)
                         {
-                            writer.WriteLine($"cbde.store %{OpId(decl.Initializer.Value)}, %{id} : memref<i32> {GetLocation(decl)}");
+                            writer.WriteLine($"cbde.store %{OpId(decl.Initializer.Value)}, %{id} : memref<{MLIRType(decl)}> {GetLocation(decl)}");
                         }
                     }
                     break;
                 case SyntaxKind.SimpleAssignmentExpression:
                     {
                         var assign = op as AssignmentExpressionSyntax;
+                        if (!SupportedTypes(assign))
+                        {
+                            return;
+                        }
                         var lhs = semanticModel.GetSymbolInfo(assign.Left).Symbol.DeclaringSyntaxReferences[0].GetSyntax();
-                        writer.WriteLine($"cbde.store %{OpId(assign.Right)}, %{OpId(lhs)} : memref<i32> {GetLocation(op)}");
+                        writer.WriteLine($"cbde.store %{OpId(assign.Right)}, %{OpId(lhs)} : memref<{MLIRType(assign)}> {GetLocation(op)}");
                         break;
                     }
                 default:
-                    writer.WriteLine($"%{OpId(op)} = constant {OpId(op)} : i32 {GetLocation(op)} // {op.ToFullString()} ({op.Kind()})");
+                    writer.WriteLine($"%{OpId(op)} = constant unit {GetLocation(op)} // {op.ToFullString()} ({op.Kind()})");
                     break;
             }
         }
+
+        private void ExtractBinaryExpression(SyntaxNode op)
+        {
+            var binExpr = op as BinaryExpressionSyntax;
+            if (!SupportedTypes(binExpr.Left, binExpr.Right,binExpr))
+            {
+                writer.WriteLine($"// Skip binary expression on unsupported types {op.ToFullString()}");
+                return;
+            }
+            // TODO : C#8 : Use switch expression
+            string opName;
+            switch (binExpr.Kind())
+            {
+                case SyntaxKind.AddExpression: opName = "addi"; break;
+                case SyntaxKind.SubtractExpression: opName = "subi"; break;
+                case SyntaxKind.MultiplyExpression: opName = "muli"; break;
+                case SyntaxKind.DivideExpression:  opName = "divis"; break;
+                case SyntaxKind.ModuloExpression:  opName = "remis"; break;
+                default:
+                    {
+                        writer.WriteLine($"%{OpId(op)} = cbde.unknown : {MLIRType(binExpr)} {GetLocation(binExpr)} // Unknown operator {op.ToFullString()}");
+                        return;
+                    }
+            }
+            writer.WriteLine($"%{OpId(op)} = {opName} %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : {MLIRType(binExpr)} {GetLocation(binExpr)}");
+        }
+
+        private bool SupportedTypes(params ExpressionSyntax [] exprs)
+        {
+            return exprs.All(expr => IsTypeKnown(semanticModel.GetTypeInfo(expr).Type));
+        }
+
         private void ExportComparison(string compName, SyntaxNode op)
         {
             var binExpr = op as BinaryExpressionSyntax;
+            if (!SupportedTypes(binExpr.Left, binExpr.Right))
+            {
+                writer.WriteLine($"%{OpId(op)} = cbde.unknown : i1  {GetLocation(binExpr)} // comparison of unknown type: {op.ToFullString()}");
+                return;
+            }
             // The type is the type of the operands, not of the result, which is always i1
-            writer.WriteLine($"%{OpId(op)} = cmpi \"{compName}\", %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : i32 {GetLocation(op)}");
+            writer.WriteLine($"%{OpId(op)} = cmpi \"{compName}\", %{OpId(binExpr.Left)}, %{OpId(binExpr.Right)} : {MLIRType(binExpr.Left)} {GetLocation(binExpr)}");
+
         }
 
         private string GetLocation(SyntaxNode node)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.UnitTest
             var pi = new ProcessStartInfo
             {
                 FileName = mlirCheckerPath,
-                Arguments = path,
+                Arguments = '"' + path + '"',
                 UseShellExecute = false,
                 // RedirectStandardOutput = true,
                 RedirectStandardError = true

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -276,6 +276,28 @@ int ForEachLoop()
 ";
             ValidateCodeGeneration(code);
         }
+
+        [TestMethod]
+        public void WorkWithLong()
+        {
+            var code = @"
+long withLong()
+{
+    long l = 10;
+    long total = 0;
+    for(long i = 0; i < l; ++i)
+    {
+        total += i;
+    }
+    if (total != 55)
+    {
+        return total;
+    }
+    return total;
+}
+";
+            ValidateCodeGeneration(code);
+        }
     }
 }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -1,0 +1,88 @@
+﻿extern alias csharp;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using csharp::SonarAnalyzer.ControlFlowGraph.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.ControlFlowGraph;
+
+namespace SonarAnalyzer.UnitTest
+{
+    [TestClass]
+    public class MlirExportTest
+    {
+        [TestMethod]
+        public void SimpleMethod()
+        {
+            var code = @"
+class C
+{
+    int Mult(int i, int j)
+    {
+        return i*j;
+    }
+
+    void Empty() {}
+    void Nop(int i) { int j = 2*i;}
+
+    int Cond(int i) { return i%2 == 0 ? i/2 : i*3 +1; }
+    int Cond2(int i)
+    {
+        if (i%2 == 0)
+            return i/2;
+        else
+            return i*3 +1;
+    }
+}
+";
+            using (var writer = new StreamWriter(Path.Combine(Path.GetTempPath(), "csharp.mlir")))
+            {
+                ExportFunction(code, writer, "Empty");
+                ExportFunction(code, writer, "Nop");
+                ExportFunction(code, writer, "Mult");
+                ExportFunction(code, writer, "Cond");
+                ExportFunction(code, writer, "Cond2");
+            }
+
+            var dot = CfgSerializer.Serialize("Cond2", GetCfgForMethod(code, "Cond2"));
+        }
+
+        private static void ExportFunction(string code, TextWriter writer, string functionName)
+        {
+            (var method, var semanticModel) = TestHelper.Compile(code).GetMethod(functionName);
+            var exporter = new MLIRExporter(writer, semanticModel);
+            exporter.ExportFunction(method);
+        }
+        protected IControlFlowGraph GetCfgForMethod(string code, string methodName)
+        {
+            (var method, var semanticModel) = TestHelper.Compile(code).GetMethod(methodName);
+
+            return CSharpControlFlowGraph.Create(method.Body, semanticModel);
+        }
+
+    }
+}
+
+public class C
+{
+    public int Mult(int i, int j)
+    {
+        return i * j;
+    }
+
+    public void Empty() { }
+    void Nop(int i) { int j = 2 * i; }
+    public int Cond(int i) { return i % 2 == 0 ? i / 2 : i * 3 + 1; }
+    public int Cond2(int i)
+    {
+        if (i % 2 == 0)
+            return i / 2;
+        else
+            return i * 3 + 1;
+    }
+}
+

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -1,11 +1,6 @@
 ﻿extern alias csharp;
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using csharp::SonarAnalyzer.ControlFlowGraph.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.ControlFlowGraph;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -44,9 +44,17 @@ namespace SonarAnalyzer.UnitTest
         public void SimpleMethod()
         {
             var code = @"
-void simple() {
-    int i = 1;
-    int j = (i==2) ? 3 : 4;
+void complexTernaryOk(bool b1, bool b2, bool b3, bool b4, int i) {
+    int j = ( (b1 && b2) || (b3 && b4)) ? 3 : ((i==1 || b4) ? 3 : 4);
+}
+void complexTernaryNotOk(bool b1, bool b2, bool b3, bool b4) {
+    int j = ( (b1 && b2) || (b3 && b4)) ? 3 : (b1?1:2) + (b2?3:4);
+}
+void nestedTernariesIsOk( bool b1, bool b2 ) {
+    int i = (b1?1:(b2?3:4));
+}
+void combinedTernariesIsNotOk( bool b1, bool b2 ) {
+    int i = (b1?1:2) + (b2?3:4);
 }
 int DummyCond() {
 	int i = 2;
@@ -71,7 +79,7 @@ int DummyCond2() {
 	return 5;
 }
 ";
-            var dot = GetCfgGraph(code, "simple");
+            var dot = GetCfgGraph(code, "combinedTernariesIsNotOk");
             ValidateCodeGeneration(code);
         }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -94,8 +94,44 @@ class C
             }
             ValidateIR(path);
         }
+        protected IControlFlowGraph GetCfgForMethod(string code, string methodName)
+        {
+            (var method, var semanticModel) = TestHelper.Compile(code).GetMethod(methodName);
+
+            return CSharpControlFlowGraph.Create(method.Body, semanticModel);
+        }
+
 
         public TestContext TestContext { get; set; } // Set automatically by MsTest
+
+        [TestMethod]
+        public void IfThenElse()
+        {
+            var code = @"
+void UselessCondition(int i) {
+    if (i == 0) {
+        if (i != 0) {
+            int j = 2 * i;
+        }
+    }
+}
+
+int WithReturn(int i) {
+    if (i == 0) {
+        if (i != 0) {
+            int j = 2 * i;
+        }
+    }
+    return i;
+}";
+            var dot = GetCfgGraph(code, "WithReturn");
+            ValidateCodeGeneration(code);
+        }
+
+        private string GetCfgGraph(string code, string methodName)
+        {
+            return CfgSerializer.Serialize(methodName, GetCfgForMethod(code, methodName));
+        }
     }
 }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -19,7 +19,7 @@ namespace SonarAnalyzer.UnitTest
         [ClassInitialize]
         public static void checkExecutableExists(TestContext tc)
         {
-            Assert.IsTrue(File.Exists(mlirCheckerPath), "We need mlir-cbde.exe to validate the generated IR");
+            // Assert.IsTrue(File.Exists(mlirCheckerPath), "We need mlir-cbde.exe to validate the generated IR");
         }
 
         public static void ValidateIR(string path)
@@ -44,26 +44,34 @@ namespace SonarAnalyzer.UnitTest
         public void SimpleMethod()
         {
             var code = @"
-class C
-{
-    int Mult(int i, int j)
-    {
-        return i*j;
-    }
-
-    void Empty() {}
-    void Nop(int i) { int j = 2*i;}
-
-    //int Cond(int i) { return i%2 == 0 ? i/2 : i*3 +1; }
-    int Cond2(int i)
-    {
-        if (i%2 == 0)
-            return i/2;
-        else
-            return i*3 +1;
-    }
+void simple() {
+    int i = 1;
+    int j = (i==2) ? 3 : 4;
+}
+int DummyCond() {
+	int i = 2;
+    int a = (i==2)?i+1:i-1;
+	if (2 == i) {
+		return 3;
+	}
+	return 4;
+}
+int DummyCond2() {
+	int i = 7;
+	if (i > 0 ) {
+        int k = 0;
+        k = k - 2;
+        if(i < k) {
+		    return 3;
+        }
+        else {
+            return 4;
+        }
+	}
+	return 5;
 }
 ";
+            var dot = GetCfgGraph(code, "simple");
             ValidateCodeGeneration(code);
         }
 
@@ -87,12 +95,13 @@ class C
         private void ValidateCodeGeneration(string code, bool withLoc)
         {
             var locPath = withLoc ? ".loc" : "";
-            var path = Path.Combine(Path.GetTempPath(), $"csharp.{TestContext.TestName}{locPath}.mlir");
+            //var path = Path.Combine(Path.GetTempPath(), $"csharp.{TestContext.TestName}{locPath}.mlir");
+            var path = ("test.mlir");
             using (var writer = new StreamWriter(path))
             {
                 ExportAllMethods(code, writer, withLoc);
             }
-            ValidateIR(path);
+            // ValidateIR(path);
         }
 
         private void ValidateCodeGeneration(string code)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -132,6 +132,132 @@ int WithReturn(int i) {
         {
             return CfgSerializer.Serialize(methodName, GetCfgForMethod(code, methodName));
         }
+
+        [TestMethod]
+        public void WhileLoops()
+        {
+            var code = @"
+private int WhileLoop(int i)
+{
+    while (i<100)
+    {
+        i = i * i;
+    }
+    return i;
+}
+private int WhileLoopBreak(int i)
+{
+    while (i < 100)
+    {
+        i = i * i;
+        if (i == 49)
+        {
+            break;
+        }
+    }
+    return i;
+}
+private int WhileLoopContinue(int i)
+{
+    while (i < 100)
+    {
+        if (i == 42)
+        {
+            continue;
+        }
+    }
+    return i;
+}
+";
+            ValidateCodeGeneration(code);
+
+        }
+
+        [TestMethod]
+        public void DoWhileLoops()
+        {
+            var code = @"
+private int WhileLoop(int i)
+{
+    do
+    {
+        i = i * i;
+    } while (i<100)
+    return i;
+}
+private int WhileLoopBreak(int i)
+{
+    do
+    {
+        i = i * i;
+        if (i == 49)
+        {
+            break;
+        }
+    } while (i < 100)
+    return i;
+}
+private int WhileLoopContinue(int i)
+{
+    do 
+    {
+        if (i == 42)
+        {
+            continue;
+        }
+    } while (i < 100)
+    return i;
+}
+";
+            ValidateCodeGeneration(code);
+
+        }
+
+
+        [TestMethod]
+        public void ForLoops()
+        {
+            var code = @"
+private int ForLoop(int i)
+{
+    int total = 0;
+    for (int j = 0 ; j<=i ;++j)
+    {
+        total += j;
+    }
+    return total;
+}
+private int ForLoopBreak(int i)
+{
+    int total = 0;
+    for (int j = 0 ; j<=i ;++j)
+    {
+        total += j;
+        if (total > 500)
+        {
+            break;
+        }
+    }
+    return total;
+}
+private int ForLoopContinue(int i)
+{
+    int total = 0;
+    for (int j = 0 ; j<=i ;++j)
+    {
+        if (j % 13 == 0)
+        {
+            continue;
+        }
+        total += j;
+    }
+    return total;
+}
+";
+            ValidateCodeGeneration(code);
+
+        }
+
     }
 }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MlirExportTest.cs
@@ -257,7 +257,25 @@ private int ForLoopContinue(int i)
             ValidateCodeGeneration(code);
 
         }
-
+        [TestMethod]
+        public void ForEachLoops()
+        {
+            var code = @"
+int ForEachLoop()
+{
+    var a = new int [10];
+    foreach(var i in a)
+    {
+        if (i == 0)
+        {
+            return i;
+        }
+    }
+    return 0;
+}
+";
+            ValidateCodeGeneration(code);
+        }
     }
 }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -94,9 +94,9 @@
     <Content Include="ResourceTests\ProjectOutFolderPath.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="..\..\..\..\SonarCBDE\build\mlirChecker\Release\mlir-cbde.exe" Link="mlir-cbde.exe">
+<!--    <None Include="..\..\..\..\SonarCBDE\build\mlirChecker\Release\mlir-cbde.exe" Link="mlir-cbde.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    </None> -->
     <None Include="Common\Resources\input.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -94,6 +94,9 @@
     <Content Include="ResourceTests\ProjectOutFolderPath.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="..\..\..\..\SonarCBDE\build\mlirChecker\Release\mlir-cbde.exe" Link="mlir-cbde.exe">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Common\Resources\input.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -115,6 +118,10 @@
     <ProjectReference Include="..\..\src\SonarAnalyzer.VisualBasic\SonarAnalyzer.VisualBasic.csproj">
       <Aliases>global,vbnet</Aliases>
     </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="PresentationFramework" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
WIP.
Implementation of ternary operator.
Limited by the cfg.
Currently:
- probably ok if ternaries are nested and not combined (children of the same ast node)
   example: void f(bool b1, bool b2) { (b1?1:(b2?3:4)); }
- bad mlir generated if ternaries are combined 
   example: void f(bool b1, bool b2) { (b1?1:2) + (b2?3:4); }