### PR TITLE
Revert "Use the latest version of .Net 5 (#3564)"

### DIFF
--- a/azure-pipelines-external.yml
+++ b/azure-pipelines-external.yml
@@ -19,7 +19,7 @@ stages:
       - task: UseDotNet@2
         inputs:
           packageType: sdk
-          version: 5.0.100-preview.8.20417.9
+          version: 5.0.100-preview.7.20366.6
           installationPath: $(Agent.ToolsDirectory)/dotnet
         displayName: "Install NET 5 SDK preview"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,7 +150,7 @@ stages:
       - task: UseDotNet@2
         inputs:
           packageType: sdk
-          version: 5.0.100-preview.8.20417.9
+          version: 5.0.100-preview.7.20366.6
           installationPath: $(Agent.ToolsDirectory)/dotnet
         displayName: "Install NET 5 SDK preview"
 
@@ -274,7 +274,7 @@ stages:
       - task: UseDotNet@2
         inputs:
           packageType: sdk
-          version: 5.0.100-preview.8.20417.9
+          version: 5.0.100-preview.7.20366.6
           installationPath: $(Agent.ToolsDirectory)/dotnet
         displayName: "Install NET 5 SDK preview"
 

--- a/sonaranalyzer-dotnet/its/sources/Net5/global.json
+++ b/sonaranalyzer-dotnet/its/sources/Net5/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "5.0.100-preview.8.20417.9"
+    "version": "5.0.100-preview.7.20366.6"
   }
 }


### PR DESCRIPTION
This reverts commit 45b65f5035b5cc4f7c452a1a7f5579d829692f6b.

On the new version the build becomes unstable due to:
```
C:\hostedtoolcache\windows\dotnet\sdk\5.0.100-preview.8.20417.9\Roslyn\Microsoft.CSharp.Core.targets(70,5): error : Fatal error. System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt. [D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.csproj]
C:\hostedtoolcache\windows\dotnet\sdk\5.0.100-preview.8.20417.9\Roslyn\Microsoft.CSharp.Core.targets(70,5): error :    at Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEMethodSymbol.get_ExplicitInterfaceImplementations() [D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.csproj]
C:\hostedtoolcache\windows\dotnet\sdk\5.0.100-preview.8.20417.9\Roslyn\Microsoft.CSharp.Core.targets(70,5): error :    at Microsoft.CodeAnalysis.CSharp.Symbols.SymbolExtensions.GetExplicitInterfaceImplementations(Microsoft.CodeAnalysis.CSharp.Symbol) [D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.csproj]
C:\hostedtoolcache\windows\dotnet\sdk\5.0.100-preview.8.20417.9\Roslyn\Microsoft.CSharp.Core.targets(70,5): error :    at Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol.MakeExplicitInterfaceImplementationMap() [D:\a\1\s\sonaranalyzer-dotnet\src\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.csproj]
...
```
Source: https://sonarsource.visualstudio.com/DotNetTeam%20Project/_build/results?buildId=21206&view=logs&j=23c99647-d7e1-5b83-b5fb-f7e97f8a9ce7&s=43f5a5d8-8b7c-5b93-7098-b5f8fdd5b816&t=0075a4ce-4d44-5a4c-36ef-97ab11b0917b&l=5281