### PR TITLE
Update sonarlint metafiles; fix path to SonarLint.xml in csproj files

### DIFF
--- a/sonaranalyzer-dotnet/.sonarlint/SonarAnalyzer.slconfig
+++ b/sonaranalyzer-dotnet/.sonarlint/SonarAnalyzer.slconfig
@@ -9,7 +9,7 @@
   "Profiles": {
     "CSharp": {
       "ProfileKey": "AVxYKDdrFTbgxqUNcakm",
-      "ProfileTimestamp": "2019-05-07T17:01:40+02:00"
+      "ProfileTimestamp": "2020-01-10T11:36:33+01:00"
     }
   }
 }

--- a/sonaranalyzer-dotnet/.sonarlint/sonaranalyzer-dotnetCSharp.ruleset
+++ b/sonaranalyzer-dotnet/.sonarlint/sonaranalyzer-dotnetCSharp.ruleset
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="SonarQube - SonarAnalyzer .Net Sonar way" Description="This rule set was automatically generated from SonarQube.&#xD;&#xA;https://sonarcloud.io/profiles/show?key=AVxYKDdrFTbgxqUNcakm" ToolsVersion="15.0">
+<RuleSet Name="SonarQube - SonarAnalyzer .Net Sonar way" Description="This rule set was automatically generated from SonarQube.&#xD;&#xA;https://sonarcloud.io/profiles/show?key=AVxYKDdrFTbgxqUNcakm" ToolsVersion="16.0">
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <Rule Id="S100" Action="None" />
     <Rule Id="S1006" Action="Warning" />
@@ -26,6 +26,7 @@
     <Rule Id="S1121" Action="Warning" />
     <Rule Id="S1123" Action="Warning" />
     <Rule Id="S1125" Action="Warning" />
+    <Rule Id="S1128" Action="Warning" />
     <Rule Id="S113" Action="None" />
     <Rule Id="S1134" Action="Warning" />
     <Rule Id="S1135" Action="Warning" />
@@ -40,6 +41,7 @@
     <Rule Id="S1185" Action="Warning" />
     <Rule Id="S1186" Action="Warning" />
     <Rule Id="S1192" Action="None" />
+    <Rule Id="S1199" Action="Warning" />
     <Rule Id="S1200" Action="None" />
     <Rule Id="S1206" Action="Warning" />
     <Rule Id="S121" Action="None" />
@@ -109,10 +111,12 @@
     <Rule Id="S2228" Action="None" />
     <Rule Id="S2234" Action="Warning" />
     <Rule Id="S2245" Action="Warning" />
+    <Rule Id="S2251" Action="Warning" />
+    <Rule Id="S2252" Action="Warning" />
     <Rule Id="S2255" Action="Warning" />
     <Rule Id="S2259" Action="Warning" />
     <Rule Id="S2275" Action="Warning" />
-    <Rule Id="S2278" Action="Warning" />
+    <Rule Id="S2278" Action="None" />
     <Rule Id="S2290" Action="Warning" />
     <Rule Id="S2291" Action="Warning" />
     <Rule Id="S2292" Action="Warning" />
@@ -139,6 +143,7 @@
     <Rule Id="S2387" Action="None" />
     <Rule Id="S2436" Action="Warning" />
     <Rule Id="S2437" Action="Warning" />
+    <Rule Id="S2479" Action="Warning" />
     <Rule Id="S2486" Action="Warning" />
     <Rule Id="S2551" Action="Warning" />
     <Rule Id="S2583" Action="Warning" />
@@ -156,6 +161,7 @@
     <Rule Id="S2758" Action="Warning" />
     <Rule Id="S2760" Action="None" />
     <Rule Id="S2761" Action="Warning" />
+    <Rule Id="S2857" Action="Warning" />
     <Rule Id="S2930" Action="Warning" />
     <Rule Id="S2931" Action="None" />
     <Rule Id="S2933" Action="Warning" />
@@ -240,7 +246,7 @@
     <Rule Id="S3610" Action="Warning" />
     <Rule Id="S3626" Action="Warning" />
     <Rule Id="S3655" Action="Warning" />
-    <Rule Id="S3693" Action="Warning" />
+    <Rule Id="S3693" Action="None" />
     <Rule Id="S3717" Action="None" />
     <Rule Id="S3776" Action="Warning" />
     <Rule Id="S3869" Action="Warning" />
@@ -271,6 +277,7 @@
     <Rule Id="S3927" Action="Warning" />
     <Rule Id="S3928" Action="Warning" />
     <Rule Id="S3937" Action="None" />
+    <Rule Id="S3949" Action="Warning" />
     <Rule Id="S3956" Action="None" />
     <Rule Id="S3962" Action="None" />
     <Rule Id="S3963" Action="Warning" />
@@ -320,12 +327,14 @@
     <Rule Id="S4061" Action="Warning" />
     <Rule Id="S4069" Action="None" />
     <Rule Id="S4070" Action="Warning" />
+    <Rule Id="S4136" Action="Warning" />
     <Rule Id="S4142" Action="None" />
     <Rule Id="S4143" Action="Warning" />
     <Rule Id="S4144" Action="Warning" />
     <Rule Id="S4158" Action="Warning" />
     <Rule Id="S4159" Action="Warning" />
     <Rule Id="S4200" Action="Warning" />
