### PR TITLE
UnusedPrivateMember throws 'NullReferenceException' in SonarLint

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
@@ -268,8 +268,15 @@ namespace SonarAnalyzer.Helpers
             }
         }
 
-        private static IMethodSymbol GetDefaultConstructor(INamedTypeSymbol namedType) =>
-            namedType.InstanceConstructors.FirstOrDefault(IsDefaultConstructor);
+        private static IMethodSymbol GetDefaultConstructor(INamedTypeSymbol namedType)
+        {
+            // See https://github.com/SonarSource/sonar-dotnet/issues/3155
+            if (namedType != null && namedType.InstanceConstructors != null)
+            {
+                return namedType.InstanceConstructors.FirstOrDefault(IsDefaultConstructor);
+            }
+            return null;
+        }
 
         private static bool IsDefaultConstructor(IMethodSymbol constructor) =>
             constructor.Parameters.Length == 0;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.Constructors.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.Constructors.cs
@@ -144,5 +144,20 @@ public class PrivateConstructors
 }
 ", new CS.UnusedPrivateMember());
         }
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void UnusedPrivateMember_Illegal_Interface_Constructor()
+        {
+            // While typing code in IDE, we can end up in a state where an interface has a constructor defined.
+            // Even though this results in a compiler error (CS0526), IDE will still trigger rules on the interface.
+            Verifier.VerifyCSharpAnalyzer(@"
+public interface IInterface
+{
+    // UnusedPrivateMember rule does not trigger AD0001 error from NullReferenceException
+    IInterface() {} // Error [CS0526]
+}
+", new CS.UnusedPrivateMember(), checkMode: CompilationErrorBehavior.Ignore);
+        }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
@@ -180,6 +180,16 @@ namespace UnityEditor
         }
 
         [TestMethod]
+        [TestCategory("Rule")]
+        public void UnusedPrivateMember_FromCSharp8()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\UnusedPrivateMember.CSharp8.cs",
+                new CS.UnusedPrivateMember(),
+                ParseOptionsHelper.FromCSharp8,
+                additionalReferences: NuGetMetadataReference.NETStandardV2_1_0);
+        }
+
+        [TestMethod]
         [TestCategory("CodeFix")]
         public void UnusedPrivateMember_CodeFix()
         {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.CSharp8.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.CSharp8.cs
@@ -1,0 +1,15 @@
+﻿namespace Tests.Diagnostics
+{
+    public interface MyInterface1
+    {
+        public void Method1() { }
+    }
+
+    public class Class1
+    {
+        private interface MyInterface2 // Noncompliant
+        {
+            public void Method1() { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3155 
