### PR TITLE
Update sonar-plugin-api to 7.9

### DIFF
--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -63,7 +63,7 @@
   </scm>
 
   <properties>
-    <sonar.version>7.3</sonar.version>
+    <sonar.version>7.9</sonar.version>
     <sonarLTS.version>6.7</sonarLTS.version>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <sonarAnalyzer.workDirectory>${project.build.directory}/analyzer</sonarAnalyzer.workDirectory>

--- a/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/CSharpPluginTest.java
+++ b/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/CSharpPluginTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.junit.Test;
 import org.sonar.api.Plugin;
+import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.config.PropertyDefinition;
@@ -47,7 +48,7 @@ public class CSharpPluginTest {
 
   @Test
   public void getExtensions() {
-    SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SCANNER);
+    SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
 
     Plugin.Context context = new Plugin.Context(sonarRuntime);
     new CSharpPlugin().define(context);

--- a/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/CSharpTest.java
+++ b/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/CSharpTest.java
@@ -21,6 +21,7 @@ package org.sonar.plugins.csharp;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.internal.MapSettings;
@@ -36,7 +37,7 @@ public class CSharpTest {
 
   @Before
   public void init() {
-    PropertyDefinitions defs = new PropertyDefinitions(new CSharpPropertyDefinitions(SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SCANNER)).create());
+    PropertyDefinitions defs = new PropertyDefinitions(new CSharpPropertyDefinitions(SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY)).create());
     settings = new MapSettings(defs);
     csharp = new CSharp(settings.asConfig());
   }

--- a/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/SonarVersion.java
+++ b/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/SonarVersion.java
@@ -19,13 +19,14 @@
  */
 package org.sonar.plugins.csharp;
 
+import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
 
 public class SonarVersion {
-  static final SonarRuntime SQ_74_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SERVER);
-  static final SonarRuntime SQ_73_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(7, 3), SonarQubeSide.SERVER);
-  static final SonarRuntime SQ_67_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(6, 7), SonarQubeSide.SERVER);
+  static final SonarRuntime SQ_74_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
+  static final SonarRuntime SQ_73_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(7, 3), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
+  static final SonarRuntime SQ_67_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(6, 7), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
 }

--- a/sonar-dotnet-shared-library/pom.xml
+++ b/sonar-dotnet-shared-library/pom.xml
@@ -14,7 +14,7 @@
   <description>Share code between C# and VB.NET plugins</description>
 
   <properties>
