### PR TITLE
Improve SymbolicValue error message and seal DisposableConstraint

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/Constraints/DisposableConstraint.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/Constraints/DisposableConstraint.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.SymbolicExecution.Constraints
 {
-    public class DisposableConstraint : SymbolicValueConstraint
+    public sealed class DisposableConstraint : SymbolicValueConstraint
     {
         public static readonly DisposableConstraint Disposed = new DisposableConstraint();
         public static readonly DisposableConstraint NotDisposed = new DisposableConstraint();

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/Constraints/SymbolicValueConstraints.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/Constraints/SymbolicValueConstraints.cs
@@ -129,7 +129,7 @@ namespace SonarAnalyzer.SymbolicExecution.Constraints
         public override bool Equals(object obj) => obj is SymbolicValueConstraints other &&
                 this.constraints.DictionaryEquals(other.constraints);
 
-        // for debugging
+        // for debugging and error logging
         public override string ToString()
         {
             return string.Join(", ", this.constraints.Values);

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/SymbolicValue.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/SymbolicValue.cs
@@ -168,7 +168,7 @@ namespace SonarAnalyzer.SymbolicExecution
             }
             else
             {
-                throw UnexpectedConstraintException(constraint);
+                throw UnexpectedConstraintException(constraint, oldConstraints);
             }
         }
 
@@ -190,7 +190,7 @@ namespace SonarAnalyzer.SymbolicExecution
             }
             else
             {
-                throw UnexpectedConstraintException(constraint);
+                throw UnexpectedConstraintException(constraint, oldConstraints);
             }
         }
 
@@ -260,8 +260,8 @@ namespace SonarAnalyzer.SymbolicExecution
             return new[] { programState };
         }
 
-        private static Exception UnexpectedConstraintException(SymbolicValueConstraint constraint) =>
-            new NotSupportedException($"Unexpected constraint type: {constraint.GetType().Name}.");
+        private static Exception UnexpectedConstraintException(SymbolicValueConstraint constraint, SymbolicValueConstraints oldConstraints = null) =>
+            new NotSupportedException($"Unexpected constraint type: {constraint.GetType().Name}." + (oldConstraints == null ? null : "Old constraints: " + oldConstraints));
 
         private class BoolLiteralSymbolicValue : SymbolicValue
         {


### PR DESCRIPTION
This should help with future diagnostics of #3403 

All SE constraints except DisposableConstraint were sealed. 