### PR TITLE
Fix S3937 FP and other improvements on number pattern checks

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
@@ -90,8 +90,8 @@ namespace SonarAnalyzer.Rules.CSharp
                     return true;
                 }
 
-                // all should have the same size, except the first.
-                if (groups.Skip(1).Any(g => g != size))
+                // all should have the same size, except the first, and the size should at least be 2.
+                if (size < 2 || groups.Skip(1).Any(g => g != size))
                 {
                     return true;
                 }
@@ -108,9 +108,6 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 return false;
             }
-
-            // The first decimal group should be one smaller.
-            decimals[0]++;
 
             size = size == NotFound ? decimals[0] : size;
 

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
@@ -137,10 +137,12 @@ namespace SonarAnalyzer.Rules.CSharp
                 return false;
             }
 
-            // the second group is assumed to be leading.
+            // the first group is allowed to contain less digits that the other ones,
+            // so take the expected length from the second group.
             var groupLength = groupLengths[1];
 
-            // first should not be bigger, and the size per group should be at least 2.
+            // we consider groups of 1 digit irregular.
+            // first should not be bigger.
             if (groupLength < 2 || groupLengths[0] > groupLength)
             {
                 return true;

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
@@ -66,6 +66,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.NumericLiteralExpression);
         }
 
+        /// <remarks>internal for test purposes.</remarks>
         internal static bool HasIrregularPattern(string numericToken)
         {
             var splitted = StripNumericPreAndSuffix(numericToken).Split(Dot);
@@ -119,14 +120,18 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static string StripNumericPreAndSuffix(string numericToken)
         {
+            var start = 0;
+            var length = numericToken.Length;
+
             // hexadecimal en binary prefixes
-            var start = numericToken.StartsWith("0x", StringComparison.InvariantCultureIgnoreCase)
-                || numericToken.StartsWith("0b", StringComparison.InvariantCultureIgnoreCase) ? 2 : 0;
-
-            var length = numericToken.Length - start;
-
+            if (numericToken.StartsWith("0x", StringComparison.InvariantCultureIgnoreCase) ||
+                numericToken.StartsWith("0b", StringComparison.InvariantCultureIgnoreCase))
+            {
+                start = 2;
+                length -= 2;
+            }
             // UL suffix.
-            if (numericToken.EndsWith("UL", StringComparison.OrdinalIgnoreCase))
+            else if (numericToken.EndsWith("UL", StringComparison.OrdinalIgnoreCase))
             {
                 length -= 2;
             }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
@@ -130,8 +130,9 @@ namespace SonarAnalyzer.Rules.CSharp
                 start = 2;
                 length -= 2;
             }
-            // UL suffix.
-            else if (numericToken.EndsWith("UL", StringComparison.OrdinalIgnoreCase))
+            // UL and LU suffix.
+            else if (numericToken.EndsWith("UL", StringComparison.OrdinalIgnoreCase) ||
+                numericToken.EndsWith("LU", StringComparison.OrdinalIgnoreCase))
             {
                 length -= 2;
             }
@@ -140,6 +141,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 length--;
             }
+
             return numericToken.Substring(start, length);
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
@@ -60,6 +60,10 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow("0xFFFF_FFFF_FFFFF", "Last group bigger than 4")]
         [DataRow("0xFFFF_FFFF_FFFFF", "Last group bigger than 4")]
         [DataRow("1.234_5678E2", "Exponential format with bigger last group")]
+        [DataRow("____", "Only underscores")]
+        [DataRow("__.__", "Only underscores and a dot")]
+        [DataRow("0xFF___FF___FF", "Multiple _'s as separator")]
+        [DataRow("0xFF________FF___FF", "Multiple irregular _'s as separator")]
         public void HasIrregularPattern(string numericToken, string message)
         {
             Assert.IsTrue(NumberPatternShouldBeRegular.HasIrregularPattern(numericToken), message);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
@@ -55,9 +55,12 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow("123_123_12_123", "Another group has a different size")]
         [DataRow("1_123.123_1234", "Last decimal group is bigger")]
         [DataRow(".123_123_1234", "No group before the dot")]
