### PR TITLE
Reuse symbolic execution logic in EmptyNullableValueAccess and ObjectsShouldNotBeDisposedMoreThanOnce

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyNullableValueAccess.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyNullableValueAccess.cs
@@ -142,7 +142,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private class AnalysisContext : ISymbolicExecutionAnalysisContext
+        private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext
         {
             private readonly HashSet<IdentifierNameSyntax> nullIdentifiers = new HashSet<IdentifierNameSyntax>();
             private readonly NullValueAccessedCheck nullPointerCheck;

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ISymbolicExecutionAnalysisContext.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ISymbolicExecutionAnalysisContext.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2020 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace SonarAnalyzer.Rules.SymbolicExecution
+{
+    // The implementing class is responsible to encapsulate the generated data during method analysis (like diagnostics
+    // or cached nodes) and clear it and the end.
+    public interface ISymbolicExecutionAnalysisContext : IDisposable
+    {
+        IEnumerable<Diagnostic> GetDiagnostics();
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ISymbolicExecutionAnalyzer.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ISymbolicExecutionAnalyzer.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -18,23 +18,16 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-extern alias csharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using csharp::SonarAnalyzer.Rules.CSharp;
-using SonarAnalyzer.UnitTest.TestFramework;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using SonarAnalyzer.SymbolicExecution;
 
-namespace SonarAnalyzer.UnitTest.Rules
+namespace SonarAnalyzer.Rules.SymbolicExecution
 {
-    [TestClass]
-    public class EmptyNullableValueAccessTest
+    internal interface ISymbolicExecutionAnalyzer
     {
-        [TestMethod]
-        [TestCategory("Rule")]
-        public void EmptyNullableValueAccess()
-        {
-            Verifier.VerifyAnalyzer(@"TestCases\EmptyNullableValueAccess.cs", new EmptyNullableValueAccess(),
-                                ParseOptionsHelper.FromCSharp8,
-                                additionalReferences: NuGetMetadataReference.NETStandardV2_1_0);
-        }
+        IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; }
+
+        ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph);
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnce.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnce.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph) => new AnalysisContext(explodedGraph);
 
-        private class AnalysisContext : ISymbolicExecutionAnalysisContext
+        private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext
         {
             // Store the nodes that should be reported and ignore duplicate reports for the same node.
             // This is needed because we generate two CFG blocks for the finally statements and even

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactory.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactory.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2020 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Rules.CSharp;
+
+namespace SonarAnalyzer.Rules.SymbolicExecution
+{
+    internal sealed class SymbolicExecutionAnalyzerFactory
+    {
+        private readonly ImmutableArray<ISymbolicExecutionAnalyzer> analyzers;
+
+        public ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+
+        public SymbolicExecutionAnalyzerFactory()
+        {
+            // Symbolic execution analyzers and supported diagnostics will not change at runtime so they can be cached safely.
+            this.analyzers = ImmutableArray.Create<ISymbolicExecutionAnalyzer>(new EmptyNullableValueAccess());
+
+            SupportedDiagnostics = this.analyzers.SelectMany(analyzer => analyzer.SupportedDiagnostics).ToImmutableArray();
+        }
+
+        public IEnumerable<ISymbolicExecutionAnalyzer> GetEnabledAnalyzers(SyntaxNodeAnalysisContext context) =>
+            // Enabled analyzers can be changed at runtime in the IDE or by using connected mode in SonarLint and because of this
+            // they cannot be cached.
+            this.analyzers.Where(analyzer => HasEnabledDiagnostics(analyzer, context.Compilation.Options));
+
+        private static bool HasEnabledDiagnostics(ISymbolicExecutionAnalyzer analyzer, CompilationOptions options) =>
+            analyzer.SupportedDiagnostics.Any(diagnosticDescriptor => IsEnabled(options, diagnosticDescriptor));
+
+        private static bool IsEnabled(CompilationOptions options, DiagnosticDescriptor diagnosticDescriptor) =>
+            diagnosticDescriptor.GetEffectiveSeverity(options) != ReportDiagnostic.Suppress;
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactory.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactory.cs
@@ -36,17 +36,17 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
         public SymbolicExecutionAnalyzerFactory()
         {
             // Symbolic execution analyzers and supported diagnostics will not change at runtime so they can be safely cached.
-            this.analyzers = ImmutableArray.Create<ISymbolicExecutionAnalyzer>(
+            analyzers = ImmutableArray.Create<ISymbolicExecutionAnalyzer>(
                 new EmptyNullableValueAccess(),
                 new ObjectsShouldNotBeDisposedMoreThanOnce());
 
-            SupportedDiagnostics = this.analyzers.SelectMany(analyzer => analyzer.SupportedDiagnostics).ToImmutableArray();
+            SupportedDiagnostics = analyzers.SelectMany(analyzer => analyzer.SupportedDiagnostics).ToImmutableArray();
         }
 
         public IEnumerable<ISymbolicExecutionAnalyzer> GetEnabledAnalyzers(SyntaxNodeAnalysisContext context) =>
             // Enabled analyzers can be changed at runtime in the IDE or by using connected mode in SonarLint and because of this
             // they cannot be cached.
-            this.analyzers.Where(analyzer => HasEnabledDiagnostics(analyzer, context.Compilation.Options));
+            analyzers.Where(analyzer => HasEnabledDiagnostics(analyzer, context.Compilation.Options));
 
         private static bool HasEnabledDiagnostics(ISymbolicExecutionAnalyzer analyzer, CompilationOptions options) =>
             analyzer.SupportedDiagnostics.Any(diagnosticDescriptor => IsEnabled(options, diagnosticDescriptor));

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactory.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactory.cs
@@ -35,8 +35,10 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
 
         public SymbolicExecutionAnalyzerFactory()
         {
-            // Symbolic execution analyzers and supported diagnostics will not change at runtime so they can be cached safely.
-            this.analyzers = ImmutableArray.Create<ISymbolicExecutionAnalyzer>(new EmptyNullableValueAccess());
+            // Symbolic execution analyzers and supported diagnostics will not change at runtime so they can be safely cached.
+            this.analyzers = ImmutableArray.Create<ISymbolicExecutionAnalyzer>(
+                new EmptyNullableValueAccess(),
+                new ObjectsShouldNotBeDisposedMoreThanOnce());
 
             SupportedDiagnostics = this.analyzers.SelectMany(analyzer => analyzer.SupportedDiagnostics).ToImmutableArray();
         }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactory.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactory.cs
@@ -23,11 +23,14 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
 using SonarAnalyzer.Rules.CSharp;
 
 namespace SonarAnalyzer.Rules.SymbolicExecution
 {
-    internal sealed class SymbolicExecutionAnalyzerFactory
+    [Rule(EmptyNullableValueAccess.DiagnosticId, LanguageNames.CSharp)]
+    [Rule(ObjectsShouldNotBeDisposedMoreThanOnce.DiagnosticId, LanguageNames.CSharp)]
+    internal sealed class SymbolicExecutionAnalyzerFactory : IRuleFactory
     {
         private readonly ImmutableArray<ISymbolicExecutionAnalyzer> analyzers;
 

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -33,6 +33,7 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     [Rule(EmptyNullableValueAccess.DiagnosticId)]
+    [Rule(ObjectsShouldNotBeDisposedMoreThanOnce.DiagnosticId)]
     public sealed class SymbolicExecutionRunner : SonarDiagnosticAnalyzer
     {
         private readonly SymbolicExecutionAnalyzerFactory symbolicExecutionAnalyzerFactory = new SymbolicExecutionAnalyzerFactory();

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2020 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+using SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.SymbolicExecution;
+
+namespace SonarAnalyzer.Rules.SymbolicExecution
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Rule(EmptyNullableValueAccess.DiagnosticId)]
+    public sealed class SymbolicExecutionRunner : SonarDiagnosticAnalyzer
+    {
+        private readonly SymbolicExecutionAnalyzerFactory symbolicExecutionAnalyzerFactory = new SymbolicExecutionAnalyzerFactory();
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+
+        public SymbolicExecutionRunner()
+        {
+            SupportedDiagnostics = this.symbolicExecutionAnalyzerFactory.SupportedDiagnostics;
+        }
+
+        protected override void Initialize(SonarAnalysisContext context)
+        {
+            context.RegisterExplodedGraphBasedAnalysis(Analyze);
+        }
+
+        private void Analyze(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
+        {
+            var analyzerContexts = InitializeAnalyzers(explodedGraph, context).ToList();
+
+            try
+            {
+                explodedGraph.Walk();
+            }
+            finally
+            {
+                foreach (var diagnostic in analyzerContexts.SelectMany(analyzerContext => analyzerContext.GetDiagnostics()))
+                {
+                    context.ReportDiagnosticWhenActive(diagnostic);
+                }
+
+                analyzerContexts.ForEach(analyzerContext => analyzerContext.Dispose());
+            }
+        }
+
+        private IEnumerable<ISymbolicExecutionAnalysisContext> InitializeAnalyzers(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+            this.symbolicExecutionAnalyzerFactory
+                .GetEnabledAnalyzers(context)
+                .Select(analyzer => analyzer.AddChecks(explodedGraph));
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -42,7 +41,7 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
 
         public SymbolicExecutionRunner()
         {
-            SupportedDiagnostics = this.symbolicExecutionAnalyzerFactory.SupportedDiagnostics;
+            SupportedDiagnostics = symbolicExecutionAnalyzerFactory.SupportedDiagnostics;
         }
 
         protected override void Initialize(SonarAnalysisContext context)
@@ -70,7 +69,7 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
         }
 
         private IEnumerable<ISymbolicExecutionAnalysisContext> InitializeAnalyzers(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
-            this.symbolicExecutionAnalyzerFactory
+            symbolicExecutionAnalyzerFactory
                 .GetEnabledAnalyzers(context)
                 .Select(analyzer => analyzer.AddChecks(explodedGraph));
     }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -23,16 +23,12 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.SymbolicExecution;
 
 namespace SonarAnalyzer.Rules.SymbolicExecution
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    [Rule(EmptyNullableValueAccess.DiagnosticId)]
-    [Rule(ObjectsShouldNotBeDisposedMoreThanOnce.DiagnosticId)]
     public sealed class SymbolicExecutionRunner : SonarDiagnosticAnalyzer
     {
         private readonly SymbolicExecutionAnalyzerFactory symbolicExecutionAnalyzerFactory = new SymbolicExecutionAnalyzerFactory();

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Common/IRuleFactory.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Common/IRuleFactory.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -18,21 +18,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 
 namespace SonarAnalyzer.Common
 {
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public sealed class RuleAttribute : Attribute
+    public interface IRuleFactory
     {
-        public string Key { get; }
-
-        public string[] Languages { get; }
-
-        public RuleAttribute(string key, params string[] languages)
-        {
-            Key = key;
-            Languages = languages;
-        }
+        public ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/RuleDetailBuilder.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/RuleDetailBuilder.cs
@@ -52,13 +52,6 @@ namespace SonarAnalyzer.Utilities
                 .SelectMany(t => GetRuleDetailFromRuleAttributes(t, language));
         }
 
-        public static IEnumerable<RuleDetail> GetParameterlessRuleDetails(AnalyzerLanguage language)
-        {
-            return new RuleFinder()
-                .GetParameterlessAnalyzerTypes(language)
-                .SelectMany(t => GetRuleDetailFromRuleAttributes(t, language));
-        }
-
         private static IEnumerable<RuleDetail> GetRuleDetailFromRuleAttributes(Type analyzerType,
             AnalyzerLanguage language)
         {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/RuleFinder.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/RuleFinder.cs
@@ -19,7 +19,6 @@
  */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/RuleFinder.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/RuleFinder.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Utilities
         {
             diagnosticAnalyzers = PackagedRuleAssemblies
                 .SelectMany(assembly => assembly.GetTypes())
-                .Where(t => t.IsSubclassOf(typeof(DiagnosticAnalyzer)) || t.IsSubclassOf(typeof(IRuleFactory)))
+                .Where(t => t.IsSubclassOf(typeof(DiagnosticAnalyzer)) || typeof(IRuleFactory).IsAssignableFrom(t))
                 .Where(t => t.GetCustomAttributes<RuleAttribute>().Any())
                 .ToList();
         }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/RuleFinder.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/RuleFinder.cs
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Utilities
 
         internal IEnumerable<Type> AllAnalyzerTypes => diagnosticAnalyzers;
 
-        private static AnalyzerLanguage GetTargetLanguages(MemberInfo analyzerType)
+        internal static AnalyzerLanguage GetTargetLanguages(MemberInfo analyzerType)
         {
             var languages = GetLanguages(analyzerType);
 
@@ -85,10 +85,18 @@ namespace SonarAnalyzer.Utilities
         private static IEnumerable<string> GetLanguages(MemberInfo analyzerType)
         {
             var diagnosticAttribute = analyzerType.GetCustomAttributes<DiagnosticAnalyzerAttribute>().FirstOrDefault();
+            if (diagnosticAttribute != null)
+            {
+                return diagnosticAttribute.Languages;
+            }
 
-            return diagnosticAttribute == null
-                ? analyzerType.GetCustomAttributes<RuleAttribute>().FirstOrDefault()?.Languages
-                : diagnosticAttribute.Languages;
+            var ruleAttribute = analyzerType.GetCustomAttributes<RuleAttribute>().FirstOrDefault();
+            if (ruleAttribute?.Languages != null)
+            {
+                return ruleAttribute.Languages;
+            }
+
+            throw new Exception($"Can not find any language for the given type {analyzerType.Name}!");
         }
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/RuleFinder.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/RuleFinder.cs
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Utilities
                 return ruleAttribute.Languages;
             }
 
-            throw new Exception($"Can not find any language for the given type {analyzerType.Name}!");
+            throw new NotSupportedException($"Can not find any language for the given type {analyzerType.Name}!");
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Common/RuleFinderTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Common/RuleFinderTest.cs
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void GetTargetLanguagesThrowsIfTypeDoesNotHaveLanguageInfo()
         {
-            Assert.ThrowsException<Exception>(() => RuleFinder.GetTargetLanguages(typeof(string)));
+            Assert.ThrowsException<NotSupportedException>(() => RuleFinder.GetTargetLanguages(typeof(string)));
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Common/RuleFinderTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Common/RuleFinderTest.cs
@@ -19,6 +19,7 @@
  */
 
 extern alias csharp;
+using System;
 using System.Linq;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using FluentAssertions;
@@ -64,6 +65,12 @@ namespace SonarAnalyzer.UnitTest.Common
 
             countParameterless = finder.GetParameterlessAnalyzerTypes(AnalyzerLanguage.VisualBasic).Count();
             finder.AllAnalyzerTypes.Should().HaveCountGreaterThan(countParameterless);
+        }
+
+        [TestMethod]
+        public void GetTargetLanguagesThrowsIfTypeDoesNotHaveLanguageInfo()
+        {
+            Assert.ThrowsException<Exception>(() => RuleFinder.GetTargetLanguages(typeof(string)));
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Constants.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Constants.cs
@@ -24,5 +24,8 @@ namespace SonarAnalyzer.UnitTest
     {
         internal const string NuGetLatestVersion = "LATEST";
         internal const string DotNetCore220Version = "2.2.0";
+
+        internal const string EmptyNullableValueAccess = "S3655";
+        internal const string ObjectsShouldNotBeDisposedMoreThanOnce = "S3966";
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Constants.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Constants.cs
@@ -24,8 +24,5 @@ namespace SonarAnalyzer.UnitTest
     {
         internal const string NuGetLatestVersion = "LATEST";
         internal const string DotNetCore220Version = "2.2.0";
-
-        internal const string EmptyNullableValueAccess = "S3655";
-        internal const string ObjectsShouldNotBeDisposedMoreThanOnce = "S3966";
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/ResourceTests/GeneratedResourcesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/ResourceTests/GeneratedResourcesTest.cs
@@ -59,16 +59,14 @@ namespace SonarAnalyzer.UnitTest.ResourceTests
             rulesFromResources.Should().Equal(rulesFromClasses);
         }
 
-        private static string[] GetRulesFromClasses(Assembly assembly)
-        {
-            return assembly.GetTypes()
-                           .Where(typeof(SonarDiagnosticAnalyzer).IsAssignableFrom)
-                           .Where(t => !t.IsAbstract)
-                           .Where(IsNotUtilityAnalyzer)
-                           .SelectMany(GetRuleNamesFromAttributes)
-                           .OrderBy(name => name)
-                           .ToArray();
-        }
+        private static string[] GetRulesFromClasses(Assembly assembly) =>
+            assembly.GetTypes()
+                .Where(t => typeof(SonarDiagnosticAnalyzer).IsAssignableFrom(t) || typeof(IRuleFactory).IsAssignableFrom(t))
+                .Where(t => !t.IsAbstract)
+                .Where(IsNotUtilityAnalyzer)
+                .SelectMany(GetRuleNamesFromAttributes)
+                .OrderBy(name => name)
+                .ToArray();
 
         private static bool IsNotUtilityAnalyzer(Type arg)
         {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/ResourceTests/GeneratedResourcesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/ResourceTests/GeneratedResourcesTest.cs
@@ -30,6 +30,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.Rules;
+using SonarAnalyzer.Utilities;
 using vbnet::SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.UnitTest.ResourceTests
@@ -57,6 +58,30 @@ namespace SonarAnalyzer.UnitTest.ResourceTests
             var rulesFromClasses = GetRulesFromClasses(typeof(VisualBasicSyntaxHelper).Assembly);
 
             rulesFromResources.Should().Equal(rulesFromClasses);
+        }
+
+        [TestMethod]
+        public void ThereShouldBeRuleDetailsForAllCSharpRuleClasses()
+        {
+            var ruleDetailsKeys = RuleDetailBuilder.GetAllRuleDetails(AnalyzerLanguage.CSharp)
+                .Select(rd => rd.Key)
+                .OrderBy(key => key);
+
+            var rulesFromClasses = GetRulesFromClasses(typeof(CSharpSyntaxHelper).Assembly).OrderBy(key => key);
+
+            ruleDetailsKeys.Should().Equal(rulesFromClasses);
+        }
+
+        [TestMethod]
+        public void ThereShouldBeRuleDetailsForAllVbNetRuleClasses()
+        {
+            var ruleDetailsKeys = RuleDetailBuilder.GetAllRuleDetails(AnalyzerLanguage.VisualBasic)
+                .Select(rd => rd.Key)
+                .OrderBy(key => key);
+
+            var rulesFromClasses = GetRulesFromClasses(typeof(VisualBasicSyntaxHelper).Assembly).OrderBy(key => key);
+
+            ruleDetailsKeys.Should().Equal(rulesFromClasses);
         }
 
         private static string[] GetRulesFromClasses(Assembly assembly) =>

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyNullableValueAccessTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyNullableValueAccessTest.cs
@@ -1,0 +1,42 @@
+/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2020 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+extern alias csharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Rules.SymbolicExecution;
+using SonarAnalyzer.UnitTest.TestFramework;
+
+namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
+{
+    [TestClass]
+    public class EmptyNullableValueAccessTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void EmptyNullableValueAccess()
+        {
+            // Symbolic execution analyzers are run by the SymbolicExecutionRunner
+            Verifier.VerifyAnalyzer(@"TestCases\EmptyNullableValueAccess.cs",
+                new SymbolicExecutionRunner(),
+                ParseOptionsHelper.FromCSharp8,
+                additionalReferences: NuGetMetadataReference.NETStandardV2_1_0);
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnceTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnceTest.cs
@@ -19,8 +19,8 @@
  */
 
 extern alias csharp;
-using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Rules.SymbolicExecution;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules
@@ -32,8 +32,9 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void ObjectsShouldNotBeDisposedMoreThanOnce()
         {
+            // Symbolic execution analyzers are run by the SymbolicExecutionRunner
             Verifier.VerifyAnalyzer(@"TestCases\ObjectsShouldNotBeDisposedMoreThanOnce.cs",
-                new ObjectsShouldNotBeDisposedMoreThanOnce(),
+                new SymbolicExecutionRunner(),
                 ParseOptionsHelper.FromCSharp8,
                 additionalReferences: NuGetMetadataReference.NETStandardV2_1_0);
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactoryTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactoryTest.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
             var sut = new SymbolicExecutionAnalyzerFactory();
             var supportedDiagnostics = sut.SupportedDiagnostics.Select(descriptor => descriptor.Id).ToList();
 
-            CollectionAssert.AreEquivalent(supportedDiagnostics, new[] {"S3655"});
+            CollectionAssert.AreEquivalent(supportedDiagnostics, new[] {"S3655", "S3966"});
         }
 
         [DataTestMethod]
@@ -55,7 +55,11 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
         public void GetEnabledAnalyzers_ReturnsDiagnostic_WhenEnabled(ReportDiagnostic reportDiagnostic)
         {
             var sut = new SymbolicExecutionAnalyzerFactory();
-            var diagnostics = new Dictionary<string, ReportDiagnostic> {{"S3655", reportDiagnostic}}.ToImmutableDictionary();
+            var diagnostics = new Dictionary<string, ReportDiagnostic>
+            {
+                {"S3655", reportDiagnostic},
+                {"S3966", ReportDiagnostic.Suppress}
+            }.ToImmutableDictionary();
             var context = CreateSyntaxNodeAnalysisContext(diagnostics);
             var analyzers = sut.GetEnabledAnalyzers(context).ToList();
             var enabledAnalyzers =
@@ -70,7 +74,11 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
         public void GetEnabledAnalyzers_ReturnsEmptyList_WhenDiagnosticsAreDisabled()
         {
             var sut = new SymbolicExecutionAnalyzerFactory();
-            var diagnostics = new Dictionary<string, ReportDiagnostic> {{"S3655", ReportDiagnostic.Suppress}}.ToImmutableDictionary();
+            var diagnostics = new Dictionary<string, ReportDiagnostic>
+            {
+                {"S3655", ReportDiagnostic.Suppress},
+                {"S3966", ReportDiagnostic.Suppress}
+            }.ToImmutableDictionary();
             var context = CreateSyntaxNodeAnalysisContext(diagnostics);
             var analyzers = sut.GetEnabledAnalyzers(context).ToList();
             var enabledAnalyzers =

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactoryTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactoryTest.cs
@@ -36,12 +36,14 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
         [TestMethod]
         public void SupportedDiagnostics_ReturnsSymbolicExecutionRuleDescriptors()
         {
-            // Currently only EmptyNullableValueAccess was updated to use the new analyzer.
-
             var sut = new SymbolicExecutionAnalyzerFactory();
             var supportedDiagnostics = sut.SupportedDiagnostics.Select(descriptor => descriptor.Id).ToList();
 
-            CollectionAssert.AreEquivalent(supportedDiagnostics, new[] {"S3655", "S3966"});
+            CollectionAssert.AreEquivalent(supportedDiagnostics, new[]
+            {
+                Constants.EmptyNullableValueAccess,
+                Constants.ObjectsShouldNotBeDisposedMoreThanOnce
+            });
         }
 
         [DataTestMethod]
@@ -57,8 +59,8 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
             var sut = new SymbolicExecutionAnalyzerFactory();
             var diagnostics = new Dictionary<string, ReportDiagnostic>
             {
-                {"S3655", reportDiagnostic},
-                {"S3966", ReportDiagnostic.Suppress}
+                {Constants.EmptyNullableValueAccess, reportDiagnostic},
+                {Constants.ObjectsShouldNotBeDisposedMoreThanOnce, ReportDiagnostic.Suppress}
             }.ToImmutableDictionary();
             var context = CreateSyntaxNodeAnalysisContext(diagnostics);
             var analyzers = sut.GetEnabledAnalyzers(context).ToList();
@@ -67,7 +69,7 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
                     .SelectMany(analyzer => analyzer.SupportedDiagnostics.Select(descriptor => descriptor.Id))
                     .ToList();
 
-            CollectionAssert.AreEquivalent(enabledAnalyzers, new[] {"S3655"});
+            CollectionAssert.AreEquivalent(enabledAnalyzers, new[] {Constants.EmptyNullableValueAccess});
         }
 
         [TestMethod]
@@ -76,8 +78,8 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
             var sut = new SymbolicExecutionAnalyzerFactory();
             var diagnostics = new Dictionary<string, ReportDiagnostic>
             {
-                {"S3655", ReportDiagnostic.Suppress},
-                {"S3966", ReportDiagnostic.Suppress}
+                {Constants.EmptyNullableValueAccess, ReportDiagnostic.Suppress},
+                {Constants.ObjectsShouldNotBeDisposedMoreThanOnce, ReportDiagnostic.Suppress}
             }.ToImmutableDictionary();
             var context = CreateSyntaxNodeAnalysisContext(diagnostics);
             var analyzers = sut.GetEnabledAnalyzers(context).ToList();

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactoryTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactoryTest.cs
@@ -1,0 +1,101 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2020 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Rules.SymbolicExecution;
+
+namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
+{
+    [TestClass]
+    public class SymbolicExecutionAnalyzerFactoryTest
+    {
+        [TestMethod]
+        public void SupportedDiagnostics_ReturnsSymbolicExecutionRuleDescriptors()
+        {
+            // Currently only EmptyNullableValueAccess was updated to use the new analyzer.
+
+            var sut = new SymbolicExecutionAnalyzerFactory();
+            var supportedDiagnostics = sut.SupportedDiagnostics.Select(descriptor => descriptor.Id).ToList();
+
+            CollectionAssert.AreEquivalent(supportedDiagnostics, new[] {"S3655"});
+        }
+
+        [DataTestMethod]
+        [DataRow(ReportDiagnostic.Default)]
+        [DataRow(ReportDiagnostic.Error)]
+        [DataRow(ReportDiagnostic.Info)]
+        [DataRow(ReportDiagnostic.Warn)]
+        // According to the doc of Hidden: Non-visible to user. The diagnostic is reported to the IDE diagnostic engine, however.
+        // https://docs.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2019#rule-severity
+        [DataRow(ReportDiagnostic.Hidden)]
+        public void GetEnabledAnalyzers_ReturnsDiagnostic_WhenEnabled(ReportDiagnostic reportDiagnostic)
+        {
+            var sut = new SymbolicExecutionAnalyzerFactory();
+            var diagnostics = new Dictionary<string, ReportDiagnostic> {{"S3655", reportDiagnostic}}.ToImmutableDictionary();
+            var context = CreateSyntaxNodeAnalysisContext(diagnostics);
+            var analyzers = sut.GetEnabledAnalyzers(context).ToList();
+            var enabledAnalyzers =
+                analyzers
+                    .SelectMany(analyzer => analyzer.SupportedDiagnostics.Select(descriptor => descriptor.Id))
+                    .ToList();
+
+            CollectionAssert.AreEquivalent(enabledAnalyzers, new[] {"S3655"});
+        }
+
+        [TestMethod]
+        public void GetEnabledAnalyzers_ReturnsEmptyList_WhenDiagnosticsAreDisabled()
+        {
+            var sut = new SymbolicExecutionAnalyzerFactory();
+            var diagnostics = new Dictionary<string, ReportDiagnostic> {{"S3655", ReportDiagnostic.Suppress}}.ToImmutableDictionary();
+            var context = CreateSyntaxNodeAnalysisContext(diagnostics);
+            var analyzers = sut.GetEnabledAnalyzers(context).ToList();
+            var enabledAnalyzers =
+                analyzers
+                    .SelectMany(analyzer => analyzer.SupportedDiagnostics.Select(descriptor => descriptor.Id))
+                    .ToList();
+
+            CollectionAssert.AreEquivalent(enabledAnalyzers, new List<string>());
+        }
+
+        private static SyntaxNodeAnalysisContext CreateSyntaxNodeAnalysisContext(ImmutableDictionary<string, ReportDiagnostic> diagnostics)
+        {
+            var syntaxTree = CSharpSyntaxTree.ParseText(@"public class Empty { }", new CSharpParseOptions());
+
+            return new SyntaxNodeAnalysisContext(syntaxTree.GetRoot(),
+                CreateCSharpCompilation(diagnostics, syntaxTree).GetSemanticModel(syntaxTree),
+                new AnalyzerOptions(ImmutableArray<AdditionalText>.Empty),
+                diagnostic => { },
+                diagnostic => true,
+                CancellationToken.None);
+        }
+
+        private static CSharpCompilation CreateCSharpCompilation(ImmutableDictionary<string, ReportDiagnostic> diagnostics, SyntaxTree syntaxTree) =>
+            CSharpCompilation
+                .Create("Assembly.dll", new[] {syntaxTree}, null, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithSpecificDiagnosticOptions(diagnostics));
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactoryTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionAnalyzerFactoryTest.cs
@@ -33,6 +33,9 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
     [TestClass]
     public class SymbolicExecutionAnalyzerFactoryTest
     {
+        private const string EmptyNullableValueAccess = "S3655";
+        private const string ObjectsShouldNotBeDisposedMoreThanOnce = "S3966";
+
         [TestMethod]
         public void SupportedDiagnostics_ReturnsSymbolicExecutionRuleDescriptors()
         {
@@ -41,8 +44,8 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
 
             CollectionAssert.AreEquivalent(supportedDiagnostics, new[]
             {
-                Constants.EmptyNullableValueAccess,
-                Constants.ObjectsShouldNotBeDisposedMoreThanOnce
+                EmptyNullableValueAccess,
+                ObjectsShouldNotBeDisposedMoreThanOnce
             });
         }
 
@@ -59,8 +62,8 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
             var sut = new SymbolicExecutionAnalyzerFactory();
             var diagnostics = new Dictionary<string, ReportDiagnostic>
             {
-                {Constants.EmptyNullableValueAccess, reportDiagnostic},
-                {Constants.ObjectsShouldNotBeDisposedMoreThanOnce, ReportDiagnostic.Suppress}
+                {EmptyNullableValueAccess, reportDiagnostic},
+                {ObjectsShouldNotBeDisposedMoreThanOnce, ReportDiagnostic.Suppress}
             }.ToImmutableDictionary();
             var context = CreateSyntaxNodeAnalysisContext(diagnostics);
             var analyzers = sut.GetEnabledAnalyzers(context).ToList();
@@ -69,7 +72,7 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
                     .SelectMany(analyzer => analyzer.SupportedDiagnostics.Select(descriptor => descriptor.Id))
                     .ToList();
 
-            CollectionAssert.AreEquivalent(enabledAnalyzers, new[] {Constants.EmptyNullableValueAccess});
+            CollectionAssert.AreEquivalent(enabledAnalyzers, new[] {EmptyNullableValueAccess});
         }
 
         [TestMethod]
@@ -78,8 +81,8 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
             var sut = new SymbolicExecutionAnalyzerFactory();
             var diagnostics = new Dictionary<string, ReportDiagnostic>
             {
-                {Constants.EmptyNullableValueAccess, ReportDiagnostic.Suppress},
-                {Constants.ObjectsShouldNotBeDisposedMoreThanOnce, ReportDiagnostic.Suppress}
+                {EmptyNullableValueAccess, ReportDiagnostic.Suppress},
+                {ObjectsShouldNotBeDisposedMoreThanOnce, ReportDiagnostic.Suppress}
             }.ToImmutableDictionary();
             var context = CreateSyntaxNodeAnalysisContext(diagnostics);
             var analyzers = sut.GetEnabledAnalyzers(context).ToList();


### PR DESCRIPTION
This commit introduces `SymbolicExecutionRunner` which allows the reuse of the generated exploded graph and walking it one single time for all the symbolic execution rules.

As a proof of concept, `SymbolicExecutionRunner` is now executing the `EmptyNullableValueAccess` and `ObjectsShouldNotBeDisposedMoreThanOnce` analyzers which are refactored to implement `ISymbolicExecutionAnalyzer` instead of `SonarDiagnosticAnalyzer`.

With this refactoring the overall analysis time drops ~6%.

Fixes: #3341