### PR TITLE
Improve handling for CoalesceAssignments

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharp/CSharpExplodedGraph.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharp/CSharpExplodedGraph.cs
@@ -1189,7 +1189,10 @@ namespace SonarAnalyzer.SymbolicExecution
             var newProgramState = programState;
             newProgramState = newProgramState.PopValue(out var sv);
 
-            if (!CSharpControlFlowGraphBuilder.IsAssignmentWithSimpleLeftSide(assignment))
+            if (!CSharpControlFlowGraphBuilder.IsAssignmentWithSimpleLeftSide(assignment) &&
+                // For CoalesceAssignmentExpression the stack contains only the result of the expression and because of that
+                // we can't pop the left side of the expression from the stack.
+                !assignment.IsKind(SyntaxKindEx.CoalesceAssignmentExpression))
             {
                 newProgramState = newProgramState.PopValue();
             }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/SymbolicExecution/ExplodedGraphTests.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/SymbolicExecution/ExplodedGraphTests.cs
@@ -1032,6 +1032,29 @@ namespace Test
             context.WalkWithInstructions(5);
         }
 
+        [TestMethod]
+        [TestCategory("Symbolic execution")]
+        public void ExplodedGraph_CoalesceAssignmentOnProperty()
+        {
+            var context = new ExplodedGraphContext("return options.Property ??= 1");
+
+            context.ExplodedGraph.InstructionProcessed +=
+                (sender, args) =>
+                {
+                    var instruction = args.Instruction.ToString();
+
+                    if (instruction != "options.Property ??= 1")
+                    {
+                        return;
+                    }
+
+                    // The symbolic value corresponding to the expression result should have the NotNull constraint an all branches.
+                    args.ProgramState.HasConstraint(args.ProgramState.PeekValue(), ObjectConstraint.NotNull).Should().BeTrue();
+                };
+
+            context.WalkWithExitBlocks(5, 2);
+        }
+
         private class ExplodedGraphContext
         {
             public readonly SemanticModel SemanticModel;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionEvaluatesToConstant.CSharp8.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionEvaluatesToConstant.CSharp8.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Tests.Diagnostics
 {
@@ -104,7 +105,7 @@ namespace Tests.Diagnostics
             return UseValueInside();
         }
 
-        void NullCoalesceAssignment(string a, string b, string c)
+        void NullCoalesceAssignment(string a, string b, string c, Options options)
         {
             a ??= "(empty)";
             if (a == null)  // Noncompliant
@@ -122,8 +123,37 @@ namespace Tests.Diagnostics
             {                               // Secondary
                 throw new ArgumentNullException(nameof(c)); // never executed
             }
-        }
 
+            if ((options.First ??= "(empty)") == null)  // Noncompliant
+            {                                           // Secondary
+                throw new ArgumentNullException(nameof(c)); // never executed
+            }
+
+            if ((options.First ??= options.Second ??= "(empty)") == null)  // Noncompliant
+            {                                                              // Secondary
+                throw new ArgumentNullException(nameof(c)); // never executed
+            }
+
+            if ((options.field ??= "(empty)") == null)  // Noncompliant
+            {                                           // Secondary
+                throw new ArgumentNullException(nameof(c)); // never executed
+            }
+
+            var list = new List<string>();
+            if ((list[0] ??= "(empty)") == null)  // Noncompliant
+            {                                     // Secondary
+                throw new ArgumentNullException(nameof(c)); // never executed
+            }
+        }
+    }
+
+    public class Options
+    {
+        public string First { get; set; }
+
+        public string Second { get; set; }
+
+        public string field;
     }
 
     // See https://github.com/SonarSource/sonar-dotnet/issues/2496


### PR DESCRIPTION
Previously, handling of coalesce assignments on object properties 
was resulting in an error.

e.g. `obj.Property ??= 1`


