### PR TITLE
Update the expected path for AnalyzeGeneratedVb

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/AnalyzeGeneratedVb/AnalyzeGeneratedVb-{C4F122A1-A51D-4194-998F-686A6EF31E44}-S1451.json
+++ b/sonaranalyzer-dotnet/its/expected/AnalyzeGeneratedVb/AnalyzeGeneratedVb-{C4F122A1-A51D-4194-998F-686A6EF31E44}-S1451.json
@@ -4,7 +4,7 @@
 "id":  "S1451",
 "message":  "Add or update the header of this file.",
 "location":  {
-"uri":  "C:\Users\Andrei\AppData\Local\Temp\.NETFramework,Version=v4.5.2.AssemblyAttributes.vb",
+"uri":  "replaced",
 "region":  {
 "startLine":  1,
 "startColumn":  1,


### PR DESCRIPTION
This VB file was forgotten to be updated - the equivalent CS file has 'replaced' in URI

(sonaranalyzer-dotnet\its\expected\AnalyzeGenerated\AnalyzeGeneratedFiles-6389f4a4-59fd-497b-bb52-4414b1320d29-S1451.json)