### PR TITLE
Fix S2699 FP: NUnit 3.0 TestCase + ExpectedResult

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldContainAssertion.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldContainAssertion.cs
@@ -56,6 +56,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (methodSymbol == null ||
                         !methodSymbol.IsTestMethod() ||
                         methodSymbol.HasExpectedExceptionAttribute() ||
+                        methodSymbol.HasAssertionInAttribute() ||
                         IsTestIgnored(methodSymbol))
                     {
                         return;

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
@@ -111,7 +111,12 @@ namespace SonarAnalyzer.Helpers
             method.GetAttributes().Any(a =>
                 a.AttributeClass.Is(KnownType.NUnit_Framework_TestCaseAttribute) &&
                 a.NamedArguments.Any(arg => arg.Key == "ExpectedResult"));
+public static bool HasAssertionInAttribute(this IMethodSymbol method) =>
+    method.GetAttributes().Any(IsTestCaseAttributeWithExpectedResult);
 
+private static bool IsTestCaseAttributeWithExpectedResult(AttributeData a) =>
+    a.AttributeClass.Is(KnownType.NUnit_Framework_TestCaseAttribute) &&
+    a.NamedArguments.Any(arg => arg.Key == "ExpectedResult");
         public static bool IsMsTestOrNUnitTestIgnored(this IMethodSymbol method)
         {
             var attributes = method.GetAttributes();

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
@@ -108,15 +108,12 @@ namespace SonarAnalyzer.Helpers
             method.GetAttributes().Any(a => a.AttributeClass.IsAny(KnownExpectedExceptionAttributes));
 
         public static bool HasAssertionInAttribute(this IMethodSymbol method) =>
-            method.GetAttributes().Any(a =>
-                a.AttributeClass.Is(KnownType.NUnit_Framework_TestCaseAttribute) &&
-                a.NamedArguments.Any(arg => arg.Key == "ExpectedResult"));
-public static bool HasAssertionInAttribute(this IMethodSymbol method) =>
-    method.GetAttributes().Any(IsTestCaseAttributeWithExpectedResult);
+            method.GetAttributes().Any(IsTestCaseAttributeWithExpectedResult);
 
-private static bool IsTestCaseAttributeWithExpectedResult(AttributeData a) =>
-    a.AttributeClass.Is(KnownType.NUnit_Framework_TestCaseAttribute) &&
-    a.NamedArguments.Any(arg => arg.Key == "ExpectedResult");
+        private static bool IsTestCaseAttributeWithExpectedResult(AttributeData a) =>
+            a.AttributeClass.Is(KnownType.NUnit_Framework_TestCaseAttribute) &&
+            a.NamedArguments.Any(arg => arg.Key == "ExpectedResult");
+
         public static bool IsMsTestOrNUnitTestIgnored(this IMethodSymbol method)
         {
             var attributes = method.GetAttributes();

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
@@ -107,6 +107,11 @@ namespace SonarAnalyzer.Helpers
         public static bool HasExpectedExceptionAttribute(this IMethodSymbol method) =>
             method.GetAttributes().Any(a => a.AttributeClass.IsAny(KnownExpectedExceptionAttributes));
 
+        public static bool HasAssertionInAttribute(this IMethodSymbol method) =>
+            method.GetAttributes().Any(a =>
+                a.AttributeClass.Is(KnownType.NUnit_Framework_TestCaseAttribute) &&
+                a.NamedArguments.Any(arg => arg.Key == "ExpectedResult"));
+
         public static bool IsMsTestOrNUnitTestIgnored(this IMethodSymbol method)
         {
             var attributes = method.GetAttributes();

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         }
 
         [DataTestMethod]
-        [DataRow("2.5.7.10213", "4.19.4")]
+        [DataRow("3.11.0", "4.19.4")]
         [DataRow(Constants.NuGetLatestVersion, "4.19.4")]
         [TestCategory("Rule")]
         public void TestMethodShouldContainAssertion_NUnit(string testFwkVersion, string fluentVersion)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
@@ -432,5 +432,11 @@
         {
             return type.GetType().ToString();
         }
+
+        [TestCase(typeof(string[]), "System.String[]")]
+        public string NoNamedParameter(Type type) // Noncompliant FP
+        {
+            return type.GetType().ToString();
+        }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
@@ -1,6 +1,7 @@
 ﻿namespace TestNUnit
 {
     using System;
+    using System.Collections.Generic;
     using FluentAssertions;
     using NUnit.Framework;
 
@@ -417,6 +418,19 @@
         [Ignore("Some reason")]
         public void Theory15() // Don't raise on skipped test methods
         {
+        }
+    }
+
+    [TestFixture]
+    public class TypeExtensionsTests
+    {
+        [TestCase(typeof(string), ExpectedResult = "System.String")]
+        [TestCase(typeof(string[]), ExpectedResult = "System.String[]")]
+        [TestCase(typeof(List<string>), ExpectedResult = "List<System.String>")]
+        [TestCase(typeof(List<(string, int)>), ExpectedResult = "List<ValueTuple<System.String,System.Int32>>")]
+        public string GetFriendlyFullName(Type type)
+        {
+            return type.GetType().ToString();
         }
     }
 }


### PR DESCRIPTION
Also upgrade UT to run with NUnit 3.11 as baseline

Fix  #2451