### PR TITLE
Fix S1128 FP: using System.Linq query syntax missing cases

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UnnecessaryUsings.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UnnecessaryUsings.cs
@@ -166,8 +166,8 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 foreach (var usingDirective in this.usingDirectivesFromParent)
                 {
-                    if (usingDirective.Name.ToString() == "System.Linq" &&
-                        this.context.SemanticModel.GetSymbolInfo(usingDirective.Name).Symbol is INamespaceSymbol namespaceSymbol)
+                    if (this.context.SemanticModel.GetSymbolInfo(usingDirective.Name).Symbol is INamespaceSymbol namespaceSymbol &&
+                        namespaceSymbol.ToDisplayString() == "System.Linq")
                     {
                         systemLinqNamespace = namespaceSymbol;
                         return true;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.Fixed.Batch.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.Fixed.Batch.cs
@@ -140,7 +140,7 @@ namespace LinqQuery1
     {
         public void DoLinqQuery(List<string> myList)
         {
-            var linkQuery = from item in myList select item.GetType();
+            var query = from item in myList select item.GetType();
         }
     }
 }
@@ -152,7 +152,21 @@ namespace LinqQuery2
     {
         public void DoLinqQuery(List<string> myList)
         {
-            var linkQuery = from item in myList select item.GetType();
+            var query = from item in myList select item.GetType();
+        }
+    }
+}
+
+namespace LinqQuery3.System.Linq { }
+
+namespace LinqQuery3
+{
+    using global::System.Linq;
+    class LinqQueryUser
+    {
+        public void DoLinqQuery(List<string> myList)
+        {
+            var query = from item in myList select item.GetType();
         }
     }
 }
@@ -169,7 +183,7 @@ namespace System
     {
         public void DoLinqQuery(List<string> myList)
         {
-            var linkQuery = from item in myList select item.GetType();
+            var query = from item in myList select item.GetType();
         }
     }
 }
@@ -182,7 +196,7 @@ namespace LinqQueryWithoutUsing
     {
         public void DoLinqQuery(List<string> myList)
         {
-            var linkQuery = from item in myList select item.GetType(); // Error [CS1935] - Could not find an implementation of the query pattern for source type 'List<string>'.
+            var query = from item in myList select item.GetType(); // Error [CS1935] - Could not find an implementation of the query pattern for source type 'List<string>'.
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.Fixed.Batch.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.Fixed.Batch.cs
@@ -133,9 +133,38 @@ namespace AwaitExtensionUser
     }
 }
 
