### PR TITLE
Compute coverage for both .Net 4.8 and .Net 5

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,6 +255,7 @@ stages:
 
           # This step needs to be manually done on CI agents. See https://github.com/OpenCover/opencover/raw/master/main/OpenCover.Documentation/Usage.pdf
           regsvr32 $(NUGET_PACKAGES)\opencover\4.7.922\tools\x86\OpenCover.Profiler.dll
+          regsvr32 $(NUGET_PACKAGES)\opencover\4.7.922\tools\x64\OpenCover.Profiler.dll
 
           $supportedFrameworks = @('net48', 'net5.0')
           Foreach ($framework in $supportedFrameworks)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ stages:
 
           Write-Host "Remove .Net 5 target for UnitTest project"
 
-          ((Get-Content -Path $testProjFileName -raw) -Replace "net48;netcoreapp3.1;net5.0","net48;netcoreapp3.1") | Set-Content -Path $testProjFileName
+          ((Get-Content -Path $testProjFileName -raw) -Replace "net48;net5.0","net48") | Set-Content -Path $testProjFileName
 
           Write-Host "Show test project after we modified the target frameworks to exclude net5"
           Get-Content -Path $testProjFileName
@@ -255,7 +255,7 @@ stages:
           regsvr32 $(NUGET_PACKAGES)\opencover\4.7.922\tools\x86\OpenCover.Profiler.dll
           regsvr32 $(NUGET_PACKAGES)\opencover\4.7.922\tools\x64\OpenCover.Profiler.dll
 
