### PR TITLE
Update orchestrator to 3.27.0.2172

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-ws</artifactId>
-      <version>7.9.1</version>
+      <version>7.9</version>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.ucfg</groupId>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.26.0.2111</version>
+      <version>3.27.0.2172</version>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.scanner.msbuild</groupId>
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-ws</artifactId>
-      <version>7.9</version>
+      <version>7.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.ucfg</groupId>


### PR DESCRIPTION
Fixes #2617
Use of deprecated methods was already removed in PR #2486
This version update is just a formality, as the removed API were already not used anymore by our codebase