-        [DataRow("0xFF_FF_FFF_FF", "3rd group is bigger.")]
-        [DataRow("0xFF_FF_FFF", "Last group bigger than 2.")]
-        [DataRow("0xFFFF_FFFF_FFFFF", "Last group bigger than 4.")]
+        [DataRow("0xFF_FF_FFF_FF", "3rd group is bigger")]
+        [DataRow("0xFF_FF_FFF", "Last group bigger than 2")]
+        [DataRow("0xFFFF_FFFF_FFFFF", "Last group bigger than 4")]
+        [DataRow("0xFFFF_FFFF_FFFFF", "Last group bigger than 4")]
+        [DataRow("1.234_5E2", "Exponential format with smaller last group")]
+        [DataRow("1.234_5678E2", "Exponential format with bigger last group")]
         public void HasIrregularPattern(string numericToken, string message)
         {
             Assert.IsTrue(NumberPatternShouldBeRegular.HasIrregularPattern(numericToken), message);
@@ -67,16 +70,19 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         [DataRow(".123_123_123_1", "No group before the dot")]
         [DataRow("123", "No group character")]
+        [DataRow("1_123_123LU", "With LU suffix")]
         [DataRow("1_123_123UL", "With UL suffix")]
         [DataRow("1_123_123L", "With L suffix")]
         [DataRow("1.1.1", "Two dots")]
         [DataRow("0b1010_1010", "With binary prefix")]
         [DataRow("0xFF_FF_12", "With hexadecimal prefix")]
+        [DataRow("0xFF_FF_E2", "With hexadecimal prefix with E but not exponential")]
         [DataRow("1_123_123", "first group smaller")]
         [DataRow("123_123_123", "All blocks equal size")]
         [DataRow("1_123.123_123", "All decimal groups have the same size")]
         [DataRow("1_123.123_123_12", "Last decimal group is smaller")]
         [DataRow("1_123.1234567", "Only one group of decimals")]
+        [DataRow("1.234_567E2", "Exponential format with regular size")]
         public void HasRegularPattern(string numericToken, string message)
         {
             Assert.IsFalse(NumberPatternShouldBeRegular.HasIrregularPattern(numericToken), message);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -45,6 +45,37 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzer(@"TestCases\NumberPatternShouldBeRegular.cs",
                 new NumberPatternShouldBeRegular(),
                 ParseOptionsHelper.FromCSharp7);
+        }
+
+        [DataTestMethod]
+        [TestCategory("Rule")]
+        [DataRow("123_12", "First group is bigger then the second")]
+        [DataRow("1234_123_123", "First group is bigger then the others")]
+        [DataRow("123_123_12_123", "Another group has a different size")]
+        [DataRow("1_123.23_1234", "Last decimal group is bigger")]
+        [DataRow(".23_123_1234", "No group before the dot")]
+        public void HasIrregularPattern(string numericToken, string message)
+        {
+            Assert.IsTrue(NumberPatternShouldBeRegular.HasIrregularPattern(numericToken), message);
+        }
+
+        [DataTestMethod]
+        [TestCategory("Rule")]
+        [DataRow(".23_123_123_1", "No group before the dot")]
+        [DataRow("123", "No group character")]
+        [DataRow("1_123_123UL", "With UL suffix")]
+        [DataRow("1_123_123L", "With L suffix")]
+        [DataRow("1.1.1", "Two dots")]
+        [DataRow("0b1010_1010", "With binary prefix")]
+        [DataRow("0xFF_FF_12", "With hexadecimal prefix")]
+        [DataRow("1_123_123", "first group smaller")]
+        [DataRow("123_123_123", "All blocks equal size")]
+        [DataRow("1_123.23_123", "First decimal group after dot is one smaller")]
+        [DataRow("1_123.23_123_12", "Last decimal group is smaller")]
+        [DataRow("1_123.1234567", "Only one group of decimals")]
+        public void HasRegularPattern(string numericToken, string message)
+        {
+            Assert.IsFalse(NumberPatternShouldBeRegular.HasIrregularPattern(numericToken), message);
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
@@ -49,11 +49,12 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [DataTestMethod]
         [TestCategory("Rule")]
+        [DataRow("1_1_1", "Group size of 1")]
         [DataRow("123_12", "First group is bigger then the second")]
         [DataRow("1234_123_123", "First group is bigger then the others")]
         [DataRow("123_123_12_123", "Another group has a different size")]
-        [DataRow("1_123.23_1234", "Last decimal group is bigger")]
-        [DataRow(".23_123_1234", "No group before the dot")]
+        [DataRow("1_123.123_1234", "Last decimal group is bigger")]
+        [DataRow(".123_123_1234", "No group before the dot")]
         public void HasIrregularPattern(string numericToken, string message)
         {
             Assert.IsTrue(NumberPatternShouldBeRegular.HasIrregularPattern(numericToken), message);
@@ -61,7 +62,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [DataTestMethod]
         [TestCategory("Rule")]
-        [DataRow(".23_123_123_1", "No group before the dot")]
+        [DataRow(".123_123_123_1", "No group before the dot")]
         [DataRow("123", "No group character")]
         [DataRow("1_123_123UL", "With UL suffix")]
         [DataRow("1_123_123L", "With L suffix")]
@@ -70,8 +71,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow("0xFF_FF_12", "With hexadecimal prefix")]
         [DataRow("1_123_123", "first group smaller")]
         [DataRow("123_123_123", "All blocks equal size")]
-        [DataRow("1_123.23_123", "First decimal group after dot is one smaller")]
-        [DataRow("1_123.23_123_12", "Last decimal group is smaller")]
+        [DataRow("1_123.123_123", "All decimal groups have the same size")]
+        [DataRow("1_123.123_123_12", "Last decimal group is smaller")]
         [DataRow("1_123.1234567", "Only one group of decimals")]
         public void HasRegularPattern(string numericToken, string message)
         {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
@@ -59,7 +59,6 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow("0xFF_FF_FFF", "Last group bigger than 2")]
         [DataRow("0xFFFF_FFFF_FFFFF", "Last group bigger than 4")]
         [DataRow("0xFFFF_FFFF_FFFFF", "Last group bigger than 4")]
-        [DataRow("1.234_5E2", "Exponential format with smaller last group")]
         [DataRow("1.234_5678E2", "Exponential format with bigger last group")]
         public void HasIrregularPattern(string numericToken, string message)
         {
@@ -71,7 +70,10 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow(".123_123_123_1", "No group before the dot")]
         [DataRow("123", "No group character")]
         [DataRow("1_123_123LU", "With LU suffix")]
+        [DataRow("2_123_123lu", "With lu suffix")]
+        [DataRow("3_123_123lU", "With lU suffix")]
         [DataRow("1_123_123UL", "With UL suffix")]
+        [DataRow("2_123_123ul", "With ul suffix")]
         [DataRow("1_123_123L", "With L suffix")]
         [DataRow("1.1.1", "Two dots")]
         [DataRow("0b1010_1010", "With binary prefix")]
@@ -82,7 +84,16 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow("1_123.123_123", "All decimal groups have the same size")]
         [DataRow("1_123.123_123_12", "Last decimal group is smaller")]
         [DataRow("1_123.1234567", "Only one group of decimals")]
-        [DataRow("1.234_567E2", "Exponential format with regular size")]
+        [DataRow("1.234_567E2", "Scientific format with regular size")]
+        [DataRow("1.234_5E2", "Scientific format with smaller last group")]
+        [DataRow("134.45E-2f", "Scientific format f suffix")]
+        [DataRow("134.45E12M", "Scientific format M suffix")]
+        [DataRow("1.0", "Simple floating point")]
+        [DataRow("3D", "Floating point with D suffix")]
+        [DataRow("4d", "Floating point with d suffix")]
+        [DataRow("5M", "Floating point with M suffix")]
+        [DataRow("6m", "Floating point with m suffix")]
+        [DataRow("3_000.5F", "Floating point with group size")]
         public void HasRegularPattern(string numericToken, string message)
         {
             Assert.IsFalse(NumberPatternShouldBeRegular.HasIrregularPattern(numericToken), message);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/NumberPatternShouldBeRegularTest.cs
@@ -55,6 +55,9 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow("123_123_12_123", "Another group has a different size")]
         [DataRow("1_123.123_1234", "Last decimal group is bigger")]
         [DataRow(".123_123_1234", "No group before the dot")]
+        [DataRow("0xFF_FF_FFF_FF", "3rd group is bigger.")]
+        [DataRow("0xFF_FF_FFF", "Last group bigger than 2.")]
+        [DataRow("0xFFFF_FFFF_FFFFF", "Last group bigger than 4.")]
         public void HasIrregularPattern(string numericToken, string message)
         {
             Assert.IsTrue(NumberPatternShouldBeRegular.HasIrregularPattern(numericToken), message);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NumberPatternShouldBeRegular.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NumberPatternShouldBeRegular.cs
@@ -46,7 +46,7 @@ namespace Tests.Diagnostics
             int million = 1_000_00_000;  // Noncompliant {{Review this number; its irregular pattern indicates an error.}}
 //                        ^^^^^^^^^^^^
 
-            var x = 1_234.56_78; // Noncompliant
+            var x = 1_234.56_78_1; // Noncompliant
 
             var y = 1_234_5; // Noncompliant
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NumberPatternShouldBeRegular.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NumberPatternShouldBeRegular.cs
@@ -12,6 +12,7 @@ namespace Tests.Diagnostics
 
             // decimal notation
             var balance = 2_435_951.68;
+            double groupsizes = 1_234.56_78;
             var x = 1_234.11111;
 
             // hexadecimal notation

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NumberPatternShouldBeRegular.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NumberPatternShouldBeRegular.cs
@@ -12,8 +12,8 @@ namespace Tests.Diagnostics
 
             // decimal notation
             var balance = 2_435_951.68;
-            double groupsizes = 1_234.56_78;
-            var x = 1_234.11111;
+            double multiGroupLengths = 1_234.56_78;
+            var groupsBeforDot = 1_234.11111;
 
             // hexadecimal notation
             var num = 0x01_00;
@@ -47,7 +47,7 @@ namespace Tests.Diagnostics
             int million = 1_000_00_000;  // Noncompliant {{Review this number; its irregular pattern indicates an error.}}
 //                        ^^^^^^^^^^^^
 
-            var x = 1_234.56_78_1; // Noncompliant
+            var x = 1_234.56_78_123; // Noncompliant
 
             var y = 1_234_5; // Noncompliant
 


### PR DESCRIPTION
Fixes #3165

Take binary and hexadecimal prefixes into account.

All groups should have the same size with these exceptions:
* first group before the dot is allowed to be shorter.
* last group after the dot is allowed to be shorter.
* It is allowed to only have groups before the dot.
* the first group after the dot (if multiple) should be one shorter than the group size

Specially the last one was missing.
``` C#
var amout = 1_123_123.23_123_12m; 
```