### PR TITLE
Allow import of internal issues with invalid location

### DIFF
--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/SarifParserCallbackImpl.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/SarifParserCallbackImpl.java
@@ -195,14 +195,14 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
   }
 
   private void createIssue(InputFile inputFile, String ruleId, Location primaryLocation, Collection<Location> secondaryLocations, String repositoryKey) {
-    boolean isOwnRepository = isOwnRepository(repositoryKey);
+    boolean isSonarSourceRepository  = isSonarSourceRepository(repositoryKey);
 
     NewIssue newIssue = context.newIssue();
     newIssue
       .forRule(RuleKey.of(repositoryKey, ruleId))
-      .at(createPrimaryLocation(inputFile, primaryLocation, newIssue::newLocation, !isOwnRepository));
+      .at(createPrimaryLocation(inputFile, primaryLocation, newIssue::newLocation, !isSonarSourceRepository ));
 
-    populateSecondaryLocations(secondaryLocations, newIssue::newLocation, newIssue::addLocation, !isOwnRepository);
+    populateSecondaryLocations(secondaryLocations, newIssue::newLocation, newIssue::addLocation, !isSonarSourceRepository );
 
     newIssue.save();
   }
@@ -314,7 +314,7 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
     }
   }
 
-  private static boolean isOwnRepository(String repositoryKey){
+  private static boolean isSonarSourceRepository(String repositoryKey){
     return OWN_REPOSITORIES.contains(repositoryKey);
   }
 

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/SarifParserCallbackImpl.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/SarifParserCallbackImpl.java
@@ -20,9 +20,11 @@
 package org.sonarsource.dotnet.shared.plugins;
 
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -53,6 +55,7 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
   private static final Logger LOG = Loggers.get(SarifParserCallbackImpl.class);
 
   private static final String EXTERNAL_ENGINE_ID = "roslyn";
+  private static final List<String> OWN_REPOSITORIES =  Arrays.asList("csharpsquid", "vbnet");
   private final SensorContext context;
   private final Map<String, String> repositoryKeyByRoslynRuleKey;
   private final Set<Issue> savedIssues = new HashSet<>();
@@ -162,10 +165,10 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
 
   private void createExternalIssue(InputFile inputFile, String ruleId, @Nullable String level, Location primaryLocation, Collection<Location> secondaryLocations) {
     NewExternalIssue newIssue = newExternalIssue(ruleId);
-    newIssue.at(createPrimaryLocation(inputFile, primaryLocation, newIssue::newLocation));
+    newIssue.at(createPrimaryLocation(inputFile, primaryLocation, newIssue::newLocation, true));
     setExternalIssueSeverityAndType(ruleId, level, newIssue);
 
-    populateSecondaryLocations(secondaryLocations, newIssue::newLocation, newIssue::addLocation);
+    populateSecondaryLocations(secondaryLocations, newIssue::newLocation, newIssue::addLocation, true);
 
     newIssue.save();
   }
@@ -192,22 +195,26 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
   }
 
   private void createIssue(InputFile inputFile, String ruleId, Location primaryLocation, Collection<Location> secondaryLocations, String repositoryKey) {
+    boolean isOwnRepository = isOwnRepository(repositoryKey);
+
     NewIssue newIssue = context.newIssue();
     newIssue
       .forRule(RuleKey.of(repositoryKey, ruleId))
-      .at(createPrimaryLocation(inputFile, primaryLocation, newIssue::newLocation));
+      .at(createPrimaryLocation(inputFile, primaryLocation, newIssue::newLocation, !isOwnRepository));
 
-    populateSecondaryLocations(secondaryLocations, newIssue::newLocation, newIssue::addLocation);
+    populateSecondaryLocations(secondaryLocations, newIssue::newLocation, newIssue::addLocation, !isOwnRepository);
 
     newIssue.save();
   }
 
-  private static NewIssueLocation createPrimaryLocation(InputFile inputFile, Location primaryLocation, Supplier<NewIssueLocation> newIssueLocationSupplier) {
-    return createIssueLocation(inputFile, primaryLocation, newIssueLocationSupplier);
+  private static NewIssueLocation createPrimaryLocation(InputFile inputFile, Location primaryLocation, Supplier<NewIssueLocation> newIssueLocationSupplier,
+    boolean isLocationResilient) {
+
+    return createIssueLocation(inputFile, primaryLocation, newIssueLocationSupplier, isLocationResilient);
   }
 
   private void populateSecondaryLocations(Collection<Location> secondaryLocations, Supplier<NewIssueLocation> newIssueLocationSupplier,
-    Consumer<NewIssueLocation> newIssueLocationConsumer) {
+    Consumer<NewIssueLocation> newIssueLocationConsumer, boolean isLocationResilient) {
     for (Location secondaryLocation : secondaryLocations) {
       InputFile inputFile = context.fileSystem().inputFile(context.fileSystem().predicates()
         .hasAbsolutePath(secondaryLocation.getAbsolutePath()));
@@ -215,12 +222,13 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
         continue;
       }
 
-      NewIssueLocation newIssueLocation = createIssueLocation(inputFile, secondaryLocation, newIssueLocationSupplier);
+      NewIssueLocation newIssueLocation = createIssueLocation(inputFile, secondaryLocation, newIssueLocationSupplier, isLocationResilient);
       newIssueLocationConsumer.accept(newIssueLocation);
     }
   }
 