-          $supportedFrameworks = @('net48','netcoreapp3.1','net5.0')
+          $supportedFrameworks = @('net48', 'net5.0')
           Foreach ($framework in $supportedFrameworks)
           {
             & $(NUGET_PACKAGES)\opencover\4.7.922\tools\OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test $testProjFileName --no-build -c $(BuildConfiguration) -f $framework" -returntargetcode -filter:"+[SonarAnalyzer.CFG]* +[SonarAnalyzer]* +[SonarAnalyzer.CSharp]* +[SonarAnalyzer.Utilities]* +[SonarAnalyzer.VisualBasic]*" -output:tests\coverage.$framework.xml -oldStyle

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -251,8 +251,9 @@ stages:
           & dotnet build $testProjFileName -c $(BuildConfiguration)
           Test-ExitCode "ERROR: UnitTest project build FAILED."
 
-          Write-Host "Register OpenCover profilers. This step needs to be done manually on CI agents. See https://github.com/OpenCover/opencover/raw/master/main/OpenCover.Documentation/Usage.pdf"
-          regsvr32 $(NUGET_PACKAGES)\opencover\4.7.922\tools\x86\OpenCover.Profiler.dll
+          Write-Host "Register OpenCover profilers!"
+
+          # This step needs to be manually done on CI agents. See https://github.com/OpenCover/opencover/raw/master/main/OpenCover.Documentation/Usage.pdf
           regsvr32 $(NUGET_PACKAGES)\opencover\4.7.922\tools\x64\OpenCover.Profiler.dll
 
           $supportedFrameworks = @('net48', 'net5.0')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -213,7 +213,7 @@ stages:
           projectName: 'SonarAnalyzer .Net'
           projectVersion: '$(SONAR_PROJECT_VERSION)'
           extraProperties: |
-            sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/**/coverage.xml"
+            sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/**/coverage.**.xml"
             sonar.analysis.buildNumber=$(Build.BuildId)
             sonar.analysis.pipeline=$(Build.BuildId)
             sonar.analysis.sha1=$(System.PullRequest.SourceCommitId)
@@ -231,7 +231,7 @@ stages:
           projectName: 'SonarAnalyzer .Net'
           projectVersion: '$(SONAR_PROJECT_VERSION)'
           extraProperties: |
-            sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/**/coverage.xml"
+            sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/**/coverage.**.xml"
             sonar.analysis.buildNumber=$(Build.BuildId)
             sonar.analysis.pipeline=$(Build.BuildId)
             sonar.analysis.sha1=$(Build.SourceVersion)
@@ -251,20 +251,16 @@ stages:
           & dotnet build $testProjFileName -c $(BuildConfiguration)
           Test-ExitCode "ERROR: UnitTest project build FAILED."
 
-          Write-Host "List Sonar*.dll files"
-          Get-ChildItem -Recurse .\tests\SonarAnalyzer.UnitTest\bin\${BuildConfiguration}\ -Filter Sonar*.dll
+          Write-Host "Register OpenCover profilers. This step needs to be done manually on CI agents. See https://github.com/OpenCover/opencover/raw/master/main/OpenCover.Documentation/Usage.pdf"
+          regsvr32 $(NUGET_PACKAGES)\opencover\4.7.922\tools\x86\OpenCover.Profiler.dll
+          regsvr32 $(NUGET_PACKAGES)\opencover\4.7.922\tools\x64\OpenCover.Profiler.dll
 
-          Write-Host "UTs .Net 4.8 and compute coverage"
-          & $(NUGET_PACKAGES)\opencover\4.7.922\tools\OpenCover.Console.exe -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:"test tests\SonarAnalyzer.UnitTest\bin\$(BuildConfiguration)\net48\SonarAnalyzer.UnitTest.dll --nologo" -returntargetcode -filter:"+[SonarAnalyzer.CFG]* +[SonarAnalyzer]* +[SonarAnalyzer.CSharp]* +[SonarAnalyzer.Utilities]* +[SonarAnalyzer.VisualBasic]*" -output:tests\coverage.xml -oldStyle -register:Path32
-          Test-ExitCode "ERROR: Unit tests for .NET 4.8 and compute coverage FAILED."
-
-          Write-Host "UTs .Net Core 3.1"
-          & dotnet test $testProjFileName -c $(BuildConfiguration) --no-build --no-restore --nologo -f netcoreapp3.1
-          Test-ExitCode "ERROR: Unit tests for .NET Core 3.1 FAILED."
-
-          Write-Host "UTs .Net 5"
-          & dotnet test $testProjFileName -c $(BuildConfiguration) --no-build --no-restore --nologo -f net5.0
-          Test-ExitCode "ERROR: Unit tests for .NET 5 FAILED."
+          $supportedFrameworks = @('net48','netcoreapp3.1','net5.0')
+          Foreach ($framework in $supportedFrameworks)
+          {
+            & $(NUGET_PACKAGES)\opencover\4.7.922\tools\OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test $testProjFileName --no-build -c $(BuildConfiguration) -f $framework" -returntargetcode -filter:"+[SonarAnalyzer.CFG]* +[SonarAnalyzer]* +[SonarAnalyzer.CSharp]* +[SonarAnalyzer.Utilities]* +[SonarAnalyzer.VisualBasic]*" -output:tests\coverage.$framework.xml -oldStyle
+            Test-ExitCode "ERROR: Unit tests for $framework FAILED."
+          }
 
           cd ..
         displayName: '.Net UTs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -254,7 +254,7 @@ stages:
           Write-Host "Register OpenCover profilers!"
 
           # This step needs to be manually done on CI agents. See https://github.com/OpenCover/opencover/raw/master/main/OpenCover.Documentation/Usage.pdf
-          regsvr32 $(NUGET_PACKAGES)\opencover\4.7.922\tools\x64\OpenCover.Profiler.dll
+          regsvr32 $(NUGET_PACKAGES)\opencover\4.7.922\tools\x86\OpenCover.Profiler.dll
 
           $supportedFrameworks = @('net48', 'net5.0')
           Foreach ($framework in $supportedFrameworks)

--- a/scripts/build/build-utils.ps1
+++ b/scripts/build/build-utils.ps1
@@ -151,10 +151,6 @@ function Invoke-UnitTests([string]$binPath, [string]$buildConfiguration) {
 
     $testProjFileName = "tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj"
 
-    Write-Header "Running unit tests .NET Core 3.1"
-    dotnet test  $testProjFileName -f netcoreapp3.1 -v minimal -c $buildConfiguration --no-build --no-restore
-    Test-ExitCode "ERROR: Unit tests for .NET Core 3.1 FAILED."
-
     Write-Header "Running unit tests .NET 5"
     dotnet test  $testProjFileName -f net5.0 -v minimal -c $buildConfiguration --no-build --no-restore
     Test-ExitCode "ERROR: Unit tests for .NET 5 FAILED."

--- a/sonaranalyzer-dotnet/its/ReviewDiffs/ReviewDiffs.csproj
+++ b/sonaranalyzer-dotnet/its/ReviewDiffs/ReviewDiffs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <SonarQubeExclude>true</SonarQubeExclude>
     <ProjectGuid>{7e3adcd6-01d7-44e2-b12f-c485c35c8a9c}</ProjectGuid>

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/AspNetCoreMetadataReference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/AspNetCoreMetadataReference.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#if NET5_0
+#if NET
 
 using References = System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.MetadataReference>;
 using static SonarAnalyzer.UnitTest.MetadataReferences.MetadataReferenceFactory;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/AspNetCoreMetadataReference.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/MetadataReferences/AspNetCoreMetadataReference.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#if NETCOREAPP
+#if NET5_0
 
 using References = System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.MetadataReference>;
 using static SonarAnalyzer.UnitTest.MetadataReferences.MetadataReferenceFactory;

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DeliveringDebugFeaturesInProductionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DeliveringDebugFeaturesInProductionTest.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 new VisualBasic.DeliveringDebugFeaturesInProduction(),
                 additionalReferences: AdditionalReferencesNetCore2);
 
-#if NET5_0
+#if NET
 
         [TestMethod]
         [TestCategory("Rule")]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DeliveringDebugFeaturesInProductionTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DeliveringDebugFeaturesInProductionTest.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 new VisualBasic.DeliveringDebugFeaturesInProduction(),
                 additionalReferences: AdditionalReferencesNetCore2);
 
