### PR TITLE
Fix build errors when using VS2015

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>SonarAnalyzer.CFG</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <ProjectGuid>{F766F556-CB91-408A-9149-EB963DE1B817}</ProjectGuid>
     <LangVersion>8</LangVersion>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <AssemblyName>SonarAnalyzer</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/SonarAnalyzer.Utilities.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Utilities/SonarAnalyzer.Utilities.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <AssemblyName>SonarAnalyzer.Utilities</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.Vsix.csproj
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Vsix/SonarAnalyzer.Vsix.csproj
@@ -112,12 +112,16 @@
       <Name>SonarAnalyzer.Common</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
+      <!-- https://github.com/dotnet/sdk/issues/433 -->
+      <AdditionalProperties>TargetFramework=net461</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="..\SonarAnalyzer.CFG\SonarAnalyzer.CFG.csproj">
       <Project>{F766F556-CB91-408A-9149-EB963DE1B817}</Project>
       <Name>SonarAnalyzer.CFG</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
+      <!-- https://github.com/dotnet/sdk/issues/433 -->
+      <AdditionalProperties>TargetFramework=net461</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Visual Studio 2015 does not support .Net Standard out of the box.

In order to keep compatibility we will target both .Net 4.6.1 and .Net Standard 2.0 but use only .Net 4.6.1 in plugin.