+    <Rule Id="S4201" Action="Warning" />
     <Rule Id="S4210" Action="Warning" />
     <Rule Id="S4211" Action="Warning" />
     <Rule Id="S4212" Action="None" />
@@ -344,11 +353,14 @@
     <Rule Id="S4456" Action="Warning" />
     <Rule Id="S4457" Action="Warning" />
     <Rule Id="S4462" Action="None" />
+    <Rule Id="S4487" Action="Warning" />
     <Rule Id="S4507" Action="Warning" />
     <Rule Id="S4524" Action="Warning" />
     <Rule Id="S4564" Action="None" />
     <Rule Id="S4581" Action="Warning" />
+    <Rule Id="S4583" Action="Warning" />
     <Rule Id="S4586" Action="Warning" />
+    <Rule Id="S4635" Action="Warning" />
     <Rule Id="S4784" Action="Warning" />
     <Rule Id="S4787" Action="Warning" />
     <Rule Id="S4790" Action="Warning" />
@@ -356,8 +368,12 @@
     <Rule Id="S4818" Action="Warning" />
     <Rule Id="S4823" Action="Warning" />
     <Rule Id="S4829" Action="Warning" />
+    <Rule Id="S4830" Action="Warning" />
     <Rule Id="S4834" Action="Warning" />
+    <Rule Id="S5034" Action="Warning" />
     <Rule Id="S5042" Action="Warning" />
+    <Rule Id="S5542" Action="Warning" />
+    <Rule Id="S5547" Action="Warning" />
     <Rule Id="S818" Action="Warning" />
     <Rule Id="S881" Action="None" />
     <Rule Id="S907" Action="Warning" />

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
@@ -34,4 +34,10 @@
     <WarningsAsErrors />
     <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\.sonarlint\SonarLint.xml">
+      <Link>Properties\SonarLint.xml</Link>
+    </AdditionalFiles>
+  </ItemGroup>
 </Project>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <EmbeddedResource Include="CBDE/windows/dotnet-symbolic-execution.exe" />
   </ItemGroup>
-  
+
   <!--
     This PropertyGroup is used as a hack to prevent the NU1605 issue to be reported as an error. The rule is detecting
     the downgrade of System.Collections.Immutable from 1.2.0 to 1.1.37 (VS 2015 Update 3 only embeds 1.1.37).
@@ -46,4 +46,10 @@
   </PropertyGroup>
 
   <Import Project=".\DownloadCBDE.targets" />
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\.sonarlint\SonarLint.xml">
+      <Link>Properties\SonarLint.xml</Link>
+    </AdditionalFiles>
+  </ItemGroup>
 </Project>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -54,5 +54,9 @@
     <WarningsAsErrors />
     <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
-
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\.sonarlint\SonarLint.xml">
+      <Link>Properties\SonarLint.xml</Link>
+    </AdditionalFiles>
+  </ItemGroup>
 </Project>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/SonarAnalyzer.Utilities.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/SonarAnalyzer.Utilities.csproj
@@ -37,4 +37,9 @@
     <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\.sonarlint\SonarLint.xml">
+      <Link>Properties\SonarLint.xml</Link>
+    </AdditionalFiles>
+  </ItemGroup>
 </Project>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
@@ -39,4 +39,9 @@
     <Rspec2Resx>vbnet</Rspec2Resx>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\.sonarlint\SonarLint.xml">
+      <Link>Properties\SonarLint.xml</Link>
+    </AdditionalFiles>
+  </ItemGroup>
 </Project>

--- a/sonaranalyzer-dotnet/tests/CBDE/CBDEArguments/CBDEArguments.csproj
+++ b/sonaranalyzer-dotnet/tests/CBDE/CBDEArguments/CBDEArguments.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/sonaranalyzer-dotnet/tests/CBDE/CBDEFails/CBDEFails.csproj
+++ b/sonaranalyzer-dotnet/tests/CBDE/CBDEFails/CBDEFails.csproj
@@ -12,6 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/sonaranalyzer-dotnet/tests/CBDE/CBDESucceedsWithIncorrectResults/CBDESucceedsWithIncorrectResults.csproj
+++ b/sonaranalyzer-dotnet/tests/CBDE/CBDESucceedsWithIncorrectResults/CBDESucceedsWithIncorrectResults.csproj
@@ -12,6 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/sonaranalyzer-dotnet/tests/CBDE/CBDEWaitAndSucceeds/CBDEWaitAndSucceeds.csproj
+++ b/sonaranalyzer-dotnet/tests/CBDE/CBDEWaitAndSucceeds/CBDEWaitAndSucceeds.csproj
@@ -12,6 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\src\SonarLint.xml">
+    <AdditionalFiles Include="..\..\.sonarlint\SonarLint.xml">
       <Link>Properties\SonarLint.xml</Link>
     </AdditionalFiles>
   </ItemGroup>


### PR DESCRIPTION
Related to #3007 

This contains changes:
- autogenerated files from binding SonarLint to SonarCloud (we have new rules in SonarWay since the last update in May 2019)
- fixing the path to the local SonarLint.xml

I tested the usage of SonarLint.xml in projects with a local SQ instance with S1451 enables in the QP. It works 😄 