-namespace LinqQuery
+namespace LinqQuery1
 {
     using System.Linq; // Compliant - statement is needed for query syntax
+    class LinqQueryUser
+    {
+        public void DoLinqQuery(List<string> myList)
+        {
+            var linkQuery = from item in myList select item.GetType();
+        }
+    }
+}
+
+namespace LinqQuery2
+{
+    using global::System.Linq; // Compliant - statement is needed for query syntax
+    class LinqQueryUser
+    {
+        public void DoLinqQuery(List<string> myList)
+        {
+            var linkQuery = from item in myList select item.GetType();
+        }
+    }
+}
+
+namespace NoLinqQuery
+{
+    class UnusedLinqImport { }
+}
+
+namespace System
+{
+    using Linq; // Compliant - statement is needed for query syntax
     class LinqQueryUser
     {
         public void DoLinqQuery(List<string> myList)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.Fixed.Batch.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.Fixed.Batch.cs
@@ -136,9 +136,9 @@ namespace AwaitExtensionUser
 namespace LinqQuery1
 {
     using System.Linq; // Compliant - statement is needed for query syntax
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType();
         }
@@ -148,9 +148,9 @@ namespace LinqQuery1
 namespace LinqQuery2
 {
     using global::System.Linq; // Compliant - statement is needed for query syntax
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType();
         }
@@ -162,9 +162,9 @@ namespace LinqQuery3.System.Linq { }
 namespace LinqQuery3
 {
     using global::System.Linq;
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType();
         }
@@ -179,9 +179,9 @@ namespace NoLinqQuery
 namespace System
 {
     using Linq; // Compliant - statement is needed for query syntax
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType();
         }
@@ -192,9 +192,9 @@ namespace System
 // a QueryExpressionSyntax is in the code
 namespace LinqQueryWithoutUsing
 {
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType(); // Error [CS1935] - Could not find an implementation of the query pattern for source type 'List<string>'.
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.Fixed.cs
@@ -140,7 +140,7 @@ namespace LinqQuery1
     {
         public void DoLinqQuery(List<string> myList)
         {
-            var linkQuery = from item in myList select item.GetType();
+            var query = from item in myList select item.GetType();
         }
     }
 }
@@ -152,7 +152,21 @@ namespace LinqQuery2
     {
         public void DoLinqQuery(List<string> myList)
         {
-            var linkQuery = from item in myList select item.GetType();
+            var query = from item in myList select item.GetType();
+        }
+    }
+}
+
+namespace LinqQuery3.System.Linq { }
+
+namespace LinqQuery3
+{
+    using global::System.Linq;
+    class LinqQueryUser
+    {
+        public void DoLinqQuery(List<string> myList)
+        {
+            var query = from item in myList select item.GetType();
         }
     }
 }
@@ -169,7 +183,7 @@ namespace System
     {
         public void DoLinqQuery(List<string> myList)
         {
-            var linkQuery = from item in myList select item.GetType();
+            var query = from item in myList select item.GetType();
         }
     }
 }
@@ -182,7 +196,7 @@ namespace LinqQueryWithoutUsing
     {
         public void DoLinqQuery(List<string> myList)
         {
-            var linkQuery = from item in myList select item.GetType(); // Error [CS1935] - Could not find an implementation of the query pattern for source type 'List<string>'.
+            var query = from item in myList select item.GetType(); // Error [CS1935] - Could not find an implementation of the query pattern for source type 'List<string>'.
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.Fixed.cs
@@ -133,9 +133,38 @@ namespace AwaitExtensionUser
     }
 }
 
-namespace LinqQuery
+namespace LinqQuery1
 {
     using System.Linq; // Compliant - statement is needed for query syntax
+    class LinqQueryUser
+    {
+        public void DoLinqQuery(List<string> myList)
+        {
+            var linkQuery = from item in myList select item.GetType();
+        }
+    }
+}
+
+namespace LinqQuery2
+{
+    using global::System.Linq; // Compliant - statement is needed for query syntax
+    class LinqQueryUser
+    {
+        public void DoLinqQuery(List<string> myList)
+        {
+            var linkQuery = from item in myList select item.GetType();
+        }
+    }
+}
+
+namespace NoLinqQuery
+{
+    class UnusedLinqImport { }
+}
+
+namespace System
+{
+    using Linq; // Compliant - statement is needed for query syntax
     class LinqQueryUser
     {
         public void DoLinqQuery(List<string> myList)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.Fixed.cs
@@ -136,9 +136,9 @@ namespace AwaitExtensionUser
 namespace LinqQuery1
 {
     using System.Linq; // Compliant - statement is needed for query syntax
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType();
         }
@@ -148,9 +148,9 @@ namespace LinqQuery1
 namespace LinqQuery2
 {
     using global::System.Linq; // Compliant - statement is needed for query syntax
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType();
         }
@@ -162,9 +162,9 @@ namespace LinqQuery3.System.Linq { }
 namespace LinqQuery3
 {
     using global::System.Linq;
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType();
         }
@@ -179,9 +179,9 @@ namespace NoLinqQuery
 namespace System
 {
     using Linq; // Compliant - statement is needed for query syntax
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType();
         }
@@ -192,9 +192,9 @@ namespace System
 // a QueryExpressionSyntax is in the code
 namespace LinqQueryWithoutUsing
 {
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType(); // Error [CS1935] - Could not find an implementation of the query pattern for source type 'List<string>'.
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.cs
@@ -146,7 +146,7 @@ namespace LinqQuery1
     {
         public void DoLinqQuery(List<string> myList)
         {
-            var linkQuery = from item in myList select item.GetType();
+            var query = from item in myList select item.GetType();
         }
     }
 }
@@ -158,7 +158,22 @@ namespace LinqQuery2
     {
         public void DoLinqQuery(List<string> myList)
         {
-            var linkQuery = from item in myList select item.GetType();
+            var query = from item in myList select item.GetType();
+        }
+    }
+}
+
+namespace LinqQuery3.System.Linq { }
+
+namespace LinqQuery3
+{
+    using System.Linq; // Noncompliant - This is 'LinqQuery3.System.Linq' whose import is indeed unnecessary
+    using global::System.Linq;
+    class LinqQueryUser
+    {
+        public void DoLinqQuery(List<string> myList)
+        {
+            var query = from item in myList select item.GetType();
         }
     }
 }
@@ -176,7 +191,7 @@ namespace System
     {
         public void DoLinqQuery(List<string> myList)
         {
-            var linkQuery = from item in myList select item.GetType();
+            var query = from item in myList select item.GetType();
         }
     }
 }
