### PR TITLE
Update RSPECs before the release of 8.4

### DIFF
--- a/sonaranalyzer-dotnet/rspec/cs/S5042_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S5042_c#.html
@@ -19,7 +19,7 @@ or memory of the operating system where the archive is expanded making the targe
 <p>You are at risk if you answered yes to any of those questions.</p>
 <p> </p>
 <h2>Recommended Secure Coding Practices</h2>
-<p>Validate the full path of the extracted file against the full path of the directory where files are expanded.</p>
+<p>Validate the full path of the extracted file against the full path of the directory where files are expanded:</p>
 <ul>
   <li> the canonical path of the expanded file must start with the canonical path of the directory where files are extracted. </li>
   <li> the name of the archive entry must not contain "..", i.e. reference to a parent directory. </li>

--- a/sonaranalyzer-dotnet/rspec/cs/S5542_c#.html
+++ b/sonaranalyzer-dotnet/rspec/cs/S5542_c#.html
@@ -1,7 +1,7 @@
 <p>To perform secure cryptography, operation modes and padding scheme are essentials and should be used correctly according to the encryption
 algorithm:</p>
 <ul>
-  <li> For block cipher encryption algorithms (like AES, blowfish ...), the GCM (Galois Counter Mode) mode, witch <a
+  <li> For block cipher encryption algorithms (like AES), the GCM (Galois Counter Mode) mode, which <a
   href="https://en.wikipedia.org/wiki/Galois/Counter_Mode#Mathematical_basis">works internally</a> with zero/no padding scheme, is recommended. At the
   opposite, these modes and/or schemes are highly discouraged:
     <ul>

--- a/sonaranalyzer-dotnet/rspec/vbnet/S5042_vb.net.html
+++ b/sonaranalyzer-dotnet/rspec/vbnet/S5042_vb.net.html
@@ -19,7 +19,7 @@ or memory of the operating system where the archive is expanded making the targe
 <p>You are at risk if you answered yes to any of those questions.</p>
 <p> </p>
 <h2>Recommended Secure Coding Practices</h2>
-<p>Validate the full path of the extracted file against the full path of the directory where files are expanded.</p>
+<p>Validate the full path of the extracted file against the full path of the directory where files are expanded:</p>
 <ul>
   <li> the canonical path of the expanded file must start with the canonical path of the directory where files are extracted. </li>
   <li> the name of the archive entry must not contain "..", i.e. reference to a parent directory. </li>

--- a/sonaranalyzer-dotnet/rspec/vbnet/S5542_vb.net.html
+++ b/sonaranalyzer-dotnet/rspec/vbnet/S5542_vb.net.html
@@ -1,7 +1,7 @@
 <p>To perform secure cryptography, operation modes and padding scheme are essentials and should be used correctly according to the encryption
 algorithm:</p>
 <ul>
-  <li> For block cipher encryption algorithms (like AES, blowfish ...), the GCM (Galois Counter Mode) mode, witch <a
+  <li> For block cipher encryption algorithms (like AES), the GCM (Galois Counter Mode) mode, which <a
   href="https://en.wikipedia.org/wiki/Galois/Counter_Mode#Mathematical_basis">works internally</a> with zero/no padding scheme, is recommended. At the
   opposite, these modes and/or schemes are highly discouraged:
     <ul>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/sonarpedia.json
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/sonarpedia.json
@@ -3,5 +3,5 @@
   "languages": [
     "CSH"
   ],
-  "latest-update": "2020-01-31T07:00:52.012596400Z"
+  "latest-update": "2020-02-18T15:19:29.102096600Z"
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S5042_cs.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S5042_cs.html
@@ -19,7 +19,7 @@ or memory of the operating system where the archive is expanded making the targe
 <p>You are at risk if you answered yes to any of those questions.</p>
 <p> </p>
 <h2>Recommended Secure Coding Practices</h2>
-<p>Validate the full path of the extracted file against the full path of the directory where files are expanded.</p>
+<p>Validate the full path of the extracted file against the full path of the directory where files are expanded:</p>
 <ul>
   <li> the canonical path of the expanded file must start with the canonical path of the directory where files are extracted. </li>
   <li> the name of the archive entry must not contain "..", i.e. reference to a parent directory. </li>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S5042_vb.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S5042_vb.html
@@ -19,7 +19,7 @@ or memory of the operating system where the archive is expanded making the targe
 <p>You are at risk if you answered yes to any of those questions.</p>
 <p> </p>
 <h2>Recommended Secure Coding Practices</h2>
-<p>Validate the full path of the extracted file against the full path of the directory where files are expanded.</p>
+<p>Validate the full path of the extracted file against the full path of the directory where files are expanded:</p>
 <ul>
   <li> the canonical path of the expanded file must start with the canonical path of the directory where files are extracted. </li>
   <li> the name of the archive entry must not contain "..", i.e. reference to a parent directory. </li>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S5542_cs.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S5542_cs.html
@@ -1,7 +1,7 @@
 <p>To perform secure cryptography, operation modes and padding scheme are essentials and should be used correctly according to the encryption
 algorithm:</p>
 <ul>
-  <li> For block cipher encryption algorithms (like AES, blowfish ...), the GCM (Galois Counter Mode) mode, witch <a
+  <li> For block cipher encryption algorithms (like AES), the GCM (Galois Counter Mode) mode, which <a
   href="https://en.wikipedia.org/wiki/Galois/Counter_Mode#Mathematical_basis">works internally</a> with zero/no padding scheme, is recommended. At the
   opposite, these modes and/or schemes are highly discouraged:
     <ul>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S5542_vb.html
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/Rules.Description/S5542_vb.html
@@ -1,7 +1,7 @@
 <p>To perform secure cryptography, operation modes and padding scheme are essentials and should be used correctly according to the encryption
 algorithm:</p>
 <ul>
-  <li> For block cipher encryption algorithms (like AES, blowfish ...), the GCM (Galois Counter Mode) mode, witch <a
+  <li> For block cipher encryption algorithms (like AES), the GCM (Galois Counter Mode) mode, which <a
   href="https://en.wikipedia.org/wiki/Galois/Counter_Mode#Mathematical_basis">works internally</a> with zero/no padding scheme, is recommended. At the
   opposite, these modes and/or schemes are highly discouraged:
     <ul>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/sonarpedia.json
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/sonarpedia.json
@@ -3,5 +3,5 @@
   "languages": [
     "VBNET"
   ],
-  "latest-update": "2020-01-30T15:18:06.217001400Z"
+  "latest-update": "2020-02-18T15:41:04.959540200Z"
 }


### PR DESCRIPTION
Intentionally ignore the update to S4426 (must be done in #3097, together with the update of the implementation)

Fixes #3091 
