### PR TITLE
Move metadata reference builders in dedicated folder

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/AspNetMvcHelper_IsControllerMethod.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/AspNetMvcHelper_IsControllerMethod.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 
 namespace SonarAnalyzer.UnitTest.Helpers
 {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/MethodSignatureHelperTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/MethodSignatureHelperTest.cs
@@ -27,6 +27,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CSharpSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
 using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/NetFrameworkVersionProviderTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/NetFrameworkVersionProviderTest.cs
@@ -26,6 +26,7 @@ using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Helpers

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/TypeDeclarationSyntaxExtensionsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/TypeDeclarationSyntaxExtensionsTest.cs
@@ -25,6 +25,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Helpers

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/TypeHelperTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/TypeHelperTest.cs
@@ -25,6 +25,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 
 namespace SonarAnalyzer.UnitTest.Helpers
 {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/FrameworkMetadataReference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/FrameworkMetadataReference.cs
@@ -19,25 +19,14 @@
  */
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.IO;
 using Microsoft.CodeAnalysis;
 
-namespace SonarAnalyzer.UnitTest
+using static SonarAnalyzer.UnitTest.MetadataReferences.MetadataReferenceFactory;
+
+namespace SonarAnalyzer.UnitTest.MetadataReferences
 {
     internal static class FrameworkMetadataReference
     {
-        #region Helpers
-
-        private static readonly string systemAssembliesFolder =
-            new FileInfo(typeof(object).Assembly.Location).Directory.FullName;
-
-        private static IEnumerable<MetadataReference> Create(string assemblyName) =>
-            ImmutableArray.Create((MetadataReference)MetadataReference.CreateFromFile(
-                Path.Combine(systemAssembliesFolder, assemblyName)));
-
-        #endregion Helpers
-
         internal static IEnumerable<MetadataReference> MicrosoftVisualBasic { get; }
             = Create("Microsoft.VisualBasic.dll");
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/MetadataReferenceFactory.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/MetadataReferenceFactory.cs
@@ -18,24 +18,21 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-extern alias csharp;
-using csharp::SonarAnalyzer.Rules.CSharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarAnalyzer.UnitTest.MetadataReferences;
-using SonarAnalyzer.UnitTest.TestFramework;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using Microsoft.CodeAnalysis;
 
-namespace SonarAnalyzer.UnitTest.Rules
+namespace SonarAnalyzer.UnitTest.MetadataReferences
 {
-    [TestClass]
-    public class SetLocaleForDataTypesTest
+    internal static class MetadataReferenceFactory
     {
-        [TestMethod]
-        [TestCategory("Rule")]
-        public void SetLocaleForDataTypes()
-        {
-            Verifier.VerifyAnalyzer(@"TestCases\SetLocaleForDataTypes.cs",
-                new SetLocaleForDataTypes(),
-                additionalReferences: FrameworkMetadataReference.SystemData);
-        }
+        private static readonly string SystemAssembliesFolder = new FileInfo(typeof(object).Assembly.Location).Directory.FullName;
+
+        public static IEnumerable<MetadataReference> Create(string assemblyName) =>
+            ImmutableArray.Create(CreateReference(assemblyName));
+
+        internal static MetadataReference CreateReference(string assemblyName) =>
+            MetadataReference.CreateFromFile(Path.Combine(SystemAssembliesFolder, assemblyName));
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/NuGetMetadataReference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/NuGetMetadataReference.cs
@@ -23,7 +23,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.UnitTest.TestFramework;
 
-namespace SonarAnalyzer.UnitTest
+namespace SonarAnalyzer.UnitTest.MetadataReferences
 {
     internal static class NuGetMetadataReference
     {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Performance/PerformanceTests.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Performance/PerformanceTests.cs
@@ -33,6 +33,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Performance

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
@@ -23,6 +23,7 @@ extern alias csharp;
 using System.Linq;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AsyncVoidMethodTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AsyncVoidMethodTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CertificateValidationCheckTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CertificateValidationCheckTest.cs
@@ -22,6 +22,7 @@ extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using System.Linq;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ClassNameTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ClassNameTest.cs
@@ -24,6 +24,7 @@ extern alias vbnet;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CSharp = csharp::SonarAnalyzer.Rules.CSharp;
 using VisualBasic = vbnet::SonarAnalyzer.Rules.VisualBasic;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CollectionPropertiesShouldBeReadOnlyTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CollectionPropertiesShouldBeReadOnlyTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConditionEvaluatesToConstantTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConditionEvaluatesToConstantTest.cs
@@ -25,6 +25,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.Rules.SymbolicExecution;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConfiguringLoggersTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConfiguringLoggersTest.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConstructorArgumentValueShouldExistTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConstructorArgumentValueShouldExistTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConsumeValueTaskCorrectlyTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConsumeValueTaskCorrectlyTest.cs
@@ -24,6 +24,7 @@ using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
 using System.Linq;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ControllingPermissionsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ControllingPermissionsTest.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CSharp = csharp::SonarAnalyzer.Rules.CSharp;
 using VisualBasic = vbnet::SonarAnalyzer.Rules.VisualBasic;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CookieShouldBeHttpOnlyTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CookieShouldBeHttpOnlyTest.cs
@@ -25,6 +25,7 @@ using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CookieShouldBeSecureTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CookieShouldBeSecureTest.cs
@@ -26,6 +26,7 @@ using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CryptographicKeyShouldNotBeTooShortTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CryptographicKeyShouldNotBeTooShortTest.cs
@@ -24,6 +24,7 @@ using System.Linq;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DeadStoresTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DeadStoresTest.cs
@@ -23,6 +23,7 @@ using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.UnitTest.TestFramework;
 using System.Linq;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DeliveringDebugFeaturesInProductionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DeliveringDebugFeaturesInProductionTest.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CSharp = csharp::SonarAnalyzer.Rules.CSharp;
 using VisualBasic = vbnet::SonarAnalyzer.Rules.VisualBasic;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotCallExitMethodsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotCallExitMethodsTest.cs
@@ -21,6 +21,7 @@
 
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotDecreaseMemberVisibilityTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotDecreaseMemberVisibilityTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotInstantiateSharedClassesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotInstantiateSharedClassesTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseIifTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseIifTest.cs
@@ -19,6 +19,7 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseLiteralBoolInAssertionsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseLiteralBoolInAssertionsTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EmptyMethodTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EmptyMethodTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EncryptionAlgorithmsShouldBeSecureTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EncryptionAlgorithmsShouldBeSecureTest.cs
@@ -19,6 +19,7 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CSharp = SonarAnalyzer.Rules.CSharp;
 using VisualBasic = SonarAnalyzer.Rules.VisualBasic;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ExecutingSqlQueriesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ExecutingSqlQueriesTest.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CSharp = csharp::SonarAnalyzer.Rules.CSharp;
 using VisualBasic = vbnet::SonarAnalyzer.Rules.VisualBasic;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ExpandingArchivesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ExpandingArchivesTest.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CSharp = csharp::SonarAnalyzer.Rules.CSharp;
 using VisualBasic = vbnet::SonarAnalyzer.Rules.VisualBasic;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ExpectedExceptionAttributeShouldNotBeUsedTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ExpectedExceptionAttributeShouldNotBeUsedTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/HttpPostControllerActionShouldValidateInputTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/HttpPostControllerActionShouldValidateInputTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/InfiniteRecursionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/InfiniteRecursionTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/InheritedCollidingInterfaceMembersTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/InheritedCollidingInterfaceMembersTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/JwtSignedTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/JwtSignedTest.cs
@@ -21,6 +21,7 @@
 using csharp = SonarAnalyzer.Rules.CSharp;
 using vbnet = SonarAnalyzer.Rules.VisualBasic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/LdapConnectionShouldBeSecureTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/LdapConnectionShouldBeSecureTest.cs
@@ -22,6 +22,7 @@ extern alias csharp;
 using System.Linq;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkWindowsFormsMainWithStaThreadTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MarkWindowsFormsMainWithStaThreadTest.cs
@@ -21,6 +21,7 @@
 using csharp = SonarAnalyzer.Rules.CSharp;
 using vbnet = SonarAnalyzer.Rules.VisualBasic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MemberShouldBeStaticTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MemberShouldBeStaticTest.cs
@@ -24,6 +24,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodOverloadOptionalParameterTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodOverloadOptionalParameterTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodOverrideAddsParamsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodOverrideAddsParamsTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodOverrideChangedDefaultValueTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodOverrideChangedDefaultValueTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodParameterUnusedTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodParameterUnusedTest.cs
@@ -19,6 +19,7 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CS = SonarAnalyzer.Rules.CSharp;
 using VB = SonarAnalyzer.Rules.VisualBasic;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodShouldBeNamedAccordingToSynchronicityTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodShouldBeNamedAccordingToSynchronicityTest.cs
@@ -23,6 +23,7 @@ extern alias csharp;
 using System.Linq;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MutableFieldsShouldNotBePublicReadonlyTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MutableFieldsShouldNotBePublicReadonlyTest.cs
@@ -22,6 +22,7 @@ extern alias csharp;
 
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MutableFieldsShouldNotBePublicStaticTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MutableFieldsShouldNotBePublicStaticTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ParameterNamesInPartialMethodTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ParameterNamesInPartialMethodTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/PartCreationPolicyShouldBeUsedWithExportAttributeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/PartCreationPolicyShouldBeUsedWithExportAttributeTest.cs
@@ -19,6 +19,7 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using csharp = SonarAnalyzer.Rules.CSharp;
 using vbnet = SonarAnalyzer.Rules.VisualBasic;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/PropertiesAccessCorrectFieldTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/PropertiesAccessCorrectFieldTest.cs
@@ -24,6 +24,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.UnitTest.TestFramework;
 using System.Collections.Generic;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using CS = SonarAnalyzer.Rules.CSharp;
 using VB = SonarAnalyzer.Rules.VisualBasic;
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/PropertiesShouldBePreferredTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/PropertiesShouldBePreferredTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/RedundantArgumentTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/RedundantArgumentTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/RedundantJumpStatementTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/RedundantJumpStatementTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/RestrictDeserializedTypesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/RestrictDeserializedTypesTest.cs
@@ -27,6 +27,7 @@ using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.Rules.SymbolicExecution;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ReturnEmptyCollectionInsteadOfNullTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ReturnEmptyCollectionInsteadOfNullTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ShouldImplementExportedInterfacesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ShouldImplementExportedInterfacesTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SqlKeywordsDelimitedBySpaceTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SqlKeywordsDelimitedBySpaceTest.cs
@@ -22,6 +22,7 @@ extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using System.Linq;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/StaticFieldInitializerOrderTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/StaticFieldInitializerOrderTest.cs
@@ -21,6 +21,7 @@ extern alias csharp;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/StaticFieldWrittenFromInstanceMemberTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/StaticFieldWrittenFromInstanceMemberTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyCollectionsShouldNotBeEnumeratedTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyCollectionsShouldNotBeEnumeratedTest.cs
@@ -23,6 +23,7 @@ using System.Collections.Immutable;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.Rules.SymbolicExecution;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyNullableValueAccessTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyNullableValueAccessTest.cs
@@ -23,6 +23,7 @@ using System.Collections.Immutable;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.Rules.SymbolicExecution;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InvalidCastToInterfaceTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InvalidCastToInterfaceTest.cs
@@ -24,6 +24,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.Rules.SymbolicExecution;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/NullPointerDereferenceTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/NullPointerDereferenceTest.cs
@@ -24,6 +24,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.Rules.SymbolicExecution;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnceTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnceTest.cs
@@ -23,6 +23,7 @@ using System.Collections.Immutable;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.Rules.SymbolicExecution;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNullTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNullTest.cs
@@ -23,6 +23,7 @@ using System.Collections.Immutable;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.Rules.SymbolicExecution;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionRulesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionRulesTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Rules.SymbolicExecution;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestClassShouldHaveTestMethodTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestClassShouldHaveTestMethodTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
@@ -23,6 +23,7 @@ extern alias csharp;
 using System.Linq;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldHaveCorrectSignature.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldHaveCorrectSignature.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldNotBeIgnoredTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldNotBeIgnoredTest.cs
@@ -23,6 +23,7 @@ extern alias csharp;
 using System.Linq;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TrackNotImplementedExceptionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TrackNotImplementedExceptionTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TypesShouldNotExtendOutdatedBaseTypesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/TypesShouldNotExtendOutdatedBaseTypesTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
@@ -19,6 +19,7 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CS = SonarAnalyzer.Rules.CSharp;
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UriShouldNotBeHardcodedTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UriShouldNotBeHardcodedTest.cs
@@ -24,6 +24,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UseUriInsteadOfStringTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UseUriInsteadOfStringTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UsingCookiesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UsingCookiesTest.cs
@@ -27,6 +27,7 @@ using Microsoft.CodeAnalysis;
 using System.Linq;
 using System.Collections.Generic;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/WcfMissingContractAttributeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/WcfMissingContractAttributeTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/WcfNonVoidOneWayTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/WcfNonVoidOneWayTest.cs
@@ -21,6 +21,7 @@
 extern alias csharp;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Rules

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/XmlExternalEntityShouldNotBeParsedTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/XmlExternalEntityShouldNotBeParsedTest.cs
@@ -26,6 +26,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.UnitTest.TestFramework;
 using System.Linq;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
@@ -24,6 +24,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 
 namespace SonarAnalyzer.UnitTest.TestFramework
 {


### PR DESCRIPTION
- Moved `FramworkMetadataReference` to `MetadataReferences` folder
- Moved `NuGetMetadataReference` to `MetadataReferences` folder
- Extracted `MetadataReferenceFactory` (from `FramworkMetadataReference`) -> this will be used by `CoreMetadataReference`