### PR TITLE
Rename Java parent project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,9 @@
   <version>8.14-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>SonarC# parent</name>
-  <description>Code Analyzer for C#</description>
-  <url>http://redirect.sonarsource.com/plugins/csharp.html</url>
+  <name>.NET Analyzers parent</name>
+  <description>Code Analyzers for .NET</description>
+  <url>https://github.com/SonarSource/sonar-dotnet</url>
   <inceptionYear>2014</inceptionYear>
   <organization>
     <name>SonarSource</name>
@@ -28,34 +28,6 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-
-  <developers>
-    <developer>
-      <id>aleve</id>
-      <name>Amaury Levé</name>
-      <organization>SonarSource</organization>
-    </developer>
-	<developer>
-      <id>vhristov</id>
-      <name>Valeri Hristov</name>
-      <organization>SonarSource</organization>
-    </developer>
-	<developer>
-      <id>jgyerik</id>
-      <name>Janos Gyerik</name>
-      <organization>SonarSource</organization>
-    </developer>
-	<developer>
-      <id>dmeneses</id>
-      <name>Duarte Meneses</name>
-      <organization>SonarSource</organization>
-    </developer>
-	<developer>
-      <id>jhenry</id>
-      <name>Julien Henry</name>
-      <organization>SonarSource</organization>
-    </developer>
-  </developers>
 
   <modules>
     <module>sonar-dotnet-shared-library</module>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <groupId>org.sonarsource.dotnet</groupId>
-  <artifactId>sonar-csharp</artifactId>
+  <artifactId>sonar-dotnet</artifactId>
   <version>8.14-SNAPSHOT</version>
   <packaging>pom</packaging>
 

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -27,34 +27,6 @@
     </license>
   </licenses>
 
-  <developers>
-    <developer>
-      <id>aleve</id>
-      <name>Amaury Levé</name>
-      <organization>SonarSource</organization>
-    </developer>
-    <developer>
-      <id>vhristov</id>
-      <name>Valeri Hristov</name>
-      <organization>SonarSource</organization>
-    </developer>
-    <developer>
-      <id>jgyerik</id>
-      <name>Janos Gyerik</name>
-      <organization>SonarSource</organization>
-    </developer>
-    <developer>
-      <id>dmeneses</id>
-      <name>Duarte Meneses</name>
-      <organization>SonarSource</organization>
-    </developer>
-    <developer>
-      <id>jhenry</id>
-      <name>Julien Henry</name>
-      <organization>SonarSource</organization>
-    </developer>
-  </developers>
-
   <scm>
     <connection>scm:git:git@github.com:SonarSource/sonar-dotnet.git</connection>
     <developerConnection>scm:git:git@github.com:SonarSource/sonar-dotnet.git</developerConnection>

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>org.sonarsource.dotnet</groupId>
-    <artifactId>sonar-csharp</artifactId>
+    <artifactId>sonar-dotnet</artifactId>
     <version>8.14-SNAPSHOT</version>
   </parent>
 

--- a/sonar-dotnet-shared-library/pom.xml
+++ b/sonar-dotnet-shared-library/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>org.sonarsource.dotnet</groupId>
-    <artifactId>sonar-csharp</artifactId>
+    <artifactId>sonar-dotnet</artifactId>
     <version>8.14-SNAPSHOT</version>
   </parent>
 

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -28,34 +28,6 @@
     </license>
   </licenses>
 
-  <developers>
-    <developer>
-      <id>aleve</id>
-      <name>Amaury Levé</name>
-      <organization>SonarSource</organization>
-    </developer>
-    <developer>
-      <id>vhristov</id>
-      <name>Valeri Hristov</name>
-      <organization>SonarSource</organization>
-    </developer>
-    <developer>
-      <id>jgyerik</id>
-      <name>Janos Gyerik</name>
-      <organization>SonarSource</organization>
-    </developer>
-    <developer>
-      <id>dmeneses</id>
-      <name>Duarte Meneses</name>
-      <organization>SonarSource</organization>
-    </developer>
-    <developer>
-      <id>jhenry</id>
-      <name>Julien Henry</name>
-      <organization>SonarSource</organization>
-    </developer>
-  </developers>
-
   <scm>
     <connection>scm:git:git@github.com:SonarSource/sonar-dotnet.git</connection>
     <developerConnection>scm:git:git@github.com:SonarSource/sonar-dotnet.git</developerConnection>

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>org.sonarsource.dotnet</groupId>
-    <artifactId>sonar-csharp</artifactId>
+    <artifactId>sonar-dotnet</artifactId>
     <version>8.14-SNAPSHOT</version>
   </parent>
 

--- a/sonaranalyzer-dotnet/pom.xml
+++ b/sonaranalyzer-dotnet/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.sonarsource.dotnet</groupId>
-    <artifactId>sonar-csharp</artifactId>
+    <artifactId>sonar-dotnet</artifactId>
     <version>8.14-SNAPSHOT</version>
   </parent>
 
@@ -38,7 +38,7 @@
 
   <issueManagement>
     <system>GitHub Issues</system>
-    <url>https://github.com/SonarSource/sonar-csharp/issues</url>
+    <url>https://github.com/SonarSource/sonar-dotnet/issues</url>
   </issueManagement>
 
   <properties>


### PR DESCRIPTION
For historical reasons, the parent project for both .NET analyzers was still called `sonar-csharp`. With some leftovers on other places. Same confusion is in SonarCloud and [SonarC# parent
](https://sonarcloud.io/dashboard?id=org.sonarsource.dotnet%3Asonar-csharp) project name and project key.
This PR should fix that.

I've stopped CI to prevent creating new duplicate project on SC. My plan is:
* [x] Review this PR
* [x] Freeze commits
* [ ] Wait for last CI to finish in the repo
* [ ] Manually rename SC project and change project key (.NET Champion needed)
* [ ] Run CI against new SC setup
* [ ] Merge
* [ ] Rebase all branches
* [ ] Unfreeze commits