-#if NETCOREAPP
+#if NET5_0
 
         [TestMethod]
         [TestCategory("Rule")]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DisposableMemberInNonDisposableClassTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DisposableMemberInNonDisposableClassTest.cs
@@ -22,7 +22,7 @@ extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.UnitTest.TestFramework;
-#if NET5_0
+#if NET
 using SonarAnalyzer.UnitTest.MetadataReferences;
 #endif
 
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void DisposableMemberInNonDisposableClass_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\DisposableMemberInNonDisposableClass.CSharp9.cs", new DisposableMemberInNonDisposableClass());
 
-#if NET5_0 // IAsyncDisposable is available only on .Net
+#if NET // IAsyncDisposable is available only on .Net
         [TestMethod]
         public void DisposableMemberInNonDisposableClass_IAsyncDisposable() =>
             Verifier.VerifyCSharpAnalyzer(@"

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DisposableMemberInNonDisposableClassTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DisposableMemberInNonDisposableClassTest.cs
@@ -22,7 +22,7 @@ extern alias csharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using csharp::SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.UnitTest.TestFramework;
-#if NETCOREAPP
+#if NET5_0
 using SonarAnalyzer.UnitTest.MetadataReferences;
 #endif
 
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void DisposableMemberInNonDisposableClass_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\DisposableMemberInNonDisposableClass.CSharp9.cs", new DisposableMemberInNonDisposableClass());
 
-#if NETCOREAPP // IAsyncDisposable is available only on .Net Core
+#if NET5_0 // IAsyncDisposable is available only on .Net
         [TestMethod]
         public void DisposableMemberInNonDisposableClass_IAsyncDisposable() =>
             Verifier.VerifyCSharpAnalyzer(@"

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotCallGCSuppressFinalizeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotCallGCSuppressFinalizeTest.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void DoNotCallGCSuppressFinalize() =>
             Verifier.VerifyAnalyzer(@"TestCases\DoNotCallGCSuppressFinalize.cs", new DoNotCallGCSuppressFinalize());
 
-#if NET5_0
+#if NET
         [TestMethod]
         [TestCategory("Rule")]
         public void DoNotCallGCSuppressFinalize_NetCore() =>

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotCallGCSuppressFinalizeTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotCallGCSuppressFinalizeTest.cs
@@ -33,14 +33,12 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void DoNotCallGCSuppressFinalize() =>
             Verifier.VerifyAnalyzer(@"TestCases\DoNotCallGCSuppressFinalize.cs", new DoNotCallGCSuppressFinalize());
 
-#if NETCOREAPP
+#if NET5_0
         [TestMethod]
         [TestCategory("Rule")]
         public void DoNotCallGCSuppressFinalize_NetCore() =>
             Verifier.VerifyAnalyzer(@"TestCases\DoNotCallGCSuppressFinalize.NetCore.cs", new DoNotCallGCSuppressFinalize(), ParseOptionsHelper.FromCSharp8);
-#endif
 
-#if NET5_0
         [TestMethod]
         [TestCategory("Rule")]
         public void DoNotCallGCSuppressFinalize_Net5() =>

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotDecreaseMemberVisibilityTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/DoNotDecreaseMemberVisibilityTest.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 #endif
                 options: ParseOptionsHelper.FromCSharp8);
 
-#if NET5_0
+#if NET
         [TestMethod]
         [TestCategory("Rule")]
         public void DoNotDecreaseMemberVisibility_CSharp9() =>

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EmptyMethodTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/EmptyMethodTest.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 options: ParseOptionsHelper.FromCSharp8);
         }
 
