### PR TITLE
S1144, S4487: Read symbols only for known names

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
@@ -249,15 +249,13 @@ namespace SonarAnalyzer.Helpers
         private ImmutableArray<ISymbol> GetSymbols<TSyntaxNode>(TSyntaxNode node)
             where TSyntaxNode : SyntaxNode
         {
-            return GetCandidateSymbols(GetSemanticModel(node).GetSymbolInfo(node)).ToImmutableArray();
+            var symbolInfo = GetSemanticModel(node).GetSymbolInfo(node);
 
-            static IEnumerable<ISymbol> GetCandidateSymbols(SymbolInfo symbolInfo)
-            {
-                return new[] { symbolInfo.Symbol }
-                    .Concat(symbolInfo.CandidateSymbols)
-                    .Select(GetOriginalDefinition)
-                    .WhereNotNull();
-            }
+            return new[] { symbolInfo.Symbol }
+                .Concat(symbolInfo.CandidateSymbols)
+                .Select(GetOriginalDefinition)
+                .WhereNotNull()
+                .ToImmutableArray();
 
             static ISymbol GetOriginalDefinition(ISymbol candidateSymbol)
             {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
@@ -150,8 +150,7 @@ namespace SonarAnalyzer.Helpers
             // We are visiting a ctor with no initializer and the compiler will automatically
             // call the default constructor of the type if declared, or the base type if the
             // current type does not declare a default constructor.
-            if (node.Initializer == null &&
-                IsKnownIdentifier(node.Identifier))
+            if (node.Initializer == null && IsKnownIdentifier(node.Identifier))
             {
                 var constructor = (IMethodSymbol)GetDeclaredSymbol(node);
                 var implicitlyCalledConstructor = GetImplicitlyCalledConstructor(constructor);

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
@@ -94,7 +94,7 @@ namespace SonarAnalyzer.Helpers
 
         public override void VisitIdentifierName(IdentifierNameSyntax node)
         {
-            if (HasKnownIdentifier(node))
+            if (IsKnownIdentifier(node.Identifier))
             {
                 var symbols = GetSymbols(node);
                 TryStoreFieldAccess(node, symbols);
@@ -117,7 +117,7 @@ namespace SonarAnalyzer.Helpers
 
         public override void VisitGenericName(GenericNameSyntax node)
         {
-            if (HasKnownIdentifier(node))
+            if (IsKnownIdentifier(node.Identifier))
             {
                 UsedSymbols.UnionWith(GetSymbols(node));
             }
@@ -325,9 +325,6 @@ namespace SonarAnalyzer.Helpers
                 ? AccessorAccess.Both
                 : AccessorAccess.Get;
         }
-
-        private bool HasKnownIdentifier(SimpleNameSyntax nameSyntax) =>
-            IsKnownIdentifier(nameSyntax.Identifier);
 
         private bool IsKnownIdentifier(SyntaxToken identifier) =>
             knownSymbolNames.Contains(identifier.ValueText);

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
@@ -128,11 +128,8 @@ namespace SonarAnalyzer.Helpers
         public override void VisitElementAccessExpression(ElementAccessExpressionSyntax node)
         {
             var symbols = GetSymbols(node);
-
             UsedSymbols.UnionWith(symbols);
-
             TryStorePropertyAccess(node, symbols);
-
             base.VisitElementAccessExpression(node);
         }
 

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
@@ -339,6 +339,7 @@ namespace SonarAnalyzer.Helpers
             {
                 MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
                 IdentifierNameSyntax identifierName => identifierName.Identifier.ValueText,
+                GenericNameSyntax genericNameSyntax => genericNameSyntax.Identifier.ValueText,
                 _ => string.Empty
             };
 

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -105,9 +105,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                 removableInternalTypes.Add(internalSymbol);
                             }
 
-                            var usageCollector = new CSharpSymbolUsageCollector(
-                                c.Compilation.GetSemanticModel,
-                                removableSymbolsCollector.PrivateSymbols.Select(s => s.Name).ToHashSet());
+                            var usageCollector = new CSharpSymbolUsageCollector(c.Compilation.GetSemanticModel, removableSymbolsCollector.PrivateSymbols);
 
                             if (!VisitDeclaringReferences(namedType, usageCollector, c.Compilation, includeGeneratedFile: true))
                             {
@@ -133,9 +131,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                 return;
                             }
 
-                            var usageCollector = new CSharpSymbolUsageCollector(
-                                c.Compilation.GetSemanticModel,
-                                removableInternalTypes.Select(s => s.Name).ToHashSet());
+                            var usageCollector = new CSharpSymbolUsageCollector(c.Compilation.GetSemanticModel, removableInternalTypes.ToHashSet());
 
                             foreach (var syntaxTree in c.Compilation.SyntaxTrees
                                                         .Where(tree => !tree.IsGenerated(CSharpGeneratedCodeRecognizer.Instance, c.Compilation)))
@@ -154,7 +150,7 @@ namespace SonarAnalyzer.Rules.CSharp
         }
 
         private static IEnumerable<Diagnostic> GetDiagnosticsForUnusedPrivateMembers(CSharpSymbolUsageCollector usageCollector, ISet<ISymbol> removableSymbols,
-            string accessibility, BidirectionalDictionary<ISymbol, SyntaxNode> fieldLikeSymbols)
+                                                                                     string accessibility, BidirectionalDictionary<ISymbol, SyntaxNode> fieldLikeSymbols)
         {
             var unusedSymbols = GetUnusedSymbols(usageCollector, removableSymbols);
 
@@ -369,6 +365,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     ConditionalStore((IMethodSymbol)GetDeclaredSymbol(node), IsRemovableMethod);
                 }
+
                 base.VisitConstructorDeclaration(node);
             }
 

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -105,7 +105,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                 removableInternalTypes.Add(internalSymbol);
                             }
 
