### PR TITLE
Fix OpenCover branch coverage import by using BranchPoints

### DIFF
--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/BranchPoint.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/BranchPoint.java
@@ -25,13 +25,15 @@ class BranchPoint {
   private final int offsetEnd;
   private final int startLine;
   private final int hits;
+  private final int path;
   private final String filePath;
 
-  public BranchPoint(String filePath, int startLine, int offset, int offsetEnd, int hits) {
+  public BranchPoint(String filePath, int startLine, int offset, int offsetEnd, int path, int hits) {
     this.filePath = filePath;
     this.startLine = startLine;
     this.offset = offset;
     this.offsetEnd = offsetEnd;
+    this.path = path;
     this.hits = hits;
   }
 
@@ -48,6 +50,6 @@ class BranchPoint {
   }
 
   public String getUniqueKey() {
-    return String.format("%s-%d-%d-%d", filePath, startLine, offset, offsetEnd);
+    return String.format("%s-%d-%d-%d-%d", filePath, startLine, offset, offsetEnd, path);
   }
 }

--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/BranchPoint.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/BranchPoint.java
@@ -25,6 +25,7 @@ class BranchPoint {
   private final int offsetEnd;
   private final int startLine;
   private final int hits;
+  // identifier for code path
   private final int path;
   private final String filePath;
 

--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/BranchPoint.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/BranchPoint.java
@@ -1,0 +1,53 @@
+/*
+ * SonarSource :: .NET :: Shared library
+ * Copyright (C) 2014-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.plugins.dotnet.tests;
+
+class BranchPoint {
+  private final int offset;
+  private final int offsetEnd;
+  private final int startLine;
+  private final int hits;
+  private final String filePath;
+
+  public BranchPoint(String filePath, int startLine, int offset, int offsetEnd, int hits) {
+    this.filePath = filePath;
+    this.startLine = startLine;
+    this.offset = offset;
+    this.offsetEnd = offsetEnd;
+    this.hits = hits;
+  }
+
+  public int getStartLine() {
+    return startLine;
+  }
+
+  public int getHits() {
+    return hits;
+  }
+
+  public String getFilePath() {
+    return filePath;
+  }
+
+  public String getUniqueKey() {
+    return String.format("%s-%d-%d-%d", filePath, startLine, offset, offsetEnd);
+  }
+}

--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/Coverage.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/Coverage.java
@@ -129,7 +129,9 @@ public class Coverage {
           }
         }
 
-        result.add(new BranchCoverage(line, groupsByKey.size(), coveredBranchPoints));
+        if(groupsByKey.size() > 1) {
+          result.add(new BranchCoverage(line, groupsByKey.size(), coveredBranchPoints));
+        }
       }
     }
 

--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/Coverage.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/Coverage.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class Coverage {
 
@@ -34,6 +35,7 @@ public class Coverage {
   private static final int SPECIAL_HITS_NON_EXECUTABLE = -1;
   private final Map<String, int[]> hitsByLineAndFile = new HashMap<>();
   private final Map<String, List<BranchCoverage>> branchCoverageByFile = new HashMap<>();
+  private final List<BranchPoint> branchPoints = new ArrayList<>();
 
   void addHits(String file, int line, int hits) {
     int[] oldHitsByLine = hitsByLineAndFile.get(file);
@@ -59,6 +61,10 @@ public class Coverage {
       oldHitsByLine[i] = 0;
     }
     oldHitsByLine[i] += hits;
+  }
+
+  public void add(BranchPoint branchPoint){
+    branchPoints.add(branchPoint);
   }
 
   public void addBranchCoverage(String file, BranchCoverage branchCoverage){
@@ -97,13 +103,43 @@ public class Coverage {
     return result;
   }
 
-  List<BranchCoverage> getBranchCoverage(String file){
+  List<BranchCoverage> getBranchCoverageBySequencePoints(String file) {
     return branchCoverageByFile.getOrDefault(file, new ArrayList<>());
+  }
+
+  List<BranchCoverage> getBranchCoverage(String file) {
+    List<BranchCoverage> result = new ArrayList<>();
+
+    Map<Integer, List<BranchPoint>> branchPointsPerLine = branchPoints.stream()
+      .filter(point -> point.getFilePath().equals(file))
+      .collect(Collectors.groupingBy(BranchPoint::getStartLine));
+
+    for (Map.Entry<Integer, List<BranchPoint>> lineBranchPoints : branchPointsPerLine.entrySet()){
+      if (lineBranchPoints.getValue().size() > 1){
+        int line = lineBranchPoints.getKey();
+
+        List<BranchPoint> linePoints = lineBranchPoints.getValue();
+        Map<String, List<BranchPoint>> groupsByCoverageKey = linePoints.stream().collect(Collectors.groupingBy(BranchPoint::getUniqueKey));
+
+        int coveredBranchPoints = 0;
+        for (Map.Entry<String, List<BranchPoint>> group: groupsByCoverageKey.entrySet()){
+          if (group.getValue().stream().filter(point -> point.getHits() >0).count() > 0){
+            coveredBranchPoints++;
+          }
+        }
+
+        result.add(new BranchCoverage(line, groupsByCoverageKey.size(), coveredBranchPoints));
+      }
+    }
+
+    return result;
   }
 
   void mergeWith(Coverage otherCoverage) {
     mergeLineHits(otherCoverage);
     mergeBranchCoverage(otherCoverage);
+
+    branchPoints.addAll(otherCoverage.branchPoints);
   }
 
   private void mergeLineHits(Coverage otherCoverage){

--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/Coverage.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/Coverage.java
@@ -103,6 +103,7 @@ public class Coverage {
     return result;
   }
 
+  // this is the "custom coverage" we have for multiple statements per line coverage
   List<BranchCoverage> getBranchCoverageBySequencePoints(String file) {
     return branchCoverageByFile.getOrDefault(file, new ArrayList<>());
   }
@@ -119,16 +120,16 @@ public class Coverage {
         int line = lineBranchPoints.getKey();
 
         List<BranchPoint> linePoints = lineBranchPoints.getValue();
-        Map<String, List<BranchPoint>> groupsByCoverageKey = linePoints.stream().collect(Collectors.groupingBy(BranchPoint::getUniqueKey));
+        Map<String, List<BranchPoint>> groupsByKey = linePoints.stream().collect(Collectors.groupingBy(BranchPoint::getUniqueKey));
 
         int coveredBranchPoints = 0;
-        for (Map.Entry<String, List<BranchPoint>> group: groupsByCoverageKey.entrySet()){
+        for (Map.Entry<String, List<BranchPoint>> group: groupsByKey.entrySet()){
           if (group.getValue().stream().filter(point -> point.getHits() >0).count() > 0){
             coveredBranchPoints++;
           }
         }
 
-        result.add(new BranchCoverage(line, groupsByCoverageKey.size(), coveredBranchPoints));
+        result.add(new BranchCoverage(line, groupsByKey.size(), coveredBranchPoints));
       }
     }
 

--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/CoverageReportImportSensor.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/CoverageReportImportSensor.java
@@ -152,6 +152,13 @@ public class CoverageReportImportSensor implements Sensor {
       newCoverage.lineHits(entry.getKey(), entry.getValue());
     }
 
+    for (BranchCoverage branchCoverage : coverage.getBranchCoverageBySequencePoints(filePath)){
+      LOG.trace("Found estimated branch coverage entry on line '{}', with total conditions '{}' and covered conditions '{}'.",
+        branchCoverage.getLine(), branchCoverage.getConditions(), branchCoverage.getCoveredConditions());
+      fileHasCoverage = true;
+      newCoverage.conditions(branchCoverage.getLine(), branchCoverage.getConditions(), branchCoverage.getCoveredConditions());
+    }
+
     for (BranchCoverage branchCoverage : coverage.getBranchCoverage(filePath)){
       LOG.trace("Found branch coverage entry on line '{}', with total conditions '{}' and covered conditions '{}'.",
         branchCoverage.getLine(), branchCoverage.getConditions(), branchCoverage.getCoveredConditions());

--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/OpenCoverReportParser.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/OpenCoverReportParser.java
@@ -150,10 +150,11 @@ public class OpenCoverReportParser implements CoverageParser {
 
         int offset = xmlParserHelper.getRequiredIntAttribute("offset");
         int offsetEnd = xmlParserHelper.getRequiredIntAttribute("offsetend");
+        int path = xmlParserHelper.getRequiredIntAttribute("path");
         int visitCount = xmlParserHelper.getRequiredIntAttribute("vc");
 
         if (isSupported.test(filePath)) {
-          coverage.add(new BranchPoint(filePath, line, offset, offsetEnd, visitCount));
+          coverage.add(new BranchPoint(filePath, line, offset, offsetEnd, path, visitCount));
         } else {
           LOG.debug("OpenCover parser: Skipping the fileId '{}', line '{}', vc '{}' because file '{}'" +
               " is not indexed or does not have the supported language.",

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/BranchPointTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/BranchPointTest.java
@@ -27,6 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BranchPointTest {
   @Test
   public void givenBranchPointData_getUniqueKey_containsFilePathStartLineAndOffsets(){
-    assertThat(new BranchPoint("path", 1, 2, 3, 4).getUniqueKey()).isEqualTo("path-1-2-3");
+    assertThat(new BranchPoint("path", 1, 2, 3, 4, 5).getUniqueKey()).isEqualTo("path-1-2-3-4");
   }
 }

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/BranchPointTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/BranchPointTest.java
@@ -1,0 +1,32 @@
+/*
+ * SonarSource :: .NET :: Shared library
+ * Copyright (C) 2014-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package org.sonar.plugins.dotnet.tests;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BranchPointTest {
+  @Test
+  public void givenBranchPointData_getUniqueKey_containsFilePathStartLineAndOffsets(){
+    assertThat(new BranchPoint("path", 1, 2, 3, 4).getUniqueKey()).isEqualTo("path-1-2-3");
+  }
+}

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageReportImportSensorTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageReportImportSensorTest.java
@@ -138,6 +138,8 @@ public class CoverageReportImportSensorTest {
     assertThat(context.lineHits("foo:Foo.cs", 4)).isEqualTo(0);
     assertThat(context.coveredConditions("foo:Foo.cs", 1)).isEqualTo(2);
     assertThat(context.coveredConditions("foo:Foo.cs", 4)).isEqualTo(3);
+    assertThat(context.coveredConditions("foo:Foo.cs", 5)).isEqualTo(1);
+    assertThat(context.coveredConditions("foo:Foo.cs", 6)).isEqualTo(2);
   }
 
   @Test
@@ -147,6 +149,8 @@ public class CoverageReportImportSensorTest {
     assertThat(context.lineHits("foo:Foo.cs", 4)).isEqualTo(0);
     assertThat(context.coveredConditions("foo:Foo.cs", 1)).isEqualTo(2);
     assertThat(context.coveredConditions("foo:Foo.cs", 4)).isEqualTo(3);
+    assertThat(context.coveredConditions("foo:Foo.cs", 5)).isEqualTo(1);
+    assertThat(context.coveredConditions("foo:Foo.cs", 6)).isEqualTo(2);
   }
 
   @Test
@@ -235,10 +239,15 @@ public class CoverageReportImportSensorTest {
     when(coverage.hits(bazPath)).thenReturn(ImmutableMap.<Integer, Integer>builder()
       .put(42, 1)
       .build());
-    when(coverage.getBranchCoverage(fooPath)).thenReturn(ImmutableList.<BranchCoverage>builder()
+    when(coverage.getBranchCoverageBySequencePoints(fooPath)).thenReturn(ImmutableList.<BranchCoverage>builder()
       .add(new BranchCoverage(1, 5, 2))
       .add(new BranchCoverage(4, 3, 3))
       .build());
+    when(coverage.getBranchCoverage(fooPath)).thenReturn(ImmutableList.<BranchCoverage>builder()
+      .add(new BranchCoverage(5, 2, 1))
+      .add(new BranchCoverage(6, 3, 2))
+      .build());
+
 
     DefaultInputFile inputFile = new TestInputFileBuilder("foo", baseDir, new File(baseDir, "Foo.cs"))
       .setLanguage("cs")

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageTest.java
@@ -70,7 +70,7 @@ public class CoverageTest {
   }
 
   @Test
-  public void testBranchCoverage(){
+  public void testBranchCoverageBySequencePoint(){
     Coverage first = new Coverage();
 
     BranchCoverage fooFirstLine = new BranchCoverage(1, 6, 3);
@@ -83,8 +83,8 @@ public class CoverageTest {
     first.addBranchCoverage("foo.txt", fooThirdLine);
     first.addBranchCoverage("bar.txt", barFirstLine);
 
-    assertThat(first.getBranchCoverage("foo.txt")).containsExactly(fooFirstLine, fooThirdLine);
-    assertThat(first.getBranchCoverage("bar.txt")).containsExactly(barFirstLine);
+    assertThat(first.getBranchCoverageBySequencePoints("foo.txt")).containsExactly(fooFirstLine, fooThirdLine);
+    assertThat(first.getBranchCoverageBySequencePoints("bar.txt")).containsExactly(barFirstLine);
 
     Coverage second = new Coverage();
 
@@ -93,8 +93,8 @@ public class CoverageTest {
 
     second.mergeWith(first);
 
-    assertThat(second.getBranchCoverage("foo.txt")).containsExactly(fooFirstLine, fooThirdLine);
-    assertThat(second.getBranchCoverage("bar.txt")).containsExactly(new BranchCoverage(2, 4, 3), barFirstLine);
+    assertThat(second.getBranchCoverageBySequencePoints("foo.txt")).containsExactly(fooFirstLine, fooThirdLine);
+    assertThat(second.getBranchCoverageBySequencePoints("bar.txt")).containsExactly(new BranchCoverage(2, 4, 3), barFirstLine);
   }
 
   @Test
@@ -103,21 +103,128 @@ public class CoverageTest {
     Coverage coverage = new Coverage();
 
     coverage.addBranchCoverage(fileName, new BranchCoverage(1, 2, 1));
-    assertThat(coverage.getBranchCoverage(fileName)).containsExactly(new BranchCoverage(1, 2, 1));
+    assertThat(coverage.getBranchCoverageBySequencePoints(fileName)).containsExactly(new BranchCoverage(1, 2, 1));
 
     coverage.addBranchCoverage(fileName, new BranchCoverage(3, 2, 1));
-    assertThat(coverage.getBranchCoverage(fileName)).containsExactly(
+    assertThat(coverage.getBranchCoverageBySequencePoints(fileName)).containsExactly(
       new BranchCoverage(1, 2, 1),
       new BranchCoverage(3, 2, 1));
 
     coverage.addBranchCoverage(fileName, new BranchCoverage(3, 3, 2));
-    assertThat(coverage.getBranchCoverage(fileName)).containsExactly(
+    assertThat(coverage.getBranchCoverageBySequencePoints(fileName)).containsExactly(
       new BranchCoverage(1, 2, 1),
       new BranchCoverage(3, 5, 3));
 
     coverage.addBranchCoverage(fileName, new BranchCoverage(3, 4, 4));
-    assertThat(coverage.getBranchCoverage(fileName)).containsExactly(
+    assertThat(coverage.getBranchCoverageBySequencePoints(fileName)).containsExactly(
       new BranchCoverage(1, 2, 1),
       new BranchCoverage(3, 9, 7));
+  }
+
+
+  @Test
+  public void givenEmptyListOfBranchPoints_getBranchCoverage_returnsEmpty() {
+    Coverage sut = new Coverage();
+
+    assertThat(sut.getBranchCoverage("fileName")).isEmpty();
+  }
+
+  @Test
+  public void givenSingleBranchPoint_getBranchCoverage_returnsEmpty() {
+    final String filePath = "filePath";
+
+    Coverage sut = new Coverage();
+    sut.add(new BranchPoint(filePath, 1, 2, 3, 4));
+
+    assertThat(sut.getBranchCoverage(filePath)).isEmpty();
+  }
+
+  @Test
+  public void givenSingleBranchPointPerFile_getBranchCoverage_returnsEmpty() {
+    final String firstPath = "firstPath";
+    final String secondPath = "secondPath";
+
+    Coverage sut = new Coverage();
+    sut.add(new BranchPoint(firstPath, 1, 2, 3, 4));
+    sut.add(new BranchPoint(secondPath, 1, 5, 6, 7));
+
+    assertThat(sut.getBranchCoverage(firstPath)).isEmpty();
+    assertThat(sut.getBranchCoverage(secondPath)).isEmpty();
+  }
+
+  @Test
+  public void givenSingleBranchPointPerLine_getBranchCoverage_returnsEmpty() {
+    final String filePath = "filePath";
+
+    Coverage sut = new Coverage();
+    sut.add(new BranchPoint(filePath, 1, 2, 3, 4));
+    sut.add(new BranchPoint(filePath, 2, 5, 6, 7));
+
+    assertThat(sut.getBranchCoverage(filePath)).isEmpty();
+  }
+
+  @Test
+  public void givenMultipleBranchPointsPerLine_getBranchCoverage_returnsBranchCoverage() {
+    final String filePath = "filePath";
+
+    Coverage sut = new Coverage();
+    // Both branch points covered
+    sut.add(new BranchPoint(filePath, 1, 1, 3, 2));
+    sut.add(new BranchPoint(filePath, 1, 4, 6, 1));
+
+    // Only 2 out of 3 branch points covered
+    sut.add(new BranchPoint(filePath, 2, 1, 3, 2));
+    sut.add(new BranchPoint(filePath, 2, 4, 6, 0));
+    sut.add(new BranchPoint(filePath, 2, 6, 8, 4));
+
+    // No branch points covered
+    sut.add(new BranchPoint(filePath, 3, 1, 3, 0));
+    sut.add(new BranchPoint(filePath, 3, 4, 6, 0));
+
+    // Same branch points appear multiple times, none covered (when tests are split in multiple test projects)
+    sut.add(new BranchPoint(filePath, 4, 1, 3, 0));
+    sut.add(new BranchPoint(filePath, 4, 4, 6, 0));
+    sut.add(new BranchPoint(filePath, 4, 1, 3, 0));
+    sut.add(new BranchPoint(filePath, 4, 4, 6, 0));
+
+    // Same branch points appear multiple times, same coverage (when tests are split in multiple test projects)
+    sut.add(new BranchPoint(filePath, 5, 1, 3, 1));
+    sut.add(new BranchPoint(filePath, 5, 4, 6, 0));
+    sut.add(new BranchPoint(filePath, 5, 1, 3, 1));
+    sut.add(new BranchPoint(filePath, 5, 4, 6, 0));
+
+    // Same branch points appear multiple times, different coverage (when tests are split in multiple test projects)
+    sut.add(new BranchPoint(filePath, 6, 1, 3, 1));
+    sut.add(new BranchPoint(filePath, 6, 4, 6, 0));
+    sut.add(new BranchPoint(filePath, 6, 1, 3, 0));
+    sut.add(new BranchPoint(filePath, 6, 4, 6, 1));
+
+    assertThat(sut.getBranchCoverage(filePath))
+      .hasSize(6)
+      .containsOnly(
+        new BranchCoverage(1, 2, 2),
+        new BranchCoverage(2, 3, 2),
+        new BranchCoverage(3, 2, 0),
+        new BranchCoverage(4, 2, 0),
+        new BranchCoverage(5, 2, 1),
+        new BranchCoverage(6, 2, 2)
+      );
+  }
+
+  @Test
+  public void givenMultipleBranchPointsPerLineInDifferentFiles_getBranchCoverage_returnsBranchCoverage() {
+    final String firstPath = "firstPath";
+    final String secondPath = "secondPath";
+
+    Coverage sut = new Coverage();
+    sut.add(new BranchPoint(firstPath, 1, 1, 3, 2));
+    sut.add(new BranchPoint(firstPath, 1, 4, 6, 1));
+
+    sut.add(new BranchPoint(secondPath, 1, 5, 8, 2));
+    sut.add(new BranchPoint(secondPath, 1, 10, 12, 0));
+    sut.add(new BranchPoint(secondPath, 1, 12, 14, 0));
+
+    assertThat(sut.getBranchCoverage(firstPath)).containsOnly(new BranchCoverage(1, 2, 2));
+    assertThat(sut.getBranchCoverage(secondPath)).containsOnly(new BranchCoverage(1, 3, 1));
   }
 }

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageTest.java
@@ -136,6 +136,8 @@ public class CoverageTest {
     Coverage sut = new Coverage();
     sut.add(new BranchPoint(filePath, 1, 2, 3, 4));
 
+    // Normally this case should not happen but if we have only one branch point
+    // we should not report coverage as line coverage is already covering that.
     assertThat(sut.getBranchCoverage(filePath)).isEmpty();
   }
 
@@ -148,6 +150,8 @@ public class CoverageTest {
     sut.add(new BranchPoint(firstPath, 1, 2, 3, 4));
     sut.add(new BranchPoint(secondPath, 1, 5, 6, 7));
 
+    // Normally this case should not happen but if we have only one branch point
+    // we should not report coverage as line coverage is already covering that.
     assertThat(sut.getBranchCoverage(firstPath)).isEmpty();
     assertThat(sut.getBranchCoverage(secondPath)).isEmpty();
   }

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageTest.java
@@ -134,7 +134,7 @@ public class CoverageTest {
     final String filePath = "filePath";
 
     Coverage sut = new Coverage();
-    sut.add(new BranchPoint(filePath, 1, 2, 3, 4));
+    sut.add(new BranchPoint(filePath, 1, 2, 3, 4, 5));
 
     // Normally this case should not happen but if we have only one branch point
     // we should not report coverage as line coverage is already covering that.
@@ -147,8 +147,8 @@ public class CoverageTest {
     final String secondPath = "secondPath";
 
     Coverage sut = new Coverage();
-    sut.add(new BranchPoint(firstPath, 1, 2, 3, 4));
-    sut.add(new BranchPoint(secondPath, 1, 5, 6, 7));
+    sut.add(new BranchPoint(firstPath, 1, 2, 3, 4, 5));
+    sut.add(new BranchPoint(secondPath, 1, 6, 7, 8, 9));
 
     // Normally this case should not happen but if we have only one branch point
     // we should not report coverage as line coverage is already covering that.
@@ -161,10 +161,46 @@ public class CoverageTest {
     final String filePath = "filePath";
 
     Coverage sut = new Coverage();
-    sut.add(new BranchPoint(filePath, 1, 2, 3, 4));
-    sut.add(new BranchPoint(filePath, 2, 5, 6, 7));
+    sut.add(new BranchPoint(filePath, 1, 2, 3, 4, 5));
+    sut.add(new BranchPoint(filePath, 2, 6, 7, 8, 9));
 
     assertThat(sut.getBranchCoverage(filePath)).isEmpty();
+  }
+
+  @Test
+  public void branchPointsMerging() {
+    final String filePath = "filePath";
+
+    Coverage sut = new Coverage();
+
+    // Identical branch points are merged
+    sut.add(new BranchPoint(filePath, 1, 1, 2, 0, 1));
+    sut.add(new BranchPoint(filePath, 1, 1, 2, 0, 1));
+
+    // Branch points with different line are not merged
+    sut.add(new BranchPoint(filePath, 2, 1, 2, 0, 1));
+    sut.add(new BranchPoint(filePath, 3, 1, 2, 0, 1));
+
+    // Branch points with different offset are not merged
+    sut.add(new BranchPoint(filePath, 4, 1, 2, 0, 1));
+    sut.add(new BranchPoint(filePath, 4, 2, 2, 0, 1));
+
+    // Branch points with different offsetEnd are not merged
+    sut.add(new BranchPoint(filePath, 5, 1, 2, 0, 1));
+    sut.add(new BranchPoint(filePath, 5, 1, 3, 0, 1));
+
+    // Branch points with different path are not merged
+    sut.add(new BranchPoint(filePath, 6, 1, 2, 0, 1));
+    sut.add(new BranchPoint(filePath, 6, 1, 2, 1, 1));
+
+    assertThat(sut.getBranchCoverage(filePath))
+      .hasSize(3)
+      .containsOnly(
+        // For the first 3 lines we will not report branch coverage since they have only one branch point each.
+        new BranchCoverage(4, 2, 2),
+        new BranchCoverage(5, 2, 2),
+        new BranchCoverage(6, 2, 2)
+      );
   }
 
   @Test
@@ -173,35 +209,35 @@ public class CoverageTest {
 
     Coverage sut = new Coverage();
     // Both branch points covered
-    sut.add(new BranchPoint(filePath, 1, 1, 3, 2));
-    sut.add(new BranchPoint(filePath, 1, 4, 6, 1));
+    sut.add(new BranchPoint(filePath, 1, 1, 3, 0, 1));
+    sut.add(new BranchPoint(filePath, 1, 4, 6, 1, 1));
 
     // Only 2 out of 3 branch points covered
-    sut.add(new BranchPoint(filePath, 2, 1, 3, 2));
-    sut.add(new BranchPoint(filePath, 2, 4, 6, 0));
-    sut.add(new BranchPoint(filePath, 2, 6, 8, 4));
+    sut.add(new BranchPoint(filePath, 2, 1, 3, 0, 2));
+    sut.add(new BranchPoint(filePath, 2, 4, 6, 1, 0));
+    sut.add(new BranchPoint(filePath, 2, 6, 8, 2, 4));
 
     // No branch points covered
-    sut.add(new BranchPoint(filePath, 3, 1, 3, 0));
-    sut.add(new BranchPoint(filePath, 3, 4, 6, 0));
+    sut.add(new BranchPoint(filePath, 3, 1, 3, 0, 0));
+    sut.add(new BranchPoint(filePath, 3, 4, 6, 1, 0));
 
     // Same branch points appear multiple times, none covered (when tests are split in multiple test projects)
-    sut.add(new BranchPoint(filePath, 4, 1, 3, 0));
-    sut.add(new BranchPoint(filePath, 4, 4, 6, 0));
-    sut.add(new BranchPoint(filePath, 4, 1, 3, 0));
-    sut.add(new BranchPoint(filePath, 4, 4, 6, 0));
+    sut.add(new BranchPoint(filePath, 4, 1, 3, 0, 0));
+    sut.add(new BranchPoint(filePath, 4, 4, 6, 1, 0));
+    sut.add(new BranchPoint(filePath, 4, 1, 3, 0, 0));
+    sut.add(new BranchPoint(filePath, 4, 4, 6, 1, 0));
 
     // Same branch points appear multiple times, same coverage (when tests are split in multiple test projects)
-    sut.add(new BranchPoint(filePath, 5, 1, 3, 1));
-    sut.add(new BranchPoint(filePath, 5, 4, 6, 0));
-    sut.add(new BranchPoint(filePath, 5, 1, 3, 1));
-    sut.add(new BranchPoint(filePath, 5, 4, 6, 0));
+    sut.add(new BranchPoint(filePath, 5, 1, 3, 0, 1));
+    sut.add(new BranchPoint(filePath, 5, 4, 6, 1, 0));
+    sut.add(new BranchPoint(filePath, 5, 1, 3, 0, 1));
+    sut.add(new BranchPoint(filePath, 5, 4, 6, 1, 0));
 
     // Same branch points appear multiple times, different coverage (when tests are split in multiple test projects)
-    sut.add(new BranchPoint(filePath, 6, 1, 3, 1));
-    sut.add(new BranchPoint(filePath, 6, 4, 6, 0));
-    sut.add(new BranchPoint(filePath, 6, 1, 3, 0));
-    sut.add(new BranchPoint(filePath, 6, 4, 6, 1));
+    sut.add(new BranchPoint(filePath, 6, 1, 3, 0, 1));
+    sut.add(new BranchPoint(filePath, 6, 4, 6, 1, 0));
+    sut.add(new BranchPoint(filePath, 6, 1, 3, 0, 0));
+    sut.add(new BranchPoint(filePath, 6, 4, 6, 1, 1));
 
     assertThat(sut.getBranchCoverage(filePath))
       .hasSize(6)
@@ -221,12 +257,12 @@ public class CoverageTest {
     final String secondPath = "secondPath";
 
     Coverage sut = new Coverage();
-    sut.add(new BranchPoint(firstPath, 1, 1, 3, 2));
-    sut.add(new BranchPoint(firstPath, 1, 4, 6, 1));
+    sut.add(new BranchPoint(firstPath, 1, 1, 3, 0, 2));
+    sut.add(new BranchPoint(firstPath, 1, 4, 6, 1, 1));
 
-    sut.add(new BranchPoint(secondPath, 1, 5, 8, 2));
-    sut.add(new BranchPoint(secondPath, 1, 10, 12, 0));
-    sut.add(new BranchPoint(secondPath, 1, 12, 14, 0));
+    sut.add(new BranchPoint(secondPath, 1, 5, 8, 0, 2));
+    sut.add(new BranchPoint(secondPath, 1, 10, 12, 1, 0));
+    sut.add(new BranchPoint(secondPath, 1, 12, 14, 2, 0));
 
     assertThat(sut.getBranchCoverage(firstPath)).containsOnly(new BranchCoverage(1, 2, 2));
     assertThat(sut.getBranchCoverage(secondPath)).containsOnly(new BranchCoverage(1, 3, 1));

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageTest.java
@@ -177,19 +177,19 @@ public class CoverageTest {
     sut.add(new BranchPoint(filePath, 1, 1, 2, 0, 1));
     sut.add(new BranchPoint(filePath, 1, 1, 2, 0, 1));
 
-    // Branch points with different line are not merged
+    // Branch points with different line are not aggregated
     sut.add(new BranchPoint(filePath, 2, 1, 2, 0, 1));
     sut.add(new BranchPoint(filePath, 3, 1, 2, 0, 1));
 
-    // Branch points with different offset are not merged
+    // Branch points with different offset are correctly aggregated
     sut.add(new BranchPoint(filePath, 4, 1, 2, 0, 1));
     sut.add(new BranchPoint(filePath, 4, 2, 2, 0, 1));
 
-    // Branch points with different offsetEnd are not merged
+    // Branch points with different offsetEnd are correctly aggregated
     sut.add(new BranchPoint(filePath, 5, 1, 2, 0, 1));
     sut.add(new BranchPoint(filePath, 5, 1, 3, 0, 1));
 
-    // Branch points with different path are not merged
+    // Branch points with different path are correctly aggregated
     sut.add(new BranchPoint(filePath, 6, 1, 2, 0, 1));
     sut.add(new BranchPoint(filePath, 6, 1, 2, 1, 1));
 

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/DotCoverReportParserTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/DotCoverReportParserTest.java
@@ -120,7 +120,7 @@ public class DotCoverReportParserTest {
         Assertions.entry(34, 1)
       );
 
-    assertThat(coverage.getBranchCoverage(filePath))
+    assertThat(coverage.getBranchCoverageBySequencePoints(filePath))
       .hasSize(4)
       .containsOnly(
         // line 7: CoveredGet , UncoveredProperty and CoveredSet on the same line

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/OpenCoverReportParserTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/OpenCoverReportParserTest.java
@@ -133,10 +133,25 @@ public class OpenCoverReportParserTest {
     assertThat(coverage.getBranchCoverage(filePath))
       .hasSize(5)
       .contains(
+        //  if (x == 0 || y < 0)
         new BranchCoverage(9, 4 , 2),
+
+        // _ = y == 0 || z == 0;
         new BranchCoverage(12, 2 , 1),
+
+        // _ = x == y || y == z;
         new BranchCoverage(13, 2, 1),
+
+        // _ = y == 0 || z == 0; _ = x == y || y == z;
         new BranchCoverage(14, 4, 2),
+
+        // return x < 2
+        //    ? y < 3
+        //        ? z < 1
+        //            ? 1
+        //            : 2
+        //        : 3
+        //    : 4;
         new BranchCoverage(18, 6, 3));
   }
 
@@ -156,6 +171,7 @@ public class OpenCoverReportParserTest {
     Coverage coverage = new Coverage();
     String filePath = new File("BranchCoverage3296\\Code\\ValueProvider.cs").getCanonicalPath();
 
+    // Notice we pass "alwaysFalse" as a predicate
     new OpenCoverReportParser(alwaysFalse).accept(new File("src/test/resources/opencover/code_tested_by_multiple_projects.xml"), coverage);
     assertThat(coverage.files()).isEmpty();
     assertThat(coverage.getBranchCoverage(filePath)).isEmpty();

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/OpenCoverReportParserTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/OpenCoverReportParserTest.java
@@ -167,6 +167,27 @@ public class OpenCoverReportParserTest {
   }
 
   @Test
+  public void branchCoverage_multipleCodePaths_analyzedByMultipleProjects() throws Exception {
+    Coverage coverage = new Coverage();
+    String filePath = new File("SwitchCoverage\\SwitchCoverage\\Foo.cs").getCanonicalPath();
+
+    OpenCoverReportParser parser = new OpenCoverReportParser(alwaysTrue);
+
+    parser.accept(new File("src/test/resources/opencover/switch_expression_multiple_test_projects_1.xml"), coverage);
+    parser.accept(new File("src/test/resources/opencover/switch_expression_multiple_test_projects_2.xml"), coverage);
+
+    assertThat(coverage.files()).contains(filePath);
+    assertThat(coverage.hits(filePath))
+      .hasSize(1)
+      .contains(Assertions.entry(8, 4));
+
+    assertThat(coverage.getBranchCoverage(filePath))
+      .hasSize(1)
+      // the switch expression gets transformed to a more complex IL representation, hence 8 conditions
+      .contains(new BranchCoverage(8, 8 , 6));
+  }
+
+  @Test
   public void branchCoverage_codeFile_unsupportedFile() throws Exception {
     Coverage coverage = new Coverage();
     String filePath = new File("BranchCoverage3296\\Code\\ValueProvider.cs").getCanonicalPath();

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/VisualStudioCoverageXmlReportParserTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/VisualStudioCoverageXmlReportParserTest.java
@@ -117,7 +117,7 @@ public class VisualStudioCoverageXmlReportParserTest {
 
     assertThat(coverage.hits(filePath)).containsExactly(Assertions.entry(11, 1));
 
-    assertThat(coverage.getBranchCoverage(filePath))
+    assertThat(coverage.getBranchCoverageBySequencePoints(filePath))
       .containsExactly(new BranchCoverage(11, 2, 1));
 
     assertThat(logTester.logs(LoggerLevel.INFO).get(0)).startsWith("Parsing the Visual Studio coverage XML report ");
@@ -144,7 +144,7 @@ public class VisualStudioCoverageXmlReportParserTest {
 
     assertThat(coverage.hits(filePath)).containsOnly(Assertions.entry(11, 2));
 
-    assertThat(coverage.getBranchCoverage(filePath))
+    assertThat(coverage.getBranchCoverageBySequencePoints(filePath))
       .containsExactly(new BranchCoverage(11, 6, 2));
 
     assertThat(logTester.logs(LoggerLevel.INFO).get(0)).startsWith("Parsing the Visual Studio coverage XML report ");
@@ -191,7 +191,7 @@ public class VisualStudioCoverageXmlReportParserTest {
         Assertions.entry(29, 1));
 
     // the unreachable code is taken into consideration by the coverage tool
-    assertThat(coverage.getBranchCoverage(filePath))
+    assertThat(coverage.getBranchCoverageBySequencePoints(filePath))
       .hasSize(4)
       .containsOnly(
       // line 11: CoveredGet , UncoveredProperty and CoveredSet on the same line

--- a/sonar-dotnet-shared-library/src/test/resources/opencover/code_tested_by_multiple_projects.xml
+++ b/sonar-dotnet-shared-library/src/test/resources/opencover/code_tested_by_multiple_projects.xml
@@ -1,0 +1,4106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Below is the code for which this coverage file has been created,
+together with the commands to generate the file and the tools versions.
+
+Note: the file paths were manually changed inside the report to be relative.
+________________________________________________________
+namespace Code
+{
+    public class ValueProvider
+    {
+        public int GetValue(bool condition) => condition
+            ? 1
+            : 2;
+    }
+}
+________________________________________________________
+using Code;
+using NUnit.Framework;
+
+namespace FirstTestSuite
+{
+    public class ValueProviderTests
+    {
+        [Test]
+        public void Test1()
+        {
+            Assert.That(new ValueProvider().GetValue(false), Is.EqualTo(2));
+        }
+    }
+}
+________________________________________________________
+using Code;
+using NUnit.Framework;
+
+namespace SecondTestSuite
+{
+    public class Tests
+    {
+        [Test]
+        public void Test1()
+        {
+            Assert.That(new ValueProvider().GetValue(true), Is.EqualTo(1));
+        }
+    }
+}
+-->
+<CoverageSession xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4.7.922.0">
+    <Summary numSequencePoints="2" visitedSequencePoints="2" numBranchPoints="6" visitedBranchPoints="4" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" maxCrapScore="3" minCrapScore="2" visitedClasses="2" numClasses="2" visitedMethods="2" numMethods="2" />
+    <Modules>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5C-D3-E5-60-AC-A8-D6-45-77-6C-59-CA-FE-F1-49-32-B4-41-29-2D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\dotnet.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:30Z</ModuleTime>
+            <ModuleName>dotnet</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D2-6E-C4-85-DC-1F-C3-EB-0C-2E-07-EA-F9-33-C9-A6-25-57-E7-D6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Cli.Utils.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Cli.Utils</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1E-D4-CD-15-2C-94-E4-C6-19-88-4A-EC-70-23-9C-38-12-8A-35-87">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.PlatformAbstractions.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.PlatformAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BF-BC-9F-90-71-42-03-E3-AC-AA-D2-39-9E-84-5C-00-62-70-39-BA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.CodePages.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.CodePages</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="38-09-CE-F2-E5-95-B5-A8-49-DB-F2-B2-FC-2A-62-56-4F-D2-91-39">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Configurer.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Configurer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="92-1F-FF-56-13-04-47-E6-38-08-43-E5-EA-24-FA-0D-43-16-F9-E2">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Cli.CommandLine.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:42Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Cli.CommandLine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-34-21-D2-ED-90-2B-0C-6B-31-85-04-D0-F6-D6-13-31-C9-61-F8">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.InternalAbstractions.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.InternalAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F0-C5-75-3F-22-17-B9-2C-E6-C3-3C-A7-4D-EE-AF-C8-FF-35-92-AC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.CompilerServices.Unsafe.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.CompilerServices.Unsafe</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="DD-89-83-66-26-E0-B9-BF-DD-51-53-00-1B-5A-80-96-5A-0A-01-79">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.ApplicationInsights.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:02Z</ModuleTime>
+            <ModuleName>Microsoft.ApplicationInsights</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AB-8D-BE-78-8D-87-D4-81-9F-34-C0-7E-08-39-0F-DB-91-CE-92-49">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TemplateEngine.Cli.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:46Z</ModuleTime>
+            <ModuleName>Microsoft.TemplateEngine.Cli</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="70-58-B8-D8-D1-66-CB-C6-C4-F9-5F-80-03-7C-74-A2-D8-CA-6A-98">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-4C-1D-C3-E8-DB-38-EA-0D-64-CB-BD-58-BC-F2-B0-E2-99-42-93">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.XDocument</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Private.Xml.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.RegularExpressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9E-63-EF-9A-D8-E6-C0-64-EB-31-79-F5-8C-35-7D-C2-C5-D2-94-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Http.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:44Z</ModuleTime>
+            <ModuleName>System.Net.Http</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-8F-70-B6-4E-19-5D-AD-A4-E6-F3-7F-0E-80-A2-3F-81-B0-99-64">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Globalization.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Globalization</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A5-D1-78-2C-3D-8D-E9-D4-52-E4-0C-B0-3D-34-F4-8D-7A-08-C6-C3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Security.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Net.Security</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2D-D2-58-DD-BA-4D-D9-A2-D8-99-CB-EF-60-05-5F-E6-2B-B1-A8-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.X509Certificates.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.X509Certificates</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F1-9F-EA-39-E9-B6-89-2A-58-18-83-8F-AC-C2-48-C5-4B-91-2A-5E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Requests.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Requests</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E7-62-66-DE-57-93-B4-25-D0-E5-B1-77-A2-DF-82-65-19-35-D3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NetworkInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Net.NetworkInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FA-59-51-C6-D3-6C-0B-D8-35-01-96-30-1E-15-48-22-E9-1D-84-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TemplateEngine.Utils.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:46Z</ModuleTime>
+            <ModuleName>Microsoft.TemplateEngine.Utils</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-CF-CB-AB-4F-25-B8-44-23-16-25-EC-27-DB-10-94-9B-5F-78-77">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Registry.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Registry</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EF-F5-62-5F-AF-AF-B2-EE-AD-D8-B0-5F-2F-34-FF-0C-C9-DD-5C-66">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tools.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tools</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C1-41-1B-16-60-41-0D-35-CE-85-82-6D-04-AB-CE-5C-88-E8-BE-91">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+            <ModuleName>System.IO</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A5-1D-73-D2-8D-F6-70-B7-B7-8B-00-F4-17-70-7F-2A-98-D3-1C-F9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CC-FC-9F-9B-3F-02-43-A8-4C-9F-1C-AD-15-23-EF-34-31-D4-A6-0C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.Compression.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:40Z</ModuleTime>
+            <ModuleName>System.IO.Compression</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="47-20-F1-42-9C-3C-11-60-EE-D5-38-37-4E-D7-48-C3-66-42-34-0F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Framework.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9E-74-A8-58-6C-B8-D8-AD-35-90-C4-AB-A7-24-4E-54-43-53-8E-2F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.DiagnosticSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.Diagnostics.DiagnosticSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-17-3D-BA-13-03-55-32-76-CF-3D-AE-B3-52-14-5F-95-F5-3E-85">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Timer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Timer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EE-DF-4B-C9-A1-40-03-5F-56-1A-DB-D7-E8-A0-BC-A6-12-34-84-1E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Sockets.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:08Z</ModuleTime>
+            <ModuleName>System.Net.Sockets</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E6-CE-DF-D3-05-01-F5-61-41-53-0C-FF-2C-87-01-04-6E-EB-B1-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NameResolution.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Net.NameResolution</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="76-87-37-3D-BD-CF-7C-E5-90-89-7B-D5-45-86-01-3E-47-72-1F-6D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\MSBuild.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>MSBuild</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="47-20-F1-42-9C-3C-11-60-EE-D5-38-37-4E-D7-48-C3-66-42-34-0F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Framework.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.RegularExpressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="58-59-35-07-07-DE-52-C3-80-D9-CC-BF-5D-FA-04-DF-29-C6-52-ED">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.Build</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BF-BC-9F-90-71-42-03-E3-AC-AA-D2-39-9E-84-5C-00-62-70-39-BA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.CodePages.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.CodePages</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5C-D3-E5-60-AC-A8-D6-45-77-6C-59-CA-FE-F1-49-32-B4-41-29-2D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\dotnet.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:30Z</ModuleTime>
+            <ModuleName>dotnet</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="38-09-CE-F2-E5-95-B5-A8-49-DB-F2-B2-FC-2A-62-56-4F-D2-91-39">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Configurer.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Configurer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="03-C3-25-61-A9-3B-57-DB-78-E8-F7-85-5D-BE-8C-07-5D-B0-8C-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Encoding.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Encoding</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-34-21-D2-ED-90-2B-0C-6B-31-85-04-D0-F6-D6-13-31-C9-61-F8">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.InternalAbstractions.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.InternalAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D2-6E-C4-85-DC-1F-C3-EB-0C-2E-07-EA-F9-33-C9-A6-25-57-E7-D6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Cli.Utils.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Cli.Utils</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="DD-89-83-66-26-E0-B9-BF-DD-51-53-00-1B-5A-80-96-5A-0A-01-79">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.ApplicationInsights.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:02Z</ModuleTime>
+            <ModuleName>Microsoft.ApplicationInsights</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1E-D4-CD-15-2C-94-E4-C6-19-88-4A-EC-70-23-9C-38-12-8A-35-87">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.PlatformAbstractions.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.PlatformAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F0-C5-75-3F-22-17-B9-2C-E6-C3-3C-A7-4D-EE-AF-C8-FF-35-92-AC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.CompilerServices.Unsafe.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.CompilerServices.Unsafe</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="70-58-B8-D8-D1-66-CB-C6-C4-F9-5F-80-03-7C-74-A2-D8-CA-6A-98">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-4C-1D-C3-E8-DB-38-EA-0D-64-CB-BD-58-BC-F2-B0-E2-99-42-93">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.XDocument</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Private.Xml.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-8F-70-B6-4E-19-5D-AD-A4-E6-F3-7F-0E-80-A2-3F-81-B0-99-64">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Globalization.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Globalization</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BD-4A-A7-E3-52-A8-34-61-7F-29-11-AF-BF-90-FC-16-AD-AB-40-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.Dataflow.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks.Dataflow</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-CF-CB-AB-4F-25-B8-44-23-16-25-EC-27-DB-10-94-9B-5F-78-77">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Registry.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Registry</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="04-D0-77-B5-F7-72-0B-E6-E8-AA-8F-4B-A0-A0-C9-C0-4C-69-37-D9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.Parallel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks.Parallel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="88-E7-E8-96-8F-48-99-50-8E-E1-DF-4C-0E-D5-D8-C5-0D-62-22-36">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Tasks.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Tasks.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="7A-E6-CA-81-95-20-D1-FF-17-80-B7-2A-AB-83-B3-0A-F1-99-1E-2A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Utilities.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:42Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Utilities.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E4-51-7F-05-08-F3-02-02-27-8E-E8-21-7C-ED-F0-78-12-BA-03-DA">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Build.Tasks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>NuGet.Build.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="11-27-AE-76-EA-89-8D-78-90-4F-7C-8D-62-56-14-CD-EF-02-37-D9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9A-73-83-D7-DB-DD-27-CD-88-01-22-D7-EF-C7-FF-A7-B2-07-F7-3B">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Commands.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Commands</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="36-E8-16-54-B7-19-BD-A8-2A-38-DC-64-7B-B6-08-2C-AE-DF-59-4A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.ProjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.ProjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FE-01-7B-00-A1-9B-C4-BC-2A-13-7F-59-A4-6F-55-59-DD-49-B7-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.Pipes.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:04Z</ModuleTime>
+            <ModuleName>System.IO.Pipes</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="80-8D-68-67-13-D9-19-58-91-D7-B1-B6-1B-CF-9B-3C-AC-80-89-94">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.NuGetSdkResolver.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:36Z</ModuleTime>
+            <ModuleName>Microsoft.Build.NuGetSdkResolver</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="49-E0-50-A5-D9-8A-25-15-AE-1C-26-42-E6-99-0B-49-D2-F5-CB-DA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.FileVersionInfo.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.FileVersionInfo</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="42-A4-D5-63-DA-C9-6B-42-3E-CF-98-F9-FB-80-3B-23-4D-E8-7E-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="76-87-37-3D-BD-CF-7C-E5-90-89-7B-D5-45-86-01-3E-47-72-1F-6D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\MSBuild.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>MSBuild</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="47-20-F1-42-9C-3C-11-60-EE-D5-38-37-4E-D7-48-C3-66-42-34-0F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Framework.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.RegularExpressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="58-59-35-07-07-DE-52-C3-80-D9-CC-BF-5D-FA-04-DF-29-C6-52-ED">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.Build</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BF-BC-9F-90-71-42-03-E3-AC-AA-D2-39-9E-84-5C-00-62-70-39-BA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.CodePages.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.CodePages</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FE-01-7B-00-A1-9B-C4-BC-2A-13-7F-59-A4-6F-55-59-DD-49-B7-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.Pipes.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:04Z</ModuleTime>
+            <ModuleName>System.IO.Pipes</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-03-66-B3-A4-0E-6D-59-00-DF-29-69-D0-2E-C0-08-26-E6-F1-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.AccessControl.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.AccessControl</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-03-66-B3-A4-0E-6D-59-00-DF-29-69-D0-2E-C0-08-26-E6-F1-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.AccessControl.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.AccessControl</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BD-4A-A7-E3-52-A8-34-61-7F-29-11-AF-BF-90-FC-16-AD-AB-40-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.Dataflow.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks.Dataflow</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5C-D3-E5-60-AC-A8-D6-45-77-6C-59-CA-FE-F1-49-32-B4-41-29-2D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\dotnet.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:30Z</ModuleTime>
+            <ModuleName>dotnet</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="76-87-37-3D-BD-CF-7C-E5-90-89-7B-D5-45-86-01-3E-47-72-1F-6D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\MSBuild.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>MSBuild</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="38-09-CE-F2-E5-95-B5-A8-49-DB-F2-B2-FC-2A-62-56-4F-D2-91-39">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Configurer.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Configurer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="47-20-F1-42-9C-3C-11-60-EE-D5-38-37-4E-D7-48-C3-66-42-34-0F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Framework.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.RegularExpressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="58-59-35-07-07-DE-52-C3-80-D9-CC-BF-5D-FA-04-DF-29-C6-52-ED">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.Build</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BF-BC-9F-90-71-42-03-E3-AC-AA-D2-39-9E-84-5C-00-62-70-39-BA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.CodePages.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.CodePages</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FE-01-7B-00-A1-9B-C4-BC-2A-13-7F-59-A4-6F-55-59-DD-49-B7-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.Pipes.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:04Z</ModuleTime>
+            <ModuleName>System.IO.Pipes</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-03-66-B3-A4-0E-6D-59-00-DF-29-69-D0-2E-C0-08-26-E6-F1-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.AccessControl.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.AccessControl</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BD-4A-A7-E3-52-A8-34-61-7F-29-11-AF-BF-90-FC-16-AD-AB-40-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.Dataflow.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks.Dataflow</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-CF-CB-AB-4F-25-B8-44-23-16-25-EC-27-DB-10-94-9B-5F-78-77">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Registry.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Registry</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5C-D3-E5-60-AC-A8-D6-45-77-6C-59-CA-FE-F1-49-32-B4-41-29-2D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\dotnet.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:30Z</ModuleTime>
+            <ModuleName>dotnet</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="38-09-CE-F2-E5-95-B5-A8-49-DB-F2-B2-FC-2A-62-56-4F-D2-91-39">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Configurer.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Configurer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="04-D0-77-B5-F7-72-0B-E6-E8-AA-8F-4B-A0-A0-C9-C0-4C-69-37-D9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.Parallel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks.Parallel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-CF-CB-AB-4F-25-B8-44-23-16-25-EC-27-DB-10-94-9B-5F-78-77">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Registry.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Registry</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="7A-E6-CA-81-95-20-D1-FF-17-80-B7-2A-AB-83-B3-0A-F1-99-1E-2A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Utilities.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:42Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Utilities.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="04-D0-77-B5-F7-72-0B-E6-E8-AA-8F-4B-A0-A0-C9-C0-4C-69-37-D9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.Parallel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks.Parallel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="7A-E6-CA-81-95-20-D1-FF-17-80-B7-2A-AB-83-B3-0A-F1-99-1E-2A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Utilities.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:42Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Utilities.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B6-58-2E-A2-A7-DF-F0-53-14-F6-45-D8-42-D5-5A-6B-69-F7-12-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Formatters.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Formatters</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B6-58-2E-A2-A7-DF-F0-53-14-F6-45-D8-42-D5-5A-6B-69-F7-12-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Formatters.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Formatters</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B6-58-2E-A2-A7-DF-F0-53-14-F6-45-D8-42-D5-5A-6B-69-F7-12-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Formatters.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Formatters</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="88-E7-E8-96-8F-48-99-50-8E-E1-DF-4C-0E-D5-D8-C5-0D-62-22-36">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Tasks.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Tasks.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="88-E7-E8-96-8F-48-99-50-8E-E1-DF-4C-0E-D5-D8-C5-0D-62-22-36">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Tasks.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Tasks.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-32-2C-E5-EA-D1-3F-48-26-FC-68-8B-AF-F0-AD-51-5E-49-3A-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Sdks\Microsoft.NET.Sdk\tools\netcoreapp2.1\Microsoft.NET.Build.Tasks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>Microsoft.NET.Build.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-32-2C-E5-EA-D1-3F-48-26-FC-68-8B-AF-F0-AD-51-5E-49-3A-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Sdks\Microsoft.NET.Sdk\tools\netcoreapp2.1\Microsoft.NET.Build.Tasks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>Microsoft.NET.Build.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-32-2C-E5-EA-D1-3F-48-26-FC-68-8B-AF-F0-AD-51-5E-49-3A-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Sdks\Microsoft.NET.Sdk\tools\netcoreapp2.1\Microsoft.NET.Build.Tasks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>Microsoft.NET.Build.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-58-94-5C-AE-F2-A7-8A-8B-30-7C-11-FD-9F-26-D2-52-A0-20-73">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Configuration.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Configuration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E4-51-7F-05-08-F3-02-02-27-8E-E8-21-7C-ED-F0-78-12-BA-03-DA">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Build.Tasks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>NuGet.Build.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E4-51-7F-05-08-F3-02-02-27-8E-E8-21-7C-ED-F0-78-12-BA-03-DA">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Build.Tasks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>NuGet.Build.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="11-27-AE-76-EA-89-8D-78-90-4F-7C-8D-62-56-14-CD-EF-02-37-D9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="11-27-AE-76-EA-89-8D-78-90-4F-7C-8D-62-56-14-CD-EF-02-37-D9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9A-73-83-D7-DB-DD-27-CD-88-01-22-D7-EF-C7-FF-A7-B2-07-F7-3B">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Commands.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Commands</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9A-73-83-D7-DB-DD-27-CD-88-01-22-D7-EF-C7-FF-A7-B2-07-F7-3B">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Commands.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Commands</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="36-E8-16-54-B7-19-BD-A8-2A-38-DC-64-7B-B6-08-2C-AE-DF-59-4A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.ProjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.ProjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="36-E8-16-54-B7-19-BD-A8-2A-38-DC-64-7B-B6-08-2C-AE-DF-59-4A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.ProjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.ProjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-58-94-5C-AE-F2-A7-8A-8B-30-7C-11-FD-9F-26-D2-52-A0-20-73">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Configuration.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Configuration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-58-94-5C-AE-F2-A7-8A-8B-30-7C-11-FD-9F-26-D2-52-A0-20-73">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Configuration.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Configuration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.XDocument</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.XDocument</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Private.Xml.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Private.Xml.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="81-0C-F3-3E-51-92-D0-E4-C7-7A-C4-D0-2E-C3-CC-6C-34-E6-D7-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Versioning.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>NuGet.Versioning</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="81-0C-F3-3E-51-92-D0-E4-C7-7A-C4-D0-2E-C3-CC-6C-34-E6-D7-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Versioning.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>NuGet.Versioning</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="81-0C-F3-3E-51-92-D0-E4-C7-7A-C4-D0-2E-C3-CC-6C-34-E6-D7-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Versioning.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>NuGet.Versioning</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3C-6B-ED-4B-FA-6C-10-19-4A-12-34-FC-E0-70-F3-70-7C-58-BD-82">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Newtonsoft.Json.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>Newtonsoft.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6F-CC-2C-76-AC-42-0E-1D-29-DC-BE-AB-E0-6D-A4-C2-9D-0C-27-23">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.Expressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:18Z</ModuleTime>
+            <ModuleName>System.Linq.Expressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6D-0F-A0-D8-6E-D9-3D-12-46-84-DE-CC-44-CE-CF-2B-96-27-29-EA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.TypeConverter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.ComponentModel.TypeConverter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="18-71-46-94-36-55-BA-42-DC-70-B8-FB-CB-47-53-46-BC-07-97-6F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Packaging.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Packaging</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-CA-FC-BE-CF-59-51-70-73-DF-FA-12-D9-07-FF-31-9C-F2-7B-3A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.LibraryModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.LibraryModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8A-CB-B6-B3-E3-37-ED-90-BE-07-BD-2E-2B-E8-75-50-F6-12-63-7B">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Protocol.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Protocol</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="71-2C-E9-CA-85-B8-8F-D9-04-1B-18-26-60-00-6A-A4-C4-26-BB-A6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Credentials.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.Credentials</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="03-E9-A6-34-43-87-E3-D3-27-29-CB-80-91-3F-B1-99-54-02-59-17">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.DependencyResolver.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.DependencyResolver.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-C7-5C-FC-1E-89-3E-67-F0-53-6B-39-C4-C0-61-BC-52-35-9C-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6E-50-A1-2A-7E-70-B6-5C-B5-48-65-1E-90-FC-92-89-65-1A-F5-6F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Numerics.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Numerics</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B3-44-E0-6E-7A-CB-1B-06-37-3E-84-75-01-86-B8-6B-40-5A-F6-CE">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.Build.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:46Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Build</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B3-44-E0-6E-7A-CB-1B-06-37-3E-84-75-01-86-B8-6B-40-5A-F6-CE">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.Build.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:46Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Build</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-84-10-73-D5-25-3C-C8-54-CA-05-A9-21-5F-EC-4F-D6-B7-11-E4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\mscorlib.dll</ModulePath>
+            <ModuleTime>2020-02-21T02:00:46Z</ModuleTime>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-84-10-73-D5-25-3C-C8-54-CA-05-A9-21-5F-EC-4F-D6-B7-11-E4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\mscorlib.dll</ModulePath>
+            <ModuleTime>2020-02-21T02:00:46Z</ModuleTime>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F0-C5-75-3F-22-17-B9-2C-E6-C3-3C-A7-4D-EE-AF-C8-FF-35-92-AC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.CompilerServices.Unsafe.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.CompilerServices.Unsafe</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="36-E8-16-54-B7-19-BD-A8-2A-38-DC-64-7B-B6-08-2C-AE-DF-59-4A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.ProjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.ProjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F0-C5-75-3F-22-17-B9-2C-E6-C3-3C-A7-4D-EE-AF-C8-FF-35-92-AC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.CompilerServices.Unsafe.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.CompilerServices.Unsafe</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="36-E8-16-54-B7-19-BD-A8-2A-38-DC-64-7B-B6-08-2C-AE-DF-59-4A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.ProjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.ProjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-84-10-73-D5-25-3C-C8-54-CA-05-A9-21-5F-EC-4F-D6-B7-11-E4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\mscorlib.dll</ModulePath>
+            <ModuleTime>2020-02-21T02:00:46Z</ModuleTime>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="42-A4-D5-63-DA-C9-6B-42-3E-CF-98-F9-FB-80-3B-23-4D-E8-7E-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="42-A4-D5-63-DA-C9-6B-42-3E-CF-98-F9-FB-80-3B-23-4D-E8-7E-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B3-44-E0-6E-7A-CB-1B-06-37-3E-84-75-01-86-B8-6B-40-5A-F6-CE">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.Build.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:46Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Build</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EF-F5-62-5F-AF-AF-B2-EE-AD-D8-B0-5F-2F-34-FF-0C-C9-DD-5C-66">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tools.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tools</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C1-41-1B-16-60-41-0D-35-CE-85-82-6D-04-AB-CE-5C-88-E8-BE-91">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+            <ModuleName>System.IO</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A5-1D-73-D2-8D-F6-70-B7-B7-8B-00-F4-17-70-7F-2A-98-D3-1C-F9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CC-FC-9F-9B-3F-02-43-A8-4C-9F-1C-AD-15-23-EF-34-31-D4-A6-0C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.Compression.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:40Z</ModuleTime>
+            <ModuleName>System.IO.Compression</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9E-63-EF-9A-D8-E6-C0-64-EB-31-79-F5-8C-35-7D-C2-C5-D2-94-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Http.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:44Z</ModuleTime>
+            <ModuleName>System.Net.Http</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A5-D1-78-2C-3D-8D-E9-D4-52-E4-0C-B0-3D-34-F4-8D-7A-08-C6-C3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Security.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Net.Security</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2D-D2-58-DD-BA-4D-D9-A2-D8-99-CB-EF-60-05-5F-E6-2B-B1-A8-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.X509Certificates.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.X509Certificates</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="36-E8-16-54-B7-19-BD-A8-2A-38-DC-64-7B-B6-08-2C-AE-DF-59-4A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.ProjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.ProjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="81-0C-F3-3E-51-92-D0-E4-C7-7A-C4-D0-2E-C3-CC-6C-34-E6-D7-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Versioning.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>NuGet.Versioning</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="18-71-46-94-36-55-BA-42-DC-70-B8-FB-CB-47-53-46-BC-07-97-6F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Packaging.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Packaging</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="11-27-AE-76-EA-89-8D-78-90-4F-7C-8D-62-56-14-CD-EF-02-37-D9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4F-0A-ED-F6-02-69-AD-2A-C5-2B-2C-93-BD-A8-93-87-63-5A-5E-FD">
+            <ModulePath>BranchCoverage3296\.sonarqube\bin\SonarScanner.MSBuild.Tasks.dll</ModulePath>
+            <ModuleTime>2019-11-06T10:01:08Z</ModuleTime>
+            <ModuleName>SonarScanner.MSBuild.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="06-FE-91-56-B3-97-3C-54-B4-DF-B8-F2-2C-63-4C-B2-7B-B5-56-11">
+            <ModulePath>BranchCoverage3296\.sonarqube\bin\SonarScanner.MSBuild.Common.dll</ModulePath>
+            <ModuleTime>2019-11-06T10:01:08Z</ModuleTime>
+            <ModuleName>SonarScanner.MSBuild.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-BE-1B-A1-47-C7-A9-22-1A-36-76-9C-CD-84-A9-47-AB-29-BF-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XmlSerializer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Xml.XmlSerializer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="06-80-9E-D1-73-4C-C3-26-E9-10-FB-BA-48-03-C8-00-F3-CE-AD-3F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-28-72-75-40-0A-51-3A-66-C2-5F-6B-3C-7B-2D-19-EA-73-0E-B4">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Roslyn\Microsoft.Build.Tasks.CodeAnalysis.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Tasks.CodeAnalysis</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="81-0C-F3-3E-51-92-D0-E4-C7-7A-C4-D0-2E-C3-CC-6C-34-E6-D7-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Versioning.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>NuGet.Versioning</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="81-0C-F3-3E-51-92-D0-E4-C7-7A-C4-D0-2E-C3-CC-6C-34-E6-D7-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Versioning.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>NuGet.Versioning</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="18-71-46-94-36-55-BA-42-DC-70-B8-FB-CB-47-53-46-BC-07-97-6F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Packaging.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Packaging</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="18-71-46-94-36-55-BA-42-DC-70-B8-FB-CB-47-53-46-BC-07-97-6F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Packaging.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Packaging</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="11-27-AE-76-EA-89-8D-78-90-4F-7C-8D-62-56-14-CD-EF-02-37-D9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="11-27-AE-76-EA-89-8D-78-90-4F-7C-8D-62-56-14-CD-EF-02-37-D9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="88-C2-81-23-88-9B-01-F5-41-12-93-F2-07-C5-30-2F-E9-C7-6C-F6">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Core.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="88-C2-81-23-88-9B-01-F5-41-12-93-F2-07-C5-30-2F-E9-C7-6C-F6">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Core.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Metadata</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Metadata</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="ED-AD-51-03-F6-38-CC-C2-AA-8C-6C-A7-26-44-05-C3-B7-66-2C-5B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.MemoryMappedFiles.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:04Z</ModuleTime>
+            <ModuleName>System.IO.MemoryMappedFiles</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="ED-AD-51-03-F6-38-CC-C2-AA-8C-6C-A7-26-44-05-C3-B7-66-2C-5B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.MemoryMappedFiles.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:04Z</ModuleTime>
+            <ModuleName>System.IO.MemoryMappedFiles</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4F-0A-ED-F6-02-69-AD-2A-C5-2B-2C-93-BD-A8-93-87-63-5A-5E-FD">
+            <ModulePath>BranchCoverage3296\.sonarqube\bin\SonarScanner.MSBuild.Tasks.dll</ModulePath>
+            <ModuleTime>2019-11-06T10:01:08Z</ModuleTime>
+            <ModuleName>SonarScanner.MSBuild.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="06-FE-91-56-B3-97-3C-54-B4-DF-B8-F2-2C-63-4C-B2-7B-B5-56-11">
+            <ModulePath>BranchCoverage3296\.sonarqube\bin\SonarScanner.MSBuild.Common.dll</ModulePath>
+            <ModuleTime>2019-11-06T10:01:08Z</ModuleTime>
+            <ModuleName>SonarScanner.MSBuild.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4F-0A-ED-F6-02-69-AD-2A-C5-2B-2C-93-BD-A8-93-87-63-5A-5E-FD">
+            <ModulePath>BranchCoverage3296\.sonarqube\bin\SonarScanner.MSBuild.Tasks.dll</ModulePath>
+            <ModuleTime>2019-11-06T10:01:08Z</ModuleTime>
+            <ModuleName>SonarScanner.MSBuild.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="06-FE-91-56-B3-97-3C-54-B4-DF-B8-F2-2C-63-4C-B2-7B-B5-56-11">
+            <ModulePath>BranchCoverage3296\.sonarqube\bin\SonarScanner.MSBuild.Common.dll</ModulePath>
+            <ModuleTime>2019-11-06T10:01:08Z</ModuleTime>
+            <ModuleName>SonarScanner.MSBuild.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-BE-1B-A1-47-C7-A9-22-1A-36-76-9C-CD-84-A9-47-AB-29-BF-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XmlSerializer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Xml.XmlSerializer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-BE-1B-A1-47-C7-A9-22-1A-36-76-9C-CD-84-A9-47-AB-29-BF-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XmlSerializer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Xml.XmlSerializer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="06-80-9E-D1-73-4C-C3-26-E9-10-FB-BA-48-03-C8-00-F3-CE-AD-3F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="06-80-9E-D1-73-4C-C3-26-E9-10-FB-BA-48-03-C8-00-F3-CE-AD-3F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-28-72-75-40-0A-51-3A-66-C2-5F-6B-3C-7B-2D-19-EA-73-0E-B4">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Roslyn\Microsoft.Build.Tasks.CodeAnalysis.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Tasks.CodeAnalysis</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-28-72-75-40-0A-51-3A-66-C2-5F-6B-3C-7B-2D-19-EA-73-0E-B4">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Roslyn\Microsoft.Build.Tasks.CodeAnalysis.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Tasks.CodeAnalysis</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C5-B4-6F-68-5D-85-FF-B9-B3-F6-E7-E5-87-BC-47-13-C3-03-85-42">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\vstest.console.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>vstest.console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C5-B4-6F-68-5D-85-FF-B9-B3-F6-E7-E5-87-BC-47-13-C3-03-85-42">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\vstest.console.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>vstest.console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="92-D6-1E-14-62-24-DB-73-F3-A0-87-8B-5C-9C-71-AE-8C-A6-49-86">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.CoreUtilities.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:48Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CoreUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="92-D6-1E-14-62-24-DB-73-F3-A0-87-8B-5C-9C-71-AE-8C-A6-49-86">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.CoreUtilities.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:48Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CoreUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-FF-45-54-97-94-E5-EE-F1-55-1C-4C-1D-ED-C5-F1-4E-56-04-D6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F4-74-D8-EC-37-07-89-F7-DE-41-4A-0C-45-90-94-9E-A5-09-14-06">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.VisualStudio.TestPlatform.Client.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Client</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4C-5D-3E-A4-C6-A7-88-97-E0-76-1D-3C-13-D7-AB-BC-57-B4-67-F9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.VisualStudio.TestPlatform.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:47:02Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-FF-45-54-97-94-E5-EE-F1-55-1C-4C-1D-ED-C5-F1-4E-56-04-D6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F4-74-D8-EC-37-07-89-F7-DE-41-4A-0C-45-90-94-9E-A5-09-14-06">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.VisualStudio.TestPlatform.Client.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Client</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4C-5D-3E-A4-C6-A7-88-97-E0-76-1D-3C-13-D7-AB-BC-57-B4-67-F9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.VisualStudio.TestPlatform.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:47:02Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C0-AF-8F-C2-7E-FA-FB-83-67-D3-56-10-08-BB-63-E8-4F-C8-F0-D3">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.PlatformAbstractions.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:48Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.PlatformAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-FA-4B-8B-8A-A0-0A-BA-5F-16-77-6A-F8-D1-03-FD-B2-46-A8-11">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.Utilities.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Utilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C0-AF-8F-C2-7E-FA-FB-83-67-D3-56-10-08-BB-63-E8-4F-C8-F0-D3">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.PlatformAbstractions.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:48Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.PlatformAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-FA-4B-8B-8A-A0-0A-BA-5F-16-77-6A-F8-D1-03-FD-B2-46-A8-11">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.Utilities.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Utilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5D-6D-F0-C2-3B-E4-3D-F4-31-9F-65-26-E3-6C-69-57-41-07-04-68">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Extensions.FileSystemGlobbing.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:42Z</ModuleTime>
+            <ModuleName>Microsoft.Extensions.FileSystemGlobbing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5D-6D-F0-C2-3B-E4-3D-F4-31-9F-65-26-E3-6C-69-57-41-07-04-68">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Extensions.FileSystemGlobbing.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:42Z</ModuleTime>
+            <ModuleName>Microsoft.Extensions.FileSystemGlobbing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F6-E7-29-AB-39-E0-7C-13-70-CF-AC-B2-AB-D0-49-87-2A-34-C1-64">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.CrossPlatEngine.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CrossPlatEngine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F6-E7-29-AB-39-E0-7C-13-70-CF-AC-B2-AB-D0-49-87-2A-34-C1-64">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.CrossPlatEngine.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CrossPlatEngine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4A-53-F5-47-1F-79-0D-C2-A0-C2-4E-CF-CA-18-30-0C-4C-0B-1E-EB">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.TestPlatform.Extensions.BlameDataCollector.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:32Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Extensions.BlameDataCollector</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="04-77-E0-D3-40-DA-95-B9-FC-B5-A1-54-7E-38-5B-86-0D-1B-18-A2">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.TestPlatform.Extensions.EventLogCollector.dll</ModulePath>
+            <ModuleTime>2020-02-04T18:55:20Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Extensions.EventLogCollector</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-84-10-73-D5-25-3C-C8-54-CA-05-A9-21-5F-EC-4F-D6-B7-11-E4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\mscorlib.dll</ModulePath>
+            <ModuleTime>2020-02-21T02:00:46Z</ModuleTime>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="73-E1-7F-C7-2D-C9-99-D8-D5-D4-21-69-B8-EB-65-4F-5D-EE-9F-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4A-53-F5-47-1F-79-0D-C2-A0-C2-4E-CF-CA-18-30-0C-4C-0B-1E-EB">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.TestPlatform.Extensions.BlameDataCollector.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:32Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Extensions.BlameDataCollector</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-10-3B-1F-DD-91-01-95-79-0E-F6-D0-4B-B1-E9-93-CF-9F-3A-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.TestPlatform.TestHostRuntimeProvider.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.TestHostRuntimeProvider</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="04-77-E0-D3-40-DA-95-B9-FC-B5-A1-54-7E-38-5B-86-0D-1B-18-A2">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.TestPlatform.Extensions.EventLogCollector.dll</ModulePath>
+            <ModuleTime>2020-02-04T18:55:20Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Extensions.EventLogCollector</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-84-10-73-D5-25-3C-C8-54-CA-05-A9-21-5F-EC-4F-D6-B7-11-E4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\mscorlib.dll</ModulePath>
+            <ModuleTime>2020-02-21T02:00:46Z</ModuleTime>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="73-E1-7F-C7-2D-C9-99-D8-D5-D4-21-69-B8-EB-65-4F-5D-EE-9F-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-10-3B-1F-DD-91-01-95-79-0E-F6-D0-4B-B1-E9-93-CF-9F-3A-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.TestPlatform.TestHostRuntimeProvider.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.TestHostRuntimeProvider</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-93-DD-90-A8-82-7B-57-C3-76-20-97-82-80-AF-83-9B-1C-6C-60">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:36Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FF-FA-57-35-2E-F1-77-97-83-A6-16-E9-B4-A3-70-07-E7-9C-31-25">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:36Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-93-DD-90-A8-82-7B-57-C3-76-20-97-82-80-AF-83-9B-1C-6C-60">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:36Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FF-FA-57-35-2E-F1-77-97-83-A6-16-E9-B4-A3-70-07-E7-9C-31-25">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:36Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Metadata</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Metadata</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-25-19-27-36-F6-C2-E1-00-4F-1C-5A-3B-B4-6F-F9-7F-69-AB-4E">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.CommunicationUtilities.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:48Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CommunicationUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-25-19-27-36-F6-C2-E1-00-4F-1C-5A-3B-B4-6F-F9-7F-69-AB-4E">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.CommunicationUtilities.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:48Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CommunicationUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3C-6B-ED-4B-FA-6C-10-19-4A-12-34-FC-E0-70-F3-70-7C-58-BD-82">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Newtonsoft.Json.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>Newtonsoft.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B6-58-2E-A2-A7-DF-F0-53-14-F6-45-D8-42-D5-5A-6B-69-F7-12-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Formatters.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Formatters</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3C-6B-ED-4B-FA-6C-10-19-4A-12-34-FC-E0-70-F3-70-7C-58-BD-82">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Newtonsoft.Json.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>Newtonsoft.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B6-58-2E-A2-A7-DF-F0-53-14-F6-45-D8-42-D5-5A-6B-69-F7-12-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Formatters.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Formatters</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-17-3D-BA-13-03-55-32-76-CF-3D-AE-B3-52-14-5F-95-F5-3E-85">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Timer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Timer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-17-3D-BA-13-03-55-32-76-CF-3D-AE-B3-52-14-5F-95-F5-3E-85">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Timer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Timer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EE-DF-4B-C9-A1-40-03-5F-56-1A-DB-D7-E8-A0-BC-A6-12-34-84-1E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Sockets.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:08Z</ModuleTime>
+            <ModuleName>System.Net.Sockets</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EE-DF-4B-C9-A1-40-03-5F-56-1A-DB-D7-E8-A0-BC-A6-12-34-84-1E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Sockets.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:08Z</ModuleTime>
+            <ModuleName>System.Net.Sockets</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E6-CE-DF-D3-05-01-F5-61-41-53-0C-FF-2C-87-01-04-6E-EB-B1-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NameResolution.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Net.NameResolution</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E6-CE-DF-D3-05-01-F5-61-41-53-0C-FF-2C-87-01-04-6E-EB-B1-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NameResolution.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Net.NameResolution</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="0C-3A-E6-E1-38-B5-90-C7-A4-B2-35-FE-13-D9-F0-F4-22-8C-DD-7F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Extensions.DependencyModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:44Z</ModuleTime>
+            <ModuleName>Microsoft.Extensions.DependencyModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="0C-3A-E6-E1-38-B5-90-C7-A4-B2-35-FE-13-D9-F0-F4-22-8C-DD-7F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Extensions.DependencyModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:44Z</ModuleTime>
+            <ModuleName>Microsoft.Extensions.DependencyModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6F-CC-2C-76-AC-42-0E-1D-29-DC-BE-AB-E0-6D-A4-C2-9D-0C-27-23">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.Expressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:18Z</ModuleTime>
+            <ModuleName>System.Linq.Expressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6F-CC-2C-76-AC-42-0E-1D-29-DC-BE-AB-E0-6D-A4-C2-9D-0C-27-23">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.Expressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:18Z</ModuleTime>
+            <ModuleName>System.Linq.Expressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6D-0F-A0-D8-6E-D9-3D-12-46-84-DE-CC-44-CE-CF-2B-96-27-29-EA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.TypeConverter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.ComponentModel.TypeConverter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6D-0F-A0-D8-6E-D9-3D-12-46-84-DE-CC-44-CE-CF-2B-96-27-29-EA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.TypeConverter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.ComponentModel.TypeConverter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-EE-9E-7D-BB-C0-BA-51-7E-90-FD-C9-D6-FD-CC-4E-A0-46-68-9C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Json.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Text.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-EE-9E-7D-BB-C0-BA-51-7E-90-FD-C9-D6-FD-CC-4E-A0-46-68-9C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Json.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Text.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-06-D3-2E-A9-D1-DF-9B-77-17-06-81-56-37-0F-29-3C-26-3C-CF">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Numerics.Vectors.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Numerics.Vectors</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F0-C5-75-3F-22-17-B9-2C-E6-C3-3C-A7-4D-EE-AF-C8-FF-35-92-AC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.CompilerServices.Unsafe.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.CompilerServices.Unsafe</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-06-D3-2E-A9-D1-DF-9B-77-17-06-81-56-37-0F-29-3C-26-3C-CF">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Numerics.Vectors.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Numerics.Vectors</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F0-C5-75-3F-22-17-B9-2C-E6-C3-3C-A7-4D-EE-AF-C8-FF-35-92-AC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.CompilerServices.Unsafe.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.CompilerServices.Unsafe</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6E-50-A1-2A-7E-70-B6-5C-B5-48-65-1E-90-FC-92-89-65-1A-F5-6F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Numerics.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Numerics</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6E-50-A1-2A-7E-70-B6-5C-B5-48-65-1E-90-FC-92-89-65-1A-F5-6F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Numerics.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Numerics</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="7D-3A-F3-83-6D-97-74-27-C8-E9-63-BA-8D-D0-48-3C-92-E3-0F-27">
+            <ModulePath>D:\tools\nuget\microsoft.testplatform.testhost\16.4.0\build\netcoreapp2.1\x64\testhost.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>testhost</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="7D-3A-F3-83-6D-97-74-27-C8-E9-63-BA-8D-D0-48-3C-92-E3-0F-27">
+            <ModulePath>D:\tools\nuget\microsoft.testplatform.testhost\16.4.0\build\netcoreapp2.1\x64\testhost.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>testhost</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="82-51-73-4E-B7-D2-16-2E-C0-8E-C4-E6-62-93-07-C8-18-AE-1F-E3">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CoreUtilities.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:00Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CoreUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="82-51-73-4E-B7-D2-16-2E-C0-8E-C4-E6-62-93-07-C8-18-AE-1F-E3">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CoreUtilities.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:00Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CoreUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3C-3B-BB-1E-4C-23-A0-8A-AE-82-07-50-C4-BD-55-77-FD-48-A8-43">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.PlatformAbstractions.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:00Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.PlatformAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-8E-CE-5F-4A-F0-53-BF-7A-86-29-F3-60-31-4E-C2-C7-92-64-BF">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CrossPlatEngine.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CrossPlatEngine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3A-01-82-3D-B5-F1-23-E3-44-29-52-01-DD-EB-29-DB-C4-C5-8C-CE">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CommunicationUtilities.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CommunicationUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3C-3B-BB-1E-4C-23-A0-8A-AE-82-07-50-C4-BD-55-77-FD-48-A8-43">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.PlatformAbstractions.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:00Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.PlatformAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="51-13-D1-D9-16-6E-B7-32-DA-55-E3-B7-9D-7A-18-56-62-3D-30-3F">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:00Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8C-92-D8-11-B9-57-FB-91-AB-D6-D1-EA-9E-0B-7D-0C-F1-03-BC-6E">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.Common.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="53-D0-A3-B9-10-36-09-21-32-F4-D0-88-75-00-B5-DC-77-89-1D-78">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Newtonsoft.Json.dll</ModulePath>
+            <ModuleTime>2016-06-13T21:06:14Z</ModuleTime>
+            <ModuleName>Newtonsoft.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-C7-5C-FC-1E-89-3E-67-F0-53-6B-39-C4-C0-61-BC-52-35-9C-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-8E-CE-5F-4A-F0-53-BF-7A-86-29-F3-60-31-4E-C2-C7-92-64-BF">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CrossPlatEngine.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CrossPlatEngine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-8F-70-B6-4E-19-5D-AD-A4-E6-F3-7F-0E-80-A2-3F-81-B0-99-64">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Globalization.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Globalization</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3A-01-82-3D-B5-F1-23-E3-44-29-52-01-DD-EB-29-DB-C4-C5-8C-CE">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CommunicationUtilities.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CommunicationUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="51-13-D1-D9-16-6E-B7-32-DA-55-E3-B7-9D-7A-18-56-62-3D-30-3F">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:00Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8C-92-D8-11-B9-57-FB-91-AB-D6-D1-EA-9E-0B-7D-0C-F1-03-BC-6E">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.Common.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="53-D0-A3-B9-10-36-09-21-32-F4-D0-88-75-00-B5-DC-77-89-1D-78">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Newtonsoft.Json.dll</ModulePath>
+            <ModuleTime>2016-06-13T21:06:14Z</ModuleTime>
+            <ModuleName>Newtonsoft.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-C7-5C-FC-1E-89-3E-67-F0-53-6B-39-C4-C0-61-BC-52-35-9C-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-8F-70-B6-4E-19-5D-AD-A4-E6-F3-7F-0E-80-A2-3F-81-B0-99-64">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Globalization.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Globalization</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EE-DF-4B-C9-A1-40-03-5F-56-1A-DB-D7-E8-A0-BC-A6-12-34-84-1E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Sockets.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:08Z</ModuleTime>
+            <ModuleName>System.Net.Sockets</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E6-CE-DF-D3-05-01-F5-61-41-53-0C-FF-2C-87-01-04-6E-EB-B1-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NameResolution.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Net.NameResolution</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EE-DF-4B-C9-A1-40-03-5F-56-1A-DB-D7-E8-A0-BC-A6-12-34-84-1E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Sockets.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:08Z</ModuleTime>
+            <ModuleName>System.Net.Sockets</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E6-CE-DF-D3-05-01-F5-61-41-53-0C-FF-2C-87-01-04-6E-EB-B1-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NameResolution.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Net.NameResolution</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-C7-5C-FC-1E-89-3E-67-F0-53-6B-39-C4-C0-61-BC-52-35-9C-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-C7-5C-FC-1E-89-3E-67-F0-53-6B-39-C4-C0-61-BC-52-35-9C-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="15-E5-50-D1-2F-F4-E8-02-DA-D7-F8-1F-A5-31-2E-52-66-E1-F3-61">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Data.Common.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+            <ModuleName>System.Data.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="42-A4-D5-63-DA-C9-6B-42-3E-CF-98-F9-FB-80-3B-23-4D-E8-7E-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="15-E5-50-D1-2F-F4-E8-02-DA-D7-F8-1F-A5-31-2E-52-66-E1-F3-61">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Data.Common.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+            <ModuleName>System.Data.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="42-A4-D5-63-DA-C9-6B-42-3E-CF-98-F9-FB-80-3B-23-4D-E8-7E-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Anonymously Hosted DynamicMethods Assembly</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Anonymously Hosted DynamicMethods Assembly</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5B-59-5A-55-C9-41-C5-0A-8E-0B-98-78-A8-43-45-E3-86-A3-5F-91">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Specialized.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections.Specialized</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="05-AF-58-DB-DA-32-BF-49-84-01-F1-55-D6-55-6F-40-94-52-FB-50">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Drawing.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Drawing.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5B-59-5A-55-C9-41-C5-0A-8E-0B-98-78-A8-43-45-E3-86-A3-5F-91">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Specialized.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections.Specialized</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="05-AF-58-DB-DA-32-BF-49-84-01-F1-55-D6-55-6F-40-94-52-FB-50">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Drawing.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Drawing.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C1-41-1B-16-60-41-0D-35-CE-85-82-6D-04-AB-CE-5C-88-E8-BE-91">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+            <ModuleName>System.IO</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-CC-E7-2C-B7-DA-57-06-96-2B-F7-01-5A-76-38-AA-26-92-87-6D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Dynamic.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Dynamic.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C1-41-1B-16-60-41-0D-35-CE-85-82-6D-04-AB-CE-5C-88-E8-BE-91">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+            <ModuleName>System.IO</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-CC-E7-2C-B7-DA-57-06-96-2B-F7-01-5A-76-38-AA-26-92-87-6D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Dynamic.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Dynamic.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6F-CC-2C-76-AC-42-0E-1D-29-DC-BE-AB-E0-6D-A4-C2-9D-0C-27-23">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.Expressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:18Z</ModuleTime>
+            <ModuleName>System.Linq.Expressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-4C-1D-C3-E8-DB-38-EA-0D-64-CB-BD-58-BC-F2-B0-E2-99-42-93">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="70-58-B8-D8-D1-66-CB-C6-C4-F9-5F-80-03-7C-74-A2-D8-CA-6A-98">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6F-CC-2C-76-AC-42-0E-1D-29-DC-BE-AB-E0-6D-A4-C2-9D-0C-27-23">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.Expressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:18Z</ModuleTime>
+            <ModuleName>System.Linq.Expressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-4C-1D-C3-E8-DB-38-EA-0D-64-CB-BD-58-BC-F2-B0-E2-99-42-93">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="70-58-B8-D8-D1-66-CB-C6-C4-F9-5F-80-03-7C-74-A2-D8-CA-6A-98">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.XDocument</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Private.Xml.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.XDocument</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Private.Xml.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.RegularExpressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.RegularExpressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Anonymously Hosted DynamicMethods Assembly</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Anonymously Hosted DynamicMethods Assembly</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="59-B3-53-C6-DD-77-03-5F-2E-4E-9A-A7-81-4B-56-D8-AB-97-8F-66">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\NUnit3.TestAdapter.dll</ModulePath>
+            <ModuleTime>2019-08-30T10:05:18Z</ModuleTime>
+            <ModuleName>NUnit3.TestAdapter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="12-76-CC-1D-71-64-A5-ED-83-74-CD-75-86-B8-02-00-13-2D-7E-D2">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\nunit.engine.api.dll</ModulePath>
+            <ModuleTime>2019-03-24T14:23:48Z</ModuleTime>
+            <ModuleName>nunit.engine.api</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="59-B3-53-C6-DD-77-03-5F-2E-4E-9A-A7-81-4B-56-D8-AB-97-8F-66">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\NUnit3.TestAdapter.dll</ModulePath>
+            <ModuleTime>2019-08-30T10:05:18Z</ModuleTime>
+            <ModuleName>NUnit3.TestAdapter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="12-76-CC-1D-71-64-A5-ED-83-74-CD-75-86-B8-02-00-13-2D-7E-D2">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\nunit.engine.api.dll</ModulePath>
+            <ModuleTime>2019-03-24T14:23:48Z</ModuleTime>
+            <ModuleName>nunit.engine.api</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-17-3D-BA-13-03-55-32-76-CF-3D-AE-B3-52-14-5F-95-F5-3E-85">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Timer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Timer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-17-3D-BA-13-03-55-32-76-CF-3D-AE-B3-52-14-5F-95-F5-3E-85">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Timer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Timer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C1-E6-95-46-6B-22-AB-AD-8C-29-08-C6-4F-A8-BC-C8-E3-D9-B3-83">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2019-04-01T16:23:50Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C1-E6-95-46-6B-22-AB-AD-8C-29-08-C6-4F-A8-BC-C8-E3-D9-B3-83">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2019-04-01T16:23:50Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Metadata</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Metadata</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-6F-E2-59-47-64-D2-E4-64-4E-96-55-60-F4-13-5C-EE-05-0B-BE">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\nunit.engine.dll</ModulePath>
+            <ModuleTime>2019-03-24T14:23:48Z</ModuleTime>
+            <ModuleName>nunit.engine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-6F-E2-59-47-64-D2-E4-64-4E-96-55-60-F4-13-5C-EE-05-0B-BE">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\nunit.engine.dll</ModulePath>
+            <ModuleTime>2019-03-24T14:23:48Z</ModuleTime>
+            <ModuleName>nunit.engine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>Mono.Cecil.dll</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Mono.Cecil</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="31-48-4C-D9-B7-64-1C-85-5D-80-A0-AB-74-1E-29-E1-94-43-80-C0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:42Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>Mono.Cecil.dll</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Mono.Cecil</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="31-48-4C-D9-B7-64-1C-85-5D-80-A0-AB-74-1E-29-E1-94-43-80-C0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:42Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A5-1D-73-D2-8D-F6-70-B7-B7-8B-00-F4-17-70-7F-2A-98-D3-1C-F9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A5-1D-73-D2-8D-F6-70-B7-B7-8B-00-F4-17-70-7F-2A-98-D3-1C-F9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-DF-92-D4-E4-7D-E2-6F-35-36-11-65-C3-69-FF-1A-0F-BE-4E-52">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\SecondTestSuite.dll</ModulePath>
+            <ModuleTime>2020-04-27T06:25:40.5318924Z</ModuleTime>
+            <ModuleName>SecondTestSuite</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9A-F7-44-9B-43-8F-1E-71-60-7A-04-D2-A8-AB-10-07-80-3D-DF-79">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\FirstTestSuite.dll</ModulePath>
+            <ModuleTime>2020-04-27T06:25:40.5318924Z</ModuleTime>
+            <ModuleName>FirstTestSuite</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="16-2A-6A-6B-DF-CD-D6-7C-53-72-D1-C2-AE-69-5C-68-F9-E9-F2-2D">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\nunit.framework.dll</ModulePath>
+            <ModuleTime>2019-05-14T20:37:24Z</ModuleTime>
+            <ModuleName>nunit.framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="16-2A-6A-6B-DF-CD-D6-7C-53-72-D1-C2-AE-69-5C-68-F9-E9-F2-2D">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\nunit.framework.dll</ModulePath>
+            <ModuleTime>2019-05-14T20:37:24Z</ModuleTime>
+            <ModuleName>nunit.framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module hash="8F-EE-CD-E3-B7-04-08-DD-B6-60-C3-50-BE-5C-7C-A3-37-F2-B9-BA">
+            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" maxCrapScore="3" minCrapScore="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Code.dll</ModulePath>
+            <ModuleTime>2020-04-27T06:25:39.7448903Z</ModuleTime>
+            <ModuleName>Code</ModuleName>
+            <Files>
+                <File uid="2" fullPath="BranchCoverage3296\Code\ValueProvider.cs" />
+            </Files>
+            <Classes>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="0" minCyclomaticComplexity="0" maxCrapScore="0" minCrapScore="0" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+                    <FullName>&lt;Module&gt;</FullName>
+                    <Methods />
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" maxCrapScore="3" minCrapScore="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+                    <FullName>Code.ValueProvider</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="3" nPathComplexity="2" sequenceCoverage="100" branchCoverage="66.67" crapScore="3" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" maxCrapScore="3" minCrapScore="3" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+                            <MetadataToken>100663297</MetadataToken>
+                            <Name>System.Int32 Code.ValueProvider::GetValue(System.Boolean)</Name>
+                            <FileRef uid="2" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1" ordinal="0" offset="0" sl="5" sc="48" el="7" ec="16" bec="2" bev="1" fileid="2" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="3" ordinal="0" offset="1" sl="5" path="0" offsetend="3" fileid="2" />
+                                <BranchPoint vc="0" uspid="5" ordinal="1" offset="1" sl="5" path="1" offsetend="6" fileid="2" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1" ordinal="0" offset="0" sl="5" sc="48" el="7" ec="16" bec="2" bev="1" fileid="2" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" crapScore="2" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+                            <MetadataToken>100663298</MetadataToken>
+                            <Name>System.Void Code.ValueProvider::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="7" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+            </Classes>
+        </Module>
+        <Module hash="8F-EE-CD-E3-B7-04-08-DD-B6-60-C3-50-BE-5C-7C-A3-37-F2-B9-BA">
+            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" maxCrapScore="3" minCrapScore="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Code.dll</ModulePath>
+            <ModuleTime>2020-04-27T06:25:39.7448903Z</ModuleTime>
+            <ModuleName>Code</ModuleName>
+            <Files>
+                <File uid="1" fullPath="BranchCoverage3296\Code\ValueProvider.cs" />
+            </Files>
+            <Classes>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="0" minCyclomaticComplexity="0" maxCrapScore="0" minCrapScore="0" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+                    <FullName>&lt;Module&gt;</FullName>
+                    <Methods />
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" maxCrapScore="3" minCrapScore="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+                    <FullName>Code.ValueProvider</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="3" nPathComplexity="2" sequenceCoverage="100" branchCoverage="66.67" crapScore="3" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" maxCrapScore="3" minCrapScore="3" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+                            <MetadataToken>100663297</MetadataToken>
+                            <Name>System.Int32 Code.ValueProvider::GetValue(System.Boolean)</Name>
+                            <FileRef uid="1" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="2" ordinal="0" offset="0" sl="5" sc="48" el="7" ec="16" bec="2" bev="1" fileid="1" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="4" ordinal="0" offset="1" sl="5" path="0" offsetend="3" fileid="1" />
+                                <BranchPoint vc="1" uspid="6" ordinal="1" offset="1" sl="5" path="1" offsetend="6" fileid="1" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="2" ordinal="0" offset="0" sl="5" sc="48" el="7" ec="16" bec="2" bev="1" fileid="1" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" crapScore="2" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+                            <MetadataToken>100663298</MetadataToken>
+                            <Name>System.Void Code.ValueProvider::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="8" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+            </Classes>
+        </Module>
+        <Module skippedDueTo="Filter" hash="6D-0F-A0-D8-6E-D9-3D-12-46-84-DE-CC-44-CE-CF-2B-96-27-29-EA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.TypeConverter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.ComponentModel.TypeConverter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6D-0F-A0-D8-6E-D9-3D-12-46-84-DE-CC-44-CE-CF-2B-96-27-29-EA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.TypeConverter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.ComponentModel.TypeConverter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+            <Classes />
+        </Module>
+    </Modules>
+</CoverageSession>

--- a/sonar-dotnet-shared-library/src/test/resources/opencover/coverage_branches.xml
+++ b/sonar-dotnet-shared-library/src/test/resources/opencover/coverage_branches.xml
@@ -2,6 +2,8 @@
 <!--
 This file was generated from the following code:
 
+using System;
+
 namespace BranchCoveragePoc
 {
     public class Calculator

--- a/sonar-dotnet-shared-library/src/test/resources/opencover/invalid_file_id.xml
+++ b/sonar-dotnet-shared-library/src/test/resources/opencover/invalid_file_id.xml
@@ -1,0 +1,4107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Below is the code for which this coverage file has been created,
+together with the commands to generate the file and the tools versions.
+
+Note: the file paths were manually changed inside the report to be relative and
+the file id was modified to be invalid
+________________________________________________________
+namespace Code
+{
+    public class ValueProvider
+    {
+        public int GetValue(bool condition) => condition
+            ? 1
+            : 2;
+    }
+}
+________________________________________________________
+using Code;
+using NUnit.Framework;
+
+namespace FirstTestSuite
+{
+    public class ValueProviderTests
+    {
+        [Test]
+        public void Test1()
+        {
+            Assert.That(new ValueProvider().GetValue(false), Is.EqualTo(2));
+        }
+    }
+}
+________________________________________________________
+using Code;
+using NUnit.Framework;
+
+namespace SecondTestSuite
+{
+    public class Tests
+    {
+        [Test]
+        public void Test1()
+        {
+            Assert.That(new ValueProvider().GetValue(true), Is.EqualTo(1));
+        }
+    }
+}
+-->
+<CoverageSession xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4.7.922.0">
+    <Summary numSequencePoints="2" visitedSequencePoints="2" numBranchPoints="6" visitedBranchPoints="4" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" maxCrapScore="3" minCrapScore="2" visitedClasses="2" numClasses="2" visitedMethods="2" numMethods="2" />
+    <Modules>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5C-D3-E5-60-AC-A8-D6-45-77-6C-59-CA-FE-F1-49-32-B4-41-29-2D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\dotnet.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:30Z</ModuleTime>
+            <ModuleName>dotnet</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D2-6E-C4-85-DC-1F-C3-EB-0C-2E-07-EA-F9-33-C9-A6-25-57-E7-D6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Cli.Utils.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Cli.Utils</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1E-D4-CD-15-2C-94-E4-C6-19-88-4A-EC-70-23-9C-38-12-8A-35-87">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.PlatformAbstractions.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.PlatformAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BF-BC-9F-90-71-42-03-E3-AC-AA-D2-39-9E-84-5C-00-62-70-39-BA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.CodePages.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.CodePages</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="38-09-CE-F2-E5-95-B5-A8-49-DB-F2-B2-FC-2A-62-56-4F-D2-91-39">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Configurer.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Configurer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="92-1F-FF-56-13-04-47-E6-38-08-43-E5-EA-24-FA-0D-43-16-F9-E2">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Cli.CommandLine.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:42Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Cli.CommandLine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-34-21-D2-ED-90-2B-0C-6B-31-85-04-D0-F6-D6-13-31-C9-61-F8">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.InternalAbstractions.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.InternalAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F0-C5-75-3F-22-17-B9-2C-E6-C3-3C-A7-4D-EE-AF-C8-FF-35-92-AC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.CompilerServices.Unsafe.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.CompilerServices.Unsafe</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="DD-89-83-66-26-E0-B9-BF-DD-51-53-00-1B-5A-80-96-5A-0A-01-79">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.ApplicationInsights.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:02Z</ModuleTime>
+            <ModuleName>Microsoft.ApplicationInsights</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AB-8D-BE-78-8D-87-D4-81-9F-34-C0-7E-08-39-0F-DB-91-CE-92-49">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TemplateEngine.Cli.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:46Z</ModuleTime>
+            <ModuleName>Microsoft.TemplateEngine.Cli</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="70-58-B8-D8-D1-66-CB-C6-C4-F9-5F-80-03-7C-74-A2-D8-CA-6A-98">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-4C-1D-C3-E8-DB-38-EA-0D-64-CB-BD-58-BC-F2-B0-E2-99-42-93">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.XDocument</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Private.Xml.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.RegularExpressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9E-63-EF-9A-D8-E6-C0-64-EB-31-79-F5-8C-35-7D-C2-C5-D2-94-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Http.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:44Z</ModuleTime>
+            <ModuleName>System.Net.Http</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-8F-70-B6-4E-19-5D-AD-A4-E6-F3-7F-0E-80-A2-3F-81-B0-99-64">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Globalization.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Globalization</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A5-D1-78-2C-3D-8D-E9-D4-52-E4-0C-B0-3D-34-F4-8D-7A-08-C6-C3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Security.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Net.Security</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2D-D2-58-DD-BA-4D-D9-A2-D8-99-CB-EF-60-05-5F-E6-2B-B1-A8-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.X509Certificates.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.X509Certificates</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F1-9F-EA-39-E9-B6-89-2A-58-18-83-8F-AC-C2-48-C5-4B-91-2A-5E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Requests.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Requests</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E7-62-66-DE-57-93-B4-25-D0-E5-B1-77-A2-DF-82-65-19-35-D3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NetworkInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Net.NetworkInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FA-59-51-C6-D3-6C-0B-D8-35-01-96-30-1E-15-48-22-E9-1D-84-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TemplateEngine.Utils.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:46Z</ModuleTime>
+            <ModuleName>Microsoft.TemplateEngine.Utils</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-CF-CB-AB-4F-25-B8-44-23-16-25-EC-27-DB-10-94-9B-5F-78-77">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Registry.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Registry</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EF-F5-62-5F-AF-AF-B2-EE-AD-D8-B0-5F-2F-34-FF-0C-C9-DD-5C-66">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tools.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tools</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C1-41-1B-16-60-41-0D-35-CE-85-82-6D-04-AB-CE-5C-88-E8-BE-91">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+            <ModuleName>System.IO</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A5-1D-73-D2-8D-F6-70-B7-B7-8B-00-F4-17-70-7F-2A-98-D3-1C-F9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CC-FC-9F-9B-3F-02-43-A8-4C-9F-1C-AD-15-23-EF-34-31-D4-A6-0C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.Compression.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:40Z</ModuleTime>
+            <ModuleName>System.IO.Compression</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="47-20-F1-42-9C-3C-11-60-EE-D5-38-37-4E-D7-48-C3-66-42-34-0F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Framework.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9E-74-A8-58-6C-B8-D8-AD-35-90-C4-AB-A7-24-4E-54-43-53-8E-2F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.DiagnosticSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.Diagnostics.DiagnosticSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-17-3D-BA-13-03-55-32-76-CF-3D-AE-B3-52-14-5F-95-F5-3E-85">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Timer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Timer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EE-DF-4B-C9-A1-40-03-5F-56-1A-DB-D7-E8-A0-BC-A6-12-34-84-1E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Sockets.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:08Z</ModuleTime>
+            <ModuleName>System.Net.Sockets</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E6-CE-DF-D3-05-01-F5-61-41-53-0C-FF-2C-87-01-04-6E-EB-B1-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NameResolution.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Net.NameResolution</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="76-87-37-3D-BD-CF-7C-E5-90-89-7B-D5-45-86-01-3E-47-72-1F-6D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\MSBuild.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>MSBuild</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="47-20-F1-42-9C-3C-11-60-EE-D5-38-37-4E-D7-48-C3-66-42-34-0F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Framework.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.RegularExpressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="58-59-35-07-07-DE-52-C3-80-D9-CC-BF-5D-FA-04-DF-29-C6-52-ED">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.Build</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BF-BC-9F-90-71-42-03-E3-AC-AA-D2-39-9E-84-5C-00-62-70-39-BA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.CodePages.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.CodePages</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5C-D3-E5-60-AC-A8-D6-45-77-6C-59-CA-FE-F1-49-32-B4-41-29-2D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\dotnet.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:30Z</ModuleTime>
+            <ModuleName>dotnet</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="38-09-CE-F2-E5-95-B5-A8-49-DB-F2-B2-FC-2A-62-56-4F-D2-91-39">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Configurer.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Configurer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="03-C3-25-61-A9-3B-57-DB-78-E8-F7-85-5D-BE-8C-07-5D-B0-8C-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Encoding.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Encoding</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-34-21-D2-ED-90-2B-0C-6B-31-85-04-D0-F6-D6-13-31-C9-61-F8">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.InternalAbstractions.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.InternalAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D2-6E-C4-85-DC-1F-C3-EB-0C-2E-07-EA-F9-33-C9-A6-25-57-E7-D6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Cli.Utils.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Cli.Utils</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="DD-89-83-66-26-E0-B9-BF-DD-51-53-00-1B-5A-80-96-5A-0A-01-79">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.ApplicationInsights.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:02Z</ModuleTime>
+            <ModuleName>Microsoft.ApplicationInsights</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1E-D4-CD-15-2C-94-E4-C6-19-88-4A-EC-70-23-9C-38-12-8A-35-87">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.PlatformAbstractions.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.PlatformAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F0-C5-75-3F-22-17-B9-2C-E6-C3-3C-A7-4D-EE-AF-C8-FF-35-92-AC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.CompilerServices.Unsafe.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.CompilerServices.Unsafe</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="70-58-B8-D8-D1-66-CB-C6-C4-F9-5F-80-03-7C-74-A2-D8-CA-6A-98">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-4C-1D-C3-E8-DB-38-EA-0D-64-CB-BD-58-BC-F2-B0-E2-99-42-93">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.XDocument</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Private.Xml.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-8F-70-B6-4E-19-5D-AD-A4-E6-F3-7F-0E-80-A2-3F-81-B0-99-64">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Globalization.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Globalization</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BD-4A-A7-E3-52-A8-34-61-7F-29-11-AF-BF-90-FC-16-AD-AB-40-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.Dataflow.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks.Dataflow</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-CF-CB-AB-4F-25-B8-44-23-16-25-EC-27-DB-10-94-9B-5F-78-77">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Registry.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Registry</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="04-D0-77-B5-F7-72-0B-E6-E8-AA-8F-4B-A0-A0-C9-C0-4C-69-37-D9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.Parallel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks.Parallel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="88-E7-E8-96-8F-48-99-50-8E-E1-DF-4C-0E-D5-D8-C5-0D-62-22-36">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Tasks.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Tasks.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="7A-E6-CA-81-95-20-D1-FF-17-80-B7-2A-AB-83-B3-0A-F1-99-1E-2A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Utilities.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:42Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Utilities.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E4-51-7F-05-08-F3-02-02-27-8E-E8-21-7C-ED-F0-78-12-BA-03-DA">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Build.Tasks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>NuGet.Build.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="11-27-AE-76-EA-89-8D-78-90-4F-7C-8D-62-56-14-CD-EF-02-37-D9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9A-73-83-D7-DB-DD-27-CD-88-01-22-D7-EF-C7-FF-A7-B2-07-F7-3B">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Commands.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Commands</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="36-E8-16-54-B7-19-BD-A8-2A-38-DC-64-7B-B6-08-2C-AE-DF-59-4A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.ProjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.ProjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FE-01-7B-00-A1-9B-C4-BC-2A-13-7F-59-A4-6F-55-59-DD-49-B7-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.Pipes.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:04Z</ModuleTime>
+            <ModuleName>System.IO.Pipes</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="80-8D-68-67-13-D9-19-58-91-D7-B1-B6-1B-CF-9B-3C-AC-80-89-94">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.NuGetSdkResolver.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:36Z</ModuleTime>
+            <ModuleName>Microsoft.Build.NuGetSdkResolver</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="49-E0-50-A5-D9-8A-25-15-AE-1C-26-42-E6-99-0B-49-D2-F5-CB-DA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.FileVersionInfo.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.FileVersionInfo</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="42-A4-D5-63-DA-C9-6B-42-3E-CF-98-F9-FB-80-3B-23-4D-E8-7E-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="76-87-37-3D-BD-CF-7C-E5-90-89-7B-D5-45-86-01-3E-47-72-1F-6D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\MSBuild.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>MSBuild</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="47-20-F1-42-9C-3C-11-60-EE-D5-38-37-4E-D7-48-C3-66-42-34-0F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Framework.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.RegularExpressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="58-59-35-07-07-DE-52-C3-80-D9-CC-BF-5D-FA-04-DF-29-C6-52-ED">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.Build</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BF-BC-9F-90-71-42-03-E3-AC-AA-D2-39-9E-84-5C-00-62-70-39-BA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.CodePages.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.CodePages</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FE-01-7B-00-A1-9B-C4-BC-2A-13-7F-59-A4-6F-55-59-DD-49-B7-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.Pipes.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:04Z</ModuleTime>
+            <ModuleName>System.IO.Pipes</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-03-66-B3-A4-0E-6D-59-00-DF-29-69-D0-2E-C0-08-26-E6-F1-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.AccessControl.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.AccessControl</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-03-66-B3-A4-0E-6D-59-00-DF-29-69-D0-2E-C0-08-26-E6-F1-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.AccessControl.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.AccessControl</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BD-4A-A7-E3-52-A8-34-61-7F-29-11-AF-BF-90-FC-16-AD-AB-40-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.Dataflow.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks.Dataflow</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5C-D3-E5-60-AC-A8-D6-45-77-6C-59-CA-FE-F1-49-32-B4-41-29-2D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\dotnet.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:30Z</ModuleTime>
+            <ModuleName>dotnet</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="76-87-37-3D-BD-CF-7C-E5-90-89-7B-D5-45-86-01-3E-47-72-1F-6D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\MSBuild.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>MSBuild</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="38-09-CE-F2-E5-95-B5-A8-49-DB-F2-B2-FC-2A-62-56-4F-D2-91-39">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Configurer.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Configurer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="47-20-F1-42-9C-3C-11-60-EE-D5-38-37-4E-D7-48-C3-66-42-34-0F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Framework.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.RegularExpressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="58-59-35-07-07-DE-52-C3-80-D9-CC-BF-5D-FA-04-DF-29-C6-52-ED">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.Build</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BF-BC-9F-90-71-42-03-E3-AC-AA-D2-39-9E-84-5C-00-62-70-39-BA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.CodePages.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.CodePages</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FE-01-7B-00-A1-9B-C4-BC-2A-13-7F-59-A4-6F-55-59-DD-49-B7-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.Pipes.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:04Z</ModuleTime>
+            <ModuleName>System.IO.Pipes</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-03-66-B3-A4-0E-6D-59-00-DF-29-69-D0-2E-C0-08-26-E6-F1-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.AccessControl.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.AccessControl</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="BD-4A-A7-E3-52-A8-34-61-7F-29-11-AF-BF-90-FC-16-AD-AB-40-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.Dataflow.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:46Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks.Dataflow</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-CF-CB-AB-4F-25-B8-44-23-16-25-EC-27-DB-10-94-9B-5F-78-77">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Registry.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Registry</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5C-D3-E5-60-AC-A8-D6-45-77-6C-59-CA-FE-F1-49-32-B4-41-29-2D">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\dotnet.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:30Z</ModuleTime>
+            <ModuleName>dotnet</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="38-09-CE-F2-E5-95-B5-A8-49-DB-F2-B2-FC-2A-62-56-4F-D2-91-39">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.DotNet.Configurer.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.DotNet.Configurer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="04-D0-77-B5-F7-72-0B-E6-E8-AA-8F-4B-A0-A0-C9-C0-4C-69-37-D9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.Parallel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks.Parallel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-CF-CB-AB-4F-25-B8-44-23-16-25-EC-27-DB-10-94-9B-5F-78-77">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Registry.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Registry</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="7A-E6-CA-81-95-20-D1-FF-17-80-B7-2A-AB-83-B3-0A-F1-99-1E-2A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Utilities.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:42Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Utilities.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="04-D0-77-B5-F7-72-0B-E6-E8-AA-8F-4B-A0-A0-C9-C0-4C-69-37-D9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.Parallel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks.Parallel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="7A-E6-CA-81-95-20-D1-FF-17-80-B7-2A-AB-83-B3-0A-F1-99-1E-2A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Utilities.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:42Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Utilities.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B6-58-2E-A2-A7-DF-F0-53-14-F6-45-D8-42-D5-5A-6B-69-F7-12-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Formatters.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Formatters</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B6-58-2E-A2-A7-DF-F0-53-14-F6-45-D8-42-D5-5A-6B-69-F7-12-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Formatters.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Formatters</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B6-58-2E-A2-A7-DF-F0-53-14-F6-45-D8-42-D5-5A-6B-69-F7-12-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Formatters.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Formatters</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="88-E7-E8-96-8F-48-99-50-8E-E1-DF-4C-0E-D5-D8-C5-0D-62-22-36">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Tasks.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Tasks.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="88-E7-E8-96-8F-48-99-50-8E-E1-DF-4C-0E-D5-D8-C5-0D-62-22-36">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Build.Tasks.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:38Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Tasks.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-32-2C-E5-EA-D1-3F-48-26-FC-68-8B-AF-F0-AD-51-5E-49-3A-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Sdks\Microsoft.NET.Sdk\tools\netcoreapp2.1\Microsoft.NET.Build.Tasks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>Microsoft.NET.Build.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-32-2C-E5-EA-D1-3F-48-26-FC-68-8B-AF-F0-AD-51-5E-49-3A-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Sdks\Microsoft.NET.Sdk\tools\netcoreapp2.1\Microsoft.NET.Build.Tasks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>Microsoft.NET.Build.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-32-2C-E5-EA-D1-3F-48-26-FC-68-8B-AF-F0-AD-51-5E-49-3A-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Sdks\Microsoft.NET.Sdk\tools\netcoreapp2.1\Microsoft.NET.Build.Tasks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>Microsoft.NET.Build.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-58-94-5C-AE-F2-A7-8A-8B-30-7C-11-FD-9F-26-D2-52-A0-20-73">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Configuration.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Configuration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E4-51-7F-05-08-F3-02-02-27-8E-E8-21-7C-ED-F0-78-12-BA-03-DA">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Build.Tasks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>NuGet.Build.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E4-51-7F-05-08-F3-02-02-27-8E-E8-21-7C-ED-F0-78-12-BA-03-DA">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Build.Tasks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>NuGet.Build.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="11-27-AE-76-EA-89-8D-78-90-4F-7C-8D-62-56-14-CD-EF-02-37-D9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="11-27-AE-76-EA-89-8D-78-90-4F-7C-8D-62-56-14-CD-EF-02-37-D9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9A-73-83-D7-DB-DD-27-CD-88-01-22-D7-EF-C7-FF-A7-B2-07-F7-3B">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Commands.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Commands</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9A-73-83-D7-DB-DD-27-CD-88-01-22-D7-EF-C7-FF-A7-B2-07-F7-3B">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Commands.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Commands</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="36-E8-16-54-B7-19-BD-A8-2A-38-DC-64-7B-B6-08-2C-AE-DF-59-4A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.ProjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.ProjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="36-E8-16-54-B7-19-BD-A8-2A-38-DC-64-7B-B6-08-2C-AE-DF-59-4A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.ProjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.ProjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-58-94-5C-AE-F2-A7-8A-8B-30-7C-11-FD-9F-26-D2-52-A0-20-73">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Configuration.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Configuration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-58-94-5C-AE-F2-A7-8A-8B-30-7C-11-FD-9F-26-D2-52-A0-20-73">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Configuration.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Configuration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.XDocument</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.XDocument</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Private.Xml.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Private.Xml.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="81-0C-F3-3E-51-92-D0-E4-C7-7A-C4-D0-2E-C3-CC-6C-34-E6-D7-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Versioning.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>NuGet.Versioning</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="81-0C-F3-3E-51-92-D0-E4-C7-7A-C4-D0-2E-C3-CC-6C-34-E6-D7-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Versioning.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>NuGet.Versioning</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="81-0C-F3-3E-51-92-D0-E4-C7-7A-C4-D0-2E-C3-CC-6C-34-E6-D7-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Versioning.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>NuGet.Versioning</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3C-6B-ED-4B-FA-6C-10-19-4A-12-34-FC-E0-70-F3-70-7C-58-BD-82">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Newtonsoft.Json.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>Newtonsoft.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6F-CC-2C-76-AC-42-0E-1D-29-DC-BE-AB-E0-6D-A4-C2-9D-0C-27-23">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.Expressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:18Z</ModuleTime>
+            <ModuleName>System.Linq.Expressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6D-0F-A0-D8-6E-D9-3D-12-46-84-DE-CC-44-CE-CF-2B-96-27-29-EA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.TypeConverter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.ComponentModel.TypeConverter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="18-71-46-94-36-55-BA-42-DC-70-B8-FB-CB-47-53-46-BC-07-97-6F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Packaging.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Packaging</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-CA-FC-BE-CF-59-51-70-73-DF-FA-12-D9-07-FF-31-9C-F2-7B-3A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.LibraryModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.LibraryModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8A-CB-B6-B3-E3-37-ED-90-BE-07-BD-2E-2B-E8-75-50-F6-12-63-7B">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Protocol.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Protocol</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="71-2C-E9-CA-85-B8-8F-D9-04-1B-18-26-60-00-6A-A4-C4-26-BB-A6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Credentials.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.Credentials</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="03-E9-A6-34-43-87-E3-D3-27-29-CB-80-91-3F-B1-99-54-02-59-17">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.DependencyResolver.Core.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.DependencyResolver.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-C7-5C-FC-1E-89-3E-67-F0-53-6B-39-C4-C0-61-BC-52-35-9C-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6E-50-A1-2A-7E-70-B6-5C-B5-48-65-1E-90-FC-92-89-65-1A-F5-6F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Numerics.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Numerics</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B3-44-E0-6E-7A-CB-1B-06-37-3E-84-75-01-86-B8-6B-40-5A-F6-CE">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.Build.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:46Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Build</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B3-44-E0-6E-7A-CB-1B-06-37-3E-84-75-01-86-B8-6B-40-5A-F6-CE">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.Build.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:46Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Build</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-84-10-73-D5-25-3C-C8-54-CA-05-A9-21-5F-EC-4F-D6-B7-11-E4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\mscorlib.dll</ModulePath>
+            <ModuleTime>2020-02-21T02:00:46Z</ModuleTime>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-84-10-73-D5-25-3C-C8-54-CA-05-A9-21-5F-EC-4F-D6-B7-11-E4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\mscorlib.dll</ModulePath>
+            <ModuleTime>2020-02-21T02:00:46Z</ModuleTime>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F0-C5-75-3F-22-17-B9-2C-E6-C3-3C-A7-4D-EE-AF-C8-FF-35-92-AC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.CompilerServices.Unsafe.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.CompilerServices.Unsafe</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="36-E8-16-54-B7-19-BD-A8-2A-38-DC-64-7B-B6-08-2C-AE-DF-59-4A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.ProjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.ProjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F0-C5-75-3F-22-17-B9-2C-E6-C3-3C-A7-4D-EE-AF-C8-FF-35-92-AC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.CompilerServices.Unsafe.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.CompilerServices.Unsafe</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="36-E8-16-54-B7-19-BD-A8-2A-38-DC-64-7B-B6-08-2C-AE-DF-59-4A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.ProjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.ProjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-84-10-73-D5-25-3C-C8-54-CA-05-A9-21-5F-EC-4F-D6-B7-11-E4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\mscorlib.dll</ModulePath>
+            <ModuleTime>2020-02-21T02:00:46Z</ModuleTime>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="42-A4-D5-63-DA-C9-6B-42-3E-CF-98-F9-FB-80-3B-23-4D-E8-7E-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="42-A4-D5-63-DA-C9-6B-42-3E-CF-98-F9-FB-80-3B-23-4D-E8-7E-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B3-44-E0-6E-7A-CB-1B-06-37-3E-84-75-01-86-B8-6B-40-5A-F6-CE">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.Build.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:46Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Build</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EF-F5-62-5F-AF-AF-B2-EE-AD-D8-B0-5F-2F-34-FF-0C-C9-DD-5C-66">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tools.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tools</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C1-41-1B-16-60-41-0D-35-CE-85-82-6D-04-AB-CE-5C-88-E8-BE-91">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+            <ModuleName>System.IO</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A5-1D-73-D2-8D-F6-70-B7-B7-8B-00-F4-17-70-7F-2A-98-D3-1C-F9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CC-FC-9F-9B-3F-02-43-A8-4C-9F-1C-AD-15-23-EF-34-31-D4-A6-0C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.Compression.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:40Z</ModuleTime>
+            <ModuleName>System.IO.Compression</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9E-63-EF-9A-D8-E6-C0-64-EB-31-79-F5-8C-35-7D-C2-C5-D2-94-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Http.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:44Z</ModuleTime>
+            <ModuleName>System.Net.Http</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A5-D1-78-2C-3D-8D-E9-D4-52-E4-0C-B0-3D-34-F4-8D-7A-08-C6-C3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Security.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Net.Security</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2D-D2-58-DD-BA-4D-D9-A2-D8-99-CB-EF-60-05-5F-E6-2B-B1-A8-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.X509Certificates.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.X509Certificates</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="36-E8-16-54-B7-19-BD-A8-2A-38-DC-64-7B-B6-08-2C-AE-DF-59-4A">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.ProjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:26Z</ModuleTime>
+            <ModuleName>NuGet.ProjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="81-0C-F3-3E-51-92-D0-E4-C7-7A-C4-D0-2E-C3-CC-6C-34-E6-D7-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Versioning.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>NuGet.Versioning</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="18-71-46-94-36-55-BA-42-DC-70-B8-FB-CB-47-53-46-BC-07-97-6F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Packaging.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Packaging</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="11-27-AE-76-EA-89-8D-78-90-4F-7C-8D-62-56-14-CD-EF-02-37-D9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4F-0A-ED-F6-02-69-AD-2A-C5-2B-2C-93-BD-A8-93-87-63-5A-5E-FD">
+            <ModulePath>BranchCoverage3296\.sonarqube\bin\SonarScanner.MSBuild.Tasks.dll</ModulePath>
+            <ModuleTime>2019-11-06T10:01:08Z</ModuleTime>
+            <ModuleName>SonarScanner.MSBuild.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="06-FE-91-56-B3-97-3C-54-B4-DF-B8-F2-2C-63-4C-B2-7B-B5-56-11">
+            <ModulePath>BranchCoverage3296\.sonarqube\bin\SonarScanner.MSBuild.Common.dll</ModulePath>
+            <ModuleTime>2019-11-06T10:01:08Z</ModuleTime>
+            <ModuleName>SonarScanner.MSBuild.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-BE-1B-A1-47-C7-A9-22-1A-36-76-9C-CD-84-A9-47-AB-29-BF-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XmlSerializer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Xml.XmlSerializer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="06-80-9E-D1-73-4C-C3-26-E9-10-FB-BA-48-03-C8-00-F3-CE-AD-3F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-28-72-75-40-0A-51-3A-66-C2-5F-6B-3C-7B-2D-19-EA-73-0E-B4">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Roslyn\Microsoft.Build.Tasks.CodeAnalysis.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Tasks.CodeAnalysis</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="81-0C-F3-3E-51-92-D0-E4-C7-7A-C4-D0-2E-C3-CC-6C-34-E6-D7-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Versioning.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>NuGet.Versioning</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="81-0C-F3-3E-51-92-D0-E4-C7-7A-C4-D0-2E-C3-CC-6C-34-E6-D7-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Versioning.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>NuGet.Versioning</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="18-71-46-94-36-55-BA-42-DC-70-B8-FB-CB-47-53-46-BC-07-97-6F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Packaging.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Packaging</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="18-71-46-94-36-55-BA-42-DC-70-B8-FB-CB-47-53-46-BC-07-97-6F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Packaging.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Packaging</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="11-27-AE-76-EA-89-8D-78-90-4F-7C-8D-62-56-14-CD-EF-02-37-D9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="11-27-AE-76-EA-89-8D-78-90-4F-7C-8D-62-56-14-CD-EF-02-37-D9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="88-C2-81-23-88-9B-01-F5-41-12-93-F2-07-C5-30-2F-E9-C7-6C-F6">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Core.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="88-C2-81-23-88-9B-01-F5-41-12-93-F2-07-C5-30-2F-E9-C7-6C-F6">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Core.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.Core</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Metadata</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Metadata</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="ED-AD-51-03-F6-38-CC-C2-AA-8C-6C-A7-26-44-05-C3-B7-66-2C-5B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.MemoryMappedFiles.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:04Z</ModuleTime>
+            <ModuleName>System.IO.MemoryMappedFiles</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="ED-AD-51-03-F6-38-CC-C2-AA-8C-6C-A7-26-44-05-C3-B7-66-2C-5B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.MemoryMappedFiles.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:04Z</ModuleTime>
+            <ModuleName>System.IO.MemoryMappedFiles</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4F-0A-ED-F6-02-69-AD-2A-C5-2B-2C-93-BD-A8-93-87-63-5A-5E-FD">
+            <ModulePath>BranchCoverage3296\.sonarqube\bin\SonarScanner.MSBuild.Tasks.dll</ModulePath>
+            <ModuleTime>2019-11-06T10:01:08Z</ModuleTime>
+            <ModuleName>SonarScanner.MSBuild.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="06-FE-91-56-B3-97-3C-54-B4-DF-B8-F2-2C-63-4C-B2-7B-B5-56-11">
+            <ModulePath>BranchCoverage3296\.sonarqube\bin\SonarScanner.MSBuild.Common.dll</ModulePath>
+            <ModuleTime>2019-11-06T10:01:08Z</ModuleTime>
+            <ModuleName>SonarScanner.MSBuild.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4F-0A-ED-F6-02-69-AD-2A-C5-2B-2C-93-BD-A8-93-87-63-5A-5E-FD">
+            <ModulePath>BranchCoverage3296\.sonarqube\bin\SonarScanner.MSBuild.Tasks.dll</ModulePath>
+            <ModuleTime>2019-11-06T10:01:08Z</ModuleTime>
+            <ModuleName>SonarScanner.MSBuild.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="06-FE-91-56-B3-97-3C-54-B4-DF-B8-F2-2C-63-4C-B2-7B-B5-56-11">
+            <ModulePath>BranchCoverage3296\.sonarqube\bin\SonarScanner.MSBuild.Common.dll</ModulePath>
+            <ModuleTime>2019-11-06T10:01:08Z</ModuleTime>
+            <ModuleName>SonarScanner.MSBuild.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-BE-1B-A1-47-C7-A9-22-1A-36-76-9C-CD-84-A9-47-AB-29-BF-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XmlSerializer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Xml.XmlSerializer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-BE-1B-A1-47-C7-A9-22-1A-36-76-9C-CD-84-A9-47-AB-29-BF-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XmlSerializer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Xml.XmlSerializer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="06-80-9E-D1-73-4C-C3-26-E9-10-FB-BA-48-03-C8-00-F3-CE-AD-3F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="06-80-9E-D1-73-4C-C3-26-E9-10-FB-BA-48-03-C8-00-F3-CE-AD-3F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-28-72-75-40-0A-51-3A-66-C2-5F-6B-3C-7B-2D-19-EA-73-0E-B4">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Roslyn\Microsoft.Build.Tasks.CodeAnalysis.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Tasks.CodeAnalysis</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-28-72-75-40-0A-51-3A-66-C2-5F-6B-3C-7B-2D-19-EA-73-0E-B4">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Roslyn\Microsoft.Build.Tasks.CodeAnalysis.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>Microsoft.Build.Tasks.CodeAnalysis</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Microsoft.GeneratedCode</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C5-B4-6F-68-5D-85-FF-B9-B3-F6-E7-E5-87-BC-47-13-C3-03-85-42">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\vstest.console.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>vstest.console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C5-B4-6F-68-5D-85-FF-B9-B3-F6-E7-E5-87-BC-47-13-C3-03-85-42">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\vstest.console.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>vstest.console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="92-D6-1E-14-62-24-DB-73-F3-A0-87-8B-5C-9C-71-AE-8C-A6-49-86">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.CoreUtilities.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:48Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CoreUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="92-D6-1E-14-62-24-DB-73-F3-A0-87-8B-5C-9C-71-AE-8C-A6-49-86">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.CoreUtilities.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:48Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CoreUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-FF-45-54-97-94-E5-EE-F1-55-1C-4C-1D-ED-C5-F1-4E-56-04-D6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F4-74-D8-EC-37-07-89-F7-DE-41-4A-0C-45-90-94-9E-A5-09-14-06">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.VisualStudio.TestPlatform.Client.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Client</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4C-5D-3E-A4-C6-A7-88-97-E0-76-1D-3C-13-D7-AB-BC-57-B4-67-F9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.VisualStudio.TestPlatform.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:47:02Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-FF-45-54-97-94-E5-EE-F1-55-1C-4C-1D-ED-C5-F1-4E-56-04-D6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F4-74-D8-EC-37-07-89-F7-DE-41-4A-0C-45-90-94-9E-A5-09-14-06">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.VisualStudio.TestPlatform.Client.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Client</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4C-5D-3E-A4-C6-A7-88-97-E0-76-1D-3C-13-D7-AB-BC-57-B4-67-F9">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.VisualStudio.TestPlatform.Common.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:47:02Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C0-AF-8F-C2-7E-FA-FB-83-67-D3-56-10-08-BB-63-E8-4F-C8-F0-D3">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.PlatformAbstractions.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:48Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.PlatformAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-FA-4B-8B-8A-A0-0A-BA-5F-16-77-6A-F8-D1-03-FD-B2-46-A8-11">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.Utilities.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Utilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C0-AF-8F-C2-7E-FA-FB-83-67-D3-56-10-08-BB-63-E8-4F-C8-F0-D3">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.PlatformAbstractions.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:48Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.PlatformAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-FA-4B-8B-8A-A0-0A-BA-5F-16-77-6A-F8-D1-03-FD-B2-46-A8-11">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.Utilities.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Utilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="43-64-EE-FB-2B-CB-04-44-D6-D5-68-E6-00-03-CA-34-D9-9A-35-C6">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:24Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5D-6D-F0-C2-3B-E4-3D-F4-31-9F-65-26-E3-6C-69-57-41-07-04-68">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Extensions.FileSystemGlobbing.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:42Z</ModuleTime>
+            <ModuleName>Microsoft.Extensions.FileSystemGlobbing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5D-6D-F0-C2-3B-E4-3D-F4-31-9F-65-26-E3-6C-69-57-41-07-04-68">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Extensions.FileSystemGlobbing.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:42Z</ModuleTime>
+            <ModuleName>Microsoft.Extensions.FileSystemGlobbing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F6-E7-29-AB-39-E0-7C-13-70-CF-AC-B2-AB-D0-49-87-2A-34-C1-64">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.CrossPlatEngine.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CrossPlatEngine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F6-E7-29-AB-39-E0-7C-13-70-CF-AC-B2-AB-D0-49-87-2A-34-C1-64">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.CrossPlatEngine.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:45:22Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CrossPlatEngine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4A-53-F5-47-1F-79-0D-C2-A0-C2-4E-CF-CA-18-30-0C-4C-0B-1E-EB">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.TestPlatform.Extensions.BlameDataCollector.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:32Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Extensions.BlameDataCollector</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="04-77-E0-D3-40-DA-95-B9-FC-B5-A1-54-7E-38-5B-86-0D-1B-18-A2">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.TestPlatform.Extensions.EventLogCollector.dll</ModulePath>
+            <ModuleTime>2020-02-04T18:55:20Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Extensions.EventLogCollector</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-84-10-73-D5-25-3C-C8-54-CA-05-A9-21-5F-EC-4F-D6-B7-11-E4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\mscorlib.dll</ModulePath>
+            <ModuleTime>2020-02-21T02:00:46Z</ModuleTime>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="73-E1-7F-C7-2D-C9-99-D8-D5-D4-21-69-B8-EB-65-4F-5D-EE-9F-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4A-53-F5-47-1F-79-0D-C2-A0-C2-4E-CF-CA-18-30-0C-4C-0B-1E-EB">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.TestPlatform.Extensions.BlameDataCollector.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:32Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Extensions.BlameDataCollector</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-10-3B-1F-DD-91-01-95-79-0E-F6-D0-4B-B1-E9-93-CF-9F-3A-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.TestPlatform.TestHostRuntimeProvider.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.TestHostRuntimeProvider</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="04-77-E0-D3-40-DA-95-B9-FC-B5-A1-54-7E-38-5B-86-0D-1B-18-A2">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.TestPlatform.Extensions.EventLogCollector.dll</ModulePath>
+            <ModuleTime>2020-02-04T18:55:20Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.Extensions.EventLogCollector</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F2-84-10-73-D5-25-3C-C8-54-CA-05-A9-21-5F-EC-4F-D6-B7-11-E4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\mscorlib.dll</ModulePath>
+            <ModuleTime>2020-02-21T02:00:46Z</ModuleTime>
+            <ModuleName>mscorlib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="73-E1-7F-C7-2D-C9-99-D8-D5-D4-21-69-B8-EB-65-4F-5D-EE-9F-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-10-3B-1F-DD-91-01-95-79-0E-F6-D0-4B-B1-E9-93-CF-9F-3A-18">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.TestPlatform.TestHostRuntimeProvider.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:40Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.TestHostRuntimeProvider</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-93-DD-90-A8-82-7B-57-C3-76-20-97-82-80-AF-83-9B-1C-6C-60">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:36Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FF-FA-57-35-2E-F1-77-97-83-A6-16-E9-B4-A3-70-07-E7-9C-31-25">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:36Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-93-DD-90-A8-82-7B-57-C3-76-20-97-82-80-AF-83-9B-1C-6C-60">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:36Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.Html.TestLogger</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FF-FA-57-35-2E-F1-77-97-83-A6-16-E9-B4-A3-70-07-E7-9C-31-25">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:36Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Metadata</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Metadata</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-25-19-27-36-F6-C2-E1-00-4F-1C-5A-3B-B4-6F-F9-7F-69-AB-4E">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.CommunicationUtilities.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:48Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CommunicationUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-25-19-27-36-F6-C2-E1-00-4F-1C-5A-3B-B4-6F-F9-7F-69-AB-4E">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.TestPlatform.CommunicationUtilities.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:48Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CommunicationUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3C-6B-ED-4B-FA-6C-10-19-4A-12-34-FC-E0-70-F3-70-7C-58-BD-82">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Newtonsoft.Json.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>Newtonsoft.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B6-58-2E-A2-A7-DF-F0-53-14-F6-45-D8-42-D5-5A-6B-69-F7-12-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Formatters.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Formatters</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3C-6B-ED-4B-FA-6C-10-19-4A-12-34-FC-E0-70-F3-70-7C-58-BD-82">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Newtonsoft.Json.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:43:48Z</ModuleTime>
+            <ModuleName>Newtonsoft.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B6-58-2E-A2-A7-DF-F0-53-14-F6-45-D8-42-D5-5A-6B-69-F7-12-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Formatters.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Formatters</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-17-3D-BA-13-03-55-32-76-CF-3D-AE-B3-52-14-5F-95-F5-3E-85">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Timer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Timer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-17-3D-BA-13-03-55-32-76-CF-3D-AE-B3-52-14-5F-95-F5-3E-85">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Timer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Timer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EE-DF-4B-C9-A1-40-03-5F-56-1A-DB-D7-E8-A0-BC-A6-12-34-84-1E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Sockets.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:08Z</ModuleTime>
+            <ModuleName>System.Net.Sockets</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EE-DF-4B-C9-A1-40-03-5F-56-1A-DB-D7-E8-A0-BC-A6-12-34-84-1E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Sockets.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:08Z</ModuleTime>
+            <ModuleName>System.Net.Sockets</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E6-CE-DF-D3-05-01-F5-61-41-53-0C-FF-2C-87-01-04-6E-EB-B1-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NameResolution.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Net.NameResolution</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E6-CE-DF-D3-05-01-F5-61-41-53-0C-FF-2C-87-01-04-6E-EB-B1-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NameResolution.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Net.NameResolution</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="0C-3A-E6-E1-38-B5-90-C7-A4-B2-35-FE-13-D9-F0-F4-22-8C-DD-7F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Extensions.DependencyModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:44Z</ModuleTime>
+            <ModuleName>Microsoft.Extensions.DependencyModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="0C-3A-E6-E1-38-B5-90-C7-A4-B2-35-FE-13-D9-F0-F4-22-8C-DD-7F">
+            <ModulePath>C:\Program Files\dotnet\sdk\3.1.201\Microsoft.Extensions.DependencyModel.dll</ModulePath>
+            <ModuleTime>2020-03-18T15:44:44Z</ModuleTime>
+            <ModuleName>Microsoft.Extensions.DependencyModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6F-CC-2C-76-AC-42-0E-1D-29-DC-BE-AB-E0-6D-A4-C2-9D-0C-27-23">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.Expressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:18Z</ModuleTime>
+            <ModuleName>System.Linq.Expressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6F-CC-2C-76-AC-42-0E-1D-29-DC-BE-AB-E0-6D-A4-C2-9D-0C-27-23">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.Expressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:18Z</ModuleTime>
+            <ModuleName>System.Linq.Expressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6D-0F-A0-D8-6E-D9-3D-12-46-84-DE-CC-44-CE-CF-2B-96-27-29-EA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.TypeConverter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.ComponentModel.TypeConverter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6D-0F-A0-D8-6E-D9-3D-12-46-84-DE-CC-44-CE-CF-2B-96-27-29-EA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.TypeConverter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.ComponentModel.TypeConverter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-EE-9E-7D-BB-C0-BA-51-7E-90-FD-C9-D6-FD-CC-4E-A0-46-68-9C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Json.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Text.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-EE-9E-7D-BB-C0-BA-51-7E-90-FD-C9-D6-FD-CC-4E-A0-46-68-9C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Json.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Text.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-06-D3-2E-A9-D1-DF-9B-77-17-06-81-56-37-0F-29-3C-26-3C-CF">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Numerics.Vectors.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Numerics.Vectors</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F0-C5-75-3F-22-17-B9-2C-E6-C3-3C-A7-4D-EE-AF-C8-FF-35-92-AC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.CompilerServices.Unsafe.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.CompilerServices.Unsafe</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-06-D3-2E-A9-D1-DF-9B-77-17-06-81-56-37-0F-29-3C-26-3C-CF">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Numerics.Vectors.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Numerics.Vectors</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F0-C5-75-3F-22-17-B9-2C-E6-C3-3C-A7-4D-EE-AF-C8-FF-35-92-AC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.CompilerServices.Unsafe.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.CompilerServices.Unsafe</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6E-50-A1-2A-7E-70-B6-5C-B5-48-65-1E-90-FC-92-89-65-1A-F5-6F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Numerics.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Numerics</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6E-50-A1-2A-7E-70-B6-5C-B5-48-65-1E-90-FC-92-89-65-1A-F5-6F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Numerics.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Numerics</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+            <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+            <ModuleName>System.Private.CoreLib</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="7D-3A-F3-83-6D-97-74-27-C8-E9-63-BA-8D-D0-48-3C-92-E3-0F-27">
+            <ModulePath>D:\tools\nuget\microsoft.testplatform.testhost\16.4.0\build\netcoreapp2.1\x64\testhost.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>testhost</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="7D-3A-F3-83-6D-97-74-27-C8-E9-63-BA-8D-D0-48-3C-92-E3-0F-27">
+            <ModulePath>D:\tools\nuget\microsoft.testplatform.testhost\16.4.0\build\netcoreapp2.1\x64\testhost.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>testhost</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="82-51-73-4E-B7-D2-16-2E-C0-8E-C4-E6-62-93-07-C8-18-AE-1F-E3">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CoreUtilities.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:00Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CoreUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="82-51-73-4E-B7-D2-16-2E-C0-8E-C4-E6-62-93-07-C8-18-AE-1F-E3">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CoreUtilities.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:00Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CoreUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>netstandard</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Tracing</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3C-3B-BB-1E-4C-23-A0-8A-AE-82-07-50-C4-BD-55-77-FD-48-A8-43">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.PlatformAbstractions.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:00Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.PlatformAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-8E-CE-5F-4A-F0-53-BF-7A-86-29-F3-60-31-4E-C2-C7-92-64-BF">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CrossPlatEngine.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CrossPlatEngine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3A-01-82-3D-B5-F1-23-E3-44-29-52-01-DD-EB-29-DB-C4-C5-8C-CE">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CommunicationUtilities.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CommunicationUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3C-3B-BB-1E-4C-23-A0-8A-AE-82-07-50-C4-BD-55-77-FD-48-A8-43">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.PlatformAbstractions.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:00Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.PlatformAbstractions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="51-13-D1-D9-16-6E-B7-32-DA-55-E3-B7-9D-7A-18-56-62-3D-30-3F">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:00Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Debug</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8C-92-D8-11-B9-57-FB-91-AB-D6-D1-EA-9E-0B-7D-0C-F1-03-BC-6E">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.Common.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="53-D0-A3-B9-10-36-09-21-32-F4-D0-88-75-00-B5-DC-77-89-1D-78">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Newtonsoft.Json.dll</ModulePath>
+            <ModuleTime>2016-06-13T21:06:14Z</ModuleTime>
+            <ModuleName>Newtonsoft.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-C7-5C-FC-1E-89-3E-67-F0-53-6B-39-C4-C0-61-BC-52-35-9C-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-8E-CE-5F-4A-F0-53-BF-7A-86-29-F3-60-31-4E-C2-C7-92-64-BF">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CrossPlatEngine.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CrossPlatEngine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-8F-70-B6-4E-19-5D-AD-A4-E6-F3-7F-0E-80-A2-3F-81-B0-99-64">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Globalization.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Globalization</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3A-01-82-3D-B5-F1-23-E3-44-29-52-01-DD-EB-29-DB-C4-C5-8C-CE">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CommunicationUtilities.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>Microsoft.TestPlatform.CommunicationUtilities</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="51-13-D1-D9-16-6E-B7-32-DA-55-E3-B7-9D-7A-18-56-62-3D-30-3F">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:00Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8C-92-D8-11-B9-57-FB-91-AB-D6-D1-EA-9E-0B-7D-0C-F1-03-BC-6E">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.Common.dll</ModulePath>
+            <ModuleTime>2019-10-24T23:20:02Z</ModuleTime>
+            <ModuleName>Microsoft.VisualStudio.TestPlatform.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="53-D0-A3-B9-10-36-09-21-32-F4-D0-88-75-00-B5-DC-77-89-1D-78">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Newtonsoft.Json.dll</ModulePath>
+            <ModuleTime>2016-06-13T21:06:14Z</ModuleTime>
+            <ModuleName>Newtonsoft.Json</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-C7-5C-FC-1E-89-3E-67-F0-53-6B-39-C4-C0-61-BC-52-35-9C-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-8F-70-B6-4E-19-5D-AD-A4-E6-F3-7F-0E-80-A2-3F-81-B0-99-64">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Globalization.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Globalization</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+            <ModuleName>System.Threading</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Diagnostics.Process</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EE-DF-4B-C9-A1-40-03-5F-56-1A-DB-D7-E8-A0-BC-A6-12-34-84-1E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Sockets.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:08Z</ModuleTime>
+            <ModuleName>System.Net.Sockets</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.Memory</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.ThreadPool</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E6-CE-DF-D3-05-01-F5-61-41-53-0C-FF-2C-87-01-04-6E-EB-B1-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NameResolution.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Net.NameResolution</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Net.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Threading.Tasks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EE-DF-4B-C9-A1-40-03-5F-56-1A-DB-D7-E8-A0-BC-A6-12-34-84-1E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Sockets.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:08Z</ModuleTime>
+            <ModuleName>System.Net.Sockets</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Threading.Overlapped</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E6-CE-DF-D3-05-01-F5-61-41-53-0C-FF-2C-87-01-04-6E-EB-B1-C7">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NameResolution.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Net.NameResolution</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+            <ModuleName>System.Private.Uri</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-C7-5C-FC-1E-89-3E-67-F0-53-6B-39-C4-C0-61-BC-52-35-9C-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal.Windows</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Claims</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Principal</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="96-C7-5C-FC-1E-89-3E-67-F0-53-6B-39-C4-C0-61-BC-52-35-9C-A0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Serialization.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="15-E5-50-D1-2F-F4-E8-02-DA-D7-F8-1F-A5-31-2E-52-66-E1-F3-61">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Data.Common.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+            <ModuleName>System.Data.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="42-A4-D5-63-DA-C9-6B-42-3E-CF-98-F9-FB-80-3B-23-4D-E8-7E-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="15-E5-50-D1-2F-F4-E8-02-DA-D7-F8-1F-A5-31-2E-52-66-E1-F3-61">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Data.Common.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+            <ModuleName>System.Data.Common</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="42-A4-D5-63-DA-C9-6B-42-3E-CF-98-F9-FB-80-3B-23-4D-E8-7E-B3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+            <ModuleName>System.ComponentModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Anonymously Hosted DynamicMethods Assembly</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Anonymously Hosted DynamicMethods Assembly</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5B-59-5A-55-C9-41-C5-0A-8E-0B-98-78-A8-43-45-E3-86-A3-5F-91">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Specialized.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections.Specialized</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="05-AF-58-DB-DA-32-BF-49-84-01-F1-55-D6-55-6F-40-94-52-FB-50">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Drawing.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Drawing.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5B-59-5A-55-C9-41-C5-0A-8E-0B-98-78-A8-43-45-E3-86-A3-5F-91">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Specialized.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+            <ModuleName>System.Collections.Specialized</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="05-AF-58-DB-DA-32-BF-49-84-01-F1-55-D6-55-6F-40-94-52-FB-50">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Drawing.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Drawing.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C1-41-1B-16-60-41-0D-35-CE-85-82-6D-04-AB-CE-5C-88-E8-BE-91">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+            <ModuleName>System.IO</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-CC-E7-2C-B7-DA-57-06-96-2B-F7-01-5A-76-38-AA-26-92-87-6D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Dynamic.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Dynamic.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C1-41-1B-16-60-41-0D-35-CE-85-82-6D-04-AB-CE-5C-88-E8-BE-91">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+            <ModuleName>System.IO</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="17-CC-E7-2C-B7-DA-57-06-96-2B-F7-01-5A-76-38-AA-26-92-87-6D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Dynamic.Runtime.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+            <ModuleName>System.Dynamic.Runtime</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6F-CC-2C-76-AC-42-0E-1D-29-DC-BE-AB-E0-6D-A4-C2-9D-0C-27-23">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.Expressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:18Z</ModuleTime>
+            <ModuleName>System.Linq.Expressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-4C-1D-C3-E8-DB-38-EA-0D-64-CB-BD-58-BC-F2-B0-E2-99-42-93">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="70-58-B8-D8-D1-66-CB-C6-C4-F9-5F-80-03-7C-74-A2-D8-CA-6A-98">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6F-CC-2C-76-AC-42-0E-1D-29-DC-BE-AB-E0-6D-A4-C2-9D-0C-27-23">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.Expressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:18Z</ModuleTime>
+            <ModuleName>System.Linq.Expressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-4C-1D-C3-E8-DB-38-EA-0D-64-CB-BD-58-BC-F2-B0-E2-99-42-93">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="70-58-B8-D8-D1-66-CB-C6-C4-F9-5F-80-03-7C-74-A2-D8-CA-6A-98">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Reflection.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+            <ModuleName>System.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.XDocument</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Private.Xml.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.ObjectModel</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.XDocument</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+            <ModuleName>System.Private.Xml.Linq</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.RegularExpressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+            <ModuleName>System.Private.Xml</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.RegularExpressions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Anonymously Hosted DynamicMethods Assembly</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+            <ModuleName>System.Reflection.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Anonymously Hosted DynamicMethods Assembly</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.Collections.NonGeneric</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.Loader</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="59-B3-53-C6-DD-77-03-5F-2E-4E-9A-A7-81-4B-56-D8-AB-97-8F-66">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\NUnit3.TestAdapter.dll</ModulePath>
+            <ModuleTime>2019-08-30T10:05:18Z</ModuleTime>
+            <ModuleName>NUnit3.TestAdapter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="12-76-CC-1D-71-64-A5-ED-83-74-CD-75-86-B8-02-00-13-2D-7E-D2">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\nunit.engine.api.dll</ModulePath>
+            <ModuleTime>2019-03-24T14:23:48Z</ModuleTime>
+            <ModuleName>nunit.engine.api</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="59-B3-53-C6-DD-77-03-5F-2E-4E-9A-A7-81-4B-56-D8-AB-97-8F-66">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\NUnit3.TestAdapter.dll</ModulePath>
+            <ModuleTime>2019-08-30T10:05:18Z</ModuleTime>
+            <ModuleName>NUnit3.TestAdapter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="12-76-CC-1D-71-64-A5-ED-83-74-CD-75-86-B8-02-00-13-2D-7E-D2">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\nunit.engine.api.dll</ModulePath>
+            <ModuleTime>2019-03-24T14:23:48Z</ModuleTime>
+            <ModuleName>nunit.engine.api</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+            <ModuleName>System.Xml.ReaderWriter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Thread</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-17-3D-BA-13-03-55-32-76-CF-3D-AE-B3-52-14-5F-95-F5-3E-85">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Timer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Timer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="25-17-3D-BA-13-03-55-32-76-CF-3D-AE-B3-52-14-5F-95-F5-3E-85">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Timer.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+            <ModuleName>System.Threading.Timer</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C1-E6-95-46-6B-22-AB-AD-8C-29-08-C6-4F-A8-BC-C8-E3-D9-B3-83">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2019-04-01T16:23:50Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Resources.ResourceManager</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+            <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="C1-E6-95-46-6B-22-AB-AD-8C-29-08-C6-4F-A8-BC-C8-E3-D9-B3-83">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\NuGet.Frameworks.dll</ModulePath>
+            <ModuleTime>2019-04-01T16:23:50Z</ModuleTime>
+            <ModuleName>NuGet.Frameworks</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Metadata</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+            <ModuleName>System.Reflection.Metadata</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Immutable</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-6F-E2-59-47-64-D2-E4-64-4E-96-55-60-F4-13-5C-EE-05-0B-BE">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\nunit.engine.dll</ModulePath>
+            <ModuleTime>2019-03-24T14:23:48Z</ModuleTime>
+            <ModuleName>nunit.engine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="E5-6F-E2-59-47-64-D2-E4-64-4E-96-55-60-F4-13-5C-EE-05-0B-BE">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\nunit.engine.dll</ModulePath>
+            <ModuleTime>2019-03-24T14:23:48Z</ModuleTime>
+            <ModuleName>nunit.engine</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="CE-43-2B-40-C0-FF-2C-68-D3-CF-AF-49-07-37-DC-D7-AA-AB-17-F3">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Buffers.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:26Z</ModuleTime>
+            <ModuleName>System.Buffers</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>Mono.Cecil.dll</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Mono.Cecil</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="31-48-4C-D9-B7-64-1C-85-5D-80-A0-AB-74-1E-29-E1-94-43-80-C0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:42Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="">
+            <ModulePath>Mono.Cecil.dll</ModulePath>
+            <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+            <ModuleName>Mono.Cecil</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="31-48-4C-D9-B7-64-1C-85-5D-80-A0-AB-74-1E-29-E1-94-43-80-C0">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:42Z</ModuleTime>
+            <ModuleName>System.IO.FileSystem.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A5-1D-73-D2-8D-F6-70-B7-B7-8B-00-F4-17-70-7F-2A-98-D3-1C-F9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="A5-1D-73-D2-8D-F6-70-B7-B7-8B-00-F4-17-70-7F-2A-98-D3-1C-F9">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+            <ModuleName>System.Text.Encoding</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="F5-DF-92-D4-E4-7D-E2-6F-35-36-11-65-C3-69-FF-1A-0F-BE-4E-52">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\SecondTestSuite.dll</ModulePath>
+            <ModuleTime>2020-04-27T06:25:40.5318924Z</ModuleTime>
+            <ModuleName>SecondTestSuite</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="9A-F7-44-9B-43-8F-1E-71-60-7A-04-D2-A8-AB-10-07-80-3D-DF-79">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\FirstTestSuite.dll</ModulePath>
+            <ModuleTime>2020-04-27T06:25:40.5318924Z</ModuleTime>
+            <ModuleName>FirstTestSuite</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="16-2A-6A-6B-DF-CD-D6-7C-53-72-D1-C2-AE-69-5C-68-F9-E9-F2-2D">
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\nunit.framework.dll</ModulePath>
+            <ModuleTime>2019-05-14T20:37:24Z</ModuleTime>
+            <ModuleName>nunit.framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="16-2A-6A-6B-DF-CD-D6-7C-53-72-D1-C2-AE-69-5C-68-F9-E9-F2-2D">
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\nunit.framework.dll</ModulePath>
+            <ModuleTime>2019-05-14T20:37:24Z</ModuleTime>
+            <ModuleName>nunit.framework</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+            <ModuleName>System.Console</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+            <ModuleName>System.Collections.Concurrent</ModuleName>
+            <Classes />
+        </Module>
+        <Module hash="8F-EE-CD-E3-B7-04-08-DD-B6-60-C3-50-BE-5C-7C-A3-37-F2-B9-BA">
+            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" maxCrapScore="3" minCrapScore="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+            <ModulePath>BranchCoverage3296\FirstTestSuite\bin\Debug\netcoreapp3.1\Code.dll</ModulePath>
+            <ModuleTime>2020-04-27T06:25:39.7448903Z</ModuleTime>
+            <ModuleName>Code</ModuleName>
+            <Files>
+                <File uid="2" fullPath="BranchCoverage3296\Code\ValueProvider.cs" />
+            </Files>
+            <Classes>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="0" minCyclomaticComplexity="0" maxCrapScore="0" minCrapScore="0" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+                    <FullName>&lt;Module&gt;</FullName>
+                    <Methods />
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" maxCrapScore="3" minCrapScore="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+                    <FullName>Code.ValueProvider</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="3" nPathComplexity="2" sequenceCoverage="100" branchCoverage="66.67" crapScore="3" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" maxCrapScore="3" minCrapScore="3" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+                            <MetadataToken>100663297</MetadataToken>
+                            <Name>System.Int32 Code.ValueProvider::GetValue(System.Boolean)</Name>
+                            <FileRef uid="2" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="1" ordinal="0" offset="0" sl="5" sc="48" el="7" ec="16" bec="2" bev="1" fileid="2" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="1" uspid="3" ordinal="0" offset="1" sl="5" path="0" offsetend="3" fileid="3" />
+                                <BranchPoint vc="0" uspid="5" ordinal="1" offset="1" sl="5" path="1" offsetend="6" fileid="4" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="1" ordinal="0" offset="0" sl="5" sc="48" el="7" ec="16" bec="2" bev="1" fileid="2" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" crapScore="2" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+                            <MetadataToken>100663298</MetadataToken>
+                            <Name>System.Void Code.ValueProvider::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="7" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+            </Classes>
+        </Module>
+        <Module hash="8F-EE-CD-E3-B7-04-08-DD-B6-60-C3-50-BE-5C-7C-A3-37-F2-B9-BA">
+            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" maxCrapScore="3" minCrapScore="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+            <ModulePath>BranchCoverage3296\SecondTestSuite\bin\Debug\netcoreapp3.1\Code.dll</ModulePath>
+            <ModuleTime>2020-04-27T06:25:39.7448903Z</ModuleTime>
+            <ModuleName>Code</ModuleName>
+            <Files>
+                <File uid="1" fullPath="BranchCoverage3296\Code\ValueProvider.cs" />
+            </Files>
+            <Classes>
+                <Class>
+                    <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="0" minCyclomaticComplexity="0" maxCrapScore="0" minCrapScore="0" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+                    <FullName>&lt;Module&gt;</FullName>
+                    <Methods />
+                </Class>
+                <Class>
+                    <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="1" maxCrapScore="3" minCrapScore="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+                    <FullName>Code.ValueProvider</FullName>
+                    <Methods>
+                        <Method visited="true" cyclomaticComplexity="3" nPathComplexity="2" sequenceCoverage="100" branchCoverage="66.67" crapScore="3" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="3" minCyclomaticComplexity="3" maxCrapScore="3" minCrapScore="3" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+                            <MetadataToken>100663297</MetadataToken>
+                            <Name>System.Int32 Code.ValueProvider::GetValue(System.Boolean)</Name>
+                            <FileRef uid="1" />
+                            <SequencePoints>
+                                <SequencePoint vc="1" uspid="2" ordinal="0" offset="0" sl="5" sc="48" el="7" ec="16" bec="2" bev="1" fileid="1" />
+                            </SequencePoints>
+                            <BranchPoints>
+                                <BranchPoint vc="0" uspid="4" ordinal="0" offset="1" sl="5" path="0" offsetend="3" fileid="3" />
+                                <BranchPoint vc="1" uspid="6" ordinal="1" offset="1" sl="5" path="1" offsetend="6" fileid="3" />
+                            </BranchPoints>
+                            <MethodPoint xsi:type="SequencePoint" vc="1" uspid="2" ordinal="0" offset="0" sl="5" sc="48" el="7" ec="16" bec="2" bev="1" fileid="1" />
+                        </Method>
+                        <Method visited="false" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" crapScore="2" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+                            <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+                            <MetadataToken>100663298</MetadataToken>
+                            <Name>System.Void Code.ValueProvider::.ctor()</Name>
+                            <SequencePoints />
+                            <BranchPoints />
+                            <MethodPoint vc="0" uspid="8" ordinal="0" offset="0" />
+                        </Method>
+                    </Methods>
+                </Class>
+            </Classes>
+        </Module>
+        <Module skippedDueTo="Filter" hash="6D-0F-A0-D8-6E-D9-3D-12-46-84-DE-CC-44-CE-CF-2B-96-27-29-EA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.TypeConverter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.ComponentModel.TypeConverter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="6D-0F-A0-D8-6E-D9-3D-12-46-84-DE-CC-44-CE-CF-2B-96-27-29-EA">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.TypeConverter.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+            <ModuleName>System.ComponentModel.TypeConverter</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+            <Classes />
+        </Module>
+        <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+            <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+            <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+            <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+            <Classes />
+        </Module>
+    </Modules>
+</CoverageSession>

--- a/sonar-dotnet-shared-library/src/test/resources/opencover/invalid_file_id.xml
+++ b/sonar-dotnet-shared-library/src/test/resources/opencover/invalid_file_id.xml
@@ -3,8 +3,10 @@
 Below is the code for which this coverage file has been created,
 together with the commands to generate the file and the tools versions.
 
-Note: the file paths were manually changed inside the report to be relative and
-the file id was modified to be invalid
+Note:
+ - the file paths were manually changed inside the report to be relative
+ - the file id was modified to be invalid
+
 ________________________________________________________
 namespace Code
 {

--- a/sonar-dotnet-shared-library/src/test/resources/opencover/switch_expression_multiple_test_projects_1.xml
+++ b/sonar-dotnet-shared-library/src/test/resources/opencover/switch_expression_multiple_test_projects_1.xml
@@ -1,0 +1,1038 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file was generated from the following code:
+
+using System;
+
+namespace SwitchCoverage
+{
+    public class Foo
+    {
+        public int Bar(string input) =>
+            input switch
+            {
+                "one" => 1,
+                "two" => 2,
+                "three" => 3,
+                _ => 0
+            };
+    }
+}
+
+Unit tests:
+
+// first test project
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SwitchCoverage;
+
+namespace SwitchCoverageTest1
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void TestMethod1()
+        {
+            Foo foo = new Foo();
+            Assert.AreEqual(1, foo.Bar("one"));
+        }
+
+        [TestMethod]
+        public void TestMethod2()
+        {
+            Foo foo = new Foo();
+            Assert.AreEqual(2, foo.Bar("two"));
+        }
+    }
+}
+
+OpenCover version 4.7.922.0
+
+-->
+<CoverageSession xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4.7.922.0">
+  <Summary numSequencePoints="11" visitedSequencePoints="9" numBranchPoints="12" visitedBranchPoints="7" sequenceCoverage="81.82" branchCoverage="58.33" maxCyclomaticComplexity="5" minCyclomaticComplexity="1" maxCrapScore="5" minCrapScore="1" visitedClasses="2" numClasses="3" visitedMethods="3" numMethods="4" />
+  <Modules>
+    <Module skippedDueTo="Filter" hash="19-A7-6E-09-56-92-7B-53-8D-DF-A8-1D-B0-92-BB-59-0C-61-4F-3C">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_32\mscorlib\v4.0_4.0.0.0__b77a5c561934e089\mscorlib.dll</ModulePath>
+      <ModuleTime>2020-01-09T19:46:54Z</ModuleTime>
+      <ModuleName>mscorlib</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="48-2E-45-6A-CA-72-5E-5B-34-6F-E1-50-FE-70-35-1E-7A-52-9E-E1">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>vstest.console</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="24-2C-03-2B-89-E0-30-E5-1F-11-C5-DC-6E-F5-2F-8E-5C-D1-37-51">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\vstest.console.exe</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>vstest.console</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="04-01-50-98-6C-72-A9-53-65-FF-BD-3F-FC-34-85-98-02-8C-55-7F">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.TestPlatform.CoreUtilities.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.CoreUtilities</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="4A-9D-81-85-DC-CF-74-ED-91-AC-6F-7B-37-3D-3E-0B-36-5C-56-66">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System\v4.0_4.0.0.0__b77a5c561934e089\System.dll</ModulePath>
+      <ModuleTime>2019-07-24T02:58:28Z</ModuleTime>
+      <ModuleName>System</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="B4-5F-71-54-5A-B1-43-E8-C8-B1-6F-51-A6-9A-FB-F3-EF-09-6F-71">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.ObjectModel</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="46-E1-5B-DC-5A-27-47-7B-BF-6B-55-98-50-04-1C-DE-F1-84-E6-6D">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.TestPlatform.Client.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Client</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="EA-40-4C-75-4E-CC-64-CB-E0-0B-95-E4-AC-4E-14-0E-4E-43-CA-2B">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.TestPlatform.Common.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Common</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="CC-DB-8A-78-1D-14-03-CA-9E-57-77-AD-02-B0-11-1E-9D-D0-F8-EB">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Core\v4.0_4.0.0.0__b77a5c561934e089\System.Core.dll</ModulePath>
+      <ModuleTime>2019-12-07T06:03:04Z</ModuleTime>
+      <ModuleName>System.Core</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D2-F0-F2-FF-AE-D0-90-7D-B9-F6-15-6E-D5-06-05-87-03-53-98-79">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.TestPlatform.PlatformAbstractions.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.PlatformAbstractions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2D-4E-7D-93-79-73-1D-3F-7A-CD-83-B3-5F-27-A4-33-E4-E0-D0-C0">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Xml\v4.0_4.0.0.0__b77a5c561934e089\System.Xml.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.3313185Z</ModuleTime>
+      <ModuleName>System.Xml</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="05-17-3D-5A-70-23-25-42-99-2A-6A-D4-9E-05-F1-BC-D8-01-CA-D5">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.TestPlatform.Utilities.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.Utilities</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2A-7B-17-4D-5F-56-2E-65-AC-46-D1-7B-18-CB-45-61-99-7F-97-68">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Configuration\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Configuration.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.5645591Z</ModuleTime>
+      <ModuleName>System.Configuration</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="EB-76-12-F8-2F-06-94-4A-61-1C-23-3B-80-33-5E-18-0B-E5-A4-72">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.TestPlatform.CrossPlatEngine.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.CrossPlatEngine</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="06-19-22-50-4F-B6-BD-65-A0-C7-8C-DE-34-EA-A5-8F-DC-ED-2D-B8">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.TestPlatform.Extensions.BlameDataCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.Extensions.BlameDataCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="91-1A-F0-77-87-7A-78-F3-40-53-63-26-E3-B3-36-1E-8A-2C-E4-9C">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.TestPlatform.Extensions.EventLogCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.Extensions.EventLogCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D7-A7-84-27-C4-A9-66-B8-8A-20-FF-57-E3-CB-C9-AD-9A-3B-B7-51">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.TestPlatform.TestHostRuntimeProvider.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.TestHostRuntimeProvider</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D7-BF-31-BE-60-D4-B9-90-1B-91-BC-82-6E-42-CB-49-44-2F-6D-7C">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.ArchitectureTools.PEReader.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.ArchitectureTools.PEReader</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="2D-C8-72-FE-35-9B-0E-78-1A-8C-2C-40-D9-83-6C-FA-C5-5F-75-D7">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.Coverage.Interop.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.Coverage.Interop</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="F6-8B-50-0B-D5-4A-17-3D-09-28-19-BF-31-6A-B6-8B-E3-58-A8-9A">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.CodedWebTestAdapter.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.CodedWebTestAdapter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="F2-D6-52-FE-00-A7-FE-8D-D4-24-AC-E7-A3-04-21-5A-AD-48-32-50">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.TmiAdapter.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.TmiAdapter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="22-1F-5F-67-0C-DD-DE-1F-03-8C-89-85-2D-9A-AD-F4-95-AA-69-5B">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.QualityTools.Common.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.QualityTools.Common</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="7E-38-11-17-B0-30-5D-45-76-2A-18-90-F0-18-13-4E-C1-B2-16-0F">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.GenericTestAdapter.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.GenericTestAdapter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D9-C5-A7-55-C2-10-DA-E0-F9-C2-DF-B2-06-83-F8-EE-B0-DB-E7-E2">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.OrderedTestAdapter.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.OrderedTestAdapter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="12-6C-F5-E3-C7-CD-E3-77-C0-CA-1C-B3-6A-92-95-AE-F9-6C-A0-DA">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="46-46-34-57-D9-E0-CB-B4-8F-54-39-13-6F-43-4F-62-5D-6B-18-36">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.VSTestIntegration.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.VSTestIntegration</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="8A-70-99-42-21-64-D6-DA-93-8F-15-58-04-49-95-95-03-34-FD-B6">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.QualityTools.UnitTestFramework</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="CD-B4-80-7E-ED-87-A1-F3-81-CB-3E-96-C0-CC-4B-81-BD-74-C4-D1">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_32\System.Data\v4.0_4.0.0.0__b77a5c561934e089\System.Data.dll</ModulePath>
+      <ModuleTime>2019-12-07T06:03:04Z</ModuleTime>
+      <ModuleName>System.Data</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="19-13-48-7E-B8-6D-86-0B-82-11-D0-29-88-B9-86-65-5D-CE-BB-B6">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.WebTestAdapter.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.WebTestAdapter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D8-54-DB-4C-35-8D-F0-9E-02-E7-C0-E3-8A-1F-38-28-64-B8-00-3C">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.ComInterfaces.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestTools.CppUnitTestFramework.ComInterfaces</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="AC-E8-F2-CF-48-EF-9B-55-DD-C4-50-E6-CF-EC-B3-35-AB-A6-D8-7B">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.CppUnitTestExtension.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestTools.CppUnitTestFramework.CppUnitTestExtension</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="60-03-96-F9-3B-1E-0D-18-F9-FE-FF-B9-4F-1B-28-3D-B7-20-39-7D">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="1D-26-3E-64-63-BC-40-62-7F-BA-67-38-AF-77-E8-9D-28-02-66-7C">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D5-C4-56-DC-17-09-1C-EA-87-1C-E8-F5-C7-29-D4-20-74-8C-96-35">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TraceDataCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TraceDataCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="41-D1-74-75-40-0C-09-3F-D4-4E-F1-AB-6F-1E-70-75-98-12-5B-FC">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.IntelliTrace.Core.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.IntelliTrace.Core</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="F1-D3-C4-19-F0-A3-97-CA-EE-78-EA-BA-5F-97-56-C8-6D-7F-01-45">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\System.Reflection.Metadata.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>System.Reflection.Metadata</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2A-5F-EB-FC-1F-8B-9B-DB-11-DF-AF-03-EE-EB-43-40-AC-5D-A5-08">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Runtime\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Runtime.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:17.086231Z</ModuleTime>
+      <ModuleName>System.Runtime</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="31-10-26-68-D1-64-10-03-21-09-D6-38-CC-CB-5F-68-D2-33-83-4E">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Runtime.InteropServices\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Runtime.InteropServices.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.4098692Z</ModuleTime>
+      <ModuleName>System.Runtime.InteropServices</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="42-26-9C-31-27-41-D7-11-67-3E-B9-52-F7-0B-89-F7-CF-DB-2A-9F">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.IO\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.IO.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.0307581Z</ModuleTime>
+      <ModuleName>System.IO</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="FB-BF-29-CE-7B-65-70-2C-55-E7-9A-03-D5-24-9F-04-A1-39-0C-A6">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\System.Collections.Immutable.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>System.Collections.Immutable</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="22-1F-F0-50-FF-7F-A0-29-DD-0C-1D-EE-12-A3-59-6D-ED-3D-47-14">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Reflection\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Reflection.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:16.8724675Z</ModuleTime>
+      <ModuleName>System.Reflection</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="53-77-EF-FE-9F-F9-EC-6E-7E-76-60-FF-15-66-89-40-9C-E0-20-59">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.IO.FileSystem\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.IO.FileSystem.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.0377466Z</ModuleTime>
+      <ModuleName>System.IO.FileSystem</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="27-DB-AC-1A-E3-0E-68-D9-4E-FB-01-38-58-7B-D4-0C-0C-06-3C-E2">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.IO.MemoryMappedFiles\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.IO.MemoryMappedFiles.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.5565597Z</ModuleTime>
+      <ModuleName>System.IO.MemoryMappedFiles</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="96-37-10-95-D6-A0-48-4B-95-E2-45-ED-F2-CC-F8-38-62-7F-B7-4A">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Runtime.Handles\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Runtime.Handles.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:17.0957374Z</ModuleTime>
+      <ModuleName>System.Runtime.Handles</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="20-90-4A-17-B6-9E-64-0F-FC-76-F1-38-55-AA-15-D2-A0-C7-C2-50">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Reflection.Extensions\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Reflection.Extensions.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:14.6041956Z</ModuleTime>
+      <ModuleName>System.Reflection.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="31-06-17-24-21-7B-94-95-95-7B-E6-A3-ED-8E-C4-61-76-81-50-E7">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Threading\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Threading.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.2693238Z</ModuleTime>
+      <ModuleName>System.Threading</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="8F-B6-AF-17-6D-95-F2-1A-C9-07-A2-52-08-07-0F-4B-AB-A1-B6-5A">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Text.Encoding\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Text.Encoding.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.1026701Z</ModuleTime>
+      <ModuleName>System.Text.Encoding</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="D7-63-79-55-E2-7C-07-44-05-DC-65-F2-1A-28-3F-C9-73-76-03-F4">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Runtime.Extensions\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Runtime.Extensions.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.6209693Z</ModuleTime>
+      <ModuleName>System.Runtime.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="BC-98-94-53-F1-64-6C-E2-64-06-9F-E1-73-E4-90-7C-0B-99-EF-63">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Text.Encoding.Extensions\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Text.Encoding.Extensions.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.1275958Z</ModuleTime>
+      <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="2A-2A-6C-70-82-27-5B-98-E6-EB-41-91-C0-3F-75-CB-8A-0B-FE-FD">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.TestPlatform.CommunicationUtilities.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.CommunicationUtilities</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="6B-0D-A7-56-17-A2-26-94-93-DC-1A-68-5D-7A-0B-07-F2-E4-8C-75">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Newtonsoft.Json.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Newtonsoft.Json</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="06-F9-8E-1A-FC-D4-91-9C-D0-32-40-16-3E-61-65-7F-A6-8C-FD-30">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.Extensions.DependencyModel.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.Extensions.DependencyModel</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="B7-47-70-CB-BE-3B-AE-84-BF-DC-39-49-BE-C0-48-89-A3-C9-6E-61">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Numerics\v4.0_4.0.0.0__b77a5c561934e089\System.Numerics.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.417806Z</ModuleTime>
+      <ModuleName>System.Numerics</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="EF-12-A7-1D-68-2E-E3-7A-F6-5E-43-AD-77-01-E8-BC-1B-19-CE-66">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Runtime.InteropServices.RuntimeInformation\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:16.8561084Z</ModuleTime>
+      <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+      <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+      <ModuleName>System.Private.CoreLib</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="2D-24-9E-08-28-FF-DB-00-08-DF-87-04-1B-84-6A-4D-EC-11-E9-CB">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\testhost.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:24Z</ModuleTime>
+      <ModuleName>testhost</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+      <ModuleName>System.Runtime</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="72-CD-4C-29-1F-8A-A2-EE-EE-49-B7-39-D7-D2-59-25-D4-15-8A-47">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CoreUtilities.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:22Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.CoreUtilities</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+      <ModuleName>netstandard</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+      <ModuleName>System.Diagnostics.Tracing</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="03-17-2D-A2-47-E8-DA-D5-28-CB-74-74-E2-56-70-6A-C0-5A-AB-58">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.PlatformAbstractions.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:22Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.PlatformAbstractions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+      <ModuleName>System.Runtime.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+      <ModuleName>System.Diagnostics.Debug</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+      <ModuleName>System.Collections</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="C3-FB-C2-9E-95-BB-9F-EC-54-E9-D6-2E-96-6F-43-6E-95-D3-F0-A1">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CrossPlatEngine.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:24Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.CrossPlatEngine</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="7E-1F-2A-CD-BD-DB-46-49-18-E0-16-C3-50-2A-47-26-74-E0-FA-63">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CommunicationUtilities.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:24Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.CommunicationUtilities</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="40-25-A6-0F-A5-B4-71-8F-77-23-6F-C1-FC-B2-A9-94-DA-7B-5F-2E">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:22Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.ObjectModel</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="C9-48-8A-EF-A0-7E-17-43-0F-BC-D2-F3-4D-26-76-B6-7D-DE-DF-67">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.Common.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:24Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Common</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="53-D0-A3-B9-10-36-09-21-32-F4-D0-88-75-00-B5-DC-77-89-1D-78">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\Newtonsoft.Json.dll</ModulePath>
+      <ModuleTime>2016-06-13T21:06:14Z</ModuleTime>
+      <ModuleName>Newtonsoft.Json</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="96-C7-5C-FC-1E-89-3E-67-F0-53-6B-39-C4-C0-61-BC-52-35-9C-A0">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+      <ModuleName>System.Runtime.Serialization.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="A6-8F-70-B6-4E-19-5D-AD-A4-E6-F3-7F-0E-80-A2-3F-81-B0-99-64">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Globalization.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+      <ModuleName>System.Globalization</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+      <ModuleName>System.Threading</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+      <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+      <ModuleName>System.Diagnostics.Process</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+      <ModuleName>System.ComponentModel.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+      <ModuleName>System.Memory</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+      <ModuleName>System.Threading.ThreadPool</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+      <ModuleName>System.Runtime.InteropServices</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+      <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+      <ModuleName>System.Net.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+      <ModuleName>System.Threading.Tasks</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="EE-DF-4B-C9-A1-40-03-5F-56-1A-DB-D7-E8-A0-BC-A6-12-34-84-1E">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Sockets.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:08Z</ModuleTime>
+      <ModuleName>System.Net.Sockets</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+      <ModuleName>System.Threading.Overlapped</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="E6-CE-DF-D3-05-01-F5-61-41-53-0C-FF-2C-87-01-04-6E-EB-B1-C7">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NameResolution.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+      <ModuleName>System.Net.NameResolution</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+      <ModuleName>System.Private.Uri</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+      <ModuleName>System.Security.Principal.Windows</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+      <ModuleName>System.Security.Claims</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+      <ModuleName>System.Security.Principal</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2A-8E-FF-4D-F2-A7-D6-AA-9E-44-17-D8-8A-11-71-D4-7C-19-DA-FF">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Runtime.Serialization\v4.0_4.0.0.0__b77a5c561934e089\System.Runtime.Serialization.dll</ModulePath>
+      <ModuleTime>2020-01-09T19:46:54Z</ModuleTime>
+      <ModuleName>System.Runtime.Serialization</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="32-74-EF-25-E3-A9-11-0C-F0-FD-2D-7E-1A-97-75-45-D0-5E-8A-A8">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Xml.Linq\v4.0_4.0.0.0__b77a5c561934e089\System.Xml.Linq.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.5069748Z</ModuleTime>
+      <ModuleName>System.Xml.Linq</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="C1-41-1B-16-60-41-0D-35-CE-85-82-6D-04-AB-CE-5C-88-E8-BE-91">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+      <ModuleName>System.IO</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="17-CC-E7-2C-B7-DA-57-06-96-2B-F7-01-5A-76-38-AA-26-92-87-6D">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Dynamic.Runtime.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+      <ModuleName>System.Dynamic.Runtime</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="6F-CC-2C-76-AC-42-0E-1D-29-DC-BE-AB-E0-6D-A4-C2-9D-0C-27-23">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.Expressions.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:18Z</ModuleTime>
+      <ModuleName>System.Linq.Expressions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="08-4C-1D-C3-E8-DB-38-EA-0D-64-CB-BD-58-BC-F2-B0-E2-99-42-93">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+      <ModuleName>System.Reflection</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="70-58-B8-D8-D1-66-CB-C6-C4-F9-5F-80-03-7C-74-A2-D8-CA-6A-98">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Extensions.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+      <ModuleName>System.Reflection.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+      <ModuleName>System.Linq</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+      <ModuleName>System.ObjectModel</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+      <ModuleName>System.Xml.XDocument</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+      <ModuleName>System.Private.Xml.Linq</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+      <ModuleName>System.Private.Xml</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+      <ModuleName>System.Text.RegularExpressions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+      <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+      <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+      <ModuleName>System.Reflection.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="">
+      <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+      <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+      <ModuleName>Anonymously Hosted DynamicMethods Assembly</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+      <ModuleName>System.Collections.NonGeneric</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+      <ModuleName>System.IO.FileSystem</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+      <ModuleName>System.Runtime.Loader</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="5C-37-15-25-14-5D-AA-CD-FE-A1-58-0B-02-CA-F0-06-3B-F0-75-3E">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll</ModulePath>
+      <ModuleTime>2020-02-03T08:45:56Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="9D-1A-06-D1-57-63-4E-2B-7F-60-AB-7C-A1-0C-67-26-0C-72-0B-31">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</ModulePath>
+      <ModuleTime>2020-02-03T08:42:14Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.TestFramework</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="14-23-11-33-8A-3E-C2-95-9C-AF-E0-44-A0-4E-01-93-24-28-69-36">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll</ModulePath>
+      <ModuleTime>2020-02-03T08:43:54Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="18-52-46-8F-91-31-7C-89-18-7F-98-66-A5-FF-E4-26-5C-68-8E-0A">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll</ModulePath>
+      <ModuleTime>2020-02-03T08:52:28Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="06-19-22-50-4F-B6-BD-65-A0-C7-8C-DE-34-EA-A5-8F-DC-ED-2D-B8">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.TestPlatform.Extensions.BlameDataCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.Extensions.BlameDataCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="73-E1-7F-C7-2D-C9-99-D8-D5-D4-21-69-B8-EB-65-4F-5D-EE-9F-B3">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+      <ModuleName>System.Xml</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+      <ModuleName>System.Xml.ReaderWriter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="F2-84-10-73-D5-25-3C-C8-54-CA-05-A9-21-5F-EC-4F-D6-B7-11-E4">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\mscorlib.dll</ModulePath>
+      <ModuleTime>2020-02-21T02:00:46Z</ModuleTime>
+      <ModuleName>mscorlib</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="91-1A-F0-77-87-7A-78-F3-40-53-63-26-E3-B3-36-1E-8A-2C-E4-9C">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.TestPlatform.Extensions.EventLogCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.Extensions.EventLogCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="1D-26-3E-64-63-BC-40-62-7F-BA-67-38-AF-77-E8-9D-28-02-66-7C">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="60-03-96-F9-3B-1E-0D-18-F9-FE-FF-B9-4F-1B-28-3D-B7-20-39-7D">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D5-C4-56-DC-17-09-1C-EA-87-1C-E8-F5-C7-29-D4-20-74-8C-96-35">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TraceDataCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TraceDataCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="88-C2-81-23-88-9B-01-F5-41-12-93-F2-07-C5-30-2F-E9-C7-6C-F6">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Core.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+      <ModuleName>System.Core</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="4A-25-21-3A-BE-77-81-CD-7C-8A-13-F5-C1-EC-79-31-83-0D-13-AA">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.ArchitectureTools.PEReader.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.ArchitectureTools.PEReader</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="A4-7B-EB-61-14-FF-0A-F1-6C-B1-3D-60-27-46-D9-09-64-D7-5C-4A">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.StackTrace.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+      <ModuleName>System.Diagnostics.StackTrace</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+      <ModuleName>System.Reflection.Metadata</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+      <ModuleName>System.Collections.Immutable</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+      <ModuleName>System.Threading.Thread</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+      <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="25-17-3D-BA-13-03-55-32-76-CF-3D-AE-B3-52-14-5F-95-F5-3E-85">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Timer.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+      <ModuleName>System.Threading.Timer</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+      <ModuleName>System.Resources.ResourceManager</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+      <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="C1-E6-95-46-6B-22-AB-AD-8C-29-08-C6-4F-A8-BC-C8-E3-D9-B3-83">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\NuGet.Frameworks.dll</ModulePath>
+      <ModuleTime>2019-04-01T16:23:50Z</ModuleTime>
+      <ModuleName>NuGet.Frameworks</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+      <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module hash="E6-3B-3B-75-A4-24-FB-65-6E-8F-F1-96-BF-3A-02-2B-FD-07-C2-11">
+      <Summary numSequencePoints="10" visitedSequencePoints="8" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="80" branchCoverage="66.67" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="1" visitedClasses="1" numClasses="2" visitedMethods="2" numMethods="3" />
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\SwitchCoverageTest1.dll</ModulePath>
+      <ModuleTime>2020-04-27T15:20:59.1349436Z</ModuleTime>
+      <ModuleName>SwitchCoverageTest1</ModuleName>
+      <Files>
+        <File uid="1" fullPath="C:\Users\Andrei\.nuget\packages\microsoft.net.test.sdk\16.5.0\build\netcoreapp2.1\Microsoft.NET.Test.Sdk.Program.cs" />
+        <File uid="2" fullPath="SwitchCoverage\SwitchCoverageTest1\UnitTest1.cs" />
+      </Files>
+      <Classes>
+        <Class>
+          <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="0" minCyclomaticComplexity="0" maxCrapScore="0" minCrapScore="0" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+          <FullName>&lt;Module&gt;</FullName>
+          <Methods />
+        </Class>
+        <Class>
+          <Summary numSequencePoints="2" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="1" visitedMethods="0" numMethods="1" />
+          <FullName>AutoGeneratedProgram</FullName>
+          <Methods>
+            <Method visited="false" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" crapScore="2" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="2" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="1" />
+              <MetadataToken>100663297</MetadataToken>
+              <Name>System.Void AutoGeneratedProgram::Main(System.String[])</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="0" uspid="1" ordinal="0" offset="0" sl="4" sc="60" el="4" ec="61" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="2" ordinal="1" offset="1" sl="4" sc="61" el="4" ec="62" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint xsi:type="SequencePoint" vc="0" uspid="1" ordinal="0" offset="0" sl="4" sc="60" el="4" ec="61" bec="0" bev="0" fileid="1" />
+            </Method>
+            <Method visited="false" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" crapScore="2" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+              <MetadataToken>100663298</MetadataToken>
+              <Name>System.Void AutoGeneratedProgram::.ctor()</Name>
+              <SequencePoints />
+              <BranchPoints />
+              <MethodPoint vc="0" uspid="3" ordinal="0" offset="0" />
+            </Method>
+          </Methods>
+        </Class>
+        <Class>
+          <Summary numSequencePoints="8" visitedSequencePoints="8" numBranchPoints="2" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="1" visitedClasses="1" numClasses="1" visitedMethods="2" numMethods="2" />
+          <FullName>SwitchCoverageTest1.UnitTest1</FullName>
+          <Methods>
+            <Method visited="true" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" crapScore="1" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="1" minCrapScore="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken>100663299</MetadataToken>
+              <Name>System.Void SwitchCoverageTest1.UnitTest1::TestMethod1()</Name>
+              <FileRef uid="2" />
+              <SequencePoints>
+                <SequencePoint vc="1" uspid="4" ordinal="0" offset="0" sl="11" sc="9" el="11" ec="10" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="1" uspid="5" ordinal="1" offset="1" sl="12" sc="13" el="12" ec="33" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="1" uspid="6" ordinal="2" offset="7" sl="13" sc="13" el="13" ec="48" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="1" uspid="7" ordinal="3" offset="25" sl="14" sc="9" el="14" ec="10" bec="0" bev="0" fileid="2" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint xsi:type="SequencePoint" vc="1" uspid="4" ordinal="0" offset="0" sl="11" sc="9" el="11" ec="10" bec="0" bev="0" fileid="2" />
+            </Method>
+            <Method visited="true" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" crapScore="1" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="1" minCrapScore="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken>100663300</MetadataToken>
+              <Name>System.Void SwitchCoverageTest1.UnitTest1::TestMethod2()</Name>
+              <FileRef uid="2" />
+              <SequencePoints>
+                <SequencePoint vc="1" uspid="8" ordinal="0" offset="0" sl="18" sc="9" el="18" ec="10" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="1" uspid="9" ordinal="1" offset="1" sl="19" sc="13" el="19" ec="33" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="1" uspid="10" ordinal="2" offset="7" sl="20" sc="13" el="20" ec="48" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="1" uspid="11" ordinal="3" offset="25" sl="21" sc="9" el="21" ec="10" bec="0" bev="0" fileid="2" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint xsi:type="SequencePoint" vc="1" uspid="8" ordinal="0" offset="0" sl="18" sc="9" el="18" ec="10" bec="0" bev="0" fileid="2" />
+            </Method>
+            <Method visited="false" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" crapScore="2" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+              <MetadataToken>100663301</MetadataToken>
+              <Name>System.Void SwitchCoverageTest1.UnitTest1::.ctor()</Name>
+              <SequencePoints />
+              <BranchPoints />
+              <MethodPoint vc="0" uspid="12" ordinal="0" offset="0" />
+            </Method>
+          </Methods>
+        </Class>
+      </Classes>
+    </Module>
+    <Module skippedDueTo="Filter" hash="31-48-4C-D9-B7-64-1C-85-5D-80-A0-AB-74-1E-29-E1-94-43-80-C0">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:42Z</ModuleTime>
+      <ModuleName>System.IO.FileSystem.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="48-69-8F-D3-34-45-06-46-29-98-3A-0A-71-C5-1A-6D-78-02-46-35">
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</ModulePath>
+      <ModuleTime>2020-02-03T08:43:06Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="6D-0F-A0-D8-6E-D9-3D-12-46-84-DE-CC-44-CE-CF-2B-96-27-29-EA">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.TypeConverter.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+      <ModuleName>System.ComponentModel.TypeConverter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+      <ModuleName>System.Collections.Concurrent</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="D0-59-FE-7C-7F-0D-36-55-42-D4-35-5B-11-52-FF-15-85-1C-6D-DB">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TextWriterTraceListener.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+      <ModuleName>System.Diagnostics.TextWriterTraceListener</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+      <ModuleName>System.Console</ModuleName>
+      <Classes />
+    </Module>
+    <Module hash="BB-9C-0F-8E-5F-FC-F9-90-9C-2F-D8-CF-15-63-3A-5B-F3-6D-AE-DE">
+      <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="9" visitedBranchPoints="5" sequenceCoverage="100" branchCoverage="55.56" maxCyclomaticComplexity="5" minCyclomaticComplexity="1" maxCrapScore="5" minCrapScore="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+      <ModulePath>SwitchCoverage\SwitchCoverageTest1\bin\Debug\netcoreapp3.1\SwitchCoverage.dll</ModulePath>
+      <ModuleTime>2020-04-27T15:20:56.9319773Z</ModuleTime>
+      <ModuleName>SwitchCoverage</ModuleName>
+      <Files>
+        <File uid="5" fullPath="SwitchCoverage\SwitchCoverage\Foo.cs" />
+      </Files>
+      <Classes>
+        <Class>
+          <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="0" minCyclomaticComplexity="0" maxCrapScore="0" minCrapScore="0" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+          <FullName>&lt;Module&gt;</FullName>
+          <Methods />
+        </Class>
+        <Class>
+          <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="9" visitedBranchPoints="5" sequenceCoverage="100" branchCoverage="55.56" maxCyclomaticComplexity="5" minCyclomaticComplexity="1" maxCrapScore="5" minCrapScore="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+          <FullName>SwitchCoverage.Foo</FullName>
+          <Methods>
+            <Method visited="true" cyclomaticComplexity="5" nPathComplexity="16" sequenceCoverage="100" branchCoverage="55.56" crapScore="5" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="9" visitedBranchPoints="5" sequenceCoverage="100" branchCoverage="55.56" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" maxCrapScore="5" minCrapScore="5" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken>100663297</MetadataToken>
+              <Name>System.Int32 SwitchCoverage.Foo::Bar(System.String)</Name>
+              <FileRef uid="5" />
+              <SequencePoints>
+                <SequencePoint vc="2" uspid="13" ordinal="0" offset="0" sl="8" sc="13" el="14" ec="14" bec="7" bev="4" fileid="5" />
+              </SequencePoints>
+              <BranchPoints>
+                <BranchPoint vc="2" uspid="14" ordinal="0" offset="1" sl="8" path="0" offsetend="3" fileid="5" />
+                <BranchPoint vc="0" uspid="15" ordinal="1" offset="1" sl="8" path="1" offsetend="56" fileid="5" />
+                <BranchPoint vc="1" uspid="16" ordinal="2" offset="14" sl="8" path="0" offsetend="16" fileid="5" />
+                <BranchPoint vc="1" uspid="17" ordinal="3" offset="14" sl="8" path="1" offsetend="44" fileid="5" />
+                <BranchPoint vc="0" uspid="18" ordinal="4" offset="27" sl="8" path="0" offsetend="29" fileid="5" />
+                <BranchPoint vc="1" uspid="19" ordinal="5" offset="27" sl="8" path="1" offsetend="48" fileid="5" />
+                <BranchPoint vc="0" uspid="20" ordinal="6" offset="40" sl="8" path="0" offsetchain="42" offsetend="56" fileid="5" />
+                <BranchPoint vc="0" uspid="21" ordinal="7" offset="40" sl="8" path="1" offsetend="52" fileid="5" />
+              </BranchPoints>
+              <MethodPoint xsi:type="SequencePoint" vc="2" uspid="13" ordinal="0" offset="0" sl="8" sc="13" el="14" ec="14" bec="7" bev="4" fileid="5" />
+            </Method>
+            <Method visited="false" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" crapScore="2" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+              <MetadataToken>100663298</MetadataToken>
+              <Name>System.Void SwitchCoverage.Foo::.ctor()</Name>
+              <SequencePoints />
+              <BranchPoints />
+              <MethodPoint vc="0" uspid="22" ordinal="0" offset="0" />
+            </Method>
+          </Methods>
+        </Class>
+      </Classes>
+    </Module>
+    <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+      <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="AA-A1-B5-37-5B-A3-3F-60-8A-4D-0B-A0-48-E4-49-D8-49-E0-96-D9">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\SMDiagnostics\v4.0_4.0.0.0__b77a5c561934e089\SMDiagnostics.dll</ModulePath>
+      <ModuleTime>2020-01-09T19:46:54Z</ModuleTime>
+      <ModuleName>SMDiagnostics</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="BB-80-4D-57-28-4C-C5-76-72-6F-11-E7-E6-86-43-26-A9-62-89-CD">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.ServiceModel.Internals\v4.0_4.0.0.0__31bf3856ad364e35\System.ServiceModel.Internals.dll</ModulePath>
+      <ModuleTime>2020-01-09T19:46:54Z</ModuleTime>
+      <ModuleName>System.ServiceModel.Internals</ModuleName>
+      <Classes />
+    </Module>
+  </Modules>
+</CoverageSession>

--- a/sonar-dotnet-shared-library/src/test/resources/opencover/switch_expression_multiple_test_projects_2.xml
+++ b/sonar-dotnet-shared-library/src/test/resources/opencover/switch_expression_multiple_test_projects_2.xml
@@ -1,0 +1,1040 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file was generated from the following code:
+
+using System;
+
+namespace SwitchCoverage
+{
+    public class Foo
+    {
+        public int Bar(string input) =>
+            input switch
+            {
+                "one" => 1,
+                "two" => 2,
+                "three" => 3,
+                _ => 0
+            };
+    }
+}
+
+Unit tests:
+
+// second test project
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SwitchCoverage;
+
+namespace SwitchCoverageTest2
+{
+    [TestClass]
+    public class Tests
+    {
+
+        [TestMethod]
+        public void Test1()
+        {
+            Foo foo = new Foo();
+            Assert.AreEqual(1, foo.Bar("one"));
+        }
+
+        [TestMethod]
+        public void Test3()
+        {
+            Foo foo = new Foo();
+            Assert.AreEqual(3, foo.Bar("three"));
+        }
+
+    }
+}
+
+OpenCover version 4.7.922.0
+
+-->
+<CoverageSession xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4.7.922.0">
+  <Summary numSequencePoints="11" visitedSequencePoints="9" numBranchPoints="12" visitedBranchPoints="8" sequenceCoverage="81.82" branchCoverage="66.67" maxCyclomaticComplexity="5" minCyclomaticComplexity="1" maxCrapScore="5" minCrapScore="1" visitedClasses="2" numClasses="3" visitedMethods="3" numMethods="4" />
+  <Modules>
+    <Module skippedDueTo="Filter" hash="19-A7-6E-09-56-92-7B-53-8D-DF-A8-1D-B0-92-BB-59-0C-61-4F-3C">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_32\mscorlib\v4.0_4.0.0.0__b77a5c561934e089\mscorlib.dll</ModulePath>
+      <ModuleTime>2020-01-09T19:46:54Z</ModuleTime>
+      <ModuleName>mscorlib</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="48-2E-45-6A-CA-72-5E-5B-34-6F-E1-50-FE-70-35-1E-7A-52-9E-E1">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>vstest.console</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="24-2C-03-2B-89-E0-30-E5-1F-11-C5-DC-6E-F5-2F-8E-5C-D1-37-51">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\vstest.console.exe</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>vstest.console</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="04-01-50-98-6C-72-A9-53-65-FF-BD-3F-FC-34-85-98-02-8C-55-7F">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.TestPlatform.CoreUtilities.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.CoreUtilities</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="4A-9D-81-85-DC-CF-74-ED-91-AC-6F-7B-37-3D-3E-0B-36-5C-56-66">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System\v4.0_4.0.0.0__b77a5c561934e089\System.dll</ModulePath>
+      <ModuleTime>2019-07-24T02:58:28Z</ModuleTime>
+      <ModuleName>System</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="B4-5F-71-54-5A-B1-43-E8-C8-B1-6F-51-A6-9A-FB-F3-EF-09-6F-71">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.ObjectModel</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="46-E1-5B-DC-5A-27-47-7B-BF-6B-55-98-50-04-1C-DE-F1-84-E6-6D">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.TestPlatform.Client.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Client</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="EA-40-4C-75-4E-CC-64-CB-E0-0B-95-E4-AC-4E-14-0E-4E-43-CA-2B">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.TestPlatform.Common.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Common</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="CC-DB-8A-78-1D-14-03-CA-9E-57-77-AD-02-B0-11-1E-9D-D0-F8-EB">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Core\v4.0_4.0.0.0__b77a5c561934e089\System.Core.dll</ModulePath>
+      <ModuleTime>2019-12-07T06:03:04Z</ModuleTime>
+      <ModuleName>System.Core</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D2-F0-F2-FF-AE-D0-90-7D-B9-F6-15-6E-D5-06-05-87-03-53-98-79">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.TestPlatform.PlatformAbstractions.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.PlatformAbstractions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2D-4E-7D-93-79-73-1D-3F-7A-CD-83-B3-5F-27-A4-33-E4-E0-D0-C0">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Xml\v4.0_4.0.0.0__b77a5c561934e089\System.Xml.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.3313185Z</ModuleTime>
+      <ModuleName>System.Xml</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="05-17-3D-5A-70-23-25-42-99-2A-6A-D4-9E-05-F1-BC-D8-01-CA-D5">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.TestPlatform.Utilities.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.Utilities</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2A-7B-17-4D-5F-56-2E-65-AC-46-D1-7B-18-CB-45-61-99-7F-97-68">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Configuration\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Configuration.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.5645591Z</ModuleTime>
+      <ModuleName>System.Configuration</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="EB-76-12-F8-2F-06-94-4A-61-1C-23-3B-80-33-5E-18-0B-E5-A4-72">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.TestPlatform.CrossPlatEngine.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.CrossPlatEngine</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="06-19-22-50-4F-B6-BD-65-A0-C7-8C-DE-34-EA-A5-8F-DC-ED-2D-B8">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.TestPlatform.Extensions.BlameDataCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.Extensions.BlameDataCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="91-1A-F0-77-87-7A-78-F3-40-53-63-26-E3-B3-36-1E-8A-2C-E4-9C">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.TestPlatform.Extensions.EventLogCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.Extensions.EventLogCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D7-A7-84-27-C4-A9-66-B8-8A-20-FF-57-E3-CB-C9-AD-9A-3B-B7-51">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.TestPlatform.TestHostRuntimeProvider.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.TestHostRuntimeProvider</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D7-BF-31-BE-60-D4-B9-90-1B-91-BC-82-6E-42-CB-49-44-2F-6D-7C">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.ArchitectureTools.PEReader.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.ArchitectureTools.PEReader</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="2D-C8-72-FE-35-9B-0E-78-1A-8C-2C-40-D9-83-6C-FA-C5-5F-75-D7">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.Coverage.Interop.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.Coverage.Interop</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="F6-8B-50-0B-D5-4A-17-3D-09-28-19-BF-31-6A-B6-8B-E3-58-A8-9A">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.CodedWebTestAdapter.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.CodedWebTestAdapter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="F2-D6-52-FE-00-A7-FE-8D-D4-24-AC-E7-A3-04-21-5A-AD-48-32-50">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.TmiAdapter.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.TmiAdapter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="22-1F-5F-67-0C-DD-DE-1F-03-8C-89-85-2D-9A-AD-F4-95-AA-69-5B">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.QualityTools.Common.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.QualityTools.Common</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="7E-38-11-17-B0-30-5D-45-76-2A-18-90-F0-18-13-4E-C1-B2-16-0F">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.GenericTestAdapter.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.GenericTestAdapter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D9-C5-A7-55-C2-10-DA-E0-F9-C2-DF-B2-06-83-F8-EE-B0-DB-E7-E2">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.OrderedTestAdapter.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.OrderedTestAdapter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="12-6C-F5-E3-C7-CD-E3-77-C0-CA-1C-B3-6A-92-95-AE-F9-6C-A0-DA">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.Trx.TestLogger</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="46-46-34-57-D9-E0-CB-B4-8F-54-39-13-6F-43-4F-62-5D-6B-18-36">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.VSTestIntegration.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.VSTestIntegration</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="8A-70-99-42-21-64-D6-DA-93-8F-15-58-04-49-95-95-03-34-FD-B6">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.QualityTools.UnitTestFramework</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="CD-B4-80-7E-ED-87-A1-F3-81-CB-3E-96-C0-CC-4B-81-BD-74-C4-D1">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_32\System.Data\v4.0_4.0.0.0__b77a5c561934e089\System.Data.dll</ModulePath>
+      <ModuleTime>2019-12-07T06:03:04Z</ModuleTime>
+      <ModuleName>System.Data</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="19-13-48-7E-B8-6D-86-0B-82-11-D0-29-88-B9-86-65-5D-CE-BB-B6">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestPlatform.Extensions.WebTestAdapter.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Extensions.WebTestAdapter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D8-54-DB-4C-35-8D-F0-9E-02-E7-C0-E3-8A-1F-38-28-64-B8-00-3C">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.ComInterfaces.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestTools.CppUnitTestFramework.ComInterfaces</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="AC-E8-F2-CF-48-EF-9B-55-DD-C4-50-E6-CF-EC-B3-35-AB-A6-D8-7B">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.CppUnitTestFramework.CppUnitTestExtension.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestTools.CppUnitTestFramework.CppUnitTestExtension</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="60-03-96-F9-3B-1E-0D-18-F9-FE-FF-B9-4F-1B-28-3D-B7-20-39-7D">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="1D-26-3E-64-63-BC-40-62-7F-BA-67-38-AF-77-E8-9D-28-02-66-7C">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D5-C4-56-DC-17-09-1C-EA-87-1C-E8-F5-C7-29-D4-20-74-8C-96-35">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TraceDataCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TraceDataCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="41-D1-74-75-40-0C-09-3F-D4-4E-F1-AB-6F-1E-70-75-98-12-5B-FC">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.IntelliTrace.Core.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.IntelliTrace.Core</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="F1-D3-C4-19-F0-A3-97-CA-EE-78-EA-BA-5F-97-56-C8-6D-7F-01-45">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\System.Reflection.Metadata.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>System.Reflection.Metadata</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2A-5F-EB-FC-1F-8B-9B-DB-11-DF-AF-03-EE-EB-43-40-AC-5D-A5-08">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Runtime\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Runtime.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:17.086231Z</ModuleTime>
+      <ModuleName>System.Runtime</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="31-10-26-68-D1-64-10-03-21-09-D6-38-CC-CB-5F-68-D2-33-83-4E">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Runtime.InteropServices\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Runtime.InteropServices.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.4098692Z</ModuleTime>
+      <ModuleName>System.Runtime.InteropServices</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="42-26-9C-31-27-41-D7-11-67-3E-B9-52-F7-0B-89-F7-CF-DB-2A-9F">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.IO\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.IO.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.0307581Z</ModuleTime>
+      <ModuleName>System.IO</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="FB-BF-29-CE-7B-65-70-2C-55-E7-9A-03-D5-24-9F-04-A1-39-0C-A6">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\System.Collections.Immutable.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>System.Collections.Immutable</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="22-1F-F0-50-FF-7F-A0-29-DD-0C-1D-EE-12-A3-59-6D-ED-3D-47-14">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Reflection\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Reflection.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:16.8724675Z</ModuleTime>
+      <ModuleName>System.Reflection</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="53-77-EF-FE-9F-F9-EC-6E-7E-76-60-FF-15-66-89-40-9C-E0-20-59">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.IO.FileSystem\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.IO.FileSystem.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.0377466Z</ModuleTime>
+      <ModuleName>System.IO.FileSystem</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="27-DB-AC-1A-E3-0E-68-D9-4E-FB-01-38-58-7B-D4-0C-0C-06-3C-E2">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.IO.MemoryMappedFiles\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.IO.MemoryMappedFiles.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.5565597Z</ModuleTime>
+      <ModuleName>System.IO.MemoryMappedFiles</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="96-37-10-95-D6-A0-48-4B-95-E2-45-ED-F2-CC-F8-38-62-7F-B7-4A">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Runtime.Handles\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Runtime.Handles.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:17.0957374Z</ModuleTime>
+      <ModuleName>System.Runtime.Handles</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="20-90-4A-17-B6-9E-64-0F-FC-76-F1-38-55-AA-15-D2-A0-C7-C2-50">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Reflection.Extensions\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Reflection.Extensions.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:14.6041956Z</ModuleTime>
+      <ModuleName>System.Reflection.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="31-06-17-24-21-7B-94-95-95-7B-E6-A3-ED-8E-C4-61-76-81-50-E7">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Threading\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Threading.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.2693238Z</ModuleTime>
+      <ModuleName>System.Threading</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="8F-B6-AF-17-6D-95-F2-1A-C9-07-A2-52-08-07-0F-4B-AB-A1-B6-5A">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Text.Encoding\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Text.Encoding.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.1026701Z</ModuleTime>
+      <ModuleName>System.Text.Encoding</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="D7-63-79-55-E2-7C-07-44-05-DC-65-F2-1A-28-3F-C9-73-76-03-F4">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Runtime.Extensions\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Runtime.Extensions.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.6209693Z</ModuleTime>
+      <ModuleName>System.Runtime.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="BC-98-94-53-F1-64-6C-E2-64-06-9F-E1-73-E4-90-7C-0B-99-EF-63">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Text.Encoding.Extensions\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Text.Encoding.Extensions.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.1275958Z</ModuleTime>
+      <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="2A-2A-6C-70-82-27-5B-98-E6-EB-41-91-C0-3F-75-CB-8A-0B-FE-FD">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.TestPlatform.CommunicationUtilities.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.CommunicationUtilities</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="6B-0D-A7-56-17-A2-26-94-93-DC-1A-68-5D-7A-0B-07-F2-E4-8C-75">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Newtonsoft.Json.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Newtonsoft.Json</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="06-F9-8E-1A-FC-D4-91-9C-D0-32-40-16-3E-61-65-7F-A6-8C-FD-30">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Microsoft.Extensions.DependencyModel.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.Extensions.DependencyModel</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="B7-47-70-CB-BE-3B-AE-84-BF-DC-39-49-BE-C0-48-89-A3-C9-6E-61">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Numerics\v4.0_4.0.0.0__b77a5c561934e089\System.Numerics.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.417806Z</ModuleTime>
+      <ModuleName>System.Numerics</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="EF-12-A7-1D-68-2E-E3-7A-F6-5E-43-AD-77-01-E8-BC-1B-19-CE-66">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Runtime.InteropServices.RuntimeInformation\v4.0_4.0.0.0__b03f5f7f11d50a3a\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:16.8561084Z</ModuleTime>
+      <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="19-DB-E7-26-74-3E-B8-3C-B9-3E-89-49-9F-20-99-D9-CF-23-FD-17">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.CoreLib.dll</ModulePath>
+      <ModuleTime>2020-02-18T20:16:14Z</ModuleTime>
+      <ModuleName>System.Private.CoreLib</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="2D-24-9E-08-28-FF-DB-00-08-DF-87-04-1B-84-6A-4D-EC-11-E9-CB">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\testhost.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:24Z</ModuleTime>
+      <ModuleName>testhost</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="45-AE-FF-2D-9F-D9-14-AE-5E-58-BC-AD-59-3F-6B-E0-C7-F9-45-CA">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+      <ModuleName>System.Runtime</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="72-CD-4C-29-1F-8A-A2-EE-EE-49-B7-39-D7-D2-59-25-D4-15-8A-47">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CoreUtilities.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:22Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.CoreUtilities</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="08-0A-47-0B-10-27-7A-98-D6-A5-5B-EC-1C-35-91-93-AB-C0-35-65">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\netstandard.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+      <ModuleName>netstandard</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="D3-FC-01-5E-22-55-B9-FD-FB-0D-0E-A5-B8-58-05-D8-DC-D2-F5-24">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Tracing.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+      <ModuleName>System.Diagnostics.Tracing</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="03-17-2D-A2-47-E8-DA-D5-28-CB-74-74-E2-56-70-6A-C0-5A-AB-58">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.PlatformAbstractions.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:22Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.PlatformAbstractions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="B8-01-4B-08-49-01-14-1F-52-C1-06-1B-E1-C4-DA-8C-8C-15-88-14">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Extensions.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+      <ModuleName>System.Runtime.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="32-77-95-87-72-D8-6D-43-AA-DA-36-9B-86-D6-99-7F-41-0E-CF-A5">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Debug.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+      <ModuleName>System.Diagnostics.Debug</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="8B-E9-5A-2E-CC-DB-5C-E1-03-05-BA-E1-31-A9-9D-6F-18-10-50-AA">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+      <ModuleName>System.Collections</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="C3-FB-C2-9E-95-BB-9F-EC-54-E9-D6-2E-96-6F-43-6E-95-D3-F0-A1">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CrossPlatEngine.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:24Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.CrossPlatEngine</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="7E-1F-2A-CD-BD-DB-46-49-18-E0-16-C3-50-2A-47-26-74-E0-FA-63">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\Microsoft.TestPlatform.CommunicationUtilities.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:24Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.CommunicationUtilities</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="40-25-A6-0F-A5-B4-71-8F-77-23-6F-C1-FC-B2-A9-94-DA-7B-5F-2E">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:22Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.ObjectModel</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="C9-48-8A-EF-A0-7E-17-43-0F-BC-D2-F3-4D-26-76-B6-7D-DE-DF-67">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.Common.dll</ModulePath>
+      <ModuleTime>2020-02-04T19:55:24Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.Common</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="53-D0-A3-B9-10-36-09-21-32-F4-D0-88-75-00-B5-DC-77-89-1D-78">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\Newtonsoft.Json.dll</ModulePath>
+      <ModuleTime>2016-06-13T21:06:14Z</ModuleTime>
+      <ModuleName>Newtonsoft.Json</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="96-C7-5C-FC-1E-89-3E-67-F0-53-6B-39-C4-C0-61-BC-52-35-9C-A0">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Serialization.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+      <ModuleName>System.Runtime.Serialization.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="A6-8F-70-B6-4E-19-5D-AD-A4-E6-F3-7F-0E-80-A2-3F-81-B0-99-64">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Globalization.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+      <ModuleName>System.Globalization</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="9C-68-F9-D9-5D-09-7B-AC-36-D7-6D-25-3D-17-F3-72-E5-1A-87-F0">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:06Z</ModuleTime>
+      <ModuleName>System.Threading</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="66-55-F3-9A-C4-53-63-95-5F-60-D2-19-0F-7E-3B-2B-85-46-FB-8D">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TraceSource.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+      <ModuleName>System.Diagnostics.TraceSource</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="4D-33-53-11-50-36-83-92-2B-29-8C-5A-FA-19-EF-5A-D4-AA-32-80">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.Process.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+      <ModuleName>System.Diagnostics.Process</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="E5-F8-08-77-40-69-F3-B4-39-9E-F4-4F-30-35-FF-75-AD-66-E9-C9">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+      <ModuleName>System.ComponentModel.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="AF-4F-3B-E9-D2-80-A0-2E-91-5B-AF-17-34-A9-F1-A6-32-C4-EC-4E">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Memory.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+      <ModuleName>System.Memory</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="FC-9A-A3-24-E8-48-FF-9E-1A-D8-C2-B3-54-1E-A8-DD-B2-E1-E3-96">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.ThreadPool.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+      <ModuleName>System.Threading.ThreadPool</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="B9-08-B2-09-3C-61-2C-3E-62-03-05-65-93-6A-84-E5-2C-0D-A7-F4">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+      <ModuleName>System.Runtime.InteropServices</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="4E-A9-32-5A-D2-0F-84-D8-73-42-C7-0B-6A-3C-7B-C0-89-B7-20-01">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\Microsoft.Win32.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+      <ModuleName>Microsoft.Win32.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2A-48-85-A6-03-C4-07-FD-29-10-28-5A-25-BF-0C-FA-03-A7-98-B2">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+      <ModuleName>System.Net.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="23-F9-09-16-3B-71-58-F5-A7-35-CA-89-4D-75-0F-3D-D0-23-DC-EB">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Tasks.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:28Z</ModuleTime>
+      <ModuleName>System.Threading.Tasks</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="EE-DF-4B-C9-A1-40-03-5F-56-1A-DB-D7-E8-A0-BC-A6-12-34-84-1E">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.Sockets.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:08Z</ModuleTime>
+      <ModuleName>System.Net.Sockets</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="87-6E-54-67-71-53-FA-C9-68-88-0D-C1-82-45-BE-68-5A-25-55-32">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Overlapped.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+      <ModuleName>System.Threading.Overlapped</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="E6-CE-DF-D3-05-01-F5-61-41-53-0C-FF-2C-87-01-04-6E-EB-B1-C7">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Net.NameResolution.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+      <ModuleName>System.Net.NameResolution</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="D5-0A-67-87-14-54-BA-3A-F2-2A-2A-B8-15-CE-D1-74-51-44-E5-FC">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Uri.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+      <ModuleName>System.Private.Uri</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2F-EF-10-A4-03-CD-85-F5-B3-28-04-C0-CA-59-04-4C-AE-A8-5D-D0">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.Windows.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+      <ModuleName>System.Security.Principal.Windows</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="79-03-C9-B3-67-3A-61-F7-6D-B6-CE-72-A2-3F-68-B5-87-C1-4B-60">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Claims.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+      <ModuleName>System.Security.Claims</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="87-DE-C4-EB-AC-4B-76-40-4C-56-AB-F2-05-44-02-D8-77-58-26-00">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Principal.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+      <ModuleName>System.Security.Principal</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2A-8E-FF-4D-F2-A7-D6-AA-9E-44-17-D8-8A-11-71-D4-7C-19-DA-FF">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Runtime.Serialization\v4.0_4.0.0.0__b77a5c561934e089\System.Runtime.Serialization.dll</ModulePath>
+      <ModuleTime>2020-01-09T19:46:54Z</ModuleTime>
+      <ModuleName>System.Runtime.Serialization</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="32-74-EF-25-E3-A9-11-0C-F0-FD-2D-7E-1A-97-75-45-D0-5E-8A-A8">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.Xml.Linq\v4.0_4.0.0.0__b77a5c561934e089\System.Xml.Linq.dll</ModulePath>
+      <ModuleTime>2019-08-20T16:07:19.5069748Z</ModuleTime>
+      <ModuleName>System.Xml.Linq</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="C1-41-1B-16-60-41-0D-35-CE-85-82-6D-04-AB-CE-5C-88-E8-BE-91">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:06Z</ModuleTime>
+      <ModuleName>System.IO</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="17-CC-E7-2C-B7-DA-57-06-96-2B-F7-01-5A-76-38-AA-26-92-87-6D">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Dynamic.Runtime.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:38Z</ModuleTime>
+      <ModuleName>System.Dynamic.Runtime</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="6F-CC-2C-76-AC-42-0E-1D-29-DC-BE-AB-E0-6D-A4-C2-9D-0C-27-23">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.Expressions.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:18Z</ModuleTime>
+      <ModuleName>System.Linq.Expressions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="08-4C-1D-C3-E8-DB-38-EA-0D-64-CB-BD-58-BC-F2-B0-E2-99-42-93">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+      <ModuleName>System.Reflection</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="70-58-B8-D8-D1-66-CB-C6-C4-F9-5F-80-03-7C-74-A2-D8-CA-6A-98">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Extensions.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+      <ModuleName>System.Reflection.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="33-87-51-E6-2F-8C-BE-1D-5B-B2-9E-51-10-1B-05-40-2C-E3-E8-1A">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Linq.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:40Z</ModuleTime>
+      <ModuleName>System.Linq</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="22-BD-0E-BF-F3-50-23-F4-33-69-45-CA-85-5A-41-AA-FF-98-13-6A">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ObjectModel.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+      <ModuleName>System.ObjectModel</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="4B-5A-EC-05-10-C3-65-A3-7C-C5-D4-52-0E-41-A4-1F-73-88-F9-01">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.XDocument.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+      <ModuleName>System.Xml.XDocument</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="68-1D-85-11-BD-EC-60-7F-F2-E8-83-FF-C6-D8-D9-CB-28-C8-8B-2A">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.Linq.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:30Z</ModuleTime>
+      <ModuleName>System.Private.Xml.Linq</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="1F-BD-6F-06-01-11-FA-A9-DB-0B-12-95-1E-A0-B6-62-C2-59-ED-05">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Private.Xml.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:38Z</ModuleTime>
+      <ModuleName>System.Private.Xml</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="9D-C0-19-0D-B9-0B-71-00-FA-44-3E-7A-92-13-79-FB-D2-34-4F-3D">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.RegularExpressions.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+      <ModuleName>System.Text.RegularExpressions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="B5-88-C5-06-06-46-BA-FC-55-0E-7A-44-AC-31-CD-F3-5B-DF-AE-0B">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.ILGeneration.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+      <ModuleName>System.Reflection.Emit.ILGeneration</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="EA-A3-EB-09-A2-39-8F-0D-B1-13-BA-6D-11-3A-EC-93-44-39-5A-D3">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Emit.Lightweight.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+      <ModuleName>System.Reflection.Emit.Lightweight</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="C8-E8-31-5D-60-D0-B9-32-02-28-DE-17-96-8F-97-91-72-F8-BE-13">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:34Z</ModuleTime>
+      <ModuleName>System.Reflection.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="">
+      <ModulePath>RefEmit_InMemoryManifestModule</ModulePath>
+      <ModuleTime>0001-01-01T00:00:00</ModuleTime>
+      <ModuleName>Anonymously Hosted DynamicMethods Assembly</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="5E-EA-96-C3-0B-C7-BF-BA-AE-4A-27-D8-9A-9A-67-A2-72-BF-89-1F">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.NonGeneric.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+      <ModuleName>System.Collections.NonGeneric</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="A6-81-2A-5B-4A-3D-C8-4D-49-04-DE-1F-DF-02-7C-B4-43-51-DE-1C">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:06:08Z</ModuleTime>
+      <ModuleName>System.IO.FileSystem</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="3D-ED-2E-29-0D-BD-86-B5-75-96-FF-B0-C8-9D-AD-4E-5B-94-58-57">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.Loader.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+      <ModuleName>System.Runtime.Loader</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="5C-37-15-25-14-5D-AA-CD-FE-A1-58-0B-02-CA-F0-06-3B-F0-75-3E">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll</ModulePath>
+      <ModuleTime>2020-02-03T08:45:56Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="9D-1A-06-D1-57-63-4E-2B-7F-60-AB-7C-A1-0C-67-26-0C-72-0B-31">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</ModulePath>
+      <ModuleTime>2020-02-03T08:42:14Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.TestFramework</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="14-23-11-33-8A-3E-C2-95-9C-AF-E0-44-A0-4E-01-93-24-28-69-36">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll</ModulePath>
+      <ModuleTime>2020-02-03T08:43:54Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="18-52-46-8F-91-31-7C-89-18-7F-98-66-A5-FF-E4-26-5C-68-8E-0A">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll</ModulePath>
+      <ModuleTime>2020-02-03T08:52:28Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="06-19-22-50-4F-B6-BD-65-A0-C7-8C-DE-34-EA-A5-8F-DC-ED-2D-B8">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.TestPlatform.Extensions.BlameDataCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.Extensions.BlameDataCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="73-E1-7F-C7-2D-C9-99-D8-D5-D4-21-69-B8-EB-65-4F-5D-EE-9F-B3">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:26Z</ModuleTime>
+      <ModuleName>System.Xml</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="2F-E1-13-B8-1E-10-AE-79-4A-CD-F8-AE-C1-F1-E8-22-10-2F-61-17">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Xml.ReaderWriter.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:28Z</ModuleTime>
+      <ModuleName>System.Xml.ReaderWriter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="F2-84-10-73-D5-25-3C-C8-54-CA-05-A9-21-5F-EC-4F-D6-B7-11-E4">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\mscorlib.dll</ModulePath>
+      <ModuleTime>2020-02-21T02:00:46Z</ModuleTime>
+      <ModuleName>mscorlib</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="91-1A-F0-77-87-7A-78-F3-40-53-63-26-E3-B3-36-1E-8A-2C-E4-9C">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.TestPlatform.Extensions.EventLogCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.TestPlatform.Extensions.EventLogCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="1D-26-3E-64-63-BC-40-62-7F-BA-67-38-AF-77-E8-9D-28-02-66-7C">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorderCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="60-03-96-F9-3B-1E-0D-18-F9-FE-FF-B9-4F-1B-28-3D-B7-20-39-7D">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestTools.DataCollection.MediaRecorder.Model</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="D5-C4-56-DC-17-09-1C-EA-87-1C-E8-F5-C7-29-D4-20-74-8C-96-35">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.TraceDataCollector.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TraceDataCollector</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="88-C2-81-23-88-9B-01-F5-41-12-93-F2-07-C5-30-2F-E9-C7-6C-F6">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Core.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:34Z</ModuleTime>
+      <ModuleName>System.Core</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="4A-25-21-3A-BE-77-81-CD-7C-8A-13-F5-C1-EC-79-31-83-0D-13-AA">
+      <ModulePath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\TestPlatform\Extensions\Microsoft.VisualStudio.ArchitectureTools.PEReader.dll</ModulePath>
+      <ModuleTime>2020-01-13T13:43:12.2277411Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.ArchitectureTools.PEReader</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="A4-7B-EB-61-14-FF-0A-F1-6C-B1-3D-60-27-46-D9-09-64-D7-5C-4A">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.StackTrace.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+      <ModuleName>System.Diagnostics.StackTrace</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="F5-4A-B0-89-01-16-50-65-5F-DD-4C-B5-70-9E-39-1A-D1-B7-FE-38">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Reflection.Metadata.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+      <ModuleName>System.Reflection.Metadata</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="01-AB-1F-C1-0A-AD-1A-D5-69-41-9D-4B-4E-1C-6F-AC-59-05-9A-48">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Immutable.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+      <ModuleName>System.Collections.Immutable</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="A3-6E-3F-5C-23-E9-CE-D4-59-A4-79-82-3A-A2-A6-D2-A6-37-0E-C2">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Thread.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+      <ModuleName>System.Threading.Thread</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="08-F9-21-BB-3C-07-A4-DA-5A-43-89-51-EB-E0-A4-B9-2F-19-F6-7D">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Algorithms.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:40Z</ModuleTime>
+      <ModuleName>System.Security.Cryptography.Algorithms</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="25-17-3D-BA-13-03-55-32-76-CF-3D-AE-B3-52-14-5F-95-F5-3E-85">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Threading.Timer.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:24Z</ModuleTime>
+      <ModuleName>System.Threading.Timer</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="57-E8-B3-F8-DB-88-F2-FB-81-BE-34-C3-AD-1E-D4-F0-DD-F0-59-D3">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Resources.ResourceManager.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:32Z</ModuleTime>
+      <ModuleName>System.Resources.ResourceManager</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="26-14-D7-B5-EB-43-C2-76-01-4F-01-5E-7B-A4-CE-E9-EB-E3-AA-B9">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Runtime.InteropServices.RuntimeInformation.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:36Z</ModuleTime>
+      <ModuleName>System.Runtime.InteropServices.RuntimeInformation</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="C1-E6-95-46-6B-22-AB-AD-8C-29-08-C6-4F-A8-BC-C8-E3-D9-B3-83">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\NuGet.Frameworks.dll</ModulePath>
+      <ModuleTime>2019-04-01T16:23:50Z</ModuleTime>
+      <ModuleName>NuGet.Frameworks</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="4E-96-5A-FC-C0-BE-6F-D4-A5-9C-B4-F8-33-D5-85-D1-B9-07-9F-89">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Text.Encoding.Extensions.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:44Z</ModuleTime>
+      <ModuleName>System.Text.Encoding.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module hash="C4-7F-F9-78-0C-CD-56-0E-F3-63-61-42-3D-4F-F6-09-2A-5B-0B-53">
+      <Summary numSequencePoints="10" visitedSequencePoints="8" numBranchPoints="3" visitedBranchPoints="2" sequenceCoverage="80" branchCoverage="66.67" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="1" visitedClasses="1" numClasses="2" visitedMethods="2" numMethods="3" />
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\UnitTestProject2.dll</ModulePath>
+      <ModuleTime>2020-04-27T15:21:52.9041962Z</ModuleTime>
+      <ModuleName>UnitTestProject2</ModuleName>
+      <Files>
+        <File uid="1" fullPath="C:\Users\Andrei\.nuget\packages\microsoft.net.test.sdk\16.5.0\build\netcoreapp2.1\Microsoft.NET.Test.Sdk.Program.cs" />
+        <File uid="2" fullPath="SwitchCoverage\UnitTestProject2\UnitTest1.cs" />
+      </Files>
+      <Classes>
+        <Class>
+          <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="0" minCyclomaticComplexity="0" maxCrapScore="0" minCrapScore="0" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+          <FullName>&lt;Module&gt;</FullName>
+          <Methods />
+        </Class>
+        <Class>
+          <Summary numSequencePoints="2" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="1" visitedMethods="0" numMethods="1" />
+          <FullName>AutoGeneratedProgram</FullName>
+          <Methods>
+            <Method visited="false" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" crapScore="2" isConstructor="false" isStatic="true" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="2" visitedSequencePoints="0" numBranchPoints="1" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="1" />
+              <MetadataToken>100663297</MetadataToken>
+              <Name>System.Void AutoGeneratedProgram::Main(System.String[])</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="0" uspid="1" ordinal="0" offset="0" sl="4" sc="60" el="4" ec="61" bec="0" bev="0" fileid="1" />
+                <SequencePoint vc="0" uspid="2" ordinal="1" offset="1" sl="4" sc="61" el="4" ec="62" bec="0" bev="0" fileid="1" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint xsi:type="SequencePoint" vc="0" uspid="1" ordinal="0" offset="0" sl="4" sc="60" el="4" ec="61" bec="0" bev="0" fileid="1" />
+            </Method>
+            <Method visited="false" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" crapScore="2" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+              <MetadataToken>100663298</MetadataToken>
+              <Name>System.Void AutoGeneratedProgram::.ctor()</Name>
+              <SequencePoints />
+              <BranchPoints />
+              <MethodPoint vc="0" uspid="3" ordinal="0" offset="0" />
+            </Method>
+          </Methods>
+        </Class>
+        <Class>
+          <Summary numSequencePoints="8" visitedSequencePoints="8" numBranchPoints="2" visitedBranchPoints="2" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="1" visitedClasses="1" numClasses="1" visitedMethods="2" numMethods="2" />
+          <FullName>SwitchCoverageTest2.Tests</FullName>
+          <Methods>
+            <Method visited="true" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" crapScore="1" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="1" minCrapScore="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken>100663299</MetadataToken>
+              <Name>System.Void SwitchCoverageTest2.Tests::Test1()</Name>
+              <FileRef uid="2" />
+              <SequencePoints>
+                <SequencePoint vc="1" uspid="4" ordinal="0" offset="0" sl="12" sc="9" el="12" ec="10" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="1" uspid="5" ordinal="1" offset="1" sl="13" sc="13" el="13" ec="33" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="1" uspid="6" ordinal="2" offset="7" sl="14" sc="13" el="14" ec="48" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="1" uspid="7" ordinal="3" offset="25" sl="15" sc="9" el="15" ec="10" bec="0" bev="0" fileid="2" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint xsi:type="SequencePoint" vc="1" uspid="4" ordinal="0" offset="0" sl="12" sc="9" el="12" ec="10" bec="0" bev="0" fileid="2" />
+            </Method>
+            <Method visited="true" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="100" branchCoverage="100" crapScore="1" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="4" visitedSequencePoints="4" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="1" minCrapScore="1" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken>100663300</MetadataToken>
+              <Name>System.Void SwitchCoverageTest2.Tests::Test3()</Name>
+              <FileRef uid="2" />
+              <SequencePoints>
+                <SequencePoint vc="1" uspid="8" ordinal="0" offset="0" sl="19" sc="9" el="19" ec="10" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="1" uspid="9" ordinal="1" offset="1" sl="20" sc="13" el="20" ec="33" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="1" uspid="10" ordinal="2" offset="7" sl="21" sc="13" el="21" ec="50" bec="0" bev="0" fileid="2" />
+                <SequencePoint vc="1" uspid="11" ordinal="3" offset="25" sl="22" sc="9" el="22" ec="10" bec="0" bev="0" fileid="2" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint xsi:type="SequencePoint" vc="1" uspid="8" ordinal="0" offset="0" sl="19" sc="9" el="19" ec="10" bec="0" bev="0" fileid="2" />
+            </Method>
+            <Method visited="false" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" crapScore="2" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+              <MetadataToken>100663301</MetadataToken>
+              <Name>System.Void SwitchCoverageTest2.Tests::.ctor()</Name>
+              <SequencePoints />
+              <BranchPoints />
+              <MethodPoint vc="0" uspid="12" ordinal="0" offset="0" />
+            </Method>
+          </Methods>
+        </Class>
+      </Classes>
+    </Module>
+    <Module skippedDueTo="Filter" hash="31-48-4C-D9-B7-64-1C-85-5D-80-A0-AB-74-1E-29-E1-94-43-80-C0">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.IO.FileSystem.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:42Z</ModuleTime>
+      <ModuleName>System.IO.FileSystem.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="48-69-8F-D3-34-45-06-46-29-98-3A-0A-71-C5-1A-6D-78-02-46-35">
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</ModulePath>
+      <ModuleTime>2020-02-03T08:43:06Z</ModuleTime>
+      <ModuleName>Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="6D-0F-A0-D8-6E-D9-3D-12-46-84-DE-CC-44-CE-CF-2B-96-27-29-EA">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.ComponentModel.TypeConverter.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:32Z</ModuleTime>
+      <ModuleName>System.ComponentModel.TypeConverter</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="8F-A1-95-7C-65-A0-95-11-53-8D-DF-11-6D-3C-AD-5D-AE-2F-D3-73">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Collections.Concurrent.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:24Z</ModuleTime>
+      <ModuleName>System.Collections.Concurrent</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="D0-59-FE-7C-7F-0D-36-55-42-D4-35-5B-11-52-FF-15-85-1C-6D-DB">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Diagnostics.TextWriterTraceListener.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:36Z</ModuleTime>
+      <ModuleName>System.Diagnostics.TextWriterTraceListener</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="32-5D-5E-82-60-49-7F-5D-44-D4-1E-BF-57-95-6F-D8-30-A6-C2-E1">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Console.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:05:30Z</ModuleTime>
+      <ModuleName>System.Console</ModuleName>
+      <Classes />
+    </Module>
+    <Module hash="BB-9C-0F-8E-5F-FC-F9-90-9C-2F-D8-CF-15-63-3A-5B-F3-6D-AE-DE">
+      <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="9" visitedBranchPoints="6" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="5" minCyclomaticComplexity="1" maxCrapScore="5" minCrapScore="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+      <ModulePath>SwitchCoverage\UnitTestProject2\bin\Debug\netcoreapp3.1\SwitchCoverage.dll</ModulePath>
+      <ModuleTime>2020-04-27T15:20:56.9319773Z</ModuleTime>
+      <ModuleName>SwitchCoverage</ModuleName>
+      <Files>
+        <File uid="5" fullPath="SwitchCoverage\SwitchCoverage\Foo.cs" />
+      </Files>
+      <Classes>
+        <Class>
+          <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="0" minCyclomaticComplexity="0" maxCrapScore="0" minCrapScore="0" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+          <FullName>&lt;Module&gt;</FullName>
+          <Methods />
+        </Class>
+        <Class>
+          <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="9" visitedBranchPoints="6" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="5" minCyclomaticComplexity="1" maxCrapScore="5" minCrapScore="2" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
+          <FullName>SwitchCoverage.Foo</FullName>
+          <Methods>
+            <Method visited="true" cyclomaticComplexity="5" nPathComplexity="16" sequenceCoverage="100" branchCoverage="66.67" crapScore="5" isConstructor="false" isStatic="false" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="1" visitedSequencePoints="1" numBranchPoints="9" visitedBranchPoints="6" sequenceCoverage="100" branchCoverage="66.67" maxCyclomaticComplexity="5" minCyclomaticComplexity="5" maxCrapScore="5" minCrapScore="5" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
+              <MetadataToken>100663297</MetadataToken>
+              <Name>System.Int32 SwitchCoverage.Foo::Bar(System.String)</Name>
+              <FileRef uid="5" />
+              <SequencePoints>
+                <SequencePoint vc="2" uspid="13" ordinal="0" offset="0" sl="8" sc="13" el="14" ec="14" bec="7" bev="5" fileid="5" />
+              </SequencePoints>
+              <BranchPoints>
+                <BranchPoint vc="2" uspid="14" ordinal="0" offset="1" sl="8" path="0" offsetend="3" fileid="5" />
+                <BranchPoint vc="0" uspid="15" ordinal="1" offset="1" sl="8" path="1" offsetend="56" fileid="5" />
+                <BranchPoint vc="1" uspid="16" ordinal="2" offset="14" sl="8" path="0" offsetend="16" fileid="5" />
+                <BranchPoint vc="1" uspid="17" ordinal="3" offset="14" sl="8" path="1" offsetend="44" fileid="5" />
+                <BranchPoint vc="1" uspid="18" ordinal="4" offset="27" sl="8" path="0" offsetend="29" fileid="5" />
+                <BranchPoint vc="0" uspid="19" ordinal="5" offset="27" sl="8" path="1" offsetend="48" fileid="5" />
+                <BranchPoint vc="0" uspid="20" ordinal="6" offset="40" sl="8" path="0" offsetchain="42" offsetend="56" fileid="5" />
+                <BranchPoint vc="1" uspid="21" ordinal="7" offset="40" sl="8" path="1" offsetend="52" fileid="5" />
+              </BranchPoints>
+              <MethodPoint xsi:type="SequencePoint" vc="2" uspid="13" ordinal="0" offset="0" sl="8" sc="13" el="14" ec="14" bec="7" bev="5" fileid="5" />
+            </Method>
+            <Method visited="false" cyclomaticComplexity="1" nPathComplexity="0" sequenceCoverage="0" branchCoverage="0" crapScore="2" isConstructor="true" isStatic="false" isGetter="false" isSetter="false">
+              <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" maxCrapScore="2" minCrapScore="2" visitedClasses="0" numClasses="0" visitedMethods="0" numMethods="0" />
+              <MetadataToken>100663298</MetadataToken>
+              <Name>System.Void SwitchCoverage.Foo::.ctor()</Name>
+              <SequencePoints />
+              <BranchPoints />
+              <MethodPoint vc="0" uspid="22" ordinal="0" offset="0" />
+            </Method>
+          </Methods>
+        </Class>
+      </Classes>
+    </Module>
+    <Module skippedDueTo="Filter" hash="55-8E-C2-A5-09-4D-3F-8C-11-59-AB-41-D5-05-B5-7B-8D-3A-AA-6E">
+      <ModulePath>C:\Program Files\dotnet\shared\Microsoft.NETCore.App\3.1.3\System.Security.Cryptography.Primitives.dll</ModulePath>
+      <ModuleTime>2020-02-28T19:04:42Z</ModuleTime>
+      <ModuleName>System.Security.Cryptography.Primitives</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="MissingPdb" hash="AA-A1-B5-37-5B-A3-3F-60-8A-4D-0B-A0-48-E4-49-D8-49-E0-96-D9">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\SMDiagnostics\v4.0_4.0.0.0__b77a5c561934e089\SMDiagnostics.dll</ModulePath>
+      <ModuleTime>2020-01-09T19:46:54Z</ModuleTime>
+      <ModuleName>SMDiagnostics</ModuleName>
+      <Classes />
+    </Module>
+    <Module skippedDueTo="Filter" hash="BB-80-4D-57-28-4C-C5-76-72-6F-11-E7-E6-86-43-26-A9-62-89-CD">
+      <ModulePath>C:\Windows\Microsoft.Net\assembly\GAC_MSIL\System.ServiceModel.Internals\v4.0_4.0.0.0__31bf3856ad364e35\System.ServiceModel.Internals.dll</ModulePath>
+      <ModuleTime>2020-01-09T19:46:54Z</ModuleTime>
+      <ModuleName>System.ServiceModel.Internals</ModuleName>
+      <Classes />
+    </Module>
+  </Modules>
+</CoverageSession>


### PR DESCRIPTION
When a code file is touched by unit tests from different test projects,
it will appear multiple times in the open cover reports. Since different
tests can cover different branches we need to correctly identify the
covered branches and count them only once.

SequencePoint does not have enough information to allow this
and because of that we have to rely on BranchPoints.

Fixes branch coverage import for #3296