-  private static NewIssueLocation createIssueLocation(InputFile inputFile, Location location, Supplier<NewIssueLocation> newIssueLocationSupplier) {
+  private static NewIssueLocation createIssueLocation(InputFile inputFile, Location location, Supplier<NewIssueLocation> newIssueLocationSupplier,
+    boolean isLocationResilient) {
 
     NewIssueLocation newIssueLocation = newIssueLocationSupplier.get()
       .on(inputFile);
@@ -231,6 +239,12 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
         location.getEndLine(), location.getEndColumn()));
 
     } catch (IllegalArgumentException ex1) {
+      LOG.debug("Precise issue location cannot be found! Location: {}", location);
+
+      if (!isLocationResilient) {
+        // Our rules should fail if they report on an invalid location
+        throw ex1;
+      }
 
       try {
         // Precise location failed, now try the line...
@@ -238,6 +252,8 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
       } catch (IllegalArgumentException ex2) {
         // Line location failed so let's report at file level (we are sure the file exists).
         // As the file was already registered previously, there is nothing to do here.
+
+        LOG.debug("Line issue location cannot be found! Location: {}", location);
       }
     }
 
@@ -296,6 +312,10 @@ public class SarifParserCallbackImpl implements SarifParserCallback {
       default:
         return Severity.INFO;
     }
+  }
+
+  private static boolean isOwnRepository(String repositoryKey){
+    return OWN_REPOSITORIES.contains(repositoryKey);
   }
 
   private static class Issue {

--- a/sonar-dotnet-shared-library/src/test/resources/RoslynDataImporterTest/roslyn-report-invalid-location.json
+++ b/sonar-dotnet-shared-library/src/test/resources/RoslynDataImporterTest/roslyn-report-invalid-location.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-1.0.0",
+  "version": "1.0.0",
+  "runs": [
+    {
+      "tool": {
+        "name": "Microsoft (R) Visual C# Compiler",
+        "version": "3.5.0.0",
+        "fileVersion": "3.5.0-beta4-20153-05 (20b9af91)",
+        "semanticVersion": "3.5.0",
+        "language": "en-US"
+      },
+      "results": [
+        {
+          "ruleId": "SA1629",
+          "level": "warning",
+          "message": "Documentation text should end with a period",
+          "locations": [
+            {
+              "resultFile": {
+                "uri": "Program.cs",
+                "region": {
+                  "startLine": 13,
+                  "startColumn": 100,
+                  "endLine": 13,
+                  "endColumn": 101
+                }
+              }
+            }
+          ],
+          "properties": {
+            "warningLevel": 1
+          }
+        },
+        {
+          "ruleId": "SA1629",
+          "level": "warning",
+          "message": "Documentation text should end with a period",
+          "locations": [
+            {
+              "resultFile": {
+                "uri": "Program.cs",
+                "region": {
+                  "startLine": 100,
+                  "startColumn": 1,
+                  "endLine": 100,
+                  "endColumn": 2
+                }
+              }
+            }
+          ],
+          "properties": {
+            "warningLevel": 1
+          }
+        }
+      ],
+      "rules": {
+        "SA1629": {
+          "id": "SA1629",
+          "shortDescription": "Documentation text should end with a period",
+          "fullDescription": "A section of the XML header documentation for a C# element does not end with a period.",
+          "defaultLevel": "warning",
+          "helpUri": "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md",
+          "properties": {
+            "category": "StyleCop.CSharp.DocumentationRules",
+            "isEnabledByDefault": true
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Issues from third-party Roslyn analyzers (including Roslyn analyzers provided by Microsoft) are included in the MSBuild output and imported by default into SonarQube.

In this case they are considered external issues and the Roslyn importer is very forgiving regarding the location:
- if the column is invalid it will use only the line
- if both column and line are invalid, it will report the issue on the file.

On the other hand, if the [SDK for SonarQube Roslyn Analyzer Plugins](https://github.com/SonarSource/sonarqube-roslyn-sdk) is used to create a plugin for the analyzers, then the issues are treated as internal and the importer will not fallback to line or file level.

This commit is changing that and allows the import of internal issues (excepting the ones from `csharpsquid` and `vbnet` repositories) with invalid location.

Fixes #2484