### PR TITLE
  Download the cbde artifacts from release instead of from builds.

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/DownloadCBDE.targets
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/DownloadCBDE.targets
@@ -15,7 +15,7 @@
     <SpecificCBDEVersion>1.0.0.14843</SpecificCBDEVersion>
   </PropertyGroup>
   <ItemGroup>
-    <CBDEUrls Include="http://repox.jfrog.io/repox/sonarsource-public-builds/org/sonarsource/cbde/$(SpecificCBDEVersion)/cbde-windows.$(SpecificCBDEVersion).zip" >
+    <CBDEUrls Include="http://repox.jfrog.io/repox/sonarsource-public-releases/org/sonarsource/cbde/$(SpecificCBDEVersion)/cbde-windows.$(SpecificCBDEVersion).zip" >
       <SubFolder>windows\</SubFolder>
       <MainExe>dotnet-symbolic-execution.exe</MainExe>
       <ZipFileName>cbde-windows.zip</ZipFileName>


### PR DESCRIPTION
This is to allow the next sonar-dotnet release. More change will come when
  the cbde release becomes automatized.