### PR TITLE
Update analyzer README

### DIFF
--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -12,21 +12,28 @@ In general, it is best to run commands from the Visual Studio Developer Command 
 
 ## Developing with Visual Studio 2017
 
-1. [Visual Studio 2017 Version 15.9](https://my.visualstudio.com/Downloads?q=visual%20studio%202017&wt.mc_id=o~msft~vscom~older-downloads)
+1. [Visual Studio 2017 Version 15.9](https://my.visualstudio.com/Downloads?q=Visual%20Studio%202017)
     - Ensure C#, VB, MSBuild, .NET Core, F#, Visual Studio Extensibility and ASP.Net and web development are included in the selected work loads
-    - Ensure Visual Studio Version is between "15.7" and "15.9"
-    - If you want to install only [Visual Studio 2019](https://visualstudio.microsoft.com/vs/) as an IDE, make sure you also install [Build Tools for Visual Studio 2017 (version 15.9)](https://my.visualstudio.com/Downloads?q=Build%20Tools%20for%20Visual%20Studio%202017%20(version%2015.9)&pgroup=) in order to have MSBuild 15 installed (see #2489)
+    - Ensure Visual Studio Version is between "15.7" and "15.9" (see #2489 and #2763)
+    - If you want to install only [Visual Studio 2019](https://my.visualstudio.com/Downloads?q=Visual%20Studio%202019) as an IDE, make sure you also install [Build Tools for Visual Studio 2017 (version 15.9)](https://my.visualstudio.com/Downloads?q=Build%20Tools%20for%20Visual%20Studio%202017%20version%2015.9) in order to have MSBuild 15 installed (see #2489)
 1. [.NET Core SDK 2.1.402](https://dotnet.microsoft.com/download/dotnet-core/2.1)
 1. Open `SonarAnalyzer.sln` in the `sonaranalyzer-dotnet` subfolder
 
 The following environment variables must be set:
-- **MSBUILD_PATH** - path to MSBuild.exe from the Visual Studio installation folder - to MSBuild 15
-- **ORCHESTRATOR_CONFIG_URL** - path to orchestrator.properties (for integration tests)
+- **JAVA_HOME**
+- **MAVEN_HOME** / **M2_HOME**
+- **MSBUILD_PATH** - path to the MSBuild.exe executable from the Visual Studio installation folder - to MSBuild 15
+- **NUGET_PATH** - path to the nuget.exe executable (related to the [plugin integration tests](./contributing-plugin.md#integration-tests))
+- **ORCHESTRATOR_CONFIG_URL** - path to orchestrator.properties file (for integration tests)
 - **rule_api_path** - path to folder containing the rule api jar
 - **Path** - the **Path** must contain:
     - the path to the dotnet core installation folder
+    - the path to the MSBuild bin folder
     - the path to the visual studo installer folder (for vswhere.exe)
-    - the path to the nuget executable folder
+    - the path to the nuget executable folder (e.g. C:\Program Files\nuget)
+    - the path to the JDK bin folder
+    - %M2_HOME%\bin
+    - the path to the Scanner For MSBuild folder and to the Scanner CLI
 
 ## Running Tests
 

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -12,14 +12,15 @@ In general, it is best to run commands from the Visual Studio Developer Command 
 
 ## Developing with Visual Studio 2017
 
-1. [Visual Studio 2017 Version 15.7](https://www.visualstudio.com/vs/preview/)
+1. [Visual Studio 2017 Version 15.9](https://my.visualstudio.com/Downloads?q=visual%20studio%202017&wt.mc_id=o~msft~vscom~older-downloads)
     - Ensure C#, VB, MSBuild, .NET Core, F#, Visual Studio Extensibility and ASP.Net and web development are included in the selected work loads
     - Ensure Visual Studio Version is between "15.7" and "15.9"
+    - If you want to install only [Visual Studio 2019](https://visualstudio.microsoft.com/vs/) as an IDE, make sure you also install [Build Tools for Visual Studio 2017 (version 15.9)](https://my.visualstudio.com/Downloads?q=Build%20Tools%20for%20Visual%20Studio%202017%20(version%2015.9)&pgroup=) in order to have MSBuild 15 installed (see #2489)
 1. [.NET Core SDK 2.1.402](https://dotnet.microsoft.com/download/dotnet-core/2.1)
 1. Open `SonarAnalyzer.sln` in the `sonaranalyzer-dotnet` subfolder
 
 The following environment variables must be set:
-- **MSBUILD_PATH** - path to MSBuild.exe from the Visual Studio installation folder
+- **MSBUILD_PATH** - path to MSBuild.exe from the Visual Studio installation folder - to MSBuild 15
 - **ORCHESTRATOR_CONFIG_URL** - path to orchestrator.properties (for integration tests)
 - **rule_api_path** - path to folder containing the rule api jar
 - **Path** - the **Path** must contain:


### PR DESCRIPTION
to include possibility to install only the VS 2017 Build Tools

This won't be relevant anymore after #2489 gets fixed...
