### PR TITLE
Fix boom due to release of dotnet core 3.0

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConfiguringLoggersTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConfiguringLoggersTest.cs
@@ -133,15 +133,14 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         private static IEnumerable<MetadataReference> AspNetCoreLoggingReferences =>
             FrameworkMetadataReference.Netstandard
-            .Concat(NuGetMetadataReference.MicrosoftAspNetCore(Constants.NuGetLatestVersion))
-            .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHosting(Constants.NuGetLatestVersion))
-            .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHostingAbstractions(Constants.NuGetLatestVersion))
-            .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHttpAbstractions(Constants.NuGetLatestVersion))
-            .Concat(NuGetMetadataReference.MicrosoftExtensionsConfigurationAbstractions(Constants.NuGetLatestVersion))
-            .Concat(NuGetMetadataReference.MicrosoftExtensionsDependencyInjectionAbstractions(Constants.NuGetLatestVersion))
-            .Concat(NuGetMetadataReference.MicrosoftExtensionsOptions(Constants.NuGetLatestVersion))
-            .Concat(NuGetMetadataReference.MicrosoftExtensionsLoggingPackages(Constants.NuGetLatestVersion))
-        ;
+            .Concat(NuGetMetadataReference.MicrosoftAspNetCore("2.2.0"))
+            .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHosting("2.2.0"))
+            .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHostingAbstractions("2.2.0"))
+            .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHttpAbstractions("2.2.0"))
+            .Concat(NuGetMetadataReference.MicrosoftExtensionsConfigurationAbstractions("2.2.0"))
+            .Concat(NuGetMetadataReference.MicrosoftExtensionsDependencyInjectionAbstractions("2.2.0"))
+            .Concat(NuGetMetadataReference.MicrosoftExtensionsOptions("2.2.0"))
+            .Concat(NuGetMetadataReference.MicrosoftExtensionsLoggingPackages("2.2.0"));
 
         private static IEnumerable<MetadataReference> Log4NetReferences =>
             NuGetMetadataReference.Log4Net(Constants.NuGetLatestVersion, "net45-full")

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DeliveringDebugFeaturesInProductionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DeliveringDebugFeaturesInProductionTest.cs
@@ -72,9 +72,9 @@ namespace SonarAnalyzer.UnitTest.Rules
         private static IEnumerable<MetadataReference> AdditionalReferences =>
             Enumerable.Empty<MetadataReference>()
                 .Concat(FrameworkMetadataReference.Netstandard)
-                .Concat(NuGetMetadataReference.MicrosoftAspNetCoreDiagnostics(Constants.NuGetLatestVersion))
-                .Concat(NuGetMetadataReference.MicrosoftAspNetCoreDiagnosticsEntityFrameworkCore(Constants.NuGetLatestVersion))
-                .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHttpAbstractions(Constants.NuGetLatestVersion))
-                .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHostingAbstractions(Constants.NuGetLatestVersion));
+                .Concat(NuGetMetadataReference.MicrosoftAspNetCoreDiagnostics("2.2.0"))
+                .Concat(NuGetMetadataReference.MicrosoftAspNetCoreDiagnosticsEntityFrameworkCore("2.2.0"))
+                .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHttpAbstractions("2.2.0"))
+                .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHostingAbstractions("2.2.0"));
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ExecutingSqlQueriesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ExecutingSqlQueriesTest.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             Verifier.VerifyAnalyzer(@"TestCases\ExecutingSqlQueries_NetCore.cs",
                 new CSharp.ExecutingSqlQueries(AnalyzerConfiguration.AlwaysEnabled),
-                additionalReferences: GetReferencesNetCore(Constants.NuGetLatestVersion));
+                additionalReferences: GetReferencesNetCore("2.2.0"));
         }
 
         [TestMethod]
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             Verifier.VerifyNoIssueReported(@"TestCases\ExecutingSqlQueries_NetCore.cs",
                 new CSharp.ExecutingSqlQueries(),
-                additionalReferences: GetReferencesNetCore(Constants.NuGetLatestVersion));
+                additionalReferences: GetReferencesNetCore("2.2.0"));
         }
 
         [TestMethod]
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzer(@"TestCases\ExecutingSqlQueries_NetCore.vb",
                 new VisualBasic.ExecutingSqlQueries(AnalyzerConfiguration.AlwaysEnabled),
                 options: ParseOptionsHelper.FromVisualBasic15,
-                additionalReferences: GetReferencesNetCore(Constants.NuGetLatestVersion));
+                additionalReferences: GetReferencesNetCore("2.2.0"));
         }
 
         [TestMethod]
@@ -87,7 +87,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             Verifier.VerifyNoIssueReported(@"TestCases\ExecutingSqlQueries_NetCore.vb",
                 new VisualBasic.ExecutingSqlQueries(),
-                additionalReferences: GetReferencesNetCore(Constants.NuGetLatestVersion));
+                additionalReferences: GetReferencesNetCore("2.2.0"));
         }
 
         private static IEnumerable<MetadataReference> GetReferencesNet46(string sqlServerCeVersion) =>


### PR DESCRIPTION
Yesterday dotnet core 3.0 got released.
So some APIs got removed, and tests started failing because we were referencing NuGetLatestVersion.