### PR TITLE
Remove deprecated APIs: SensorDescriptor.global() from CoverageReportImportSensor

### DIFF
--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/CoverageAggregator.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/CoverageAggregator.java
@@ -22,11 +22,11 @@ package org.sonar.plugins.dotnet.tests;
 import java.io.File;
 import java.util.Set;
 import java.util.function.Predicate;
-import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.internal.google.common.annotations.VisibleForTesting;
 import org.sonar.api.notifications.AnalysisWarnings;
+import org.sonar.api.scanner.ScannerSide;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -47,7 +47,7 @@ public class CoverageAggregator {
   private final VisualStudioCoverageXmlReportParser visualStudioCoverageXmlReportParser;
 
   public CoverageAggregator(CoverageConfiguration coverageConf, Configuration configuration, FileSystem fs,
-                            AnalysisWarnings analysisWarnings) {
+    AnalysisWarnings analysisWarnings) {
 
     Predicate<String> isIndexedAndSupportedLanguage = absolutePath -> fs.hasFiles(
       fs.predicates().and(
@@ -65,11 +65,11 @@ public class CoverageAggregator {
 
   @VisibleForTesting
   CoverageAggregator(CoverageConfiguration coverageConf, Configuration configuration,
-                     CoverageCache coverageCache,
-                     NCover3ReportParser ncover3ReportParser,
-                     OpenCoverReportParser openCoverReportParser,
-                     DotCoverReportsAggregator dotCoverReportsAggregator,
-                     VisualStudioCoverageXmlReportParser visualStudioCoverageXmlReportParser) {
+    CoverageCache coverageCache,
+    NCover3ReportParser ncover3ReportParser,
+    OpenCoverReportParser openCoverReportParser,
+    DotCoverReportsAggregator dotCoverReportsAggregator,
+    VisualStudioCoverageXmlReportParser visualStudioCoverageXmlReportParser) {
 
     this.coverageConf = coverageConf;
     this.configuration = configuration;

--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/CoverageReportImportSensor.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/CoverageReportImportSensor.java
@@ -25,18 +25,18 @@ import java.util.Set;
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.InputFile.Type;
-import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.coverage.NewCoverage;
 import org.sonar.api.internal.google.common.annotations.VisibleForTesting;
+import org.sonar.api.scanner.sensor.ProjectSensor;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
 /**
  * This class is responsible to handle all the C# and VB.NET code coverage reports (parse and report back to SonarQube).
  */
-public class CoverageReportImportSensor implements Sensor {
+public class CoverageReportImportSensor implements ProjectSensor {
   @VisibleForTesting
   static final File BASE_DIR = new File(".");
 
@@ -65,9 +65,7 @@ public class CoverageReportImportSensor implements Sensor {
     } else {
       descriptor.name(this.languageName + " Tests Coverage Report Import");
     }
-    descriptor.global();
     descriptor.onlyWhenConfiguration(c -> coverageAggregator.hasCoverageProperty(c::hasKey));
-
     descriptor.onlyOnLanguage(this.languageKey);
   }
 
@@ -152,7 +150,7 @@ public class CoverageReportImportSensor implements Sensor {
       newCoverage.lineHits(entry.getKey(), entry.getValue());
     }
 
-    for (BranchCoverage branchCoverage : coverage.getBranchCoverage(filePath)){
+    for (BranchCoverage branchCoverage : coverage.getBranchCoverage(filePath)) {
       LOG.trace("Found branch coverage entry on line '{}', with total conditions '{}' and covered conditions '{}'.",
         branchCoverage.getLine(), branchCoverage.getConditions(), branchCoverage.getCoveredConditions());
       fileHasCoverage = true;

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/CodeCoverageProvider.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/CodeCoverageProvider.java
@@ -21,12 +21,12 @@ package org.sonarsource.dotnet.shared.plugins;
 
 import java.util.Arrays;
 import java.util.List;
-import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.resources.Qualifiers;
+import org.sonar.api.scanner.ScannerSide;
 import org.sonar.plugins.dotnet.tests.CoverageAggregator;
 import org.sonar.plugins.dotnet.tests.CoverageConfiguration;
 import org.sonar.plugins.dotnet.tests.CoverageReportImportSensor;
@@ -137,7 +137,7 @@ public class CodeCoverageProvider {
   public class UnitTestCoverageAggregator extends CoverageAggregator {
 
     public UnitTestCoverageAggregator(Configuration configuration, FileSystem fileSystem,
-                                      AnalysisWarnings analysisWarnings) {
+      AnalysisWarnings analysisWarnings) {
       super(coverageConf, configuration, fileSystem, analysisWarnings);
     }
 
@@ -154,7 +154,7 @@ public class CodeCoverageProvider {
   public class IntegrationTestCoverageAggregator extends CoverageAggregator {
 
     public IntegrationTestCoverageAggregator(Configuration configuration, FileSystem fileSystem,
-                                             AnalysisWarnings analysisWarnings) {
+      AnalysisWarnings analysisWarnings) {
       super(itCoverageConf, configuration, fileSystem, analysisWarnings);
     }
 

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageReportImportSensorTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageReportImportSensorTest.java
@@ -31,12 +31,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
+import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.Configuration;
+import org.sonar.api.scanner.sensor.ProjectSensor;
 import org.sonar.api.utils.log.LogTester;
 import org.sonar.api.utils.log.LoggerLevel;
 
@@ -84,11 +85,8 @@ public class CoverageReportImportSensorTest {
   }
 
   @Test
-  public void describe_global_sensor() {
-    new CoverageReportImportSensor(coverageConf, coverageAggregator, "cs", "C#", false)
-      .describe(descriptor);
-
-    assertThat(descriptor.isGlobal()).isTrue();
+  public void isProjectSensor() {
+    assertThat(ProjectSensor.class.isAssignableFrom(CoverageReportImportSensor.class)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Fixes #3476