-                            var usageCollector = new CSharpSymbolUsageCollector(c.Compilation.GetSemanticModel, removableSymbolsCollector.PrivateSymbols);
+                            var usageCollector = new CSharpSymbolUsageCollector(c.Compilation, removableSymbolsCollector.PrivateSymbols);
 
                             if (!VisitDeclaringReferences(namedType, usageCollector, c.Compilation, includeGeneratedFile: true))
                             {
@@ -131,7 +131,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                 return;
                             }
 
-                            var usageCollector = new CSharpSymbolUsageCollector(c.Compilation.GetSemanticModel, removableInternalTypes.ToHashSet());
+                            var usageCollector = new CSharpSymbolUsageCollector(c.Compilation, removableInternalTypes.ToHashSet());
 
                             foreach (var syntaxTree in c.Compilation.SyntaxTrees
                                                         .Where(tree => !tree.IsGenerated(CSharpGeneratedCodeRecognizer.Instance, c.Compilation)))

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.Constructors.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.Constructors.cs
@@ -82,7 +82,7 @@ public abstract class PrivateConstructors
     public class Constructor2
     {
         public Constructor2(int a) { }
-        private Constructor2() { var x = 5; }
+        private Constructor2() { var x = 5; } // Compliant - FN
     }
 
     public class Constructor3

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.Types.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.Types.cs
@@ -157,27 +157,5 @@ public class PrivateTypes
     public static int PerformCalculation(int x, int y) => x + y;
 }
 ", new CS.UnusedPrivateMember());
-
-        [TestMethod]
-        public void UnusedPrivateMember_GuidFP() =>
-            Verifier.VerifyCSharpAnalyzer(@"
-public class Consumer
-{
-    public void Method()
-    {
-        var a = new Guid(1);
-    }
-
-    private class Guid
-    {
-        public Guid(int x) // Noncompliant - FP
-        {
-            X = x;
-        }
-
-        private int X { get; set; }
-    }
-}
-", new CS.UnusedPrivateMember());
     }
 }


### PR DESCRIPTION
By retrieving symbols only for known names, when analyzing efcore, we reduce the analysis time from ~854678ms to 
~210854ms

Partial fix for #2474 
