### PR TITLE
Using $(NugetPackageRoot) instead of $(NUGET_PACKAGES)

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -37,9 +37,9 @@
       <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
     </PropertyGroup>
     <PropertyGroup>
-      <ProtocCompiler Condition="$(IsWindows)==true">"$(NUGET_PACKAGES)/Google.Protobuf.Tools/3.6.1/tools/windows_x64/protoc.exe"</ProtocCompiler>
-      <ProtocCompiler Condition="$(IsOSX)==true">$(NUGET_PACKAGES)/google.protobuf.tools/3.6.1/tools/macosx_x64/protoc</ProtocCompiler>
-      <ProtocCompiler Condition="$(IsLinux)==true">$(NUGET_PACKAGES)/google.protobuf.tools/3.6.1/tools/linux_x64/protoc</ProtocCompiler>
+      <ProtocCompiler Condition="$(IsWindows)==true">"$(NugetPackageRoot)/Google.Protobuf.Tools/3.6.1/tools/windows_x64/protoc.exe"</ProtocCompiler>
+      <ProtocCompiler Condition="$(IsOSX)==true">$(NugetPackageRoot)/google.protobuf.tools/3.6.1/tools/macosx_x64/protoc</ProtocCompiler>
+      <ProtocCompiler Condition="$(IsLinux)==true">$(NugetPackageRoot)/google.protobuf.tools/3.6.1/tools/linux_x64/protoc</ProtocCompiler>
     </PropertyGroup>
     <Exec Command="$(ProtocCompiler) -I=./Protobuf --csharp_out=./Protobuf ./Protobuf/AnalyzerReport.proto" />
     <Message Importance="high" Text="Protobuf classes generated." />


### PR DESCRIPTION
The short version is that you can not rely on $(NUGET_PACKAGES) to be configured, but you can on $(NugetPackageRoot) . By changing this (for building with ProtoBuf) i could compile (again) locally.

See: https://github.com/NuGet/Home/issues/6301#issuecomment-350939781
