### PR TITLE
Performance improvement for GenericTypeParameterUnused

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterUnused.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterUnused.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         var declarations = declarationSymbol.DeclaringSyntaxReferences
                             .Select(reference => reference.GetSyntax());
 
-                        var typeParameterNames = helper.Parameters.Parameters.Select(typeParameter => typeParameter.Identifier.Text).ToList();
+                        var typeParameterNames = helper.Parameters.Parameters.Select(typeParameter => typeParameter.Identifier.Text).ToArray();
 
                         var usedTypeParameters = GetUsedTypeParameters(declarations, typeParameterNames, c, analysisContext.Compilation);
 
@@ -136,7 +136,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 methodSymbol.IsChangeable();
         }
 
-        private static List<string> GetUsedTypeParameters(IEnumerable<SyntaxNode> declarations, List<string> typeParameterNames,
+        private static List<string> GetUsedTypeParameters(IEnumerable<SyntaxNode> declarations, string[] typeParameterNames,
             SyntaxNodeAnalysisContext localContext,
             Compilation compilation)
         {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/GenericTypeParameterUnusedTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/GenericTypeParameterUnusedTest.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void GenericTypeParameterUnused()
         {
-            Verifier.VerifyAnalyzer(@"TestCases\GenericTypeParameterUnused.cs",
+            Verifier.VerifyAnalyzer(new [] { @"TestCases\GenericTypeParameterUnused.cs", @"TestCases\GenericTypeParameterUnused.Partial.cs" },
                 new GenericTypeParameterUnused(),
                 options: ParseOptionsHelper.FromCSharp8);
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/GenericTypeParameterUnused.Partial.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/GenericTypeParameterUnused.Partial.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections;
+using System.IO;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Tests.Diagnostics
+{
+    public partial class PartialClass<T>
+    {
+        public void Find(T x) { }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/GenericTypeParameterUnused.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/GenericTypeParameterUnused.cs
@@ -111,6 +111,7 @@ namespace Tests.Diagnostics
     {
         public void MyMethod(T2 p) { }
     }
+
     public class MyNonCompliantSpecialGenericClass<
         T1, // Compliant, not recognized that it's a non used type parameter
         T2> // Noncompliant
@@ -159,6 +160,23 @@ namespace Tests.Diagnostics
             }
 
             unsafe static void LocalStaticUnsafeFunctionWithUnusedTypeParameter<T>() { } // Noncompliant
+        }
+    }
+
+    public partial class PartialClass<T>
+    {
+    }
+
+    public class T
+    {
+        public void Method() {}
+    }
+
+    public class GenericClass<T> // Noncompliant
+    {
+        public void Method(Tests.Diagnostics.T x)
+        {
+            x.Method();
         }
     }
 }


### PR DESCRIPTION
- use structs
- filter the identifiers by name before asking for SymbolInfo

This reduces GenericTypeParameterUnused rule execution time
(using AnalyzerTool) for Entity Framework Core project from
~1315636ms to ~4531ms.
