### PR TITLE
Update RSPEC test class templates

### DIFF
--- a/scripts/rspec/rspec-templates/CSharpTestTemplate.cs
+++ b/scripts/rspec/rspec-templates/CSharpTestTemplate.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {

--- a/scripts/rspec/rspec-templates/VbNetTestTemplate.cs
+++ b/scripts/rspec/rspec-templates/VbNetTestTemplate.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -19,6 +19,7 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {


### PR DESCRIPTION
Update templates for `rspec.ps1` after #3127 refactored `Verifier.cs` into `TestFramework` namespace.