@@ -189,7 +204,7 @@ namespace LinqQueryWithoutUsing
     {
         public void DoLinqQuery(List<string> myList)
         {
-            var linkQuery = from item in myList select item.GetType(); // Error [CS1935] - Could not find an implementation of the query pattern for source type 'List<string>'.
+            var query = from item in myList select item.GetType(); // Error [CS1935] - Could not find an implementation of the query pattern for source type 'List<string>'.
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.cs
@@ -142,9 +142,9 @@ namespace AwaitExtensionUser
 namespace LinqQuery1
 {
     using System.Linq; // Compliant - statement is needed for query syntax
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType();
         }
@@ -154,9 +154,9 @@ namespace LinqQuery1
 namespace LinqQuery2
 {
     using global::System.Linq; // Compliant - statement is needed for query syntax
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType();
         }
@@ -169,9 +169,9 @@ namespace LinqQuery3
 {
     using System.Linq; // Noncompliant - This is 'LinqQuery3.System.Linq' whose import is indeed unnecessary
     using global::System.Linq;
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType();
         }
@@ -187,9 +187,9 @@ namespace NoLinqQuery
 namespace System
 {
     using Linq; // Compliant - statement is needed for query syntax
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType();
         }
@@ -200,9 +200,9 @@ namespace System
 // a QueryExpressionSyntax is in the code
 namespace LinqQueryWithoutUsing
 {
-    class LinqQueryUser
+    class Usage
     {
-        public void DoLinqQuery(List<string> myList)
+        public void DoQuery(List<string> myList)
         {
             var query = from item in myList select item.GetType(); // Error [CS1935] - Could not find an implementation of the query pattern for source type 'List<string>'.
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnnecessaryUsings.cs
@@ -139,9 +139,39 @@ namespace AwaitExtensionUser
     }
 }
 
-namespace LinqQuery
+namespace LinqQuery1
 {
     using System.Linq; // Compliant - statement is needed for query syntax
+    class LinqQueryUser
+    {
+        public void DoLinqQuery(List<string> myList)
+        {
+            var linkQuery = from item in myList select item.GetType();
+        }
+    }
+}
+
+namespace LinqQuery2
+{
+    using global::System.Linq; // Compliant - statement is needed for query syntax
+    class LinqQueryUser
+    {
+        public void DoLinqQuery(List<string> myList)
+        {
+            var linkQuery = from item in myList select item.GetType();
+        }
+    }
+}
+
+namespace NoLinqQuery
+{
+    using System.Linq; // Noncompliant
+    class UnusedLinqImport { }
+}
+
+namespace System
+{
+    using Linq; // Compliant - statement is needed for query syntax
     class LinqQueryUser
     {
         public void DoLinqQuery(List<string> myList)


### PR DESCRIPTION
Fixes #2758 
