### PR TITLE
SplitCamelCaseToWords handles UPPERCASE sequences

### DIFF
--- a/sonaranalyzer-dotnet/its/expected/Ember-MM/Ember Media Manager-{9B57D3AB-AF12-4012-B945-284C2448DC81}-S1075.json
+++ b/sonaranalyzer-dotnet/its/expected/Ember-MM/Ember Media Manager-{9B57D3AB-AF12-4012-B945-284C2448DC81}-S1075.json
@@ -121,6 +121,19 @@
 "id":  "S1075",
 "message":  "Refactor your code not to use hardcoded absolute paths or URIs.",
 "location":  {
+"uri":  "sources\Ember-MM\Ember%20Media%20Manager\dlgTVRegExProfiles.vb",
+"region":  {
+"startLine":  54,
+"startColumn":  54,
+"endLine":  54,
+"endColumn":  118
+}
+}
+},
+{
+"id":  "S1075",
+"message":  "Refactor your code not to use hardcoded absolute paths or URIs.",
+"location":  {
 "uri":  "sources\Ember-MM\Ember%20Media%20Manager\frmMain.vb",
 "region":  {
 "startLine":  4137,

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CFG/Helpers/StringExtensions.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CFG/Helpers/StringExtensions.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -23,49 +23,60 @@ using System.Text;
 
 namespace SonarAnalyzer.CFG.Helpers
 {
-    internal static class StringExtensions
+    public static class StringExtensions
     {
         /// <summary>
         /// Splits the input string to the list of words.
         ///
-        /// Letters and consecutive capital letters are ignored.
+        /// Sequence of upper case letters is considered as single word.
+        ///
         /// For example:
         /// thisIsAName => this is a name
-        /// ThisIsIt => this is it
+        /// ThisIsSMTPName => this is smtp name
         /// bin2hex => bin hex
-        /// HTML => h t m l
-        /// PEHeader => p e header
+        /// HTML => html
+        /// SOME_value => some value
+        /// PEHeader => pe header
         /// </summary>
         /// <param name="name">A string containing words.</param>
         /// <returns>A list of words (all lowercase) contained in the string.</returns>
         public static IEnumerable<string> SplitCamelCaseToWords(this string name)
         {
+            bool IsFollowedByLower(int i) => i + 1 < name.Length && char.IsLower(name[i + 1]);
+
             if (name == null)
             {
                 yield break;
             }
 
             var currentWord = new StringBuilder();
+            var hasLower = false;
 
-            foreach (var c in name)
+            for (var i = 0; i < name.Length; i++)
             {
+                var c = name[i];
                 if (!char.IsLetter(c))
                 {
                     if (currentWord.Length > 0)
                     {
                         yield return currentWord.ToString();
                         currentWord.Clear();
+                        hasLower = false;
                     }
                     continue;
                 }
 
-                if (char.IsUpper(c) && currentWord.Length > 0)
+                if (char.IsUpper(c)
+                    && currentWord.Length > 0
+                    && (hasLower || IsFollowedByLower(i)))
                 {
                     yield return currentWord.ToString();
                     currentWord.Clear();
+                    hasLower = false;
                 }
 
                 currentWord.Append(char.ToUpperInvariant(c));
+                hasLower = hasLower || char.IsLower(c);
             }
 
             if (currentWord.Length > 0)

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/StringExtensions.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/StringExtensions.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -28,44 +28,55 @@ namespace SonarAnalyzer.Helpers
         /// <summary>
         /// Splits the input string to the list of words.
         ///
-        /// Letters and consecutive capital letters are ignored.
+        /// Sequence of upper case letters is considered as single word.
+        ///
         /// For example:
         /// thisIsAName => this is a name
-        /// ThisIsIt => this is it
+        /// ThisIsSMTPName => this is smtp name
         /// bin2hex => bin hex
-        /// HTML => h t m l
-        /// PEHeader => p e header
+        /// HTML => html
+        /// SOME_value => some value
+        /// PEHeader => pe header
         /// </summary>
         /// <param name="name">A string containing words.</param>
         /// <returns>A list of words (all lowercase) contained in the string.</returns>
         public static IEnumerable<string> SplitCamelCaseToWords(this string name)
         {
+            bool IsFollowedByLower(int i) => i + 1 < name.Length && char.IsLower(name[i + 1]);
+
             if (name == null)
             {
                 yield break;
             }
 
             var currentWord = new StringBuilder();
+            var hasLower = false;
 
-            foreach (var c in name)
+            for (var i = 0; i < name.Length; i++)
             {
+                var c = name[i];
                 if (!char.IsLetter(c))
                 {
                     if (currentWord.Length > 0)
                     {
                         yield return currentWord.ToString();
                         currentWord.Clear();
+                        hasLower = false;
                     }
                     continue;
                 }
 
-                if (char.IsUpper(c) && currentWord.Length > 0)
+                if (char.IsUpper(c)
+                    && currentWord.Length > 0
+                    && (hasLower || IsFollowedByLower(i)))
                 {
                     yield return currentWord.ToString();
                     currentWord.Clear();
+                    hasLower = false;
                 }
 
                 currentWord.Append(char.ToUpperInvariant(c));
+                hasLower = hasLower || char.IsLower(c);
             }
 
             if (currentWord.Length > 0)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/StringExtensionsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/StringExtensionsTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -31,10 +31,19 @@ namespace SonarAnalyzer.UnitTest.Helpers
         public void TestSplitCamelCaseToWords()
         {
             AssertSplitEquivalent("thisIsAName", "THIS", "IS", "A", "NAME");
+            AssertSplitEquivalent("thisIsSMTPName", "THIS", "IS", "SMTP", "NAME");
             AssertSplitEquivalent("ThisIsIt", "THIS", "IS", "IT");
             AssertSplitEquivalent("bin2hex", "BIN", "HEX");
-            AssertSplitEquivalent("HTML", "H", "T", "M", "L");
-            AssertSplitEquivalent("PEHeader", "P", "E", "HEADER");
+            AssertSplitEquivalent("HTML", "HTML");
+            AssertSplitEquivalent("SOME_VALUE", "SOME", "VALUE");
+            AssertSplitEquivalent("GR8day", "GR", "DAY");
+            AssertSplitEquivalent("ThisIsEpic", "THIS", "IS", "EPIC");
+            AssertSplitEquivalent("ThisIsEPIC", "THIS", "IS", "EPIC");
+            AssertSplitEquivalent("This_is_EPIC", "THIS", "IS", "EPIC");
+            AssertSplitEquivalent("PEHeader", "PE", "HEADER");
+            AssertSplitEquivalent("PE_Header", "PE", "HEADER");
+            AssertSplitEquivalent("BigB_smallc&GIANTD", "BIG", "B","SMALLC", "GIANTD");
+            AssertSplitEquivalent("SMTPServer", "SMTP", "SERVER");
             AssertSplitEquivalent("__url_foo", "URL", "FOO");
             AssertSplitEquivalent("");
             AssertSplitEquivalent(null);
@@ -42,7 +51,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
 
         private void AssertSplitEquivalent(string name, params string[] words)
         {
-            CollectionAssert.AreEquivalent(name.SplitCamelCaseToWords().ToList(), words);
+            CollectionAssert.AreEquivalent(words, name.SplitCamelCaseToWords().ToList(), $" Value: {name}");
         }
     }
 }


### PR DESCRIPTION
Strings like `HTML`  or `PEHeader` were handled per upper case letter and splitted into `h, t, m, l` or `p, e, header`.

This causes some problems with upper-case only names like `PASSWORD` or `URL`.

New implementation is aware of upper case sequences and can handle situations like `ThisIsSMTPName` to `this, is, smtp, name`