### PR TITLE
SQ plugin: Fall back to default when Roslyn encoding is not present

### DIFF
--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/EncodingPerFile.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/EncodingPerFile.java
@@ -47,7 +47,7 @@ public class EncodingPerFile {
     Charset roslynEncoding = globalReportProcessor.getRoslynEncodingPerUri().get(uri);
     if (roslynEncoding == null) {
       // Roslyn saw the file, but it didn't recognized it's encoding. We fall back to the default encoding and accept the file.
-      LOG.warn("Roslyn encoding was not detected for '{}', using default instead.", uri);
+      LOG.warn("Roslyn can not detect encoding for '{}', using default instead.", uri);
       return true;
     }
 

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/EncodingPerFile.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/EncodingPerFile.java
@@ -21,8 +21,8 @@ package org.sonarsource.dotnet.shared.plugins;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import org.sonar.api.scanner.ScannerSide;
 import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.scanner.ScannerSide;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -44,10 +44,11 @@ public class EncodingPerFile {
     }
 
     // Case-Insensitive check
-    Charset roslynEncoding = globalReportProcessor.getRoslynEncodingPerUri().get(uri); 
+    Charset roslynEncoding = globalReportProcessor.getRoslynEncodingPerUri().get(uri);
     if (roslynEncoding == null) {
-      LOG.warn("File '{}' does not have encoding information. Skip it.", uri);
-      return false;
+      // Roslyn saw the file, but it didn't recognized it's encoding. We fall back to the default encoding and accept the file.
+      LOG.warn("Roslyn encoding was not found for '{}', using default instead.", uri);
+      return true;
     }
 
     Charset sqEncoding = inputFile.charset();

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/EncodingPerFile.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/EncodingPerFile.java
@@ -47,7 +47,7 @@ public class EncodingPerFile {
     Charset roslynEncoding = globalReportProcessor.getRoslynEncodingPerUri().get(uri);
     if (roslynEncoding == null) {
       // Roslyn saw the file, but it didn't recognized it's encoding. We fall back to the default encoding and accept the file.
-      LOG.warn("Roslyn encoding was not found for '{}', using default instead.", uri);
+      LOG.warn("Roslyn encoding was not detected for '{}', using default instead.", uri);
       return true;
     }
 

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/EncodingPerFileTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/EncodingPerFileTest.java
@@ -61,7 +61,7 @@ public class EncodingPerFileTest {
   public void should_treat_as_match_and_warn_when_roslyn_encoding_missing() throws IOException {
     assertEncodingMatch(null, fileUri, null, true);
 
-    assertThat(logTester.logs(LoggerLevel.WARN)).containsOnly(String.format("Roslyn encoding was not detected for '%s', using default instead.", fileUri.toString()));
+    assertThat(logTester.logs(LoggerLevel.WARN)).containsOnly(String.format("Roslyn can not detect encoding for '%s', using default instead.", fileUri.toString()));
   }
 
   @Test

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/EncodingPerFileTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/EncodingPerFileTest.java
@@ -61,7 +61,7 @@ public class EncodingPerFileTest {
   public void should_treat_as_match_and_warn_when_roslyn_encoding_missing() throws IOException {
     assertEncodingMatch(null, fileUri, null, true);
 
-    assertThat(logTester.logs(LoggerLevel.WARN)).containsOnly(String.format("Roslyn encoding was not found for '%s', using default instead.", fileUri.toString()));
+    assertThat(logTester.logs(LoggerLevel.WARN)).containsOnly(String.format("Roslyn encoding was not detected for '%s', using default instead.", fileUri.toString()));
   }
 
   @Test

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/EncodingPerFileTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/EncodingPerFileTest.java
@@ -29,6 +29,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LoggerLevel;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -37,6 +39,8 @@ import static org.mockito.Mockito.when;
 public class EncodingPerFileTest {
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
+  @Rule
+  public LogTester logTester = new LogTester();
 
   private URI fileUri;
 
@@ -54,8 +58,10 @@ public class EncodingPerFileTest {
   }
 
   @Test
-  public void should_treat_as_mismatch_when_roslyn_encoding_missing() throws IOException {
-    assertEncodingMatch(null, fileUri, null, false);
+  public void should_treat_as_match_and_warn_when_roslyn_encoding_missing() throws IOException {
+    assertEncodingMatch(null, fileUri, null, true);
+
+    assertThat(logTester.logs(LoggerLevel.WARN)).containsOnly(String.format("Roslyn encoding was not found for '%s', using default instead.", fileUri.toString()));
   }
 
   @Test


### PR DESCRIPTION
Fixes #3316