### PR TITLE
Fix expectation for exception text to get tests running independent of current culture

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -238,7 +238,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 new CheckFileLicense { HeaderFormat = FailingSingleLineRegexHeader, IsRegularExpression = true });
 
             action.Should().Throw<AssertFailedException>()
-                .WithMessage("*error AD0001:*'SonarAnalyzer.Rules.CSharp.CheckFileLicense'*System.InvalidOperationException*'Invalid regular expression: ['.*");
+                .WithMessage("*error AD0001:*SonarAnalyzer.Rules.CSharp.CheckFileLicense*System.InvalidOperationException*Invalid regular expression: [*");
         }
 
         [TestMethod]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldNotHaveTooManyLinesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldNotHaveTooManyLinesTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 * SonarAnalyzer for .NET
 * Copyright (C) 2015-2020 SonarSource SA
 * mailto: contact AT sonarsource DOT com
@@ -80,7 +80,7 @@ public class Foo
                 new CS.MethodsShouldNotHaveTooManyLines { Max = max });
 
             action.Should().Throw<AssertFailedException>()
-                .WithMessage("*error AD0001: * 'SonarAnalyzer.Rules.CSharp.MethodsShouldNotHaveTooManyLines' *System.InvalidOperationException* 'Invalid rule parameter: maximum number of lines = *. Must be at least 2.'.}.");
+                .WithMessage("*error AD0001: *SonarAnalyzer.Rules.CSharp.MethodsShouldNotHaveTooManyLines* *System.InvalidOperationException* *Invalid rule parameter: maximum number of lines = *. Must be at least 2.*");
         }
 
         [TestMethod]
@@ -118,7 +118,7 @@ public class Foo
                 new VB.MethodsShouldNotHaveTooManyLines { Max = max });
 
             action.Should().Throw<AssertFailedException>()
-                .WithMessage("*error AD0001: * 'SonarAnalyzer.Rules.VisualBasic.MethodsShouldNotHaveTooManyLines' *System.InvalidOperationException* 'Invalid rule parameter: maximum number of lines = *. Must be at least 2.'.}.");
+                .WithMessage("*error AD0001: *SonarAnalyzer.Rules.VisualBasic.MethodsShouldNotHaveTooManyLines* *System.InvalidOperationException* *Invalid rule parameter: maximum number of lines = *. Must be at least 2.*");
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifierTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifierTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 * SonarAnalyzer for .NET
 * Copyright (C) 2015-2020 SonarSource SA
 * mailto: contact AT sonarsource DOT com
@@ -186,7 +186,7 @@ public class UnexpectedSecondaryWithBuildError
                     new BinaryOperationWithIdenticalExpressions());
 
             action.Should().Throw<UnexpectedDiagnosticException>()
-                  .WithMessage("Unexpected build error [CS1514]: { expected on line 2");
+                  .WithMessage("Unexpected build error [CS1514]: { * on line 2");
         }
 
         [TestMethod]


### PR DESCRIPTION
reduce pattern in exception text verification

Fixes #3055
