### PR TITLE
Use $(NugetPackageRoot) instead of $(NUGET_PACKAGES)

### DIFF
--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -27,7 +27,6 @@ In general, it is best to run commands from the Visual Studio Developer Command 
     - **MAVEN_HOME** / **M2_HOME**
     - **MSBUILD_PATH** - path to the MSBuild.exe executable from the Visual Studio installation folder - to MSBuild 16
     - **NUGET_PATH** - path to the nuget.exe executable (related to the [plugin integration tests](./contributing-plugin.md#integration-tests))
-    - **NUGET_PACKAGES** - path to the local nuget cache (related to build)
     - **ORCHESTRATOR_CONFIG_URL** - url to orchestrator.properties file (for integration tests) in uri form (i.e. file:///c:/something/orchestrator.properties)
     - **RULE_API_PATH** - path to folder containing the rule api jar
     - **PATH** - the system **PATH** variable must contain:

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -37,9 +37,9 @@
       <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
     </PropertyGroup>
     <PropertyGroup>
-      <ProtocCompiler Condition="$(IsWindows)==true">"$(NUGET_PACKAGES)/Google.Protobuf.Tools/3.6.1/tools/windows_x64/protoc.exe"</ProtocCompiler>
-      <ProtocCompiler Condition="$(IsOSX)==true">$(NUGET_PACKAGES)/google.protobuf.tools/3.6.1/tools/macosx_x64/protoc</ProtocCompiler>
-      <ProtocCompiler Condition="$(IsLinux)==true">$(NUGET_PACKAGES)/google.protobuf.tools/3.6.1/tools/linux_x64/protoc</ProtocCompiler>
+      <ProtocCompiler Condition="$(IsWindows)==true">"$(NugetPackageRoot)/Google.Protobuf.Tools/3.6.1/tools/windows_x64/protoc.exe"</ProtocCompiler>
+      <ProtocCompiler Condition="$(IsOSX)==true">$(NugetPackageRoot)/google.protobuf.tools/3.6.1/tools/macosx_x64/protoc</ProtocCompiler>
+      <ProtocCompiler Condition="$(IsLinux)==true">$(NugetPackageRoot)/google.protobuf.tools/3.6.1/tools/linux_x64/protoc</ProtocCompiler>
     </PropertyGroup>
     <Exec Command="$(ProtocCompiler) -I=./Protobuf --csharp_out=./Protobuf ./Protobuf/AnalyzerReport.proto" />
     <Message Importance="high" Text="Protobuf classes generated." />


### PR DESCRIPTION
Fixes #3032

cherry-pick #3217 to run CI

> The short version is that you can not rely on $(NUGET_PACKAGES) to be configured, but you can on $(NugetPackageRoot) . By changing this (for building with ProtoBuf) i could compile (again) locally.
> 
> See: NuGet/Home#6301 (comment)
