### PR TITLE
Update rspec2resx for .NET 4.8 SDK

### DIFF
--- a/scripts/rspec/rspec2resx.ps1
+++ b/scripts/rspec/rspec2resx.ps1
@@ -31,19 +31,8 @@ param (
 Set-StrictMode -version 1.0
 $ErrorActionPreference = "Stop"
 $RuleTemplateFolder = "${PSScriptRoot}\\rspec-templates"
-
-$resgenPath = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.8 Tools\\ResGen.exe"
-if (-Not (Test-Path $resgenPath)) {
-    $resgenPath = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.7.2 Tools\\ResGen.exe"
-}
-if (-Not (Test-Path $resgenPath)) {
-    $resgenPath = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.6.1 Tools\\ResGen.exe"
-}
-if (-Not (Test-Path $resgenPath)) {
-    throw "You need to install the .NET Framework 4.8 SDK before using this script."
-}
-
 $sonaranalyzerPath = "${PSScriptRoot}\\..\\..\\sonaranalyzer-dotnet"
+$SupportedSDKs = @("4.8", "4.7.2", "4.6.1")
 
 $categoriesMap = @{
     "BUG" = "Bug";
@@ -81,6 +70,16 @@ $roslynLanguageMap = @{
     "vbnet" = "Visual Basic";
 }
 
+function FindResGen(){
+    foreach ($SDK in $SupportedSDKs){
+        $Ret = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX ${SDK} Tools\\ResGen.exe"
+        if (Test-Path $Ret) {
+            return $Ret
+        }
+    }
+    throw "You need to install the .NET Framework $($SupportedSDKs[0]) SDK before using this script."
+}
+
 # Returns a string array with rule keys for the specified language.
 function GetRules() {
     $suffix = $ruleapiLanguageMap.Get_Item($language)
@@ -93,7 +92,7 @@ function GetRules() {
     }
 }
 
-function CreateStringResources($rules) {
+function CreateStringResources($rules, $resgenPath) {
     $suffix = $ruleapiLanguageMap.Get_Item($language)
 
     $sonarWayRules = Get-Content -Raw "${rspecFolder}\\Sonar_way_profile.json" | ConvertFrom-Json
@@ -151,6 +150,7 @@ function CreateStringResources($rules) {
 
 ### SCRIPT START ###
 
+$resgenPath = FindResGen
 $rules = GetRules
-CreateStringResources $rules
+CreateStringResources $rules $resgenPath
 

--- a/scripts/rspec/rspec2resx.ps1
+++ b/scripts/rspec/rspec2resx.ps1
@@ -32,12 +32,15 @@ Set-StrictMode -version 1.0
 $ErrorActionPreference = "Stop"
 $RuleTemplateFolder = "${PSScriptRoot}\\rspec-templates"
 
-$resgenPath = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.7.2 Tools\\ResGen.exe"
+$resgenPath = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.8 Tools\\ResGen.exe"
+if (-Not (Test-Path $resgenPath)) {
+    $resgenPath = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.7.2 Tools\\ResGen.exe"
+}
 if (-Not (Test-Path $resgenPath)) {
     $resgenPath = "${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.6.1 Tools\\ResGen.exe"
 }
 if (-Not (Test-Path $resgenPath)) {
-    throw "You need to install the Windows SDK before using this script."
+    throw "You need to install the .NET Framework 4.8 SDK before using this script."
 }
 
 $sonaranalyzerPath = "${PSScriptRoot}\\..\\..\\sonaranalyzer-dotnet"
@@ -92,7 +95,7 @@ function GetRules() {
 
 function CreateStringResources($rules) {
     $suffix = $ruleapiLanguageMap.Get_Item($language)
-    
+
     $sonarWayRules = Get-Content -Raw "${rspecFolder}\\Sonar_way_profile.json" | ConvertFrom-Json
 
     $resources = New-Object System.Collections.ArrayList


### PR DESCRIPTION
Address first two points of #3008

AzureDevOps build image environment changed and original version is not working anymore.
