### PR TITLE
Rule S3655: Update SE to the new CFG and add C# 8 unit tests EmptyNullableValueAccess

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/EmptyNullableValueAccess.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/EmptyNullableValueAccess.cs
@@ -50,8 +50,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override void Initialize(SonarAnalysisContext context)
         {
-            //FIXME: Temporary silence for CFG defork
-            //context.RegisterExplodedGraphBasedAnalysis((e, c) => CheckEmptyNullableAccess(e, c));
+            context.RegisterExplodedGraphBasedAnalysis((e, c) => CheckEmptyNullableAccess(e, c));
         }
 
         private static void CheckEmptyNullableAccess(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EmptyNullableValueAccessTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EmptyNullableValueAccessTest.cs
@@ -21,19 +21,20 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
     [TestClass]
     public class EmptyNullableValueAccessTest
     {
-        //FIXME: Temporary silence for CFG defork
-        [Ignore("Temporary disabled for CFG defork")]
         [TestMethod]
         [TestCategory("Rule")]
         public void EmptyNullableValueAccess()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\EmptyNullableValueAccess.cs", new EmptyNullableValueAccess());
+            Verifier.VerifyAnalyzer(@"TestCases\EmptyNullableValueAccess.cs", new EmptyNullableValueAccess(),
+                                ParseOptionsHelper.FromCSharp8,
+                                additionalReferences: NuGetMetadataReference.NETStandardV2_1_0);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
@@ -129,6 +129,21 @@ namespace Tests.Diagnostics
             return i.Value;
         }
 
+        public int CSharp8_SwitchExpressions3(int? value)
+        {
+            return value.HasValue switch { true => value.Value, false => 0};
+        }
+
+        public int CSharp8_SwitchExpressions4(int? value)
+        {
+            return value.HasValue switch { true => 0, false => value.Value };   // FN - switch expressions are not constrained
+        }
+
+        public int CSharp8_SwitchExpressions5(int? value, bool flag)
+        {
+            return flag switch { true => value.Value, false => 0 }; // FN - switch expressions are not constrained
+        }
+
         public int CSharp8_StaticLocalFunctions(int? param)
         {
             static int ExtractValue(int? intOrNull)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
@@ -187,7 +187,6 @@ namespace Tests.Diagnostics
 
     public interface IWithDefaultImplementation
     {
-        //Default interface methods
         int DoSomething()
         {
             int? i = null;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
@@ -157,7 +157,7 @@ namespace Tests.Diagnostics
         public int CSharp8_NullCoalescingAssignment(int? param)
         {
             param ??= 42;
-            return param.Value; // OK, value is allways set
+            return param.Value; // OK, value is always set
         }
 
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
@@ -116,6 +116,35 @@ namespace Tests.Diagnostics
                 Console.WriteLine(f3.Value); // TODO: Should be NC
             }
         }
+
+        public int CSharp8_SwitchExpressions(bool zero)
+        {
+            int? i = zero switch { true => 0, _ => null };
+            return i.Value; // Noncompliant
+        }
+
+        public int CSharp8_SwitchExpressions2(bool zero)
+        {
+            int? i = zero switch { true => 0, _ => 1 };
+            return i.Value;
+        }
+
+        public int CSharp8_StaticLocalFunctions(int? param)
+        {
+            static int ExtractValue(int? intOrNull)
+            {
+                return intOrNull.Value; // FN - content of static local function is not inspected by SE
+            }
+
+            return ExtractValue(param);
+        }
+
+        public int CSharp8_NullCoalescingAssignment(int? param)
+        {
+            param ??= 42;
+            return param.Value; // OK, value is allways set
+        }
+
     }
 
     class TestLoopWithBreak
@@ -138,6 +167,16 @@ namespace Tests.Diagnostics
                     continue;
                 }
             }
+        }
+    }
+
+    public interface IWithDefaultImplementation
+    {
+        //Default interface methods
+        int DoSomething()
+        {
+            int? i = null;
+            return i.Value; //Noncompliant
         }
     }
 


### PR DESCRIPTION
Fixes #2893