-    <sonar.version>7.7</sonar.version>
+    <sonar.version>7.9</sonar.version>
     <protobuf.version>3.8.0</protobuf.version>
     <protobuf.compiler>${settings.localRepository}/com/google/protobuf/protoc/${protobuf.version}/protoc-${protobuf.version}-${os.detected.classifier}.exe</protobuf.compiler>
     <!-- used for deployment to SonarSource Artifactory -->

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/CodeCoverageProvider.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/CodeCoverageProvider.java
@@ -72,7 +72,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.nccov\", \"report1.nccov,report2.nccov\" or \"C:/report.nccov\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
+        .onlyOnQualifiers(Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(itCoverageConf.ncover3PropertyKey())
@@ -80,7 +80,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.nccov\", \"report1.nccov,report2.nccov\" or \"C:/report.nccov\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
+        .onlyOnQualifiers(Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(coverageConf.openCoverPropertyKey())
@@ -88,7 +88,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.xml\", \"report1.xml,report2.xml\" or \"C:/report.xml\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
+        .onlyOnQualifiers(Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(itCoverageConf.openCoverPropertyKey())
@@ -96,7 +96,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.xml\", \"report1.xml,report2.xml\" or \"C:/report.xml\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
+        .onlyOnQualifiers(Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(coverageConf.dotCoverPropertyKey())
@@ -104,7 +104,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.html\", \"report1.html,report2.html\" or \"C:/report.html\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
+        .onlyOnQualifiers(Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(itCoverageConf.dotCoverPropertyKey())
@@ -112,7 +112,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.html\", \"report1.html,report2.html\" or \"C:/report.html\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
+        .onlyOnQualifiers(Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(coverageConf.visualStudioCoverageXmlPropertyKey())
@@ -120,7 +120,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.coveragexml\", \"report1.coveragexml,report2.coveragexml\" or \"C:/report.coveragexml\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
+        .onlyOnQualifiers(Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(itCoverageConf.visualStudioCoverageXmlPropertyKey())
@@ -128,7 +128,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.coveragexml\", \"report1.coveragexml,report2.coveragexml\" or \"C:/report.coveragexml\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
+        .onlyOnQualifiers(Qualifiers.PROJECT)
         .multiValues(true)
         .build());
   }

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/CodeCoverageProvider.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/CodeCoverageProvider.java
@@ -72,7 +72,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.nccov\", \"report1.nccov,report2.nccov\" or \"C:/report.nccov\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(itCoverageConf.ncover3PropertyKey())
@@ -80,7 +80,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.nccov\", \"report1.nccov,report2.nccov\" or \"C:/report.nccov\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(coverageConf.openCoverPropertyKey())
@@ -88,7 +88,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.xml\", \"report1.xml,report2.xml\" or \"C:/report.xml\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(itCoverageConf.openCoverPropertyKey())
@@ -96,7 +96,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.xml\", \"report1.xml,report2.xml\" or \"C:/report.xml\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(coverageConf.dotCoverPropertyKey())
@@ -104,7 +104,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.html\", \"report1.html,report2.html\" or \"C:/report.html\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(itCoverageConf.dotCoverPropertyKey())
@@ -112,7 +112,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.html\", \"report1.html,report2.html\" or \"C:/report.html\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(coverageConf.visualStudioCoverageXmlPropertyKey())
@@ -120,7 +120,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.coveragexml\", \"report1.coveragexml,report2.coveragexml\" or \"C:/report.coveragexml\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(itCoverageConf.visualStudioCoverageXmlPropertyKey())
@@ -128,7 +128,7 @@ public class CodeCoverageProvider {
         .description("Example: \"report.coveragexml\", \"report1.coveragexml,report2.coveragexml\" or \"C:/report.coveragexml\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
         .multiValues(true)
         .build());
   }

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/PropertiesSensor.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/PropertiesSensor.java
@@ -59,7 +59,7 @@ public class PropertiesSensor implements Sensor {
 
     List<Path> roslynReportPaths = configuration.roslynReportPaths();
     if (!roslynReportPaths.isEmpty()) {
-      reportPathCollector.addRoslynDirs(roslynReportPaths.stream().map(path -> new RoslynReport(context.module(), path)).collect(Collectors.toList()));
+      reportPathCollector.addRoslynDirs(roslynReportPaths.stream().map(path -> new RoslynReport(context.project(), path)).collect(Collectors.toList()));
     }
   }
 }

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/RoslynReport.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/RoslynReport.java
@@ -21,20 +21,20 @@ package org.sonarsource.dotnet.shared.plugins;
 
 import java.nio.file.Path;
 import java.util.Objects;
-import org.sonar.api.batch.fs.InputModule;
+import org.sonar.api.scanner.fs.InputProject;
 
 public class RoslynReport {
 
-  private final InputModule module;
+  private final InputProject project;
   private final Path reportPath;
 
-  public RoslynReport(InputModule module, Path reportPath) {
-    this.module = module;
+  public RoslynReport(InputProject project, Path reportPath) {
+    this.project = project;
     this.reportPath = reportPath;
   }
 
-  public InputModule getModule() {
-    return module;
+  public InputProject getProject() {
+    return project;
   }
 
   public Path getReportPath() {
@@ -50,12 +50,12 @@ public class RoslynReport {
       return false;
     }
     RoslynReport that = (RoslynReport) o;
-    return Objects.equals(module, that.module) &&
+    return Objects.equals(project, that.project) &&
       Objects.equals(reportPath, that.reportPath);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(module, reportPath);
+    return Objects.hash(project, reportPath);
   }
 }

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/SarifParserCallbackImpl.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/SarifParserCallbackImpl.java
@@ -32,7 +32,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.InputModule;
+import org.sonar.api.scanner.fs.InputProject;
 import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.issue.NewExternalIssue;
@@ -74,25 +74,25 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
   }
 
   @Override
-  public void onProjectIssue(String ruleId, @Nullable String level, InputModule inputModule, String message) {
+  public void onProjectIssue(String ruleId, @Nullable String level, InputProject inputProject, String message) {
     // De-duplicate issues
-    Issue issue = new Issue(ruleId, inputModule.toString(), true);
+    Issue issue = new Issue(ruleId, inputProject.toString(), true);
     if (!savedIssues.add(issue)) {
       return;
     }
 
     String repositoryKey = repositoryKeyByRoslynRuleKey.get(ruleId);
     if (repositoryKey != null) {
-      createProjectLevelIssue(ruleId, inputModule, message, repositoryKey);
+      createProjectLevelIssue(ruleId, inputProject, message, repositoryKey);
     }
   }
 
-  private void createProjectLevelIssue(String ruleId, InputModule inputModule, String message, String repositoryKey) {
+  private void createProjectLevelIssue(String ruleId, InputProject inputProject, String message, String repositoryKey) {
     NewIssue newIssue = context.newIssue();
     newIssue
       .forRule(RuleKey.of(repositoryKey, ruleId))
       .at(newIssue.newLocation()
-        .on(inputModule)
+        .on(inputProject)
         .message(message))
       .save();
   }

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/UnitTestResultsProvider.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/UnitTestResultsProvider.java
@@ -57,7 +57,7 @@ public class UnitTestResultsProvider {
         .description("Example: \"report.trx\", \"report1.trx,report2.trx\" or \"C:/report.trx\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(unitTestConfiguration.nunitTestResultsFilePropertyKey())
@@ -65,7 +65,7 @@ public class UnitTestResultsProvider {
         .description("Example: \"TestResult.xml\", \"TestResult1.xml,TestResult2.xml\" or \"C:/TestResult.xml\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.MODULE)
+        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
         .multiValues(true)
         .build());
   }

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/UnitTestResultsProvider.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/UnitTestResultsProvider.java
@@ -57,7 +57,7 @@ public class UnitTestResultsProvider {
         .description("Example: \"report.trx\", \"report1.trx,report2.trx\" or \"C:/report.trx\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
+        .onlyOnQualifiers(Qualifiers.PROJECT)
         .multiValues(true)
         .build(),
       PropertyDefinition.builder(unitTestConfiguration.nunitTestResultsFilePropertyKey())
@@ -65,7 +65,7 @@ public class UnitTestResultsProvider {
         .description("Example: \"TestResult.xml\", \"TestResult1.xml,TestResult2.xml\" or \"C:/TestResult.xml\"")
         .category(category)
         .subCategory(SUBCATEGORY)
-        .onlyOnQualifiers(Qualifiers.PROJECT, Qualifiers.PROJECT)
+        .onlyOnQualifiers(Qualifiers.PROJECT)
         .multiValues(true)
         .build());
   }

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/sarif/SarifParser01And04.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/sarif/SarifParser01And04.java
@@ -24,20 +24,19 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
-import org.sonar.api.batch.fs.InputModule;
+import org.sonar.api.scanner.fs.InputProject;
 
 class SarifParser01And04 implements SarifParser {
   private static final String FILE_PROTOCOL = "file:///";
-  private final InputModule inputModule;
+  private final InputProject inputProject;
   private final JsonObject root;
   private final UnaryOperator<String> toRealPath;
 
-  SarifParser01And04(InputModule inputModule, JsonObject root, UnaryOperator<String> toRealPath) {
-    this.inputModule = inputModule;
+  SarifParser01And04(InputProject inputProject, JsonObject root, UnaryOperator<String> toRealPath) {
+    this.inputProject = inputProject;
     this.root = root;
     this.toRealPath = toRealPath;
   }
@@ -76,13 +75,13 @@ class SarifParser01And04 implements SarifParser {
 
     JsonArray locationsArray = issue.getAsJsonArray("locations");
     if (locationsArray.size() == 0) {
-      callback.onProjectIssue(ruleId, null, inputModule, message);
+      callback.onProjectIssue(ruleId, null, inputProject, message);
       return;
     }
 
     JsonObject primaryLocationObject = getAnalysisTargetAt(locationsArray, 0);
     if (primaryLocationObject == null) {
-      callback.onProjectIssue(ruleId, null, inputModule, message);
+      callback.onProjectIssue(ruleId, null, inputProject, message);
       return;
     }
 

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/sarif/SarifParser10.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/sarif/SarifParser10.java
@@ -31,21 +31,20 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
-import org.sonar.api.batch.fs.InputModule;
+import org.sonar.api.scanner.fs.InputProject;
 
 class SarifParser10 implements SarifParser {
   private static final String PROPERTIES_PROP = "properties";
   private static final String LEVEL_PROP = "level";
-  private final InputModule inputModule;
+  private final InputProject inputProject;
   private final JsonObject root;
   private final UnaryOperator<String> toRealPath;
 
-  SarifParser10(InputModule inputModule, JsonObject root, UnaryOperator<String> toRealPath) {
-    this.inputModule = inputModule;
+  SarifParser10(InputProject inputProject, JsonObject root, UnaryOperator<String> toRealPath) {
+    this.inputProject = inputProject;
     this.root = root;
     this.toRealPath = toRealPath;
   }
@@ -106,7 +105,7 @@ class SarifParser10 implements SarifParser {
     String message = resultObj.get("message").getAsString();
     String level = resultObj.has(LEVEL_PROP) ? resultObj.get(LEVEL_PROP).getAsString() : null;
     if (!handleLocationsElement(resultObj, ruleId, message, callback)) {
-      callback.onProjectIssue(ruleId, level, inputModule, message);
+      callback.onProjectIssue(ruleId, level, inputProject, message);
     }
   }
 

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/sarif/SarifParserCallback.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/sarif/SarifParserCallback.java
@@ -21,11 +21,11 @@ package org.sonarsource.dotnet.shared.sarif;
 
 import java.util.Collection;
 import javax.annotation.Nullable;
-import org.sonar.api.batch.fs.InputModule;
+import org.sonar.api.scanner.fs.InputProject;
 
 public interface SarifParserCallback {
 
-  void onProjectIssue(String ruleId, @Nullable String level, InputModule inputModule, String message);
+  void onProjectIssue(String ruleId, @Nullable String level, InputProject inputProject, String message);
 
   void onFileIssue(String ruleId, @Nullable String level, String absolutePath, String message);
 

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/sarif/SarifParserFactory.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/sarif/SarifParserFactory.java
@@ -46,10 +46,10 @@ public class SarifParserFactory {
         switch (version) {
           case "0.4":
           case "0.1":
-            return new SarifParser01And04(report.getModule(), root, toRealPath);
+            return new SarifParser01And04(report.getProject(), root, toRealPath);
           case "1.0":
           default:
-            return new SarifParser10(report.getModule(),root, toRealPath);
+            return new SarifParser10(report.getProject(),root, toRealPath);
         }
       }
     } catch (IOException e) {

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/AbstractProjectConfigurationTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/AbstractProjectConfigurationTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.internal.MapSettings;
@@ -50,7 +51,7 @@ public class AbstractProjectConfigurationTest {
   @Before
   public void setUp() {
     workDir = temp.getRoot().toPath();
-    AbstractPropertyDefinitions definitions = new AbstractPropertyDefinitions("cs", "C#", ".cs", SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SERVER)) {
+    AbstractPropertyDefinitions definitions = new AbstractPropertyDefinitions("cs", "C#", ".cs", SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SERVER, SonarEdition.COMMUNITY)) {
     };
     settings = new MapSettings(new PropertyDefinitions(definitions.create()));
   }

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/AbstractSolutionConfigurationTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/AbstractSolutionConfigurationTest.java
@@ -20,6 +20,7 @@
 package org.sonarsource.dotnet.shared.plugins;
 
 import org.junit.Test;
+import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.internal.MapSettings;
@@ -53,7 +54,7 @@ public class AbstractSolutionConfigurationTest {
       "cs",
       "C#",
       ".cs",
-      SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SERVER)) {
+      SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SERVER, SonarEdition.COMMUNITY)) {
     };
     MapSettings settings = new MapSettings(new PropertyDefinitions(definitions.create()));
     settings.setProperty("sonar.cs.analyzeGeneratedCode", analyzeGeneratedCode);

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/GeneratedFileFilterTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/GeneratedFileFilterTest.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.config.PropertyDefinitions;
@@ -54,7 +55,7 @@ public class GeneratedFileFilterTest {
       "cs",
       "C#",
       ".cs",
-      SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SERVER)) {
+      SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SERVER, SonarEdition.COMMUNITY)) {
     };
     MapSettings settings = new MapSettings(new PropertyDefinitions(definitions.create()));
     defaultConfiguration = new AbstractSolutionConfiguration(settings.asConfig(), "cs") { };

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/RoslynDataImporterTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/RoslynDataImporterTest.java
@@ -39,6 +39,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
@@ -113,7 +114,7 @@ public class RoslynDataImporterTest {
 
   @Test
   public void dont_import_external_issues_before_7_4() {
-    tester.setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(7, 3), SonarQubeSide.SCANNER));
+    tester.setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(7, 3), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
 
     Map<String, List<RuleKey>> activeRules = createActiveRules();
     roslynDataImporter.importRoslynReports(Collections.singletonList(new RoslynReport(tester.module(), workDir.resolve("roslyn-report.json"))), tester, activeRules,

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/RoslynDataImporterTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/RoslynDataImporterTest.java
@@ -93,7 +93,7 @@ public class RoslynDataImporterTest {
   @Test
   public void roslynReportIsProcessed() {
     Map<String, List<RuleKey>> activeRules = createActiveRules();
-    roslynDataImporter.importRoslynReports(Collections.singletonList(new RoslynReport(tester.module(), workDir.resolve("roslyn-report.json"))), tester, activeRules,
+    roslynDataImporter.importRoslynReports(Collections.singletonList(new RoslynReport(tester.project(), workDir.resolve("roslyn-report.json"))), tester, activeRules,
       String::toString);
 
     assertThat(tester.allIssues())
@@ -117,7 +117,7 @@ public class RoslynDataImporterTest {
     tester.setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(7, 3), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
 
     Map<String, List<RuleKey>> activeRules = createActiveRules();
-    roslynDataImporter.importRoslynReports(Collections.singletonList(new RoslynReport(tester.module(), workDir.resolve("roslyn-report.json"))), tester, activeRules,
+    roslynDataImporter.importRoslynReports(Collections.singletonList(new RoslynReport(tester.project(), workDir.resolve("roslyn-report.json"))), tester, activeRules,
       String::toString);
 
     assertThat(tester.allIssues()).hasSize(4);

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/sarif/SarifParser01And04Test.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/sarif/SarifParser01And04Test.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
-import org.sonar.api.batch.fs.InputModule;
+import org.sonar.api.scanner.fs.InputProject;
 import org.sonar.api.utils.log.LogTester;
 
 import static org.mockito.ArgumentMatchers.eq;
@@ -84,7 +84,7 @@ public class SarifParser01And04Test {
 
     verify(callback).onProjectIssue("AssemblyLevelRule", null, null, "This is an assembly level Roslyn issue with no location.");
     verify(callback).onProjectIssue("NoAnalysisTargetsLocation", null, null, "No analysis targets, report at assembly level.");
-    verify(callback, times(2)).onProjectIssue(Mockito.anyString(), Mockito.isNull(), Mockito.nullable(InputModule.class), Mockito.anyString());
+    verify(callback, times(2)).onProjectIssue(Mockito.anyString(), Mockito.isNull(), Mockito.nullable(InputProject.class), Mockito.anyString());
   }
 
   // VS 2015 Update 2
@@ -99,7 +99,7 @@ public class SarifParser01And04Test {
     inOrder.verify(callback).onIssue("S125", null, location, Collections.emptyList());
     verify(callback, only()).onIssue(Mockito.anyString(), Mockito.isNull(), Mockito.any(Location.class), Mockito.anyCollectionOf(Location.class));
 
-    verify(callback, never()).onProjectIssue(Mockito.anyString(), Mockito.isNull(), Mockito.any(InputModule.class), Mockito.anyString());
+    verify(callback, never()).onProjectIssue(Mockito.anyString(), Mockito.isNull(), Mockito.any(InputProject.class), Mockito.anyString());
   }
 
   @Test

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/sarif/SarifParserCallbackImplTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/sarif/SarifParserCallbackImplTest.java
@@ -69,7 +69,7 @@ public class SarifParserCallbackImplTest {
 
   @Test
   public void should_add_project_issues() {
-    callback.onProjectIssue("rule1", "warning", ctx.module(), "msg");
+    callback.onProjectIssue("rule1", "warning", ctx.project(), "msg");
     assertThat(ctx.allIssues()).hasSize(1);
     assertThat(ctx.allIssues().iterator().next().primaryLocation().inputComponent().key()).isEqualTo("projectKey");
     assertThat(ctx.allIssues().iterator().next().ruleKey().rule()).isEqualTo("rule1");
@@ -110,13 +110,13 @@ public class SarifParserCallbackImplTest {
 
   @Test
   public void should_ignore_project_issue_with_unknown_rule_key() {
-    callback.onProjectIssue("rule45", "warning", ctx.module(), "msg");
+    callback.onProjectIssue("rule45", "warning", ctx.project(), "msg");
     assertThat(ctx.allIssues()).isEmpty();
     assertThat(ctx.allExternalIssues()).isEmpty();
 
     callback = new SarifParserCallbackImpl(ctx, repositoryKeyByRoslynRuleKey, true, emptySet(), emptySet(), emptySet());
 
-    callback.onProjectIssue("rule45", "warning", ctx.module(), "msg");
+    callback.onProjectIssue("rule45", "warning", ctx.project(), "msg");
 
     assertThat(ctx.allIssues()).isEmpty();
     assertThat(ctx.allExternalIssues()).isEmpty();
@@ -221,8 +221,8 @@ public class SarifParserCallbackImplTest {
 
   @Test
   public void should_ignore_repeated_module_issues() {
-    callback.onProjectIssue("rule1", "warning", ctx.module(), "message");
-    callback.onProjectIssue("rule1", "warning", ctx.module(), "message");
+    callback.onProjectIssue("rule1", "warning", ctx.project(), "message");
+    callback.onProjectIssue("rule1", "warning", ctx.project(), "message");
 
     assertThat(ctx.allIssues()).hasSize(1);
     assertThat(ctx.allIssues()).extracting("ruleKey").extracting("rule")

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -63,7 +63,7 @@
   </scm>
 
   <properties>
-    <sonar.version>7.3</sonar.version>
+    <sonar.version>7.9</sonar.version>
     <sonarLTS.version>6.7</sonarLTS.version>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <sonarAnalyzer.workDirectory>${project.build.directory}/analyzer</sonarAnalyzer.workDirectory>

--- a/sonar-vbnet-plugin/src/test/java/org/sonar/plugins/vbnet/SonarVersion.java
+++ b/sonar-vbnet-plugin/src/test/java/org/sonar/plugins/vbnet/SonarVersion.java
@@ -19,13 +19,14 @@
  */
 package org.sonar.plugins.vbnet;
 
+import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
 
 public class SonarVersion {
-  static final SonarRuntime SQ_74_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SERVER);
-  static final SonarRuntime SQ_73_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(7, 3), SonarQubeSide.SERVER);
-  static final SonarRuntime SQ_67_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(6, 7), SonarQubeSide.SERVER);
+  static final SonarRuntime SQ_74_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
+  static final SonarRuntime SQ_73_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(7, 3), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
+  static final SonarRuntime SQ_67_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(6, 7), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
 }

--- a/sonar-vbnet-plugin/src/test/java/org/sonar/plugins/vbnet/VbNetPluginTest.java
+++ b/sonar-vbnet-plugin/src/test/java/org/sonar/plugins/vbnet/VbNetPluginTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.junit.Test;
 import org.sonar.api.Plugin;
+import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.config.PropertyDefinition;
@@ -47,7 +48,7 @@ public class VbNetPluginTest {
 
   @Test
   public void getExtensions() {
-    SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SCANNER);
+    SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
 
     Plugin.Context context = new Plugin.Context(sonarRuntime);
     new VbNetPlugin().define(context);

--- a/sonar-vbnet-plugin/src/test/java/org/sonar/plugins/vbnet/VbNetTest.java
+++ b/sonar-vbnet-plugin/src/test/java/org/sonar/plugins/vbnet/VbNetTest.java
@@ -21,6 +21,7 @@ package org.sonar.plugins.vbnet;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.internal.MapSettings;
@@ -36,7 +37,7 @@ public class VbNetTest {
 
   @Before
   public void init() {
-    PropertyDefinitions defs = new PropertyDefinitions(new VbNetPropertyDefinitions(SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SCANNER)).create());
+    PropertyDefinitions defs = new PropertyDefinitions(new VbNetPropertyDefinitions(SonarRuntimeImpl.forSonarQube(Version.create(7, 4), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY)).create());
     settings = new MapSettings(defs);
     vbnet = new VbNet(settings.asConfig());
   }


### PR DESCRIPTION
- update vbnet, csharp and shared plugins to sonar-plugin-api to 7.9
- use InputProject instead of InputModule
- replace Qualifiers.MODULE with PROJECT

The following warnings for deprecated APIs are remaining:
```
java: org.sonar.api.batch.ScannerSide in org.sonar.api.batch has been deprecated
java: global() in org.sonar.api.batch.sensor.SensorDescriptor has been deprecated
java: module() in org.sonar.api.batch.sensor.SensorContext has been deprecated

java: org.sonar.api.batch.bootstrap.ProjectBuilder in org.sonar.api.batch.bootstrap has been deprecated
java: org.sonar.api.batch.bootstrap.ProjectDefinition in org.sonar.api.batch.bootstrap has been deprecated
java: org.sonar.api.batch.bootstrap.ProjectBuilder.Context in org.sonar.api.batch.bootstrap.ProjectBuilder has been deprecated
java: org.sonar.api.batch.bootstrap.ProjectReactor in org.sonar.api.batch.bootstrap has been deprecated

java: path() in org.sonar.api.batch.fs.InputFile has been deprecated
```

Fix #2437