### PR TITLE
Update reproducer links to sonar-dotnet projects

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
@@ -199,7 +199,7 @@ namespace SonarAnalyzer.Helpers
                 ?? methodDeclarationBase?.ExpressionBody()?.DescendantNodes()
                 ?? Enumerable.Empty<SyntaxNode>();
 
-            // See issue: https://github.com/SonarSource/sonar-csharp/issues/416
+            // See issue: https://github.com/SonarSource/sonar-dotnet/issues/416
             // Where clause excludes nodes that are not defined on the same SyntaxTree as the SemanticModel
             // (because of partial definition).
             // More details: https://github.com/dotnet/roslyn/issues/18730

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/ImplementIDisposableCorrectly.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/ImplementIDisposableCorrectly.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -210,7 +210,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
 
                 // Because of partial classes we cannot always rely on the current semantic model.
-                // See issue: https://github.com/SonarSource/sonar-csharp/issues/690
+                // See issue: https://github.com/SonarSource/sonar-dotnet/issues/690
                 var disposeMethodSymbol = disposeMethod.SyntaxTree.GetSemanticModelOrDefault(this.semanticModel)
                     ?.GetDeclaredSymbol(disposeMethod);
                 if (disposeMethodSymbol == null)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MemberShouldBeStaticTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/MemberShouldBeStaticTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2020 SonarSource SA
  * mailto: contact AT sonarsource DOT com
@@ -72,7 +72,7 @@ public class HttpApplication1 : System.Web.HttpApplication
         [TestMethod]
         [TestCategory("Rule")]
         public void MemberShouldBeStatic_InvalidCode() =>
