### PR TITLE
Move NetStandard reference into it's own file

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/AspNetMvcHelper_IsControllerMethod.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/AspNetMvcHelper_IsControllerMethod.cs
@@ -118,7 +118,7 @@ public class Foo
 ";
             var compilation = TestHelper.Compile(code,
                 additionalReferences:
-                    FrameworkMetadataReference.Netstandard
+                    NetStandardMetadataReference.Netstandard
                         .Union(NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(aspNetMvcVersion))
                         .ToArray());
 
@@ -143,7 +143,7 @@ public class Foo : Microsoft.AspNetCore.Mvc.ControllerBase
 ";
             var compilation = TestHelper.Compile(code,
                 additionalReferences:
-                    FrameworkMetadataReference.Netstandard
+                    NetStandardMetadataReference.Netstandard
                         .Union(NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(aspNetMvcVersion))
                         .ToArray());
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/NetFrameworkVersionProviderTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/NetFrameworkVersionProviderTest.cs
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
         {
             var compilation = GetRawCompilation(FrameworkMetadataReference.Mscorlib
                 .Concat(FrameworkMetadataReference.System)
-                .Concat(FrameworkMetadataReference.Netstandard));
+                .Concat(NetStandardMetadataReference.Netstandard));
             var versionProvider = new NetFrameworkVersionProvider();
             // the local .net framework mscorlib is actually used
             versionProvider.GetDotNetFrameworkVersion(compilation).Should().Be(NetFrameworkVersion.After452);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/TypeDeclarationSyntaxExtensionsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/TypeDeclarationSyntaxExtensionsTest.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 
 namespace SonarAnalyzer.UnitTest.Helpers
@@ -84,7 +83,7 @@ namespace Test
     }
 }
 ";
-            var snippet = new SnippetCompiler(code, NuGetMetadataReference.NETStandardV2_1_0);
+            var snippet = new SnippetCompiler(code);
 
             var typeDeclaration = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<TypeDeclarationSyntax>().Single();
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/FrameworkMetadataReference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/FrameworkMetadataReference.cs
@@ -33,9 +33,6 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
         internal static IEnumerable<MetadataReference> Mscorlib { get; }
             = Create("mscorlib.dll");
 
-        internal static IEnumerable<MetadataReference> Netstandard { get; }
-            = Create("netstandard.dll");
-
         internal static IEnumerable<MetadataReference> System { get; }
             = Create("System.dll");
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/NetStandardMetadataReference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/NetStandardMetadataReference.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2020 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using static SonarAnalyzer.UnitTest.MetadataReferences.MetadataReferenceFactory;
+
+namespace SonarAnalyzer.UnitTest.MetadataReferences
+{
+    internal static class NetStandardMetadataReference
+    {
+        internal static IEnumerable<MetadataReference> Netstandard { get; }
+            = Create("netstandard.dll");
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Performance/PerformanceTests.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Performance/PerformanceTests.cs
@@ -123,7 +123,7 @@ namespace SonarAnalyzer.UnitTest.Performance
 
         private static IEnumerable<MetadataReference> GetEntityFrameworkReferencesNetCore(string entityFrameworkVersion) =>
             Enumerable.Empty<MetadataReference>()
-                .Concat(FrameworkMetadataReference.Netstandard)
+                .Concat(NetStandardMetadataReference.Netstandard)
                 .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCoreSqlServer(entityFrameworkVersion))
                 .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCoreRelational(entityFrameworkVersion));
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzer(@"TestCases\AssertionArgsShouldBePassedInCorrectOrder.Xunit.cs",
                 new AssertionArgsShouldBePassedInCorrectOrder(),
                 additionalReferences: NuGetMetadataReference.XunitFramework(testFwkVersion)
-                    .Concat(FrameworkMetadataReference.Netstandard)
+                    .Concat(NetStandardMetadataReference.Netstandard)
                     .ToArray());
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CertificateValidationCheckTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CertificateValidationCheckTest.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             Verifier.VerifyAnalyzer(@"TestCases\CertificateValidationCheck.cs",
                 new CertificateValidationCheck(),
-                additionalReferences : FrameworkMetadataReference.SystemNetHttp.Concat(FrameworkMetadataReference.Netstandard)
+                additionalReferences : FrameworkMetadataReference.SystemNetHttp.Concat(NetStandardMetadataReference.Netstandard)
                 );
         }
 
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             Verifier.VerifyAnalyzer(@"TestCases\CertificateValidationCheck.vb",
                 new SonarAnalyzer.Rules.VisualBasic.CertificateValidationCheck(),
-                additionalReferences: FrameworkMetadataReference.SystemNetHttp.Concat(FrameworkMetadataReference.Netstandard)
+                additionalReferences: FrameworkMetadataReference.SystemNetHttp.Concat(NetStandardMetadataReference.Netstandard)
                 );
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConfiguringLoggersTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ConfiguringLoggersTest.cs
@@ -134,7 +134,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         }
 
         private static IEnumerable<MetadataReference> AspNetCoreLoggingReferences =>