-#if NET5_0
+#if NET
         [TestMethod]
         [TestCategory("Rule")]
         public void EmptyMethod_CSharp9()

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ExceptionShouldNotBeThrownFromUnexpectedMethodsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/ExceptionShouldNotBeThrownFromUnexpectedMethodsTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzer(@"TestCases\ExceptionShouldNotBeThrownFromUnexpectedMethods.cs",
                 new ExceptionShouldNotBeThrownFromUnexpectedMethods(),
                 ParseOptionsHelper.FromCSharp8);
- #if NET5_0
+ #if NET
         [TestMethod]
         [TestCategory("Rule")]
         public void ExceptionShouldNotBeThrownFromUnexpectedMethods_CSharp9() =>

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/PointersShouldBePrivateTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/PointersShouldBePrivateTest.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void PointersShouldBePrivate() => Verifier.VerifyAnalyzer(@"TestCases\PointersShouldBePrivate.cs", new PointersShouldBePrivate());
 
-#if NET5_0 // Function pointers are supported only by .Net 5 runtime
+#if NET // Function pointers are supported only by .Net 5 runtime
         [TestMethod]
         [TestCategory("Rule")]
         public void PointersShouldBePrivate_CSharp9() =>

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnnecessaryUsingsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnnecessaryUsingsTest.cs
@@ -40,12 +40,12 @@ namespace SonarAnalyzer.UnitTest.Rules
                                     new CS.UnnecessaryUsings(),
                                     additionalReferences: GetAdditionalReferences());
 
+#if NET5_0
+
         [TestMethod]
         [TestCategory("Rule")]
         public void UnnecessaryUsings_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\UnnecessaryUsings.CSharp9.cs", new CS.UnnecessaryUsings());
-
-#if NETCOREAPP
 
         [TestMethod]
         [TestCategory("Rule")]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnnecessaryUsingsTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/Rules/UnnecessaryUsingsTest.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                                     new CS.UnnecessaryUsings(),
                                     additionalReferences: GetAdditionalReferences());
 
-#if NET5_0
+#if NET
 
         [TestMethod]
         [TestCategory("Rule")]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -6,7 +6,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFrameworks>net48;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0</TargetFrameworks>
     <!--
       This allows, on AzureDevops builds, to restore the NuGet packages which are not targeting .Net Standard or a compatible version by
       usign as fallbacks .Net Framwework 4.0 client profile (net40-client) and Portable profile (portable-net45+win8+wp8+wpa81).
@@ -24,8 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
-    <!-- Class AspNetCoreMetadataReference needs this FrameworkReference to generate metadata references for ASP.NET Core 3 related test cases. -->
-    <!-- We cannot remove netcoreapp3.1 target framework from UnitTest project to preserve dependent test cases. -->
+    <!-- Class AspNetCoreMetadataReference needs this FrameworkReference to generate metadata references for ASP.NET Core related test cases. -->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 


### PR DESCRIPTION
As far as I can tell opencover is considering only the first run