### PR TITLE
Split InvalidCastToInterface

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterface.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterface.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
         private const string MessageReviewFormat = "Review this cast; in this project there's no type that {0}.";
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidCastToInterfaceRuleDetails.Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidCastToInterfaceRuleConstants.Rule);
 
         protected override void Initialize(SonarAnalysisContext context)
         {
@@ -133,7 +133,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 ? $"implements both '{expressionTypeName}' and '{interfaceTypeName}'"
                 : $"extends '{expressionTypeName}' and implements '{interfaceTypeName}'";
 
-            context.ReportDiagnosticWhenActive(Diagnostic.Create(InvalidCastToInterfaceRuleDetails.Rule, issueLocation,
+            context.ReportDiagnosticWhenActive(Diagnostic.Create(InvalidCastToInterfaceRuleConstants.Rule, issueLocation,
                 string.Format(MessageReviewFormat, messageReasoning)));
         }
     }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterfaceRuleConstants.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterfaceRuleConstants.cs
@@ -23,7 +23,7 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    internal static class InvalidCastToInterfaceRuleDetails
+    internal static class InvalidCastToInterfaceRuleConstants
     {
         public const string DiagnosticId = "S1944";
         private const string MessageFormat = "{0}";

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterfaceRuleDetails.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterfaceRuleDetails.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -18,29 +18,17 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-extern alias csharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using csharp::SonarAnalyzer.Rules.CSharp;
+using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.UnitTest.TestFramework;
 
-namespace SonarAnalyzer.UnitTest.Rules
+namespace SonarAnalyzer.Rules
 {
-    [TestClass]
-    public class InvalidCastToInterfaceTest
+    internal static class InvalidCastToInterfaceRuleDetails
     {
-        [TestMethod]
-        [TestCategory("Rule")]
-        public void InvalidCastToInterface()
-        {
-            Verifier.VerifyAnalyzer(@"TestCases\InvalidCastToInterface.cs",
-                new SonarDiagnosticAnalyzer[]
-                {
-                    new InvalidCastToInterfaceSymbolicExecution(),
-                    new InvalidCastToInterface()
-                },
-                ParseOptionsHelper.FromCSharp8,
-                additionalReferences: NuGetMetadataReference.NETStandardV2_1_0);
-        }
+        public const string DiagnosticId = "S1944";
+        private const string MessageFormat = "{0}";
+
+        internal static readonly DiagnosticDescriptor Rule =
+            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
     }
 }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterfaceSymbolicExecution.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterfaceSymbolicExecution.cs
@@ -31,12 +31,12 @@ using SonarAnalyzer.SymbolicExecution.Constraints;
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    [Rule(InvalidCastToInterfaceRuleDetails.DiagnosticId)]
+    [Rule(InvalidCastToInterfaceRuleConstants.DiagnosticId)]
     public sealed class InvalidCastToInterfaceSymbolicExecution : SonarDiagnosticAnalyzer
     {
         private const string MessageDefinite = "Nullable is known to be empty, this cast throws an exception.";
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidCastToInterfaceRuleDetails.Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidCastToInterfaceRuleConstants.Rule);
 
         protected override void Initialize(SonarAnalysisContext context)
         {
@@ -94,7 +94,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                 if (!context.Equals(default(SyntaxNodeAnalysisContext)))
                 {
-                    context.ReportDiagnosticWhenActive(Diagnostic.Create(InvalidCastToInterfaceRuleDetails.Rule, castExpression.GetLocation(), MessageDefinite));
+                    context.ReportDiagnosticWhenActive(Diagnostic.Create(InvalidCastToInterfaceRuleConstants.Rule, castExpression.GetLocation(), MessageDefinite));
                 }
 
                 return null;

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterfaceSymbolicExecution.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterfaceSymbolicExecution.cs
@@ -1,0 +1,104 @@
+/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2020 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+using SonarAnalyzer.SymbolicExecution;
+using SonarAnalyzer.SymbolicExecution.Constraints;
+
+namespace SonarAnalyzer.Rules.CSharp
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Rule(InvalidCastToInterfaceRuleDetails.DiagnosticId)]
+    public sealed class InvalidCastToInterfaceSymbolicExecution : SonarDiagnosticAnalyzer
+    {
+        private const string MessageDefinite = "Nullable is known to be empty, this cast throws an exception.";
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidCastToInterfaceRuleDetails.Rule);
+
+        protected override void Initialize(SonarAnalysisContext context)
+        {
+            context.RegisterExplodedGraphBasedAnalysis(CheckEmptyNullableCast);
+        }
+
+        private static void CheckEmptyNullableCast(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
+        {
+            explodedGraph.AddExplodedGraphCheck(new NullableCastCheck(explodedGraph, context));
+            explodedGraph.Walk();
+        }
+
+        internal sealed class NullableCastCheck : ExplodedGraphCheck
+        {
+            private readonly SyntaxNodeAnalysisContext context;
+
+            public NullableCastCheck(CSharpExplodedGraph explodedGraph)
+                : base(explodedGraph)
+            {
+            }
+
+            public NullableCastCheck(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
+                : this(explodedGraph)
+            {
+                this.context = context;
+            }
+
+            public override ProgramState PreProcessInstruction(ProgramPoint programPoint, ProgramState programState)
+            {
+                var instruction = programPoint.Block.Instructions[programPoint.Offset];
+
+                return instruction.IsKind(SyntaxKind.CastExpression)
+                    ? ProcessCastAccess(programState, (CastExpressionSyntax)instruction)
+                    : programState;
+            }
+
+            private ProgramState ProcessCastAccess(ProgramState programState, CastExpressionSyntax castExpression)
+            {
+                var typeExpression = semanticModel.GetTypeInfo(castExpression.Expression).Type;
+                if (typeExpression == null ||
+                    !typeExpression.OriginalDefinition.Is(KnownType.System_Nullable_T))
+                {
+                    return programState;
+                }
+
+                var type = semanticModel.GetTypeInfo(castExpression.Type).Type;
+
+                if (type == null ||
+                    type.OriginalDefinition.Is(KnownType.System_Nullable_T) ||
+                    !semanticModel.Compilation.ClassifyConversion(typeExpression, type).IsNullable ||
+                    !programState.HasConstraint(programState.PeekValue(), ObjectConstraint.Null))
+                {
+                    return programState;
+                }
+
+                if (!context.Equals(default(SyntaxNodeAnalysisContext)))
+                {
+                    context.ReportDiagnosticWhenActive(Diagnostic.Create(InvalidCastToInterfaceRuleDetails.Rule, castExpression.GetLocation(), MessageDefinite));
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharp/CSharpExplodedGraph.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharp/CSharpExplodedGraph.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.SymbolicExecution
             // Add mandatory checks
             AddExplodedGraphCheck(new NullPointerDereference.NullPointerCheck(this));
             AddExplodedGraphCheck(new EmptyNullableValueAccess.NullValueAccessedCheck(this));
-            AddExplodedGraphCheck(new InvalidCastToInterface.NullableCastCheck(this));
+            AddExplodedGraphCheck(new InvalidCastToInterfaceSymbolicExecution.NullableCastCheck(this));
         }
 
         #region Visit*

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
@@ -122,9 +122,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         }
 
         public static IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation,
-            DiagnosticAnalyzer diagnosticAnalyzers, CompilationErrorBehavior checkMode,
+            DiagnosticAnalyzer diagnosticAnalyzer, CompilationErrorBehavior checkMode,
             bool verifyNoExceptionIsThrown = true) =>
-            GetDiagnostics(compilation, new[] {diagnosticAnalyzers}, checkMode, verifyNoExceptionIsThrown);
+            GetDiagnostics(compilation, new[] {diagnosticAnalyzer}, checkMode, verifyNoExceptionIsThrown);
 
         private static IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation,
             DiagnosticAnalyzer[] diagnosticAnalyzers, CompilationErrorBehavior checkMode,

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
@@ -44,13 +44,16 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             "BC36716" // VB12 does not support line continuation comments" i.e. a comment at the end of a multi-line statement.
         };
 
-        public static void Verify(Compilation compilation, DiagnosticAnalyzer diagnosticAnalyzer, CompilationErrorBehavior checkMode)
+        public static void Verify(Compilation compilation, DiagnosticAnalyzer diagnosticAnalyzer, CompilationErrorBehavior checkMode) =>
+            Verify(compilation, new [] {diagnosticAnalyzer}, checkMode);
+
+        public static void Verify(Compilation compilation, DiagnosticAnalyzer[] diagnosticAnalyzers, CompilationErrorBehavior checkMode)
         {
             try
             {
                 SuppressionHandler.HookSuppression();
 
-                var diagnostics = GetDiagnostics(compilation, diagnosticAnalyzer, checkMode);
+                var diagnostics = GetDiagnostics(compilation, diagnosticAnalyzers, checkMode);
 
                 var expectedIssues = new IssueLocationCollector()
                     .GetExpectedIssueLocations(compilation.SyntaxTrees.Skip(1).First().GetText().Lines)
@@ -63,7 +66,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 // method.
                 if (diagnostics.Any())
                 {
-                    SuppressionHandler.ExtensionMethodsCalledForAllDiagnostics(diagnosticAnalyzer).Should()
+                    SuppressionHandler.ExtensionMethodsCalledForAllDiagnostics(diagnosticAnalyzers).Should()
                         .BeTrue("The ReportDiagnosticWhenActive should be used instead of ReportDiagnostic");
                 }
             }
@@ -119,14 +122,21 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         }
 
         public static IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation,
-            DiagnosticAnalyzer diagnosticAnalyzer, CompilationErrorBehavior checkMode,
+            DiagnosticAnalyzer diagnosticAnalyzers, CompilationErrorBehavior checkMode,
+            bool verifyNoExceptionIsThrown = true) =>
+            GetDiagnostics(compilation, new[] {diagnosticAnalyzers}, checkMode, verifyNoExceptionIsThrown);
+
+        private static IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation,
+            DiagnosticAnalyzer[] diagnosticAnalyzers, CompilationErrorBehavior checkMode,
             bool verifyNoExceptionIsThrown = true)
         {
-            var ids = diagnosticAnalyzer.SupportedDiagnostics
+            var ids = diagnosticAnalyzers
+                .SelectMany(analyzer => analyzer.SupportedDiagnostics)
                 .Select(diagnostic => diagnostic.Id)
+                .Distinct()
                 .ToHashSet();
 
-            return GetAllDiagnostics(compilation, new[] { diagnosticAnalyzer }, checkMode, verifyNoExceptionIsThrown)
+            return GetAllDiagnostics(compilation, diagnosticAnalyzers, checkMode, verifyNoExceptionIsThrown)
                 .Where(d => ids.Contains(d.Id));
         }
 
@@ -288,13 +298,14 @@ Actual  : '{message}'");
                 counters.AddOrUpdate(ruleId, addValueFactory: key => 1, updateValueFactory: (key, count) => count + 1);
             }
 