-            FrameworkMetadataReference.Netstandard
+            NetStandardMetadataReference.Netstandard
             .Concat(NuGetMetadataReference.MicrosoftAspNetCore(Constants.DotNetCore220Version))
             .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHosting(Constants.DotNetCore220Version))
             .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHostingAbstractions(Constants.DotNetCore220Version))

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CookieShouldBeHttpOnlyTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CookieShouldBeHttpOnlyTest.cs
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         }
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences_NetCore() =>
-            FrameworkMetadataReference.Netstandard
+            NetStandardMetadataReference.Netstandard
                 .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHttpFeatures(Constants.NuGetLatestVersion));
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CookieShouldBeSecureTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/CookieShouldBeSecureTest.cs
@@ -71,7 +71,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         }
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences_NetCore() =>
-            FrameworkMetadataReference.Netstandard
+            NetStandardMetadataReference.Netstandard
                 .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHttpFeatures(Constants.NuGetLatestVersion));
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DeliveringDebugFeaturesInProductionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DeliveringDebugFeaturesInProductionTest.cs
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         private static IEnumerable<MetadataReference> AdditionalReferences =>
             Enumerable.Empty<MetadataReference>()
-                .Concat(FrameworkMetadataReference.Netstandard)
+                .Concat(NetStandardMetadataReference.Netstandard)
                 .Concat(NuGetMetadataReference.MicrosoftAspNetCoreDiagnostics(Constants.DotNetCore220Version))
                 .Concat(NuGetMetadataReference.MicrosoftAspNetCoreDiagnosticsEntityFrameworkCore(Constants.DotNetCore220Version))
                 .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHttpAbstractions(Constants.DotNetCore220Version))

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ExecutingSqlQueriesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ExecutingSqlQueriesTest.cs
@@ -100,7 +100,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         private static IEnumerable<MetadataReference> GetReferencesNetCore(string entityFrameworkVersion) =>
             Enumerable.Empty<MetadataReference>()
-                .Concat(FrameworkMetadataReference.Netstandard)
+                .Concat(NetStandardMetadataReference.Netstandard)
                 .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCore(entityFrameworkVersion))
                 .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCoreRelational(entityFrameworkVersion));
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodShouldBeNamedAccordingToSynchronicityTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MethodShouldBeNamedAccordingToSynchronicityTest.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             string aspNetCoreRoutingVersion) =>
             Verifier.VerifyAnalyzer(@"TestCases\MethodShouldBeNamedAccordingToSynchronicity.MVC.Core.cs",
                 new MethodShouldBeNamedAccordingToSynchronicity(),
-                additionalReferences: FrameworkMetadataReference.Netstandard
+                additionalReferences: NetStandardMetadataReference.Netstandard
                     .Concat(NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(aspNetCoreMvcVersion))
                     .Concat(NuGetMetadataReference.MicrosoftAspNetCoreMvcViewFeatures(aspNetCoreMvcVersion))
                     .Concat(NuGetMetadataReference.MicrosoftAspNetCoreRoutingAbstractions(aspNetCoreRoutingVersion)));

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UsingCookiesTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UsingCookiesTest.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.UnitTest.Rules
     public class UsingCookies
     {
         private static IEnumerable<MetadataReference> GetAdditionalReferences_NetCore(string packageVersion) =>
-            FrameworkMetadataReference.Netstandard
+            NetStandardMetadataReference.Netstandard
                 .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHttpAbstractions(packageVersion))
                 .Concat(NuGetMetadataReference.MicrosoftAspNetCoreHttpFeatures(packageVersion))
                 .Concat(NuGetMetadataReference.MicrosoftExtensionsPrimitives(packageVersion));

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
@@ -111,7 +111,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             if (additionalReferences != null &&
                 additionalReferences.Any(r => r.Display.Contains("\\netstandard")))
             {
-                project = project.AddReferences(FrameworkMetadataReference.Netstandard);
+                project = project.AddReferences(NetStandardMetadataReference.Netstandard);
             }
 
             return project.GetSolution();


### PR DESCRIPTION
- it is common for both `.Net Framework` and `.Net Core`
