### PR TITLE
fix S1451 FP if regex expression tries to match newline using "."

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Rules/CheckFileLicenseBase.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Rules/CheckFileLicenseBase.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules
                 unixEndingHeaderFormat += "\n";
             }
             return IsRegularExpression
-                ? Regex.IsMatch(unixEndingHeader, unixEndingHeaderFormat)
+                ? Regex.IsMatch(unixEndingHeader, unixEndingHeaderFormat, RegexOptions.Singleline)
                 : unixEndingHeader.StartsWith(unixEndingHeaderFormat, StringComparison.Ordinal);
         }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
@@ -78,7 +78,8 @@ namespace SonarAnalyzer.UnitTest.Rules
  \* along with this program; if not, write to the Free Software Foundation,
  \* Inc\., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA\.
  \*/";
-        private const string MultiSingleLineRegexHeader = "//-{5}\r\n// MyHeader\r\n//-{5}";
+        private const string MultiSingleLineRegexHeader1 = "//-{5}\r\n// MyHeader\r\n//-{5}";
+        private const string MultiSingleLineRegexHeader2 = "//-{5}.+// MyHeader.+//-{5}";
         private const string FailingSingleLineRegexHeader = "[";
 
         [TestMethod]
@@ -203,10 +204,18 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         [TestCategory("Rule")]
-        public void CheckFileLicense_WhenLicensedWithMultiSingleLineCommentStartingWithNamespaceAndRegex_ShouldBeCompliant_CS()
+        public void CheckFileLicense_WhenLicensedWithMultiSingleLineCommentStartingWithNamespaceAndRegexMultiLine_ShouldBeCompliant_CS()
         {
             Verifier.VerifyAnalyzer(@"TestCases\CheckFileLicense_MultiSingleLineLicenseStartWithNamespace.cs",
-                new CheckFileLicense { HeaderFormat = MultiSingleLineRegexHeader, IsRegularExpression = true });
+                new CheckFileLicense { HeaderFormat = MultiSingleLineRegexHeader1, IsRegularExpression = true });
+        }
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void CheckFileLicense_WhenLicensedWithMultiSingleLineCommentStartingWithNamespaceAndRegexSingleLine_ShouldBeCompliant_CS()
+        {
+            Verifier.VerifyAnalyzer(@"TestCases\CheckFileLicense_MultiSingleLineLicenseStartWithNamespace.cs",
+                new CheckFileLicense { HeaderFormat = MultiSingleLineRegexHeader2, IsRegularExpression = true });
         }
 
         [TestMethod]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
@@ -204,7 +204,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         [TestCategory("Rule")]
-        public void CheckFileLicense_WhenLicensedWithMultiSingleLineCommentStartingWithNamespaceAndRegexMultiLine_ShouldBeCompliant_CS()
+        public void CheckFileLicense_WhenLicensedWithMultiSingleLineCommentStartingWithNamespaceAndMultiLineRegexWithNewLine_ShouldBeCompliant_CS()
         {
             Verifier.VerifyAnalyzer(@"TestCases\CheckFileLicense_MultiSingleLineLicenseStartWithNamespace.cs",
                 new CheckFileLicense { HeaderFormat = MultiLineRegexWithNewLine, IsRegularExpression = true });
@@ -212,7 +212,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         [TestCategory("Rule")]
-        public void CheckFileLicense_WhenLicensedWithMultiSingleLineCommentStartingWithNamespaceAndRegexSingleLine_ShouldBeCompliant_CS()
+        public void CheckFileLicense_WhenLicensedWithMultiSingleLineCommentStartingWithNamespaceAndMultiLineRegexWithDot_ShouldBeCompliant_CS()
         {
             Verifier.VerifyAnalyzer(@"TestCases\CheckFileLicense_MultiSingleLineLicenseStartWithNamespace.cs",
                 new CheckFileLicense { HeaderFormat = MultiLineRegexWithDot, IsRegularExpression = true });

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
@@ -78,8 +78,8 @@ namespace SonarAnalyzer.UnitTest.Rules
  \* along with this program; if not, write to the Free Software Foundation,
  \* Inc\., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA\.
  \*/";
-        private const string MultiSingleLineRegexHeader1 = "//-{5}\r\n// MyHeader\r\n//-{5}";
-        private const string MultiSingleLineRegexHeader2 = "//-{5}.+// MyHeader.+//-{5}";
+        private const string MultiLineRegexWithNewLine = "//-{5}\r\n// MyHeader\r\n//-{5}";
+        private const string MultiLineRegexWithDot = "//-{5}.+// MyHeader.+//-{5}";
         private const string FailingSingleLineRegexHeader = "[";
 
         [TestMethod]
@@ -207,7 +207,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void CheckFileLicense_WhenLicensedWithMultiSingleLineCommentStartingWithNamespaceAndRegexMultiLine_ShouldBeCompliant_CS()
         {
             Verifier.VerifyAnalyzer(@"TestCases\CheckFileLicense_MultiSingleLineLicenseStartWithNamespace.cs",
-                new CheckFileLicense { HeaderFormat = MultiSingleLineRegexHeader1, IsRegularExpression = true });
+                new CheckFileLicense { HeaderFormat = MultiLineRegexWithNewLine, IsRegularExpression = true });
         }
 
         [TestMethod]
@@ -215,7 +215,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void CheckFileLicense_WhenLicensedWithMultiSingleLineCommentStartingWithNamespaceAndRegexSingleLine_ShouldBeCompliant_CS()
         {
             Verifier.VerifyAnalyzer(@"TestCases\CheckFileLicense_MultiSingleLineLicenseStartWithNamespace.cs",
-                new CheckFileLicense { HeaderFormat = MultiSingleLineRegexHeader2, IsRegularExpression = true });
+                new CheckFileLicense { HeaderFormat = MultiLineRegexWithDot, IsRegularExpression = true });
         }
 
         [TestMethod]


### PR DESCRIPTION
The configuration for S1451 supports regular expression.
I tried to configure the rule using a [popular example](https://stackoverflow.com/questions/31462870/sonarqube-rules-squids1451-copyright-and-license-headers-should-be-defined).

I was wondering why it does not work, at least not in the local analysis using roslyn analzers (SonarAnalyzer.CSharp 8.4.0.15306).

I think, it should be a compatible change to use the option `RegexOptions.Singleline`.
Then the newline character is matched by "dot".

There no separate issue so far. Is it required?

Fixes #3224