### PR TITLE
Remove deprecated APIs: SensorDescriptor.global() from UnitTestResultsImportSensor

### DIFF
--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsAggregator.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsAggregator.java
@@ -21,8 +21,8 @@ package org.sonar.plugins.dotnet.tests;
 
 import java.io.File;
 import java.util.function.Predicate;
-import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.config.Configuration;
+import org.sonar.api.scanner.ScannerSide;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -45,9 +45,9 @@ public class UnitTestResultsAggregator {
   }
 
   UnitTestResultsAggregator(UnitTestConfiguration unitTestConf, Configuration configuration,
-                            VisualStudioTestResultsFileParser visualStudioTestResultsFileParser,
-                            NUnitTestResultsFileParser nunitTestResultsFileParser,
-                            XUnitTestResultsFileParser xunitTestResultsFileParser) {
+    VisualStudioTestResultsFileParser visualStudioTestResultsFileParser,
+    NUnitTestResultsFileParser nunitTestResultsFileParser,
+    XUnitTestResultsFileParser xunitTestResultsFileParser) {
     this.unitTestConf = unitTestConf;
     this.configuration = configuration;
     this.visualStudioTestResultsFileParser = visualStudioTestResultsFileParser;

--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsAggregator.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsAggregator.java
@@ -77,21 +77,22 @@ public class UnitTestResultsAggregator {
     return hasKeyPredicate.test(unitTestConf.xunitTestResultsFilePropertyKey());
   }
 
-  UnitTestResults aggregate(WildcardPatternFileProvider wildcardPatternFileProvider, UnitTestResults unitTestResults) {
+  UnitTestResults aggregate(WildcardPatternFileProvider wildcardPatternFileProvider) {
+    UnitTestResults results = new UnitTestResults();
+
     if (hasVisualStudioTestResultsFile(configuration::hasKey)) {
-      aggregate(wildcardPatternFileProvider, configuration.getStringArray(unitTestConf.visualStudioTestResultsFilePropertyKey()), visualStudioTestResultsFileParser,
-        unitTestResults);
+      aggregate(wildcardPatternFileProvider, configuration.getStringArray(unitTestConf.visualStudioTestResultsFilePropertyKey()), visualStudioTestResultsFileParser, results);
     }
 
     if (hasNUnitTestResultsFile(configuration::hasKey)) {
-      aggregate(wildcardPatternFileProvider, configuration.getStringArray(unitTestConf.nunitTestResultsFilePropertyKey()), nunitTestResultsFileParser, unitTestResults);
+      aggregate(wildcardPatternFileProvider, configuration.getStringArray(unitTestConf.nunitTestResultsFilePropertyKey()), nunitTestResultsFileParser, results);
     }
 
     if (hasXUnitTestResultsFile(configuration::hasKey)) {
-      aggregate(wildcardPatternFileProvider, configuration.getStringArray(unitTestConf.xunitTestResultsFilePropertyKey()), xunitTestResultsFileParser, unitTestResults);
+      aggregate(wildcardPatternFileProvider, configuration.getStringArray(unitTestConf.xunitTestResultsFilePropertyKey()), xunitTestResultsFileParser, results);
     }
 
-    return unitTestResults;
+    return results;
   }
 
   private static void aggregate(WildcardPatternFileProvider wildcardPatternFileProvider, String[] reportPaths, UnitTestResultsParser parser, UnitTestResults unitTestResults) {

--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
@@ -64,23 +64,19 @@ public class UnitTestResultsImportSensor implements ProjectSensor {
   @Override
   public void execute(SensorContext context) {
     if (unitTestResultsAggregator.hasUnitTestResultsProperty()) {
-      analyze(context, new UnitTestResults()); // FIXME: Refactoring
+      try {
+        saveTestMetrics(context);
+      } catch (Exception e) {
+        LOG.warn("Could not import unit test report: '{}'", e.getMessage());
+        analysisWarnings.addUnique(String.format("Could not import unit test report for '%s'. Please check the logs for more details.", languageName));
+      }
     } else {
       LOG.debug("No unit test results property. Skip Sensor");
     }
   }
 
-  void analyze(SensorContext context, UnitTestResults unitTestResults) {
-    try {
-      saveTestMetrics(context, unitTestResults);
-    } catch (Exception e) {
-      LOG.warn("Could not import unit test report: '{}'", e.getMessage());
-      analysisWarnings.addUnique(String.format("Could not import unit test report for '%s'. Please check the logs for more details.", languageName));
-    }
-  }
-
-  private void saveTestMetrics(SensorContext context, UnitTestResults unitTestResults) {
-    UnitTestResults aggregatedResults = unitTestResultsAggregator.aggregate(wildcardPatternFileProvider, unitTestResults);
+  private void saveTestMetrics(SensorContext context) {
+    UnitTestResults aggregatedResults = unitTestResultsAggregator.aggregate(wildcardPatternFileProvider);
 
     context.<Integer>newMeasure()
       .forMetric(CoreMetrics.TESTS)

--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
@@ -43,13 +43,9 @@ public class UnitTestResultsImportSensor implements ProjectSensor {
   private final AnalysisWarnings analysisWarnings;
 
   public UnitTestResultsImportSensor(UnitTestResultsAggregator unitTestResultsAggregator, DotNetPluginMetadata pluginMetadata, AnalysisWarnings analysisWarnings) {
-    this(unitTestResultsAggregator, pluginMetadata.languageKey(), pluginMetadata.languageName(), analysisWarnings);
-  }
-
-  public UnitTestResultsImportSensor(UnitTestResultsAggregator unitTestResultsAggregator, String languageKey, String languageName, AnalysisWarnings analysisWarnings) {
     this.unitTestResultsAggregator = unitTestResultsAggregator;
-    this.languageKey = languageKey;
-    this.languageName = languageName;
+    this.languageKey = pluginMetadata.languageKey();
+    this.languageName = pluginMetadata.languageName();
     this.analysisWarnings = analysisWarnings;
   }
 

--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/UnitTestResultsImportSensor.java
@@ -20,12 +20,11 @@
 package org.sonar.plugins.dotnet.tests;
 
 import java.io.File;
-import org.sonar.api.batch.bootstrap.ProjectDefinition;
-import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.notifications.AnalysisWarnings;
+import org.sonar.api.scanner.sensor.ProjectSensor;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonarsource.dotnet.shared.plugins.DotNetPluginMetadata;
@@ -33,26 +32,22 @@ import org.sonarsource.dotnet.shared.plugins.DotNetPluginMetadata;
 /**
  * This class is responsible to handle all the C# and VB.NET unit test results reports (parse and report back to SonarQube).
  */
-public class UnitTestResultsImportSensor implements Sensor {
+public class UnitTestResultsImportSensor implements ProjectSensor {
 
   private static final Logger LOG = Loggers.get(UnitTestResultsImportSensor.class);
 
   private final WildcardPatternFileProvider wildcardPatternFileProvider = new WildcardPatternFileProvider(new File("."), File.separator);
   private final UnitTestResultsAggregator unitTestResultsAggregator;
-  private final ProjectDefinition projectDef;
   private final String languageKey;
   private final String languageName;
   private final AnalysisWarnings analysisWarnings;
 
-  public UnitTestResultsImportSensor(UnitTestResultsAggregator unitTestResultsAggregator, ProjectDefinition projectDef,
-                                     DotNetPluginMetadata pluginMetadata, AnalysisWarnings analysisWarnings) {
-    this(unitTestResultsAggregator, projectDef, pluginMetadata.languageKey(), pluginMetadata.languageName(), analysisWarnings);
+  public UnitTestResultsImportSensor(UnitTestResultsAggregator unitTestResultsAggregator, DotNetPluginMetadata pluginMetadata, AnalysisWarnings analysisWarnings) {
+    this(unitTestResultsAggregator, pluginMetadata.languageKey(), pluginMetadata.languageName(), analysisWarnings);
   }
 
-  public UnitTestResultsImportSensor(UnitTestResultsAggregator unitTestResultsAggregator, ProjectDefinition projectDef,
-    String languageKey, String languageName, AnalysisWarnings analysisWarnings) {
+  public UnitTestResultsImportSensor(UnitTestResultsAggregator unitTestResultsAggregator, String languageKey, String languageName, AnalysisWarnings analysisWarnings) {
     this.unitTestResultsAggregator = unitTestResultsAggregator;
-    this.projectDef = projectDef;
     this.languageKey = languageKey;
     this.languageName = languageName;
     this.analysisWarnings = analysisWarnings;
@@ -62,19 +57,16 @@ public class UnitTestResultsImportSensor implements Sensor {
   public void describe(SensorDescriptor descriptor) {
     String name = String.format("%s Unit Test Results Import", this.languageName);
     descriptor.name(name);
-    descriptor.global();
     descriptor.onlyOnLanguage(this.languageKey);
     descriptor.onlyWhenConfiguration(c -> unitTestResultsAggregator.hasUnitTestResultsProperty(c::hasKey));
   }
 
   @Override
   public void execute(SensorContext context) {
-    if (!unitTestResultsAggregator.hasUnitTestResultsProperty()) {
+    if (unitTestResultsAggregator.hasUnitTestResultsProperty()) {
+      analyze(context, new UnitTestResults()); // FIXME: Refactoring
+    } else {
       LOG.debug("No unit test results property. Skip Sensor");
-      return;
-    }
-    if (projectDef.getParent() == null) {
-      analyze(context, new UnitTestResults());
     }
   }
 
@@ -87,7 +79,7 @@ public class UnitTestResultsImportSensor implements Sensor {
     }
   }
 
-  private void saveTestMetrics(SensorContext context, UnitTestResults unitTestResults){
+  private void saveTestMetrics(SensorContext context, UnitTestResults unitTestResults) {
     UnitTestResults aggregatedResults = unitTestResultsAggregator.aggregate(wildcardPatternFileProvider, unitTestResults);
 
     context.<Integer>newMeasure()

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/UnitTestResultsProvider.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/UnitTestResultsProvider.java
@@ -21,10 +21,10 @@ package org.sonarsource.dotnet.shared.plugins;
 
 import java.util.Arrays;
 import java.util.List;
-import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
+import org.sonar.api.scanner.ScannerSide;
 import org.sonar.plugins.dotnet.tests.UnitTestConfiguration;
 import org.sonar.plugins.dotnet.tests.UnitTestResultsAggregator;
 import org.sonar.plugins.dotnet.tests.UnitTestResultsImportSensor;

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/UnitTestResultsAggregatorTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/UnitTestResultsAggregatorTest.java
@@ -33,7 +33,8 @@ import org.sonar.api.utils.log.LoggerLevel;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -98,10 +99,9 @@ public class UnitTestResultsAggregatorTest {
     VisualStudioTestResultsFileParser visualStudioTestResultsFileParser = mock(VisualStudioTestResultsFileParser.class);
     NUnitTestResultsFileParser nunitTestResultsFileParser = mock(NUnitTestResultsFileParser.class);
     XUnitTestResultsFileParser xunitTestResultsFileParser = mock(XUnitTestResultsFileParser.class);
-    UnitTestResults results = mock(UnitTestResults.class);
     new UnitTestResultsAggregator(unitTestConf, settings.asConfig(), visualStudioTestResultsFileParser, nunitTestResultsFileParser, xunitTestResultsFileParser)
-      .aggregate(wildcardPatternFileProvider, results);
-    verify(visualStudioTestResultsFileParser).accept(new File("foo.trx"), results);
+      .aggregate(wildcardPatternFileProvider);
+    verify(visualStudioTestResultsFileParser).accept(eq(new File("foo.trx")), notNull());
     verify(nunitTestResultsFileParser, Mockito.never()).accept(Mockito.any(File.class), Mockito.any(UnitTestResults.class));
 
     // NUnit test results only
@@ -111,11 +111,10 @@ public class UnitTestResultsAggregatorTest {
     visualStudioTestResultsFileParser = mock(VisualStudioTestResultsFileParser.class);
     nunitTestResultsFileParser = mock(NUnitTestResultsFileParser.class);
     xunitTestResultsFileParser = mock(XUnitTestResultsFileParser.class);
-    results = mock(UnitTestResults.class);
     new UnitTestResultsAggregator(unitTestConf, settings.asConfig(), visualStudioTestResultsFileParser, nunitTestResultsFileParser, xunitTestResultsFileParser)
-      .aggregate(wildcardPatternFileProvider, results);
+      .aggregate(wildcardPatternFileProvider);
     verify(visualStudioTestResultsFileParser, Mockito.never()).accept(Mockito.any(File.class), Mockito.any(UnitTestResults.class));
-    verify(nunitTestResultsFileParser).accept(new File("foo.xml"), results);
+    verify(nunitTestResultsFileParser).accept(eq(new File("foo.xml")), notNull());
 
     // XUnit test results only
     settings.clear();
@@ -124,11 +123,10 @@ public class UnitTestResultsAggregatorTest {
     visualStudioTestResultsFileParser = mock(VisualStudioTestResultsFileParser.class);
     nunitTestResultsFileParser = mock(NUnitTestResultsFileParser.class);
     xunitTestResultsFileParser = mock(XUnitTestResultsFileParser.class);
-    results = mock(UnitTestResults.class);
     new UnitTestResultsAggregator(unitTestConf, settings.asConfig(), visualStudioTestResultsFileParser, nunitTestResultsFileParser, xunitTestResultsFileParser)
-      .aggregate(wildcardPatternFileProvider, results);
+      .aggregate(wildcardPatternFileProvider);
     verify(visualStudioTestResultsFileParser, Mockito.never()).accept(Mockito.any(File.class), Mockito.any(UnitTestResults.class));
-    verify(xunitTestResultsFileParser).accept(new File("foo.xml"), results);
+    verify(xunitTestResultsFileParser).accept(eq(new File("foo.xml")), notNull());
 
     // All configured
     settings.clear();
@@ -140,21 +138,19 @@ public class UnitTestResultsAggregatorTest {
     visualStudioTestResultsFileParser = mock(VisualStudioTestResultsFileParser.class);
     nunitTestResultsFileParser = mock(NUnitTestResultsFileParser.class);
     xunitTestResultsFileParser = mock(XUnitTestResultsFileParser.class);
-    results = mock(UnitTestResults.class);
     new UnitTestResultsAggregator(unitTestConf, settings.asConfig(), visualStudioTestResultsFileParser, nunitTestResultsFileParser, xunitTestResultsFileParser)
-      .aggregate(wildcardPatternFileProvider, results);
-    verify(visualStudioTestResultsFileParser).accept(new File("foo.trx"), results);
-    verify(nunitTestResultsFileParser).accept(new File("foo.xml"), results);
-    verify(xunitTestResultsFileParser).accept(new File("foo.xml"), results);
+      .aggregate(wildcardPatternFileProvider);
+    verify(visualStudioTestResultsFileParser).accept(eq(new File("foo.trx")), notNull());
+    verify(nunitTestResultsFileParser).accept(eq(new File("foo.xml")), notNull());
+    verify(xunitTestResultsFileParser).accept(eq(new File("foo.xml")), notNull());
 
     // None configured
     settings.clear();
     visualStudioTestResultsFileParser = mock(VisualStudioTestResultsFileParser.class);
     nunitTestResultsFileParser = mock(NUnitTestResultsFileParser.class);
     xunitTestResultsFileParser = mock(XUnitTestResultsFileParser.class);
-    results = mock(UnitTestResults.class);
     new UnitTestResultsAggregator(unitTestConf, settings.asConfig(), visualStudioTestResultsFileParser, nunitTestResultsFileParser, xunitTestResultsFileParser)
-      .aggregate(wildcardPatternFileProvider, results);
+      .aggregate(wildcardPatternFileProvider);
     verify(visualStudioTestResultsFileParser, Mockito.never()).accept(Mockito.any(File.class), Mockito.any(UnitTestResults.class));
     verify(nunitTestResultsFileParser, Mockito.never()).accept(Mockito.any(File.class), Mockito.any(UnitTestResults.class));
     verify(xunitTestResultsFileParser, Mockito.never()).accept(Mockito.any(File.class), Mockito.any(UnitTestResults.class));
@@ -174,22 +170,21 @@ public class UnitTestResultsAggregatorTest {
     visualStudioTestResultsFileParser = mock(VisualStudioTestResultsFileParser.class);
     nunitTestResultsFileParser = mock(NUnitTestResultsFileParser.class);
     xunitTestResultsFileParser = mock(XUnitTestResultsFileParser.class);
-    results = mock(UnitTestResults.class);
 
     new UnitTestResultsAggregator(unitTestConf, settings.asConfig(), visualStudioTestResultsFileParser, nunitTestResultsFileParser, xunitTestResultsFileParser)
-      .aggregate(wildcardPatternFileProvider, results);
+      .aggregate(wildcardPatternFileProvider);
 
     verify(wildcardPatternFileProvider).listFiles("*.trx");
     verify(wildcardPatternFileProvider).listFiles("bar.trx");
     verify(wildcardPatternFileProvider).listFiles("foo.xml");
     verify(wildcardPatternFileProvider).listFiles("bar.xml");
 
-    verify(visualStudioTestResultsFileParser).accept(new File("foo.trx"), results);
-    verify(visualStudioTestResultsFileParser).accept(new File("bar.trx"), results);
-    verify(nunitTestResultsFileParser).accept(new File("foo.xml"), results);
-    verify(nunitTestResultsFileParser).accept(new File("bar.xml"), results);
-    verify(xunitTestResultsFileParser).accept(new File("foo2.xml"), results);
-    verify(xunitTestResultsFileParser).accept(new File("bar2.xml"), results);
+    verify(visualStudioTestResultsFileParser).accept(eq(new File("foo.trx")), notNull());
+    verify(visualStudioTestResultsFileParser).accept(eq(new File("bar.trx")), notNull());
+    verify(nunitTestResultsFileParser).accept(eq(new File("foo.xml")), notNull());
+    verify(nunitTestResultsFileParser).accept(eq(new File("bar.xml")), notNull());
+    verify(xunitTestResultsFileParser).accept(eq(new File("foo2.xml")), notNull());
+    verify(xunitTestResultsFileParser).accept(eq(new File("bar2.xml")), notNull());
   }
 
   @Test
@@ -202,10 +197,10 @@ public class UnitTestResultsAggregatorTest {
     when(wildcardPatternFileProvider.listFiles("foo.trx")).thenReturn(new HashSet<>(Collections.singletonList(new File("foo.trx"))));
 
     VisualStudioTestResultsFileParser visualStudioTestResultsFileParser = mock(VisualStudioTestResultsFileParser.class);
-    doThrow(IllegalStateException.class).when(visualStudioTestResultsFileParser).accept(any(), any());
+    doThrow(IllegalStateException.class).when(visualStudioTestResultsFileParser).accept(notNull(), notNull());
 
     new UnitTestResultsAggregator(unitTestConf, settings.asConfig(), visualStudioTestResultsFileParser, null, null)
-      .aggregate(wildcardPatternFileProvider, null);
+      .aggregate(wildcardPatternFileProvider);
 
     assertThat(logTester.logs(LoggerLevel.WARN)).containsOnly("Could not import unit test report 'foo.trx'");
   }

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/UnitTestResultsAggregatorTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/UnitTestResultsAggregatorTest.java
@@ -89,6 +89,7 @@ public class UnitTestResultsAggregatorTest {
   @Test
   public void aggregate_visual_studio_only() {
     AggregateTestContext context = new AggregateTestContext("visualStudioTestResultsFile", "foo.trx");
+    context.run();
 
     verify(context.visualStudio).accept(eq(new File("foo.trx")), notNull());
     verify(context.nunit, Mockito.never()).accept(any(), any());
@@ -98,6 +99,7 @@ public class UnitTestResultsAggregatorTest {
   @Test
   public void aggregate_nunit_only() {
     AggregateTestContext context = new AggregateTestContext("nunitTestResultsFile", "foo.xml");
+    context.run();
 
     verify(context.visualStudio, Mockito.never()).accept(any(), any());
     verify(context.nunit).accept(eq(new File("foo.xml")), notNull());
@@ -107,6 +109,7 @@ public class UnitTestResultsAggregatorTest {
   @Test
   public void aggregate_xunit_only() {
     AggregateTestContext context = new AggregateTestContext("xunitTestResultsFile", "foo.xml");
+    context.run();
 
     verify(context.visualStudio, Mockito.never()).accept(any(), any());
     verify(context.nunit, Mockito.never()).accept(any(), any());
@@ -195,7 +198,6 @@ public class UnitTestResultsAggregatorTest {
 
     public AggregateTestContext(String propertyName, String fileName) {
       add(propertyName, fileName);
-      run();
     }
 
     public void add(String propertyName, String fileName) {


### PR DESCRIPTION
Contributes #3476
