### PR TITLE
Fix AssertIgnoreScope for .NET Core

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -66,8 +66,7 @@ namespace SonarAnalyzer.Helpers
             // This is the new way SonarLint will handle how and what to report...
             if (SonarAnalysisContext.ReportDiagnostic != null)
             {
-                Debug.Assert(SonarAnalysisContext.ShouldDiagnosticBeReported == null, "Not expecting SonarLint to set both the " +
-                    "old and the new delegates.");
+                Debug.Assert(SonarAnalysisContext.ShouldDiagnosticBeReported == null, "Not expecting SonarLint to set both the old and the new delegates.");
                 SonarAnalysisContext.ReportDiagnostic(reportingContext);
                 return;
             }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/AssertIgnoreScope.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Helpers/AssertIgnoreScope.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -29,26 +29,23 @@ namespace SonarAnalyzer.UnitTest.Helpers
     /// </summary>
     public sealed class AssertIgnoreScope : IDisposable
     {
+        private readonly DefaultTraceListener listener;
+
         public AssertIgnoreScope()
         {
-#if NETFRAMEWORK // .Net Framework specific API
-            var listener = Debug.Listeners.OfType<DefaultTraceListener>().FirstOrDefault();
+            listener = Trace.Listeners.OfType<DefaultTraceListener>().FirstOrDefault();
             if (listener != null)
             {
                 listener.AssertUiEnabled = false;
             }
-#endif
         }
 
         public void Dispose()
         {
-#if NETFRAMEWORK // .Net Framework specific API
-            var listener = Debug.Listeners.OfType<DefaultTraceListener>().FirstOrDefault();
             if (listener != null)
             {
                 listener.AssertUiEnabled = true;
             }
-#endif
         }
     }
 }


### PR DESCRIPTION
`DefaultTraceListener.AssertUiEnabled` was not set for .NET core. That was causing `SonarAnalysis_WhenReportDiagnosticActionNotNull_AllowToContolWhetherOrNotToReport` to silently fail with error message logged in Tests output:

```
The active test run was aborted. Reason: Test host process crashed : Process terminated. Assertion Failed
Not expecting SonarLint to set both the old and the new delegates.
   at SonarAnalyzer.Helpers.AnalysisContextExtensions.ReportDiagnostic(ReportingContext reportingContext) in C:\Projects\sonar-dotnet\sonaranalyzer-dotnet\src\SonarAnalyzer.Common\Helpers\AnalysisContextExtensions.cs:line 69
   at SonarAnalyzer.Helpers.AnalysisContextExtensions.ReportDiagnosticWhenActive(SyntaxTreeAnalysisContext context, Diagnostic diagnostic) in C:\Projects\sonar-dotnet\sonaranalyzer-dotnet\src\SonarAnalyzer.Common\Helpers\AnalysisContextExtensions.cs:line 56
   at SonarAnalyzer.Rules.CSharp.AsyncAwaitIdentifier.<>c.<Initialize>b__7_0(SyntaxTreeAnalysisContext c) in C:\Projects\sonar-dotnet\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\Rules\AsyncAwaitIdentifier.cs:line 55
   at SonarAnalyzer.Helpers.DiagnosticAnalyzerContextHelper.<>c__DisplayClass3_1.<RegisterSyntaxTreeActionInNonGenerated>b__1(SyntaxTreeAnalysisContext c) in C:\Projects\sonar-dotnet\sonaranalyzer-dotnet\src\SonarAnalyzer.Common\Helpers\DiagnosticAnalyzerContextHelper.cs:line 98
   at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.<>c.<ExecuteSyntaxTreeActionsCore>b__54_1(ValueTuple`2 data)
```