### PR TITLE
Fix AbstractMethodParameterLookup.TryGetArgumentSyntax to handle param/ParamArray properly

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
@@ -427,7 +427,7 @@ namespace SonarAnalyzer.Helpers
         /// <summary>
         /// Returns argument expressions for given parameter.
         ///
-        /// There can be zero, one or more results based on parametr type (Optinal or ParamArray/params).
+        /// There can be zero, one or more results based on parameter type (Optional or ParamArray/params).
         /// </summary>
         public static ImmutableArray<ExpressionSyntax> ArgumentValuesForParameter(SemanticModel semanticModel, ArgumentListSyntax argumentList, string parameterName)
         {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
@@ -427,7 +427,7 @@ namespace SonarAnalyzer.Helpers
         public static ExpressionSyntax ArgumentValueForParameter(SemanticModel semanticModel, ArgumentListSyntax argumentList, string parameterName)
         {
             var methodParameterLookup = new CSharpMethodParameterLookup(argumentList, semanticModel);
-            if (methodParameterLookup.TryGetArgumentSyntax(parameterName, out var argumentSyntax))
+            if (methodParameterLookup.TryGetSyntax(parameterName, out var argumentSyntax))
             {
                 return argumentSyntax.Expression;
             }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
@@ -424,14 +424,19 @@ namespace SonarAnalyzer.Helpers
                     SyntaxFactory.IdentifierName(b)),
                 SyntaxFactory.IdentifierName(c));
 
