### PR TITLE
Correct code generation for -2147483648

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/CBDE/MLIRExporter.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/CBDE/MLIRExporter.cs
@@ -402,7 +402,14 @@ namespace SonarAnalyzer
                     break;
                 case SyntaxKind.UnaryMinusExpression:
                     var neg = op as PrefixUnaryExpressionSyntax;
-                    writer.WriteLine($"%{OpId(neg)} = cbde.neg %{OpId(getAssignmentValue(neg.Operand))} : {MLIRType(neg)} {GetLocation(neg)}");
+                    if (IsTypeKnown(semanticModel.GetTypeInfo(neg).Type) && !IsTypeKnown(semanticModel.GetTypeInfo(neg.Operand).Type))
+                    {
+                        writer.WriteLine($"%{OpId(neg)} = cbde.unknown : {MLIRType(neg)} {GetLocation(op)} // A negation changing type whose source type is unknown");
+                    }
+                    else
+                    {
+                        writer.WriteLine($"%{OpId(neg)} = cbde.neg %{OpId(getAssignmentValue(neg.Operand))} : {MLIRType(neg)} {GetLocation(neg)}");
+                    }
                     break;
                 case SyntaxKind.UnaryPlusExpression:
                     var plus = op as PrefixUnaryExpressionSyntax;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/MlirExportTest.cs
@@ -1322,6 +1322,20 @@ public bool plus()
 ";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
+        [TestMethod]
+        public void MixingUintAndNeg()
+        {
+            var code = @"
+void f() {
+  int j = -10u;
+}
+
+void g() {
+  int someInt = -2147483648;
+}
+";
+            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+        }
 
     } // Class
 


### PR DESCRIPTION
This is a special case in C# language specification, the number is an uint32, and minus this number is an int32 (and not a int64, like for -10u). But the patch handle all cases where the output of neg is known while the input is unknown.