-            // Handle invalid code causing NullReferenceException: https://github.com/SonarSource/sonar-csharp/issues/819
+            // Handle invalid code causing NullReferenceException: https://github.com/SonarSource/sonar-dotnet/issues/819
             Verifier.VerifyCSharpAnalyzer(@"
 public class Class7
 {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.Constructors.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.Constructors.cs
@@ -114,7 +114,7 @@ public class Inheritance
         public DerivedClass1() : base() { }
     }
 
-    // https://github.com/SonarSource/sonar-csharp/issues/1398
+    // https://github.com/SonarSource/sonar-dotnet/issues/1398
     private abstract class BaseClass2
     {
         protected BaseClass2() { var x = 5; }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.Methods.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.Methods.cs
@@ -142,7 +142,7 @@ public class MethodUsages
 using System.Threading.Tasks;
 public class NewClass1
 {
-    // See https://github.com/SonarSource/sonar-csharp/issues/888
+    // See https://github.com/SonarSource/sonar-dotnet/issues/888
     static async Task Main() { } // Compliant - valid main method since C# 7.1
 }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.Types.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.Types.cs
@@ -75,8 +75,8 @@ public class PrivateTypes
         [TestCategory("Rule")]
         public void UnusedPrivateMember_Types_Internals() =>
             Verifier.VerifyCSharpAnalyzer(@"
-// https://github.com/SonarSource/sonar-csharp/issues/1225
-// https://github.com/SonarSource/sonar-csharp/issues/904
+// https://github.com/SonarSource/sonar-dotnet/issues/1225
+// https://github.com/SonarSource/sonar-dotnet/issues/904
 using System;
 public class Class1
 {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void UnusedPrivateMember_DebuggerDisplay_Attribute() =>
             Verifier.VerifyCSharpAnalyzer(@"
-// https://github.com/SonarSource/sonar-csharp/issues/1195
+// https://github.com/SonarSource/sonar-dotnet/issues/1195
 [System.Diagnostics.DebuggerDisplay(""{field1}"", Name = ""{Property1} {Property3}"", Type = ""{Method1()}"")]
 public class MethodUsages
 {
@@ -125,7 +125,7 @@ public partial class PartialClass
         [TestCategory("Rule")]
         public void UnusedPrivateMember_Unity3D_Ignored() =>
             Verifier.VerifyCSharpAnalyzer(@"
-// https://github.com/SonarSource/sonar-csharp/issues/159
+// https://github.com/SonarSource/sonar-dotnet/issues/159
 public class UnityMessages1 : UnityEngine.MonoBehaviour
 {
     private void SomeMethod(bool hasFocus) { } // Compliant

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AsyncVoidMethod.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/AsyncVoidMethod.cs
@@ -29,7 +29,7 @@ namespace Tests.Diagnostics
     public class UwpCases
     {
         // A lot of classes/interfaces in UWP do not inherit from EventArgs so we had to change the detection mechanism
-        // See issue https://github.com/SonarSource/sonar-csharp/issues/704
+        // See issue https://github.com/SonarSource/sonar-dotnet/issues/704
         private interface ISuspendingEventArgs { }
 
         async void MyOtherMethod1(object o, ISuspendingEventArgs args) { }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CheckArgumentException.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CheckArgumentException.cs
@@ -163,7 +163,7 @@ namespace Tests.Diagnostics
 
         void Bar2(int a)
         {
-            // See https://github.com/SonarSource/sonar-csharp/issues/1867
+            // See https://github.com/SonarSource/sonar-dotnet/issues/1867
             throw new ArgumentNullException(null, string.Empty); // Noncompliant
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CollectionPropertiesShouldBeReadOnly.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CollectionPropertiesShouldBeReadOnly.cs
@@ -53,7 +53,7 @@ namespace Tests.Diagnostics
         List<string> GenericList { get; set; } // Noncompliant
     }
 
-    // Ignore collections marked with DataMember attribute: https://github.com/SonarSource/sonar-csharp/issues/795
+    // Ignore collections marked with DataMember attribute: https://github.com/SonarSource/sonar-dotnet/issues/795
     [DataContract]
     public class Message
     {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionEvaluatesToConstant.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ConditionEvaluatesToConstant.cs
@@ -1569,7 +1569,7 @@ namespace Tests.Diagnostics
     public class StaticMethods
     {
         object _foo1;
-        // https://github.com/SonarSource/sonar-csharp/issues/947
+        // https://github.com/SonarSource/sonar-dotnet/issues/947
         void CallToMonitorWaitShouldResetFieldConstraints()
         {
             object o = null;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/DoNotOverwriteCollectionElements.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/DoNotOverwriteCollectionElements.cs
@@ -156,7 +156,7 @@ namespace Tests.Diagnostics
         void InitTowns(IDictionary<string, string> towns, string y)
         {
             towns.Add(y, "Boston"); // Secondary
-            towns[y] = "Paris"; // Noncompliant, https://github.com/SonarSource/sonar-csharp/issues/1908
+            towns[y] = "Paris"; // Noncompliant, https://github.com/SonarSource/sonar-dotnet/issues/1908
         }
 
         void MemberBinding(IDictionary<string, string> dictionary)
@@ -205,7 +205,7 @@ namespace Tests.Diagnostics
 
         public Dictionary<string, string> Map { get; }
 
-        // See https://github.com/SonarSource/sonar-csharp/issues/1967
+        // See https://github.com/SonarSource/sonar-dotnet/issues/1967
         public void NullReference()
         {
             var act = new Action<int, int>((x, y) => x++);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -723,7 +723,7 @@ namespace Tests.Diagnostics
         }
     }
 
-    // See https://github.com/SonarSource/sonar-csharp/issues/1002
+    // See https://github.com/SonarSource/sonar-dotnet/issues/1002
     class Program
     {
         public Program(string id)
@@ -735,7 +735,7 @@ namespace Tests.Diagnostics
     class LargeCfg
     {
         // Large CFG that causes the exploded graph to hit the exploration limit
-        // See https://github.com/SonarSource/sonar-csharp/issues/767 (comments!)
+        // See https://github.com/SonarSource/sonar-dotnet/issues/767 (comments!)
         private static void MethodName(object[] table, object[][] aoTable2, ref Dictionary<double, string> dictPorts)
         {
             try

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/FieldShouldBeReadonly.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/FieldShouldBeReadonly.Fixed.cs
@@ -159,7 +159,7 @@ namespace Tests.Diagnostics
 
     public class MyAttribute : Attribute { }
 
-    // See https://github.com/SonarSource/sonar-csharp/issues/1009
+    // See https://github.com/SonarSource/sonar-dotnet/issues/1009
     // Issue with leading trivia not moved to the readonly modifier
     public class MyClassWithField
     {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/FieldShouldBeReadonly.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/FieldShouldBeReadonly.cs
@@ -160,7 +160,7 @@ namespace Tests.Diagnostics
 
     public class MyAttribute : Attribute { }
 
-    // See https://github.com/SonarSource/sonar-csharp/issues/1009
+    // See https://github.com/SonarSource/sonar-dotnet/issues/1009
     // Issue with leading trivia not moved to the readonly modifier
     public class MyClassWithField
     {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/GenericTypeParameterInOut.CSharp7.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/GenericTypeParameterInOut.CSharp7.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Tests.Diagnostics
 {
-    // https://github.com/SonarSource/sonar-csharp/issues/1513
+    // https://github.com/SonarSource/sonar-dotnet/issues/1513
     public interface IFoo1<T> // Compliant, T cannot be in or out when used in a tuple
     {
         (T, object) Process(T item);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/HardcodedIpAddress.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/HardcodedIpAddress.cs
@@ -31,7 +31,7 @@ namespace Tests.Diagnostics
 //                      ^^^^^^^^^^^^^
 
             ip = "300.0.0.0"; // Compliant, not a valid IP
-            ip = "127.0.0.1"; // Compliant, this is an exception in the rule (see: https://github.com/SonarSource/sonar-csharp/issues/1540)
+            ip = "127.0.0.1"; // Compliant, this is an exception in the rule (see: https://github.com/SonarSource/sonar-dotnet/issues/1540)
             ip = "    127.0.0.0    "; // Compliant
             ip = @"    ""127.0.0.0""    "; // Compliant
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/LiteralsShouldNotBePassedAsLocalizedParameters.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/LiteralsShouldNotBePassedAsLocalizedParameters.cs
@@ -82,7 +82,7 @@ namespace Tests.Diagnostics
 
         public void LogStuff()
         {
-            // Regression tests for https://github.com/SonarSource/sonar-csharp/issues/1464
+            // Regression tests for https://github.com/SonarSource/sonar-dotnet/issues/1464
             // S4055 should not raise issues for string literal used in the 'message' of Debug.XXX
             Debug.Assert(true, "Assertion message");                    // compliant - method on Debug
             Debug.WriteLine("Stuff happened");                          // compliant - method on Debug

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MemberShouldBeStatic.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MemberShouldBeStatic.cs
@@ -129,7 +129,7 @@ namespace Tests.Diagnostics
         public int InterfaceMethod1() => 0;
     }
 
-    // Adding exception for SuppressMessage https://github.com/SonarSource/sonar-csharp/issues/631
+    // Adding exception for SuppressMessage https://github.com/SonarSource/sonar-dotnet/issues/631
     public class Class5
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Foo", "Bar", Justification = "baz")]
@@ -157,7 +157,7 @@ namespace Tests.Diagnostics
     }
 
     // The following test cases are linked to FP when using ASP controllers.
-    // See https://github.com/SonarSource/sonar-csharp/issues/733
+    // See https://github.com/SonarSource/sonar-dotnet/issues/733
     public class WebClass1 : System.Web.Mvc.Controller
     {
         public int Foo() => 0;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MultilineBlocksWithoutBrace.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MultilineBlocksWithoutBrace.cs
@@ -166,7 +166,7 @@ Tests(); // Noncompliant
         {
             try {
               if (a)
-                Console.WriteLine(); // This statement is aligned with the '{' of the try on purpose to fix https://github.com/SonarSource/sonar-csharp/issues/264
+                Console.WriteLine(); // This statement is aligned with the '{' of the try on purpose to fix https://github.com/SonarSource/sonar-dotnet/issues/264
             } finally { }
         }
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MutableFieldsShouldNotBePublicReadonly.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/MutableFieldsShouldNotBePublicReadonly.cs
@@ -124,7 +124,7 @@ namespace Tests.Diagnostics
         public readonly ISet<string> set1, set2;
     }
 
-    // Issue #1491: https://github.com/SonarSource/sonar-csharp/issues/1491
+    // Issue #1491: https://github.com/SonarSource/sonar-dotnet/issues/1491
     public class MutableInitializedWithImmutableInConstructor
     {
         public readonly string[] foo; // Compliant - set to null in ctor

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NonAsyncTaskShouldNotReturnNull.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NonAsyncTaskShouldNotReturnNull.cs
@@ -116,7 +116,7 @@ namespace Tests.Diagnostics
             get => null; // Noncompliant
         }
 
-        // See https://github.com/SonarSource/sonar-csharp/issues/1845
+        // See https://github.com/SonarSource/sonar-dotnet/issues/1845
         public Task<object> GetObjectTask()
         {
             object GetObject()

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NotAssignedPrivateMember.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NotAssignedPrivateMember.cs
@@ -82,7 +82,7 @@ namespace Tests.Diagnostics
         public void M(ref int f) { }
     }
 
-    // https://github.com/SonarSource/sonar-csharp/issues/242
+    // https://github.com/SonarSource/sonar-dotnet/issues/242
     public class MyClass2
     {
         [StructLayout(LayoutKind.Sequential)]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
@@ -582,7 +582,7 @@ namespace Tests.Diagnostics
             o.ToString(); // Noncompliant, local variable constraints are not cleared
         }
 
-        // https://github.com/SonarSource/sonar-csharp/issues/947
+        // https://github.com/SonarSource/sonar-dotnet/issues/947
         void CallToMonitorWaitShouldResetFieldConstraints()
         {
             object o = null;
@@ -662,7 +662,7 @@ namespace Tests.Diagnostics
         public static void MyExtension(this object o) { }
     }
 
-    class Foo // https://github.com/SonarSource/sonar-csharp/issues/538
+    class Foo // https://github.com/SonarSource/sonar-dotnet/issues/538
     {
         private string bar;
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereferenceCSharp6.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereferenceCSharp6.cs
@@ -30,7 +30,7 @@ namespace Tests.Diagnostics
             return o.ToString(); // If e.Message is null, the exception won't be caught and this is not reachable
         }
 
-        // https://github.com/SonarSource/sonar-csharp/issues/1324
+        // https://github.com/SonarSource/sonar-dotnet/issues/1324
         public void FlasePositive(object o)
         {
             try

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ObjectsShouldNotBeDisposedMoreThanOnce.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ObjectsShouldNotBeDisposedMoreThanOnce.cs
@@ -120,14 +120,14 @@ namespace Tests.Diagnostics
 
         public void Close_ParametersOfDifferenceTypes(IInterface1 interface1, IDisposable interface2)
         {
-            // Regression test for https://github.com/SonarSource/sonar-csharp/issues/1038
+            // Regression test for https://github.com/SonarSource/sonar-dotnet/issues/1038
             interface1.Dispose(); // ok, only called once on each parameter
             interface2.Dispose();
         }
 
         public void Close_ParametersOfSameTypes(IInterface1 instance1, IInterface1 instance2)
         {
-            // Regression test for https://github.com/SonarSource/sonar-csharp/issues/1038
+            // Regression test for https://github.com/SonarSource/sonar-dotnet/issues/1038
             instance1.Dispose();
             instance2.Dispose();
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ParameterValidationInAsyncShouldBeWrapped.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ParameterValidationInAsyncShouldBeWrapped.cs
@@ -102,7 +102,7 @@ namespace Tests.Diagnostics
             return func();
         }
 
-        // See https://github.com/SonarSource/sonar-csharp/issues/1819
+        // See https://github.com/SonarSource/sonar-dotnet/issues/1819
         public async Task DoSomethingAsync(string value)
         {
             await Task.Delay(0);

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/PropertiesShouldBePreferred.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/PropertiesShouldBePreferred.cs
@@ -62,7 +62,7 @@ namespace MyLibrary
 
     public interface IFoo
     {
-        // See https://github.com/SonarSource/sonar-csharp/issues/1593
+        // See https://github.com/SonarSource/sonar-dotnet/issues/1593
         // and https://msdn.microsoft.com/en-us/magazine/mt797654.aspx
         IMyEnumerator GetEnumerator();
     }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.ArraySize.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.ArraySize.Fixed.cs
@@ -33,7 +33,7 @@ namespace Tests.Diagnostics
             var xxx = new int[,] { { 1, 1, 1 }, { 2, 2, 2 }, { 3, 3, 3 } };
             var yyy = new int[,] { { 1, 1, 1 }, { 2, 2, 2 }, { 3, 3, 3 } };
 
-            // see https://github.com/SonarSource/sonar-csharp/issues/1840
+            // see https://github.com/SonarSource/sonar-dotnet/issues/1840
             var multiDimIntArray = new int[][] // Compliant - type specifier is mandatory here
             {
                 new int[] { 1 } // Fixed

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.ArrayType.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.ArrayType.Fixed.cs
@@ -35,7 +35,7 @@ namespace Tests.Diagnostics
                 , 3// Fixed
                 ] { { 1, 1, 1 }, { 2, 2, 2 }, { 3, 3, 3 } };
 
-            // see https://github.com/SonarSource/sonar-csharp/issues/1840
+            // see https://github.com/SonarSource/sonar-dotnet/issues/1840
             var multiDimIntArray = new int[][] // Compliant - type specifier is mandatory here
             { new[] { 1 } // Fixed
             };

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.DelegateParameterList.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.DelegateParameterList.Fixed.cs
@@ -35,7 +35,7 @@ namespace Tests.Diagnostics
                 , 3// Fixed
                 ] { { 1, 1, 1 }, { 2, 2, 2 }, { 3, 3, 3 } };
 
-            // see https://github.com/SonarSource/sonar-csharp/issues/1840
+            // see https://github.com/SonarSource/sonar-dotnet/issues/1840
             var multiDimIntArray = new int[][] // Compliant - type specifier is mandatory here
             {
                 new int[] { 1 } // Fixed

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.ExplicitDelegate.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.ExplicitDelegate.Fixed.cs
@@ -34,7 +34,7 @@ namespace Tests.Diagnostics
                 , 3// Fixed
                 ] { { 1, 1, 1 }, { 2, 2, 2 }, { 3, 3, 3 } };
 
-            // see https://github.com/SonarSource/sonar-csharp/issues/1840
+            // see https://github.com/SonarSource/sonar-dotnet/issues/1840
             var multiDimIntArray = new int[][] // Compliant - type specifier is mandatory here
             {
                 new int[] { 1 } // Fixed

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.ExplicitNullable.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.ExplicitNullable.Fixed.cs
@@ -35,7 +35,7 @@ namespace Tests.Diagnostics
                 , 3// Fixed
                 ] { { 1, 1, 1 }, { 2, 2, 2 }, { 3, 3, 3 } };
 
-            // see https://github.com/SonarSource/sonar-csharp/issues/1840
+            // see https://github.com/SonarSource/sonar-dotnet/issues/1840
             var multiDimIntArray = new int[][] // Compliant - type specifier is mandatory here
             {
                 new int[] { 1 } // Fixed

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.LambdaParameterType.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.LambdaParameterType.Fixed.cs
@@ -35,7 +35,7 @@ namespace Tests.Diagnostics
                 , 3// Fixed
                 ] { { 1, 1, 1 }, { 2, 2, 2 }, { 3, 3, 3 } };
 
-            // see https://github.com/SonarSource/sonar-csharp/issues/1840
+            // see https://github.com/SonarSource/sonar-dotnet/issues/1840
             var multiDimIntArray = new int[][] // Compliant - type specifier is mandatory here
             {
                 new int[] { 1 } // Fixed

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.ObjectInitializer.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.ObjectInitializer.Fixed.cs
@@ -35,7 +35,7 @@ namespace Tests.Diagnostics
                 , 3// Fixed
                 ] { { 1, 1, 1 }, { 2, 2, 2 }, { 3, 3, 3 } };
 
-            // see https://github.com/SonarSource/sonar-csharp/issues/1840
+            // see https://github.com/SonarSource/sonar-dotnet/issues/1840
             var multiDimIntArray = new int[][] // Compliant - type specifier is mandatory here
             {
                 new int[] { 1 } // Fixed

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantDeclaration.cs
@@ -41,7 +41,7 @@ namespace Tests.Diagnostics
                 , 3// Noncompliant
                 ] { { 1, 1, 1 }, { 2, 2, 2 }, { 3, 3, 3 } };
 
-            // see https://github.com/SonarSource/sonar-csharp/issues/1840
+            // see https://github.com/SonarSource/sonar-dotnet/issues/1840
             var multiDimIntArray = new int[][] // Compliant - type specifier is mandatory here
             {
                 new int[] { 1 } // Noncompliant

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantJumpStatement.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/RedundantJumpStatement.cs
@@ -116,7 +116,7 @@ namespace Tests.Diagnostics
             { }
         }
 
-        // https://github.com/SonarSource/sonar-csharp/issues/1265
+        // https://github.com/SonarSource/sonar-dotnet/issues/1265
         void RegressionTest_1265()
         {
             try

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ReturnEmptyCollectionInsteadOfNull.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/ReturnEmptyCollectionInsteadOfNull.cs
@@ -76,7 +76,7 @@ namespace Tests.Diagnostics
 
         public int Age { get; private set; }
 
-        // See https://github.com/SonarSource/sonar-csharp/issues/761
+        // See https://github.com/SonarSource/sonar-dotnet/issues/761
         public List<int> Method()
         {
             Func<int?> aFunc = () =>

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/StringConcatenationInLoop.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/StringConcatenationInLoop.cs
@@ -23,7 +23,7 @@ namespace Tests.Diagnostics
 
             while (true)
             {
-                // See https://github.com/SonarSource/sonar-csharp/issues/1138
+                // See https://github.com/SonarSource/sonar-dotnet/issues/1138
                 s = s ?? "b";
             }
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/StringLiteralShouldNotBeDuplicated_Attributes.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/StringLiteralShouldNotBeDuplicated_Attributes.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 // Issue #1419 - false positive in S1192 - shouldn't look at string in attributes
-// https://github.com/SonarSource/sonar-csharp/issues/1419
+// https://github.com/SonarSource/sonar-dotnet/issues/1419
 
 // compliant - outside class and in attribute -> ignored
 [assembly: DebuggerDisplay("foo", Name = "foo", TargetTypeName = "foo")]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestClassShouldHaveTestMethod.MsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestClassShouldHaveTestMethod.MsTest.cs
@@ -61,7 +61,7 @@ namespace Tests.Diagnostics
         public void Foo_WhenFoo_ExpectsFoo() { }
     }
 
-    // See https://github.com/SonarSource/sonar-csharp/issues/1196
+    // See https://github.com/SonarSource/sonar-dotnet/issues/1196
     [TestClass]
     public class TestSubFoo : TestFooBase // Compliant - base abstract and at least 1 test in base
     {
@@ -73,7 +73,7 @@ namespace TestSetupAndCleanupAttributes
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-    // Regression tests for Bug 1486: https://github.com/SonarSource/sonar-csharp/issues/1486
+    // Regression tests for Bug 1486: https://github.com/SonarSource/sonar-dotnet/issues/1486
     // Don't raise for classes that test setup or cleanup attributes
 
     [TestClass]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestClassShouldHaveTestMethod.NUnit.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestClassShouldHaveTestMethod.NUnit.cs
@@ -85,7 +85,7 @@ namespace Tests.Diagnostics
         public void Foo_WhenFoo_ExpectsFoo() { }
     }
 
-    // See https://github.com/SonarSource/sonar-csharp/issues/1196
+    // See https://github.com/SonarSource/sonar-dotnet/issues/1196
     [TestFixture]
     public class TestSubFoo : TestFooBase // Compliant - base abstract and at least 1 test in base
     {

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.Xunit.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.Xunit.cs
@@ -1,7 +1,7 @@
 ﻿using MSTest = Microsoft.VisualStudio.TestTools.UnitTesting;
 using Xunit;
 
-// Regression test for #1705: https://github.com/SonarSource/sonar-csharp/issues/1705
+// Regression test for #1705: https://github.com/SonarSource/sonar-dotnet/issues/1705
 // The rule should not be applied to xUnit tests. Previously, the rule was raising if
 // an MSTest [Ignore] attribute was applied to a xUnit test.
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.Xunit.v1.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldNotBeIgnored.Xunit.v1.cs
@@ -4,7 +4,7 @@ using Xunit.Extensions;
 
 // Legacy xUnit (v1.9.1)
 
-// Regression test for #1705: https://github.com/SonarSource/sonar-csharp/issues/1705
+// Regression test for #1705: https://github.com/SonarSource/sonar-dotnet/issues/1705
 // The rule should not be applied to xUnit tests. Previously, the rule was raising if
 // an MSTest [Ignore] attribute was applied to a xUnit test.
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TooManyParameters_CustomValues.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TooManyParameters_CustomValues.cs
@@ -40,7 +40,7 @@ namespace Tests.Diagnostics
             F2(1, 2, 3, 4);
         }
 
-        // see https://github.com/SonarSource/sonar-csharp/issues/1459
+        // see https://github.com/SonarSource/sonar-dotnet/issues/1459
         // We should not raise for imported methods according to external definition.
         [DllImport("foo.dll")]
         public static extern void Extern(int p1, int p2, int p3, int p4); // Compliant, external definition
@@ -62,7 +62,7 @@ namespace Tests.Diagnostics
 
     public class SubClass : MyWrongClass
     {
-        // See https://github.com/SonarSource/sonar-csharp/issues/1015
+        // See https://github.com/SonarSource/sonar-dotnet/issues/1015
         // We should not raise when parent base class forces usage of too many args
         public SubClass(string a, string b, string c, string d, string e, string f, string g, string h) // Compliant (base class requires them)
             : base(a, b, c, d, e, f, g, h)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TooManyParameters_DefaultValues.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/TooManyParameters_DefaultValues.cs
@@ -38,7 +38,7 @@ namespace Tests.Diagnostics
             F2(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         }
 
-        // see https://github.com/SonarSource/sonar-csharp/issues/1459
+        // see https://github.com/SonarSource/sonar-dotnet/issues/1459
         // We should not raise for imported methods according to external definition.
         [DllImport("foo.dll")]
         public static extern void Extern(int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8, int p9, int p10); // Compliant, external definition
@@ -60,7 +60,7 @@ namespace Tests.Diagnostics
 
     public class SubClass : MyWrongClass
     {
-        // See https://github.com/SonarSource/sonar-csharp/issues/1015
+        // See https://github.com/SonarSource/sonar-dotnet/issues/1015
         // We should not raise when parent base class forces usage of too many args
         public SubClass(string a, string b, string c, string d, string e, string f, string g, string h) // Compliant (base class requires them)
             : base(a, b, c, d, e, f, g, h)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UninvokedEventDeclaration.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UninvokedEventDeclaration.cs
@@ -93,7 +93,7 @@ namespace Tests.Diagnostics
         }
     }
 
-    // See https://github.com/SonarSource/sonar-csharp/issues/1219
+    // See https://github.com/SonarSource/sonar-dotnet/issues/1219
     public class EventAccessor
     {
         private event EventHandler privateEvent;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.Fixed.Batch.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.Fixed.Batch.cs
@@ -99,7 +99,7 @@ namespace Tests.Diagnostics
 
     class NewClass1
     {
-        // See https://github.com/SonarSource/sonar-csharp/issues/888
+        // See https://github.com/SonarSource/sonar-dotnet/issues/888
         static async Task Main() // Compliant - valid main method since C# 7.1
         {
             Console.WriteLine("Test");

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.Fixed.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.Fixed.cs
@@ -83,7 +83,7 @@ namespace Tests.Diagnostics
 
     class NewClass1
     {
-        // See https://github.com/SonarSource/sonar-csharp/issues/888
+        // See https://github.com/SonarSource/sonar-dotnet/issues/888
         static async Task Main() // Compliant - valid main method since C# 7.1
         {
             Console.WriteLine("Test");

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.cs
@@ -148,7 +148,7 @@ namespace Tests.Diagnostics
 
     class NewClass1
     {
-        // See https://github.com/SonarSource/sonar-csharp/issues/888
+        // See https://github.com/SonarSource/sonar-dotnet/issues/888
         static async Task Main() // Compliant - valid main method since C# 7.1
         {
             Console.WriteLine("Test");


### PR DESCRIPTION
Cleanup related to #3648 

GitHub project was renamed from `sonar-csharp` to `sonar-dotnet` in the past. Redirect works, but the links are confusing at first glanc.