### PR TITLE
Update S2699: to support NSubstitute 4.2.1

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -370,6 +370,8 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_Xml_XmlNode = new KnownType("System.Xml.XmlNode");
         internal static readonly KnownType System_Xml_XPath_XPathNavigator = new KnownType("System.Xml.XPath.XPathNavigator");
         internal static readonly KnownType System_Xml_XPath_XPathExpression = new KnownType("System.Xml.XPath.XPathExpression");
+        internal static readonly KnownType NSubstitute_SubstituteExtensions = new KnownType("NSubstitute.SubstituteExtensions");
+        internal static readonly KnownType NSubstitute_Received = new KnownType("NSubstitute.Received");
         internal static readonly ImmutableArray<KnownType> SystemActionVariants =
             ImmutableArray.Create(
                 new KnownType("System.Action"),

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/NuGetMetadataReference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/NuGetMetadataReference.cs
@@ -44,6 +44,9 @@ namespace SonarAnalyzer.UnitTest
         public static IEnumerable<MetadataReference> FluentAssertions(string packageVersion) =>
             NugetMetadataFactory.Create("FluentAssertions", packageVersion);
 
+        public static IEnumerable<MetadataReference> NSubstitute(string packageVersion) =>
+            NugetMetadataFactory.Create("NSubstitute", packageVersion);
+
         public static IEnumerable<MetadataReference> Log4Net(string packageVersion, string targetFramework) =>
             NugetMetadataFactory.Create("log4net", packageVersion, targetFramework);
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
@@ -56,6 +56,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 new TestMethodShouldContainAssertion(),
                 additionalReferences: NuGetMetadataReference.NUnit(testFwkVersion)
                     .Concat(NuGetMetadataReference.FluentAssertions(fluentVersion))
+                    .Concat(NuGetMetadataReference.NSubstitute("4.2.1"))
                     .Concat(FrameworkMetadataReference.SystemReflection)
                     .Concat(FrameworkMetadataReference.SystemXmlXDocument)
                     .Concat(FrameworkMetadataReference.SystemXmlLinq)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
@@ -30,15 +30,16 @@ namespace SonarAnalyzer.UnitTest.Rules
     public class TestMethodShouldContainAssertionTest
     {
         [DataTestMethod]
-        [DataRow("1.1.11", "1.6.0")]
-        [DataRow(Constants.NuGetLatestVersion, "4.19.4")]
+        [DataRow("1.1.11", "1.6.0", Constants.NuGetLatestVersion)]
+        [DataRow(Constants.NuGetLatestVersion, "4.19.4", Constants.NuGetLatestVersion)]
         [TestCategory("Rule")]
-        public void TestMethodShouldContainAssertion_MSTest(string testFwkVersion, string fluentVersion)
+        public void TestMethodShouldContainAssertion_MSTest(string testFwkVersion, string fluentVersion, string nSubstituteVersion)
         {
             Verifier.VerifyAnalyzer(@"TestCases\TestMethodShouldContainAssertion.MsTest.cs",
                 new TestMethodShouldContainAssertion(),
                 additionalReferences: NuGetMetadataReference.MSTestTestFramework(testFwkVersion)
                     .Concat(NuGetMetadataReference.FluentAssertions(fluentVersion))
+                    .Concat(NuGetMetadataReference.NSubstitute(nSubstituteVersion))
                     .Concat(FrameworkMetadataReference.SystemReflection)
                     .Concat(FrameworkMetadataReference.SystemXmlXDocument)
                     .Concat(FrameworkMetadataReference.SystemXmlLinq)
@@ -47,16 +48,16 @@ namespace SonarAnalyzer.UnitTest.Rules
         }
 
         [DataTestMethod]
-        [DataRow("3.11.0", "4.19.4")]
-        [DataRow(Constants.NuGetLatestVersion, "4.19.4")]
+        [DataRow("3.11.0", "4.19.4", Constants.NuGetLatestVersion)]
+        [DataRow(Constants.NuGetLatestVersion, "4.19.4", Constants.NuGetLatestVersion)]
         [TestCategory("Rule")]
-        public void TestMethodShouldContainAssertion_NUnit(string testFwkVersion, string fluentVersion)
+        public void TestMethodShouldContainAssertion_NUnit(string testFwkVersion, string fluentVersion, string nSubstituteVersion)
         {
             Verifier.VerifyAnalyzer(@"TestCases\TestMethodShouldContainAssertion.NUnit.cs",
                 new TestMethodShouldContainAssertion(),
                 additionalReferences: NuGetMetadataReference.NUnit(testFwkVersion)
                     .Concat(NuGetMetadataReference.FluentAssertions(fluentVersion))
-                    .Concat(NuGetMetadataReference.NSubstitute("4.2.1"))
+                    .Concat(NuGetMetadataReference.NSubstitute(nSubstituteVersion))
                     .Concat(FrameworkMetadataReference.SystemReflection)
                     .Concat(FrameworkMetadataReference.SystemXmlXDocument)
                     .Concat(FrameworkMetadataReference.SystemXmlLinq)
@@ -117,15 +118,16 @@ public class Foo
         }
 
         [DataTestMethod]
-        [DataRow("2.0.0", "4.19.4")]
-        [DataRow(Constants.NuGetLatestVersion, "4.19.4")]
+        [DataRow("2.0.0", "4.19.4", Constants.NuGetLatestVersion)]
+        [DataRow(Constants.NuGetLatestVersion, "4.19.4", Constants.NuGetLatestVersion)]
         [TestCategory("Rule")]
-        public void TestMethodShouldContainAssertion_Xunit(string testFwkVersion, string fluentVersion)
+        public void TestMethodShouldContainAssertion_Xunit(string testFwkVersion, string fluentVersion, string nSubstituteVersion)
         {
             Verifier.VerifyAnalyzer(@"TestCases\TestMethodShouldContainAssertion.Xunit.cs",
                 new TestMethodShouldContainAssertion(),
                 additionalReferences: NuGetMetadataReference.XunitFramework(testFwkVersion)
                     .Concat(NuGetMetadataReference.FluentAssertions(fluentVersion))
+                    .Concat(NuGetMetadataReference.NSubstitute(nSubstituteVersion))
                     .Concat(FrameworkMetadataReference.SystemReflection)
                     .Concat(FrameworkMetadataReference.SystemXmlXDocument)
                     .Concat(FrameworkMetadataReference.SystemXmlLinq)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.MsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.MsTest.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using FluentAssertions;
+    using NSubstitute;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -281,5 +282,16 @@
         {
             var result = new Class1().Add(1, 2);
         }
+    }
+
+    /// <summary>
+    /// The NSubstitute assertions are extensively verified in the NUnit test files.
+    /// Here we just do a simple test to confirm that the errors are not raised in conjunction with MsTest.
+    /// </summary>
+    [TestClass]
+    public class NSubstituteTests
+    {
+        [TestMethod]
+        public void Received() => Substitute.For<IDisposable>().Received().Dispose();
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using FluentAssertions;
+    using NSubstitute;
     using NUnit.Framework;
 
     class BaseClass
@@ -439,4 +440,65 @@
             return type.GetType().ToString();
         }
     }
+
+    [TestFixture]
+    class NSubstituteTests
+    {
+        private readonly ICalculator calculator;
+
+        public NSubstituteTests()
+        {
+            calculator = Substitute.For<ICalculator>();
+        }
+
+        [TestCase]
+        public void NoAssert() // Noncompliant
+        {
+        }
+
+        [TestCase]
+        public void Received()
+        {
+            calculator.Received().Add(1, 2);
+        }
+
+        [TestCase]
+        public void ReceivedExpression() => calculator.Received().Add(1, 2);
+
+        [TestCase]
+        public void ReceivedNameSpace() => NSubstitute.SubstituteExtensions.Received(calculator).Add(1, 2);
+
+        [TestCase]
+        public void ReceivedWithAnyArgs()
+        {
+            calculator.ReceivedWithAnyArgs().Add(0, 0);
+        }
+
+        [TestCase]
+        public void DidNotReceived()
+        {
+            calculator.DidNotReceive().Add(1, 2);
+        }
+
+        [TestCase]
+        public void DidNotReceiveWithAnyArgs()
+        {
+            calculator.DidNotReceiveWithAnyArgs().Add(1, 2);
+        }
+
+        [TestCase]
+        public void ReceivedInOrder()
+        {
+            NSubstitute.Received.InOrder(() =>
+            {
+                calculator.Add(1, 2);
+            });
+        }
+    }
+
+    internal interface ICalculator
+    {
+        int Add(int a, int b);
+    }
 }
+

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.Xunit.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.Xunit.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using FluentAssertions;
+    using NSubstitute;
     using Xunit;
 
     public class Program
@@ -226,5 +227,15 @@
         {
             Assert.True(true);
         }
+    }
+
+    /// <summary>
+    /// The NSubstitute assertions are extensively verified in the NUnit test files.
+    /// Here we just do a simple test to confirm that the errors are not raised in conjunction with XUnit.
+    /// </summary>
+    public class NSubstituteTests
+    {
+        [Fact]
+        public void Received() => Substitute.For<IDisposable>().Received().Dispose();
     }
 }


### PR DESCRIPTION

The checks for the NSubstitute assertions are done using the actual method symbol instead of searching for keywords like it's done for the other assertions. This allows for more granular and precise matching.

Fixes #2709