### PR TITLE
Update S3966 and S3655 to support partial results

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/ConditionEvaluatesToConstant.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/ConditionEvaluatesToConstant.cs
@@ -128,7 +128,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 explodedGraph.ConditionEvaluated += ConditionEvaluatedHandler;
             }
 
-            public bool SupportsPartialResults { get; }
+            public bool SupportsPartialResults => false;
 
             public IEnumerable<Diagnostic> GetDiagnostics()
             {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyNullableValueAccess.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyNullableValueAccess.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 explodedGraph.AddExplodedGraphCheck(nullPointerCheck);
             }
 
-            public bool SupportsPartialResults => false;
+            public bool SupportsPartialResults => true;
 
             private void AddIdentifier(object sender, MemberAccessedEventArgs args) => nullIdentifiers.Add(args.Identifier);
 

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnce.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnce.cs
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 explodedGraph.AddExplodedGraphCheck(objectDisposedPointerCheck);
             }
 
-            public bool SupportsPartialResults => false;
+            public bool SupportsPartialResults => true;
 
             public void Dispose() => objectDisposedPointerCheck.ObjectDisposed -= ObjectDisposedHandler;
 

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -79,8 +79,6 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
             // reached or if an exception was thrown during analysis.
             ReportDiagnostics(analyzerContexts, context, true);
 
-            analyzerContexts.ForEach(analyzerContext => analyzerContext.Dispose());
-
             void ExplorationEndedHandler(object sender, EventArgs args)
             {
                 ReportDiagnostics(analyzerContexts, context, false);
@@ -89,11 +87,14 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
 
         private static void ReportDiagnostics(IEnumerable<ISymbolicExecutionAnalysisContext> analyzerContexts, SyntaxNodeAnalysisContext context, bool supportsPartialResults)
         {
-            foreach (var diagnostic in analyzerContexts
-                .Where(analyzerContext => analyzerContext.SupportsPartialResults == supportsPartialResults)
-                .SelectMany(analyzerContext => analyzerContext.GetDiagnostics()))
+            foreach (var analyzerContext in analyzerContexts.Where(analyzerContext => analyzerContext.SupportsPartialResults == supportsPartialResults))
             {
-                context.ReportDiagnosticWhenActive(diagnostic);
+                foreach (var diagnostic in analyzerContext.GetDiagnostics())
+                {
+                    context.ReportDiagnosticWhenActive(diagnostic);
+                }
+
+                analyzerContext.Dispose();
             }
         }
 

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/AbstractExplodedGraph.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/AbstractExplodedGraph.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.SymbolicExecution
 {
     internal abstract class AbstractExplodedGraph
     {
-        internal const int MaxStepCount = 1000;
+        internal const int MaxStepCount = 1500;
         internal const int MaxInternalStateCount = 10000;
         private const int MaxProgramPointExecutionCount = 2;
 


### PR DESCRIPTION
Additional changes:

- ensure that analyzer contexts are disposed right after diagnostics are reported
- increase max step count for symbolic execution. Some of the rules are adding additional steps and due to this we had some FNs which were correctly reported in 8.7. With this increase we can avoid those FNs and find even more TP.