### PR TITLE
Use Environment.OSVersion to verify the OS type

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/CbdeHandlerRule.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/CbdeHandlerRule.cs
@@ -28,7 +28,6 @@ using SonarAnalyzer.Common;
 using System.Collections.Immutable;
 using System.Linq;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: InternalsVisibleTo("SonarAnalyzer.UnitTest" + Signing.InternalsVisibleToPublicKey)]
@@ -68,11 +67,12 @@ namespace SonarAnalyzer.Rules.CSharp
             return new CbdeHandlerRule(true, testCbdeBinaryPath, onCbdeExecution);
         }
 
-        protected sealed override void Initialize(SonarAnalysisContext context)
+        protected override void Initialize(SonarAnalysisContext context)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            // The available platform ids are documented here: https://docs.microsoft.com/en-us/dotnet/api/system.platformid?view=netframework-4.8
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
-                new CbdeHandler(context, OnCbdeIssue, ShouldRunCbdeInContext, () => { return WorkDirectoryBasePath; },
+                new CbdeHandler(context, OnCbdeIssue, ShouldRunCbdeInContext, () => WorkDirectoryBasePath,
                     testCbdeBinaryPath, onCbdeExecution);
             }
         }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.1.37" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/packages.lock.json
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/packages.lock.json
@@ -12,6 +12,15 @@
           "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2]"
         }
       },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Direct",
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "5lV+Vejn4bKC3wEUPH2Z/FTYkaHBO0AVJqqTD+ATE0rP6jQARIJbtWKc+aF2TWGsxFeiARW8Y0lnMFHdLOJFqA==",
+        "dependencies": {
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+        }
+      },
       "System.Collections.Immutable": {
         "type": "Direct",
         "requested": "[1.1.37, )",

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.RuleDescriptorGenerator/packages.lock.json
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.RuleDescriptorGenerator/packages.lock.json
@@ -111,6 +111,14 @@
         "resolved": "1.0.27",
         "contentHash": "pwu80Ohe7SBzZ6i69LVdzowp6V+LaVRzd5F7A6QlD42vQkX0oT7KXKWWPlM/S00w1gnMQMRnEdbtOV12z6rXdQ=="
       },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.1",
+        "contentHash": "5lV+Vejn4bKC3wEUPH2Z/FTYkaHBO0AVJqqTD+ATE0rP6jQARIJbtWKc+aF2TWGsxFeiARW8Y0lnMFHdLOJFqA==",
+        "dependencies": {
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+        }
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.1.0",
@@ -362,6 +370,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.2",
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.1",
           "SonarAnalyzer": "1.0.0",
           "SonarAnalyzer.CFG": "1.0.0",
           "System.Collections.Immutable": "1.1.37",

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/packages.lock.json
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/packages.lock.json
@@ -111,6 +111,14 @@
         "resolved": "1.0.27",
         "contentHash": "pwu80Ohe7SBzZ6i69LVdzowp6V+LaVRzd5F7A6QlD42vQkX0oT7KXKWWPlM/S00w1gnMQMRnEdbtOV12z6rXdQ=="
       },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.1",
+        "contentHash": "5lV+Vejn4bKC3wEUPH2Z/FTYkaHBO0AVJqqTD+ATE0rP6jQARIJbtWKc+aF2TWGsxFeiARW8Y0lnMFHdLOJFqA==",
+        "dependencies": {
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+        }
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.1.0",
@@ -362,6 +370,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.2",
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.1",
           "SonarAnalyzer": "1.0.0",
           "SonarAnalyzer.CFG": "1.0.0",
           "System.Collections.Immutable": "1.1.37",

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/packages.lock.json
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/packages.lock.json
@@ -141,6 +141,14 @@
         "resolved": "16.4.0",
         "contentHash": "qb7PMVZMAY5iUCvB/kDUEt9xqazWKZoKY/sGpAJO4VtwgN5IcEgipCu3n0i1GPCwGbWVL6k4a8a9F+FqmADJng=="
       },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.1",
+        "contentHash": "5lV+Vejn4bKC3wEUPH2Z/FTYkaHBO0AVJqqTD+ATE0rP6jQARIJbtWKc+aF2TWGsxFeiARW8Y0lnMFHdLOJFqA==",
+        "dependencies": {
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+        }
+      },
       "Microsoft.Web.Xdt": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -273,6 +281,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.2",
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.1",
           "SonarAnalyzer": "1.0.0",
           "SonarAnalyzer.CFG": "1.0.0",
           "System.Collections.Immutable": "1.1.37",


### PR DESCRIPTION
- RuntimeInformation.IsOSPlatform is only supported starting with
.NET Framework 4.7.1 and failed on Visual Studio 2015

- Environment.OSVersion is supported starting with .Net Framework 1.1
and .Net Core 2.0

Fixes #3048
