### PR TITLE
Avoid false positives while handling tuples

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -95,7 +96,14 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static void CheckForDeadStores(CSharpSyntaxNode node, ISymbol declaration, SyntaxNodeAnalysisContext context)
         {
-            if (declaration == null || !CSharpControlFlowGraph.TryGet(node, context.SemanticModel, out var cfg))
+            if (declaration == null ||
+                node == null ||
+                // Currently the tuple expressions are not supported and this is known to cause false positives.
+                // Please check:
+                // - community feedback: https://github.com/SonarSource/sonar-dotnet/issues/3094
+                // - implementation ticket: https://github.com/SonarSource/sonar-dotnet/issues/2933
+                node.DescendantNodes().AnyOfKind(SyntaxKindEx.TupleExpression) ||
+                !CSharpControlFlowGraph.TryGet(node, context.SemanticModel, out var cfg))
             {
                 return;
             }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.cs
@@ -869,9 +869,13 @@ namespace Tests.Diagnostics
     {
         public static (int foo, int bar) M(string text)
         {
-            int b = int.Parse(text); // Noncompliant -- false positive
+            int b = int.Parse(text);
             return (1, b);
         }
-    }
 
+        public void UnusedTuple_FalseNegative()
+        {
+            (int x, int y) t = (1, 2); // Compliant - FN, tuples are not yet covered: https://github.com/SonarSource/sonar-dotnet/issues/2933
+        }
+    }
 }


### PR DESCRIPTION
Since the tuples are not yet fully supported by both CFG and symbolic
execution (#2933), **S1854** will ignore the methods which are containing them.

Fixes #3094
