### PR TITLE
Update build-utils.ps1 for net48 for UnitTests

### DIFF
--- a/scripts/build/build-utils.ps1
+++ b/scripts/build/build-utils.ps1
@@ -126,7 +126,7 @@ function Invoke-MSBuild (
 function Invoke-UnitTests([string]$binPath, [bool]$failsIfNotTest) {
     Write-Header "Running unit tests"
 
-    $escapedPath = (Join-Path $binPath "net46") -Replace '\\', '\\'
+    $escapedPath = (Join-Path $binPath "net48") -Replace '\\', '\\'
 
     Write-Debug "Running unit tests for"
     $testFiles = @()


### PR DESCRIPTION
Upgrading UnitTest project to net48 target changed the output direcotry of the build.
Script `.\scripts\build\dev-build.ps1 -restore -build -test` expected `net46` directory that didn't exists in clean solution.
