### PR TITLE
Allow building on a machine where only VS2019 has been installed

### DIFF
--- a/scripts/rspec/rspec2resx.ps1
+++ b/scripts/rspec/rspec2resx.ps1
@@ -32,7 +32,10 @@ Set-StrictMode -version 1.0
 $ErrorActionPreference = "Stop"
 $RuleTemplateFolder = "${PSScriptRoot}\\rspec-templates"
 
-$resgenPath = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.6.1 Tools\\ResGen.exe"
+$resgenPath = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.7.2 Tools\\ResGen.exe"
+if (-Not (Test-Path $resgenPath)) {
+    $resgenPath = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.6.1 Tools\\ResGen.exe"
+}
 if (-Not (Test-Path $resgenPath)) {
     throw "You need to install the Windows SDK before using this script."
 }


### PR DESCRIPTION
This change is not enough to run ITs on such a machine.