### PR TITLE
Fix S4275 Bug: C# auto-implemented readonly property with attr..

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/PropertiesAccessCorrectField.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/PropertiesAccessCorrectField.cs
@@ -142,6 +142,10 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static ExpressionSyntax SingleReturn(BlockSyntax body)
         {
+            if (body == null)
+            {
+                return null;
+            }
             var returns = body.DescendantNodes().OfType<ReturnStatementSyntax>().ToArray();
             return returns.Length == 1 ? returns.Single().Expression : null;
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/PropertiesAccessCorrectField.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/PropertiesAccessCorrectField.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using GalaSoft.MvvmLight;
 using System.Runtime.CompilerServices;
 
@@ -697,6 +698,12 @@ namespace Tests.Diagnostics
             get;
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private set;
+        }
+
+        public int ReadOnlyProperty
+        {
+            [DebuggerStepThrough]
+            get;
         }
     }
 }


### PR DESCRIPTION
C# auto-implemented readonly property with [DebuggerStepThrought] attribute was throwing NRE in SingleReturn function.