-            public static bool ExtensionMethodsCalledForAllDiagnostics(DiagnosticAnalyzer analyzer)
+            public static bool ExtensionMethodsCalledForAllDiagnostics(IEnumerable<DiagnosticAnalyzer> analyzers)
             {
                 // In general this check is not very precise, because when the tests are run in parallel
                 // we cannot determine which diagnostic was reported from which analyzer instance. In other
                 // words, we cannot distinguish between diagnostics reported from different tests. That's
                 // why we require each diagnostic to be reported through the extension methods at least once.
-                return analyzer.SupportedDiagnostics
+                return analyzers
+                    .SelectMany(analyzer => analyzer.SupportedDiagnostics)
                     .Select(d => counters.GetValueOrDefault(d.Id))
                     .Any(count => count > 0);
             }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
@@ -132,10 +132,10 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
         // This method is checking only the expected issues from the first file path provided. The rest of the paths are added to the
         // project for enabling testing of different scenarios.
-        public static void VerifyAnalyzer(IEnumerable<string> paths, SonarDiagnosticAnalyzer diagnosticAnalyzers,
+        public static void VerifyAnalyzer(IEnumerable<string> paths, SonarDiagnosticAnalyzer diagnosticAnalyzer,
             IEnumerable<ParseOptions> options = null, CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
             IEnumerable<MetadataReference> additionalReferences = null) =>
-            VerifyAnalyzer(paths, new []{ diagnosticAnalyzers}, options, checkMode, additionalReferences);
+            VerifyAnalyzer(paths, new []{ diagnosticAnalyzer}, options, checkMode, additionalReferences);
 
         private static void VerifyAnalyzer(IEnumerable<string> paths, SonarDiagnosticAnalyzer[] diagnosticAnalyzers,
             IEnumerable<ParseOptions> options = null, CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             // then add ability to shift result reports with this line number
             foreach (var compilation in solution.Compile(options?.ToArray()))
             {
-                DiagnosticVerifier.Verify(compilation, diagnosticAnalyzer, checkMode);
+                DiagnosticVerifier.Verify(compilation, new DiagnosticAnalyzer[] {diagnosticAnalyzer}, checkMode);
             }
         }
 
@@ -95,6 +95,13 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             IEnumerable<MetadataReference> additionalReferences = null)
         {
             VerifyAnalyzer(new[] { path }, diagnosticAnalyzer, options, checkMode, additionalReferences);
+        }
+
+        public static void VerifyAnalyzer(string path, SonarDiagnosticAnalyzer[] diagnosticAnalyzers,
+            IEnumerable<ParseOptions> options = null, CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
+            IEnumerable<MetadataReference> additionalReferences = null)
+        {
+            VerifyAnalyzer(new[] { path }, diagnosticAnalyzers, options, checkMode, additionalReferences);
         }
 
         public static void VerifyUtilityAnalyzer<TMessage>(IEnumerable<string> paths, UtilityAnalyzerBase diagnosticAnalyzer,
@@ -125,7 +132,12 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
         // This method is checking only the expected issues from the first file path provided. The rest of the paths are added to the
         // project for enabling testing of different scenarios.
-        public static void VerifyAnalyzer(IEnumerable<string> paths, SonarDiagnosticAnalyzer diagnosticAnalyzer,
+        public static void VerifyAnalyzer(IEnumerable<string> paths, SonarDiagnosticAnalyzer diagnosticAnalyzers,
+            IEnumerable<ParseOptions> options = null, CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
+            IEnumerable<MetadataReference> additionalReferences = null) =>
+            VerifyAnalyzer(paths, new []{ diagnosticAnalyzers}, options, checkMode, additionalReferences);
+
+        private static void VerifyAnalyzer(IEnumerable<string> paths, SonarDiagnosticAnalyzer[] diagnosticAnalyzers,
             IEnumerable<ParseOptions> options = null, CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
             IEnumerable<MetadataReference> additionalReferences = null)
         {
@@ -133,7 +145,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
             foreach (var compilation in solutionBuilder.Compile(options?.ToArray()))
             {
-                DiagnosticVerifier.Verify(compilation, diagnosticAnalyzer, checkMode);
+                DiagnosticVerifier.Verify(compilation, diagnosticAnalyzers, checkMode);
             }
         }
 


### PR DESCRIPTION
Since this rule combines two (distinct and complementary) implementations I've split it in two analyzers:
- one is doing semantic analysis
- the other symbolic execution

This split will ease #3346 implementation.
