### PR TITLE
Fix broken link in user warning

### DIFF
--- a/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/CoverageReportImportSensor.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonar/plugins/dotnet/tests/CoverageReportImportSensor.java
@@ -135,7 +135,7 @@ public class CoverageReportImportSensor implements Sensor {
       LOG.info(fileCountStatistics.toString());
       if (fileCountStatistics.mainWithCoverage == 0) {
         LOG.warn("The Code Coverage report doesn't contain any coverage data for the included files. For "
-          + "troubleshooting hints, please refer to https://docs.sonarqube.org/x/CoBh");
+          + "troubleshooting help, please visit our community forum at https://community.sonarsource.com");
       }
     }
   }

--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageReportImportSensorTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/CoverageReportImportSensorTest.java
@@ -168,7 +168,7 @@ public class CoverageReportImportSensorTest {
     assertThat(logTester.logs(LoggerLevel.INFO)).containsOnly("Coverage Report Statistics: " +
       "1 files, 0 main files, 0 main files with coverage, 1 test files, 0 project excluded files, 0 other language files.");
     assertThat(logTester.logs(LoggerLevel.WARN)).contains("The Code Coverage report doesn't contain any coverage "
-      + "data for the included files. For troubleshooting hints, please refer to https://docs.sonarqube.org/x/CoBh");
+      + "data for the included files. For troubleshooting help, please visit our community forum at https://community.sonarsource.com");
     assertThat(logTester.logs(LoggerLevel.DEBUG)).contains(
       "Analyzing coverage with wildcardPatternFileProvider with base dir '" + CoverageReportImportSensor.BASE_DIR.getAbsolutePath() + "' and file separator '\\'.",
       "Analyzing coverage after aggregate found '1' coverage files.",
@@ -192,7 +192,7 @@ public class CoverageReportImportSensorTest {
     assertThat(logTester.logs(LoggerLevel.INFO)).containsOnly("Coverage Report Statistics: " +
       "1 files, 1 main files, 0 main files with coverage, 0 test files, 0 project excluded files, 0 other language files.");
     assertThat(logTester.logs(LoggerLevel.WARN)).contains("The Code Coverage report doesn't contain any coverage "
-      + "data for the included files. For troubleshooting hints, please refer to https://docs.sonarqube.org/x/CoBh");
+      + "data for the included files. For troubleshooting help, please visit our community forum at https://community.sonarsource.com");
     assertThat(logTester.logs(LoggerLevel.DEBUG)).contains(
       "Analyzing coverage with wildcardPatternFileProvider with base dir '" + CoverageReportImportSensor.BASE_DIR.getAbsolutePath() + "' and file separator '\\'.",
       "Analyzing coverage after aggregate found '1' coverage files.",


### PR DESCRIPTION
https://docs.sonarqube.org/x/CoBh is broken.

See community threads [one](https://community.sonarsource.com/t/receiving-the-code-coverage-report-doesnt-contain-any-coverage-data-for-the-included-files-for-net-coverage/29737) and [two](https://community.sonarsource.com/t/scanner-for-msbuild-url-https-docs-sonarqube-org-x-cob-is-broken/21589).
