### PR TITLE
Add code analyzers for roslyn API usage

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.1.37" />
   </ItemGroup>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -10,6 +10,10 @@
     <PackageReference Include="Google.Protobuf" Version="3.6.1" />
     <!-- When changing this reference update ProtocExe property too! -->
     <PackageReference Include="Google.Protobuf.Tools" Version="3.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="1.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.1.37" />
   </ItemGroup>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/SonarAnalyzer.Utilities.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/SonarAnalyzer.Utilities.csproj
@@ -23,6 +23,13 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
   <!--
     This PropertyGroup is used as a hack to prevent the NU1605 issue to be reported as an error. The rule is detecting
     the downgrade of System.Collections.Immutable from 1.2.0 to 1.1.37 (VS 2015 Update 3 only embeds 1.1.37).

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.1.37" />
   </ItemGroup>


### PR DESCRIPTION
Add `Microsoft.CodeAnalysis.Analyzers` - to detect correct usage of the Roslyn APIs

You can see the rules it has here https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md