-        public static ExpressionSyntax ArgumentValueForParameter(SemanticModel semanticModel, ArgumentListSyntax argumentList, string parameterName)
+        /// <summary>
+        /// Returns argument expressions for given parameter.
+        ///
+        /// There can be zero, one or more results based on parametr type (Optinal or ParamArray/params).
+        /// </summary>
+        public static ImmutableArray<ExpressionSyntax> ArgumentValuesForParameter(SemanticModel semanticModel, ArgumentListSyntax argumentList, string parameterName)
         {
             var methodParameterLookup = new CSharpMethodParameterLookup(argumentList, semanticModel);
             if (methodParameterLookup.TryGetSyntax(parameterName, out var argumentSyntax))
             {
-                return argumentSyntax.Expression;
+                return argumentSyntax.Select(x => x.Expression).ToImmutableArray();
             }
-            return null;
+            return ImmutableArray<ExpressionSyntax>.Empty;
         }
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/ArrayCovariance.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/ArrayCovariance.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2019 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -91,7 +91,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             foreach (var argument in invocation.ArgumentList.Arguments)
             {
-                if (!methodParameterLookup.TryGetParameterSymbol(argument, out var parameter) ||
+                if (!methodParameterLookup.TryGetSymbol(argument, out var parameter) ||
                     parameter.IsParams)
                 {
                     continue;

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/EncryptionAlgorithmsShouldBeSecure.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/EncryptionAlgorithmsShouldBeSecure.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
             PropertyAccessTracker = new CSharpPropertyAccessTracker(AnalyzerConfiguration.AlwaysEnabled, rule);
             ObjectCreationTracker = new CSharpObjectCreationTracker(AnalyzerConfiguration.AlwaysEnabled, rule);
         }
-        
+
         protected override PropertyAccessCondition IsInsideObjectInitializer() =>
             (context) =>
                 context.Expression.FirstAncestorOrSelf<InitializerExpressionSyntax>() != null;
@@ -52,7 +52,9 @@ namespace SonarAnalyzer.Rules.CSharp
             (context) =>
             {
                 var argumentList = ((InvocationExpressionSyntax)context.Invocation).ArgumentList;
-                return CSharpSyntaxHelper.ArgumentValueForParameter(context.SemanticModel, argumentList, "padding") is ExpressionSyntax valueSyntax &&
+                var values = CSharpSyntaxHelper.ArgumentValuesForParameter(context.SemanticModel, argumentList, "padding");
+                return values.Length == 1 &&
+                    values[0] is ExpressionSyntax valueSyntax &&
                     context.SemanticModel.GetSymbolInfo(valueSyntax).Symbol is ISymbol symbol &&
                     symbol.Name == "Pkcs1";
             };

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2019 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -115,7 +115,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var allParameterMatches = new List<IParameterSymbol>();
             foreach (var argument in argumentList.Arguments)
             {
-                if (!methodParameterLookup.TryGetParameterSymbol(argument, out var parameter))
+                if (!methodParameterLookup.TryGetSymbol(argument, out var parameter))
                 {
                     return false;
                 }
@@ -147,7 +147,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 var argument = argumentList.Arguments[i];
                 var argumentType = argumentTypes[i];
-                if (!methodParameterLookup.TryGetParameterSymbol(argument, out var parameter))
+                if (!methodParameterLookup.TryGetSymbol(argument, out var parameter))
                 {
                     return false;
                 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/LossOfFractionInDivision.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/LossOfFractionInDivision.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2019 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -97,7 +97,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
 
             var lookup = new CSharpMethodParameterLookup(invocation, semanticModel);
-            if (!lookup.TryGetParameterSymbol(argument, out var parameter))
+            if (!lookup.TryGetSymbol(argument, out var parameter))
             {
                 type = null;
                 return false;

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/RedundantToStringCall.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/RedundantToStringCall.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2019 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -119,7 +119,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     }
 
                     var parameterLookup = new CSharpMethodParameterLookup(stringFormatInvocation, c.SemanticModel);
-                    if (parameterLookup.TryGetParameterSymbol(stringFormatArgument, out var argParameter) &&
+                    if (parameterLookup.TryGetSymbol(stringFormatArgument, out var argParameter) &&
                         argParameter.Name.StartsWith("arg", StringComparison.Ordinal))
                     {
                         c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, location, MessageCompiler));

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpInvocationTracker.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpInvocationTracker.cs
@@ -74,7 +74,8 @@ namespace SonarAnalyzer.Helpers
         internal override object ConstArgumentForParameter(InvocationContext context, string parameterName)
         {
             var argumentList = ((InvocationExpressionSyntax)context.Invocation).ArgumentList;
-            if (CSharpSyntaxHelper.ArgumentValueForParameter(context.SemanticModel, argumentList, parameterName) is ExpressionSyntax valueSyntax)
+            var values = CSharpSyntaxHelper.ArgumentValuesForParameter(context.SemanticModel, argumentList, parameterName);
+            if (values.Length == 1 && values[0] is ExpressionSyntax valueSyntax)
             {
                 return context.SemanticModel.GetConstantValue(valueSyntax).Value;
             }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpObjectCreationTracker.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpObjectCreationTracker.cs
@@ -50,7 +50,8 @@ namespace SonarAnalyzer.Helpers
         internal override object ConstArgumentForParameter(ObjectCreationContext context, string parameterName)
         {
             var argumentList = ((ObjectCreationExpressionSyntax)context.Expression).ArgumentList;
-            if (CSharpSyntaxHelper.ArgumentValueForParameter(context.SemanticModel, argumentList, parameterName) is ExpressionSyntax valueSyntax)
+            var values = CSharpSyntaxHelper.ArgumentValuesForParameter(context.SemanticModel, argumentList, parameterName);
+            if (values.Length == 1 && values[0] is ExpressionSyntax valueSyntax)
             {
                 return context.SemanticModel.GetConstantValue(valueSyntax).Value;
             }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/AbstractMethodParameterLookup.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/AbstractMethodParameterLookup.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Helpers
             MethodSymbol = methodSymbol;
         }
 
-        public bool TryGetParameterSymbol(TArgumentSyntax argument, out IParameterSymbol parameter)
+        public bool TryGetSymbol(TArgumentSyntax argument, out IParameterSymbol parameter)
         {
             parameter = null;
 
@@ -70,12 +70,12 @@ namespace SonarAnalyzer.Helpers
             return true;
         }
 
-        public bool TryGetSymbolParameter(IParameterSymbol parameter, out TArgumentSyntax argument)
+        public bool TryGetSyntax(IParameterSymbol parameter, out TArgumentSyntax argument)
         {
-            return TryGetArgumentSyntax(parameter.Name, out argument);
+            return TryGetSyntax(parameter.Name, out argument);
         }
 
-        public bool TryGetArgumentSyntax(string parameterName, out TArgumentSyntax argument)
+        public bool TryGetSyntax(string parameterName, out TArgumentSyntax argument)
         {
             foreach (var pair in GetAllArgumentParameterMappings())
             {
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.Helpers
         {
             foreach (var argument in argumentList)
             {
-                if (TryGetParameterSymbol(argument, out var parameter))
+                if (TryGetSymbol(argument, out var parameter))
                 {
                     yield return new SyntaxNodeSymbolSemanticModelTuple<TArgumentSyntax, IParameterSymbol> { SyntaxNode = argument, Symbol = parameter };
                 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/AbstractMethodParameterLookup.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/AbstractMethodParameterLookup.cs
@@ -112,7 +112,7 @@ namespace SonarAnalyzer.Helpers
         {
             if (parameter.IsParams)
             {
-                throw new System.InvalidOperationException("Cannot call TryGetSingleSyntax on ParamArray/params parameters.");
+                throw new System.InvalidOperationException("Cannot call TryGetNonParamsSyntax on ParamArray/params parameters.");
             }
             if (TryGetSyntax(parameter, out var all))
             {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/AbstractMethodParameterLookup.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/AbstractMethodParameterLookup.cs
@@ -19,6 +19,7 @@
  */
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
@@ -70,20 +71,53 @@ namespace SonarAnalyzer.Helpers
             return true;
         }
 
-        public bool TryGetSyntax(IParameterSymbol parameter, out TArgumentSyntax argument)
+        /// <summary>
+        /// Method returns array of argument syntaxes that represents all syntaxes passed to the parameter.
+        /// 
+        /// There could be multiple syntaxes for ParamArray/params.
+        /// There could be zero or one result for optional parameters.
+        /// There will be single result for normal parameters.
+        /// </summary>
+        public bool TryGetSyntax(IParameterSymbol parameter, out ImmutableArray<TArgumentSyntax> argument)
         {
             return TryGetSyntax(parameter.Name, out argument);
         }
 
-        public bool TryGetSyntax(string parameterName, out TArgumentSyntax argument)
+        /// <summary>
+        /// Method returns array of argument syntaxes that represents all syntaxes passed to the parameter.
+        /// 
+        /// There could be multiple syntaxes for ParamArray/params.
+        /// There could be zero or one result for optional parameters.
+        /// There will be single result for normal parameters.
+        public bool TryGetSyntax(string parameterName, out ImmutableArray<TArgumentSyntax> argument)
         {
+            var ret = ImmutableArray.CreateBuilder<TArgumentSyntax>();
             foreach (var pair in GetAllArgumentParameterMappings())
             {
                 if (parameterName == pair.Symbol.Name)
                 {
-                    argument = pair.SyntaxNode;
-                    return true;
+                    ret.Add(pair.SyntaxNode);
                 }
+            }
+            argument = ret.ToImmutable();
+            return !argument.IsEmpty;
+        }
+
+        /// <summary>
+        /// Method returns zero or one argument syntax that represents syntax passed to the parameter.
+        /// 
+        /// Caller must ensure that given parameter is not ParamArray/params.
+        /// </summary>
+        public bool TryGetNonParamsSyntax(IParameterSymbol parameter, out TArgumentSyntax argument)
+        {
+            if (parameter.IsParams)
+            {
+                throw new System.InvalidOperationException("Cannot call TryGetSingleSyntax on ParamArray/params parameters.");
+            }
+            if (TryGetSyntax(parameter, out var all))
+            {
+                argument = all.Single();
+                return true;
             }
             argument = null;
             return false;

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules
         protected const string MessageFormat = "Enable server certificate validation on this SSL/TLS connection";
         private readonly DiagnosticDescriptor rule;
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
-       
+
         internal abstract AbstractMethodParameterLookup<TArgumentSyntax> CreateParameterLookup(SyntaxNode argumentListNode, IMethodSymbol method);
         internal abstract KnownType GenericDelegateType();
         protected abstract Location ArgumentLocation(TArgumentSyntax argument);
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules
         protected abstract SyntaxNode LocalVariableScope(TVariableSyntax variable);
         protected abstract SyntaxNode ExtractArgumentExpressionNode(TExpressionSyntax expression);
         protected abstract SyntaxNode SyntaxFromReference(SyntaxReference reference);
-        
+
         protected CertificateValidationCheckBase(System.Resources.ResourceManager rspecResources)
         {
             rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, rspecResources);
@@ -80,10 +80,10 @@ namespace SonarAnalyzer.Rules
             if (c.SemanticModel.GetSymbolInfo(c.Node).Symbol is IMethodSymbol ctor)
             {
                 AbstractMethodParameterLookup<TArgumentSyntax> methodParamLookup = null;       //Cache, there might be more of them
-                foreach (var param in ctor.Parameters.Where(x => IsValidationDelegateType(x.Type)))
+                foreach (var param in ctor.Parameters.Where(x => !x.IsParams && IsValidationDelegateType(x.Type)))  ////Validation for TryGetNonParamsSyntax, ParamArray/params and therefore array arguments are not inspected
                 {
                     methodParamLookup = methodParamLookup ?? CreateParameterLookup(c.Node, ctor);
-                    if (methodParamLookup.TryGetSyntax(param, out var argument))
+                    if (methodParamLookup.TryGetNonParamsSyntax(param, out var argument))
                     {
                         TryReportLocations(new InspectionContext(c), ArgumentLocation(argument), ArgumentExpression(argument));
                     }
@@ -107,7 +107,7 @@ namespace SonarAnalyzer.Rules
             {
                 return true;
             }
-            else if (type is INamedTypeSymbol namedSymbol && type.OriginalDefinition.Is(GenericDelegateType())) 
+            else if (type is INamedTypeSymbol namedSymbol && type.OriginalDefinition.Is(GenericDelegateType()))
             {
                 //HttpClientHandler.ServerCertificateCustomValidationCallback uses Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool>
                 //We're actually looking for Func<Any Sender, X509Certificate2, X509Chain, SslPolicyErrors, bool>
@@ -152,7 +152,7 @@ namespace SonarAnalyzer.Rules
             switch (syntax)
             {
                 case TMethodSyntax method:                  //Direct delegate name
-                    return BlockLocations(c, method);  
+                    return BlockLocations(c, method);
                 case TParameterSyntax parameter:            //Value arrived as a parameter
                     return ParamLocations(c, parameter);
                 case TVariableSyntax variable:     //Value passed as variable
@@ -171,12 +171,15 @@ namespace SonarAnalyzer.Rules
                 var containingMethod = c.Context.SemanticModel.GetDeclaredSymbol(containingMethodDeclaration) as IMethodSymbol;
                 var identText = IdentifierText(param);
                 var paramSymbol = containingMethod.Parameters.Single(x => x.Name == identText);
-                foreach (var invocation in FindInvocationList(c.Context, FindRootClassOrModule(param), containingMethod))
+                if (!paramSymbol.IsParams)  //Validation for TryGetNonParamsSyntax, ParamArray/params and therefore array arguments are not inspected
                 {
-                    var methodParamLookup = CreateParameterLookup(invocation, containingMethod);
-                    if (methodParamLookup.TryGetSyntax(paramSymbol, out var argument))
+                    foreach (var invocation in FindInvocationList(c.Context, FindRootClassOrModule(param), containingMethod))
                     {
-                        ret.AddRange(CallStackSublocations(c, ArgumentExpression(argument)));
+                        var methodParamLookup = CreateParameterLookup(invocation, containingMethod);
+                        if (methodParamLookup.TryGetNonParamsSyntax(paramSymbol, out var argument))
+                        {
+                            ret.AddRange(CallStackSublocations(c, ArgumentExpression(argument)));
+                        }
                     }
                 }
             }
@@ -196,7 +199,7 @@ namespace SonarAnalyzer.Rules
                         SplitAssignment(x, out var leftIdentifier, out var right);
                         return new { leftIdentifier, right };
                     })
-                    .Where( x => x.leftIdentifier != null && IdentifierText(x.leftIdentifier) == identText)
+                    .Where(x => x.leftIdentifier != null && IdentifierText(x.leftIdentifier) == identText)
                     .Select(x => x.right));
             }
             var initializer = VariableInitializer(variable);

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
@@ -80,7 +80,7 @@ namespace SonarAnalyzer.Rules
             if (c.SemanticModel.GetSymbolInfo(c.Node).Symbol is IMethodSymbol ctor)
             {
                 AbstractMethodParameterLookup<TArgumentSyntax> methodParamLookup = null;       //Cache, there might be more of them
-                foreach (var param in ctor.Parameters.Where(x => !x.IsParams && IsValidationDelegateType(x.Type)))  ////Validation for TryGetNonParamsSyntax, ParamArray/params and therefore array arguments are not inspected
+                foreach (var param in ctor.Parameters.Where(x => !x.IsParams && IsValidationDelegateType(x.Type)))  //Validation for TryGetNonParamsSyntax, ParamArray/params and therefore array arguments are not inspected
                 {
                     methodParamLookup = methodParamLookup ?? CreateParameterLookup(c.Node, ctor);
                     if (methodParamLookup.TryGetNonParamsSyntax(param, out var argument))

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
@@ -83,7 +83,7 @@ namespace SonarAnalyzer.Rules
                 foreach (var param in ctor.Parameters.Where(x => IsValidationDelegateType(x.Type)))
                 {
                     methodParamLookup = methodParamLookup ?? CreateParameterLookup(c.Node, ctor);
-                    if (methodParamLookup.TryGetSymbolParameter(param, out var argument))
+                    if (methodParamLookup.TryGetSyntax(param, out var argument))
                     {
                         TryReportLocations(new InspectionContext(c), ArgumentLocation(argument), ArgumentExpression(argument));
                     }
@@ -174,7 +174,7 @@ namespace SonarAnalyzer.Rules
                 foreach (var invocation in FindInvocationList(c.Context, FindRootClassOrModule(param), containingMethod))
                 {
                     var methodParamLookup = CreateParameterLookup(invocation, containingMethod);
-                    if (methodParamLookup.TryGetSymbolParameter(paramSymbol, out var argument))
+                    if (methodParamLookup.TryGetSyntax(paramSymbol, out var argument))
                     {
                         ret.AddRange(CallStackSublocations(c, ArgumentExpression(argument)));
                     }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
@@ -246,7 +246,7 @@ namespace SonarAnalyzer.Helpers.VisualBasic
         public static ExpressionSyntax ArgumentValueForParameter(SemanticModel semanticModel, ArgumentListSyntax argumentList, string parameterName)
         {
             var methodParameterLookup = new VisualBasicMethodParameterLookup(argumentList, semanticModel);
-            if (methodParameterLookup.TryGetArgumentSyntax(parameterName, out var argumentSyntax))
+            if (methodParameterLookup.TryGetSyntax(parameterName, out var argumentSyntax))
             {
                 return argumentSyntax.GetExpression();
             }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
@@ -19,6 +19,7 @@
  */
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
@@ -243,14 +244,19 @@ namespace SonarAnalyzer.Helpers.VisualBasic
                 ? argumentList.Arguments[index].GetExpression().RemoveParentheses()
                 : null;
 
-        public static ExpressionSyntax ArgumentValueForParameter(SemanticModel semanticModel, ArgumentListSyntax argumentList, string parameterName)
+        /// <summary>
+        /// Returns argument expressions for given parameter.
+        ///
+        /// There can be zero, one or more results based on parametr type (Optinal or ParamArray/params).
+        /// </summary>
+        public static ImmutableArray<ExpressionSyntax> ArgumentValuesForParameter(SemanticModel semanticModel, ArgumentListSyntax argumentList, string parameterName)
         {
             var methodParameterLookup = new VisualBasicMethodParameterLookup(argumentList, semanticModel);
             if (methodParameterLookup.TryGetSyntax(parameterName, out var argumentSyntax))
             {
-                return argumentSyntax.GetExpression();
+                return argumentSyntax.Select(x => x.GetExpression()).ToImmutableArray();
             }
-            return null;
+            return ImmutableArray<ExpressionSyntax>.Empty;
         }
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
@@ -247,7 +247,7 @@ namespace SonarAnalyzer.Helpers.VisualBasic
         /// <summary>
         /// Returns argument expressions for given parameter.
         ///
-        /// There can be zero, one or more results based on parametr type (Optinal or ParamArray/params).
+        /// There can be zero, one or more results based on parameter type (Optional or ParamArray/params).
         /// </summary>
         public static ImmutableArray<ExpressionSyntax> ArgumentValuesForParameter(SemanticModel semanticModel, ArgumentListSyntax argumentList, string parameterName)
         {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Rules/EncryptionAlgorithmsShouldBeSecure.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Rules/EncryptionAlgorithmsShouldBeSecure.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             PropertyAccessTracker = new VisualBasicPropertyAccessTracker(AnalyzerConfiguration.AlwaysEnabled, rule);
             ObjectCreationTracker = new VisualBasicObjectCreationTracker(AnalyzerConfiguration.AlwaysEnabled, rule);
         }
-        
+
         protected override PropertyAccessCondition IsInsideObjectInitializer() =>
             (context) =>
                 context.Expression.FirstAncestorOrSelf<ObjectMemberInitializerSyntax>() != null;
@@ -53,7 +53,9 @@ namespace SonarAnalyzer.Rules.VisualBasic
             (context) =>
             {
                 var argumentList = ((InvocationExpressionSyntax)context.Invocation).ArgumentList;
-                return VisualBasicSyntaxHelper.ArgumentValueForParameter(context.SemanticModel, argumentList, "padding") is ExpressionSyntax valueSyntax &&
+                var values = VisualBasicSyntaxHelper.ArgumentValuesForParameter(context.SemanticModel, argumentList, "padding");
+                return values.Length == 1 &&
+                    values[0] is ExpressionSyntax valueSyntax &&
                     context.SemanticModel.GetSymbolInfo(valueSyntax).Symbol is ISymbol symbol &&
                     symbol.Name == "Pkcs1";
             };

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicInvocationTracker.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicInvocationTracker.cs
@@ -75,7 +75,8 @@ namespace SonarAnalyzer.Helpers
         internal override object ConstArgumentForParameter(InvocationContext context, string parameterName)
         {
             var argumentList = ((InvocationExpressionSyntax)context.Invocation).ArgumentList;
-            if (VisualBasicSyntaxHelper.ArgumentValueForParameter(context.SemanticModel, argumentList, parameterName) is ExpressionSyntax valueSyntax)
+            var values = VisualBasicSyntaxHelper.ArgumentValuesForParameter(context.SemanticModel, argumentList, parameterName);
+            if (values.Length == 1 && values[0] is ExpressionSyntax valueSyntax)
             {
                 return context.SemanticModel.GetConstantValue(valueSyntax).Value;
             }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicObjectCreationTracker.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicObjectCreationTracker.cs
@@ -51,7 +51,8 @@ namespace SonarAnalyzer.Helpers
         internal override object ConstArgumentForParameter(ObjectCreationContext context, string parameterName)
         {
             var argumentList = ((ObjectCreationExpressionSyntax)context.Expression).ArgumentList;
-            if (VisualBasicSyntaxHelper.ArgumentValueForParameter(context.SemanticModel, argumentList, parameterName) is ExpressionSyntax valueSyntax)
+            var values = VisualBasicSyntaxHelper.ArgumentValuesForParameter(context.SemanticModel, argumentList, parameterName);
+            if (values.Length == 1 && values[0] is ExpressionSyntax valueSyntax)
             {
                 return context.SemanticModel.GetConstantValue(valueSyntax).Value;
             }


### PR DESCRIPTION
Fixes #2815
