### PR TITLE
S3453: Fix FP with SafeHandle

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/ClassNotInstantiatable.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/ClassNotInstantiatable.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static void CheckClassWithOnlyUnusedPrivateConstructors(SymbolAnalysisContext context)
         {
             var namedType = context.Symbol as INamedTypeSymbol;
-            if (!IsNonStaticClassWithNoAttributes(namedType))
+            if (!IsNonStaticClassWithNoAttributes(namedType) || DerivesFromSafeHandle(namedType))
             {
                 return;
             }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Rules/ClassNotInstantiatableBase.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Rules/ClassNotInstantiatableBase.cs
@@ -91,9 +91,9 @@ namespace SonarAnalyzer.Rules
             && !HasNonPrivateConstructor(constructors)
             && constructors.All(c => !c.GetAttributes().Any());
 
-        protected static bool DerivesFromSafeHandle(INamedTypeSymbol namedType)
+        protected static bool DerivesFromSafeHandle(ITypeSymbol typeSymbol)
         {
-            return namedType.DerivesFrom(KnownType.System_Runtime_InteropServices_SafeHandle);
+            return typeSymbol.DerivesFrom(KnownType.System_Runtime_InteropServices_SafeHandle);
         }
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Rules/ClassNotInstantiatableBase.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Rules/ClassNotInstantiatableBase.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -90,5 +90,10 @@ namespace SonarAnalyzer.Rules
             constructors.Any()
             && !HasNonPrivateConstructor(constructors)
             && constructors.All(c => !c.GetAttributes().Any());
+
+        protected static bool DerivesFromSafeHandle(INamedTypeSymbol namedType)
+        {
+            return namedType.DerivesFrom(KnownType.System_Runtime_InteropServices_SafeHandle);
+        }
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Rules/ClassNotInstantiatable.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.VisualBasic/Rules/ClassNotInstantiatable.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private static void CheckClassWithOnlyUnusedPrivateConstructors(SymbolAnalysisContext context)
         {
             var namedType = context.Symbol as INamedTypeSymbol;
-            if (!IsNonStaticClassWithNoAttributes(namedType))
+            if (!IsNonStaticClassWithNoAttributes(namedType) || DerivesFromSafeHandle(namedType))
             {
                 return;
             }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassNotInstantiatable.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassNotInstantiatable.cs
@@ -97,7 +97,7 @@ namespace Tests.Diagnostics
     }
 
     // https://github.com/SonarSource/sonar-dotnet/issues/3329
-    public class Repro_3329 : System.Runtime.InteropServices.SafeHandle  // Noncompliant FP, instance will be created by PInvoke of DllImport
+    public class Repro_3329 : System.Runtime.InteropServices.SafeHandle
     {
         private Repro_3329() : base(IntPtr.Zero, true) { }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassNotInstantiatable.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassNotInstantiatable.cs
@@ -97,7 +97,7 @@ namespace Tests.Diagnostics
     }
 
     // https://github.com/SonarSource/sonar-dotnet/issues/3329
-    public class Repro_3329 : System.Runtime.InteropServices.SafeHandle 'Compliant, instance will be created by PInvoke of DllImport
+    public class Repro_3329 : System.Runtime.InteropServices.SafeHandle // Compliant, instance will be created by PInvoke of DllImport
     {
         private Repro_3329() : base(IntPtr.Zero, true) { }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassNotInstantiatable.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassNotInstantiatable.cs
@@ -97,7 +97,7 @@ namespace Tests.Diagnostics
     }
 
     // https://github.com/SonarSource/sonar-dotnet/issues/3329
-    public class Repro_3329 : System.Runtime.InteropServices.SafeHandle
+    public class Repro_3329 : System.Runtime.InteropServices.SafeHandle 'Compliant, instance will be created by PInvoke of DllImport
     {
         private Repro_3329() : base(IntPtr.Zero, true) { }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassNotInstantiatable.vb
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassNotInstantiatable.vb
@@ -101,7 +101,7 @@ Namespace Tests.Diagnostics
     End Class
 
     ' https//github.com/SonarSource/sonar-dotnet/issues/3329
-    Public Class Repro_3329
+    Public Class Repro_3329 `Compliant, instance will be created by PInvoke of DllImport
         Inherits System.Runtime.InteropServices.SafeHandle
 
         Private Sub New()

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassNotInstantiatable.vb
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassNotInstantiatable.vb
@@ -101,7 +101,7 @@ Namespace Tests.Diagnostics
     End Class
 
     ' https//github.com/SonarSource/sonar-dotnet/issues/3329
-    Public Class Repro_3329 `Compliant, instance will be created by PInvoke of DllImport
+    Public Class Repro_3329 ' Compliant, instance will be created by PInvoke of DllImport
         Inherits System.Runtime.InteropServices.SafeHandle
 
         Private Sub New()

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassNotInstantiatable.vb
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ClassNotInstantiatable.vb
@@ -101,7 +101,7 @@ Namespace Tests.Diagnostics
     End Class
 
     ' https//github.com/SonarSource/sonar-dotnet/issues/3329
-    Public Class Repro_3329 'Noncompliant FP, instance will be created by PInvoke of DllImport
+    Public Class Repro_3329
         Inherits System.Runtime.InteropServices.SafeHandle
 
         Private Sub New()


### PR DESCRIPTION
Fixes #3329

Added check for classes derived from SafeHandle to not flag S3453.

Note: I based this PR on the Repro cases to be added with #3336. Let me know if that's not desirable and I will remove the test cases from this PR again.