### PR TITLE
Fix concurrency issue on rspec generation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,7 +222,8 @@ stages:
           Get-Content -Path $testProjFileName
 
           Write-Host "Build UnitTest project"
-          dotnet build $testProjFileName -c $(BuildConfiguration)
+          # Parallel build is disabled in order to avoid concurrent resx file generation (RspecStrings.resx) which results in unpredictable build failures
+          dotnet build $testProjFileName -c $(BuildConfiguration) /m:1
 
           Write-Host "List Sonar*.dll files"
           Get-ChildItem -Recurse .\tests\SonarAnalyzer.UnitTest\bin\${BuildConfiguration}\ -Filter Sonar*.dll

--- a/scripts/rspec/rspec2resx.ps1
+++ b/scripts/rspec/rspec2resx.ps1
@@ -144,7 +144,7 @@ function CreateStringResources($rules, $resgenPath) {
     [void]$resources.Add("HelpLinkFormat=https://rules.sonarsource.com/$($helpLanguageMap.Get_Item($language))/RSPEC-{0}")
     [void]$resources.Add("RoslynLanguage=$($roslynLanguageMap.Get_Item($language))")
 
-    $rawResourcesPath = "${PSScriptRoot}\\${lang}_strings.restext"
+    $rawResourcesPath = "${PSScriptRoot}\${language}_strings.restext"
 
     Write-Host "Writing raw resources at $rawResourcesPath"
     Set-Content $rawResourcesPath $resources


### PR DESCRIPTION
Noticed during build that there are multiple points of failure:
```
D:\a\1\s\scripts\rspec\\_strings.restext : error RG0000: The process cannot access the file 'D:\a\1\s\scripts\rspec\_strings.restext' because it is being used by another process. [D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.csproj]
```

This happens because `_strings.restext` file is generated twice during build. Once for .Net 4.6.1 and once for .Net Standard. There is also an additional issue since it was supposed to be named `cs_strings.restext` and `vbnet_strings.restext` but the language prefix is missing.

```
ResGen : error RG0000: Output file is possibly corrupt.  Deleting "D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\RspecStrings.resx" [D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.csproj]
ResGen : error RG0000: Could not delete possibly corrupted output file "D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\RspecStrings.resx". [D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.csproj]
D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\RspecStrings.resx : error RG0000: Couldn't write output file "D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\RspecStrings.resx" [D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.csproj]
D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\RspecStrings.resx : error RG0000: Specific exception: "IOException"  Message: "The process cannot access the file 'D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\RspecStrings.resx' because it is being used by another process." [D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.csproj]
```

This probably happens for the same reason, the script is run twice for the same project and `sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\RspecStrings.resx` cannot be accessed. 

An example of concurrent generation from the build logs:
```
2020-08-13T13:44:39.2390443Z   Finding ResGen.exe path
2020-08-13T13:44:39.2707245Z   Finding ResGen.exe path
2020-08-13T13:44:39.3859213Z   Path found: C:\Program Files (x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.8 Tools\\ResGen.exe
2020-08-13T13:44:39.3880294Z   Path found: C:\Program Files (x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.8 Tools\\ResGen.exe
2020-08-13T13:44:39.3894808Z   Retrieving rules for language: vbnet
2020-08-13T13:44:39.3945081Z   Retrieving rules for language: vbnet
2020-08-13T13:44:40.1999079Z   Creating resources
2020-08-13T13:44:40.3056759Z   Creating resources
2020-08-13T13:44:41.7549151Z   Writing raw resources at D:\a\1\s\scripts\rspec\vbnet_strings_9601353943e04f879b5dd312bdbd711d.restext
2020-08-13T13:44:41.8967549Z   Generating resx files at D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.VisualBasic\RspecStrings.resx
2020-08-13T13:44:41.9513323Z   Writing raw resources at D:\a\1\s\scripts\rspec\vbnet_strings_8623379a0a6549c4b990d1ee56bfa34f.restext
2020-08-13T13:44:42.1549271Z   Generating resx files at D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.VisualBasic\RspecStrings.resx
2020-08-13T13:44:42.2166350Z   Read in 1368 resources from "D:\a\1\s\scripts\rspec\vbnet_strings_9601353943e04f879b5dd312bdbd711d.restext"
2020-08-13T13:44:42.2295570Z   Writing resource file...  Done.
2020-08-13T13:44:42.3707257Z   Read in 1368 resources from "D:\a\1\s\scripts\rspec\vbnet_strings_8623379a0a6549c4b990d1ee56bfa34f.restext"
2020-08-13T13:44:42.3717226Z   Writing resource file...  Done.
```