### PR TITLE
NuGet packaging: Place SonarAnalyzer.CFG.dll in a framework specific folder

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.cs.nuspec
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.cs.nuspec
@@ -9,16 +9,15 @@
     <license type="file">License.txt</license>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>CFG library for SonarSource C# plugins</description>
-    <releaseNotes></releaseNotes>
     <language>en-US</language>
     <copyright>Copyright © 2015-2019 SonarSource SA</copyright>
-    <tags></tags>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="bin\Release\net46\SonarAnalyzer.CFG.dll" target="lib" />
+    <file src="bin\Release\net46\SonarAnalyzer.CFG.dll" target="lib\net46" />
+    <file src="bin\Release\netstandard2.0\SonarAnalyzer.CFG.dll" target="lib\netstandard2.0" />
     <file src="License.txt" />
   </files>
 </package>


### PR DESCRIPTION
A complete list of TFM can be found here: https://docs.microsoft.com/en-us/dotnet/standard/frameworks

Fixes #3543 
