### PR TITLE
Fix FP on S3717 with throw expressions

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
@@ -56,19 +56,12 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ThrowStatement);
 
             context.RegisterSyntaxNodeActionInNonGenerated(
-                c =>
-                {
-                    var creationExpression = (ObjectCreationExpressionSyntax)c.Node;
-                    var throwExpression = creationExpression.Parent;
-
-                    if (throwExpression.Kind() != SyntaxKindEx.ThrowExpression)
-                    {
-                        return;
-                    }
-
-                    ReportDiagnostic(c, creationExpression, throwExpression);
-                },
-                SyntaxKind.ObjectCreationExpression);
+                 c =>
+                 {
+                     var throwExpression = (ThrowExpressionSyntaxWrapper)c.Node;
+                     ReportDiagnostic(c, throwExpression.Expression, throwExpression);
+                 },
+                 SyntaxKindEx.ThrowExpression);
         }
 
         private static void ReportDiagnostic(SyntaxNodeAnalysisContext c, ExpressionSyntax newExceptionExpression, SyntaxNode throwExpression)

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
@@ -71,11 +71,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ObjectCreationExpression);
         }
 
-        private static void ReportDiagnostic(SyntaxNodeAnalysisContext c, ExpressionSyntax expression, SyntaxNode syntax)
+        private static void ReportDiagnostic(SyntaxNodeAnalysisContext c, ExpressionSyntax newExceptionExpression, SyntaxNode throwExpression)
         {
-            if (c.SemanticModel.GetTypeInfo(expression).Type.Is(KnownType.System_NotImplementedException))
+            if (c.SemanticModel.GetTypeInfo(newExceptionExpression).Type.Is(KnownType.System_NotImplementedException))
             {
-                c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, syntax.GetLocation()));
+                c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, throwExpression.GetLocation()));
             }
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TrackNotImplementedException.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TrackNotImplementedException.cs
@@ -32,6 +32,15 @@ namespace Tests.Diagnostics
         void ByExpression() => throw new NotImplementedException(); // Noncompliant
 //                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+        int ConditionalEpxression(int i)
+            => i == 0 ? 666 : throw new NotImplementedException(); // Noncompliant
+
+        void NullCoalescing(object obj)
+        {
+            x = obj ?? throw new NotImplementedException(); // Noncompliant
+        }
+        private object x;
+
         NotImplementedException GetNewByExpression() => new NotImplementedException(); // Compliant - not thrown
     }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TrackNotImplementedException.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TrackNotImplementedException.cs
@@ -29,8 +29,10 @@ namespace Tests.Diagnostics
 //          ^^^^^^^^^
         }
 
-        void NotImplemented() =>
-            throw new NotImplementedException(); // FN
+        void ByExpression() => throw new NotImplementedException(); // Noncompliant
+//                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+        NotImplementedException GetNewByExpression() => new NotImplementedException(); // Compliant - not thrown
     }
 
     interface IInterface

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TrackNotImplementedException.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TrackNotImplementedException.cs
@@ -32,7 +32,7 @@ namespace Tests.Diagnostics
         void ByExpression() => throw new NotImplementedException(); // Noncompliant
 //                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-        int ConditionalEpxression(int i)
+        int ConditionalExpression(int i)
             => i == 0 ? 666 : throw new NotImplementedException(); // Noncompliant
 
         void NullCoalescing(object obj)


### PR DESCRIPTION
Fixes #2503 

Due to the use of an old version of Microsoft.CodeAnalysis.Charp 1.3.2 (backwards compatebility I asume), it was a bit less straight forward.