### PR TITLE
S3949: Add C# 9 tests and do not fail for unsupported language version

### DIFF
--- a/sonaranalyzer-dotnet/its/regression-test.ps1
+++ b/sonaranalyzer-dotnet/its/regression-test.ps1
@@ -447,27 +447,6 @@ function CheckInternalProjectsDifferences(){
     Write-Debug "Internal project differences verified in '${internalProjTimerElapsed}'"
 }
 
-function ChangeRuleset([string]$before, [string]$after) {
-    $rulesetFile=".\output\AllSonarAnalyzerRules.ruleset"
-    ((Get-Content -Path $rulesetFile -raw) -Replace $before,$after) | Set-Content -Path $rulesetFile
-}
-
-function DisableRule([string]$ruleId) {
-    Write-Host "Will disable rule ${ruleId}."
-
-    $toModify="<Rule Id=""${ruleId}"" Action=""Warning"" />"
-    $modifyWith="<Rule Id=""${ruleId}"" Action=""None"" />"
-    ChangeRuleset $toModify $modifyWith
-}
-
-function EnableRule([string]$ruleId) {
-    Write-Host "Will enable rule ${ruleId}."
-
-    $toModify="<Rule Id=""${ruleId}"" Action=""None"" />"
-    $modifyWith="<Rule Id=""${ruleId}"" Action=""Warning"" />"
-    ChangeRuleset $toModify $modifyWith
-}
-
 try {
     $scriptTimer = [system.diagnostics.stopwatch]::StartNew()
     . (Join-Path $PSScriptRoot "..\..\scripts\build\build-utils.ps1")
@@ -513,11 +492,7 @@ try {
     Build-Project-MSBuild "SkipGeneratedVb" "SkipGeneratedVb.sln"
 
     Build-Project-DotnetTool "NetCore31" "NetCore31.sln"
-
-    # The CBDE rule is failing for C# 9 syntax. See https://github.com/SonarSource/sonar-dotnet/issues/3439
-    DisableRule "S3949"
     Build-Project-DotnetTool "Net5" "Net5.sln"
-    EnableRule "S3949"
 
     Write-Header "Processing analyzer results"
 

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/CBDE/MlirExporter.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/CBDE/MlirExporter.cs
@@ -147,7 +147,7 @@ namespace SonarAnalyzer.CBDE
             }
             catch (Exception ex) when (semanticModel.Compilation.GetLanguageVersion() > supportedVersion && !Debugger.IsAttached)
             {
-                // We don't want to fail when exception occurs for unsupported language version
+                // We don't want to fail when the exception occurs for an unsupported language version
                 writer.WriteLine($"// Skipping function {method.Identifier.ValueText}{GetAnonymousArgumentsString(method)}, failed to generate CFG: {ex.Message}");
                 writer.WriteLine();
                 return;

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/CBDE/MlirExporter.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/CBDE/MlirExporter.cs
@@ -38,6 +38,8 @@ namespace SonarAnalyzer.CBDE
 {
     public class MlirExporter
     {
+        private const LanguageVersion supportedVersion = LanguageVersionEx.CSharp8;
+
         internal static readonly ImmutableList<SyntaxKind> unsupportedSyntaxes = new List<SyntaxKind>
         {
             SyntaxKind.AnonymousMethodExpression,
@@ -137,6 +139,19 @@ namespace SonarAnalyzer.CBDE
                 writer.WriteLine();
                 return;
             }
+
+            IControlFlowGraph cfg;
+            try
+            {
+                cfg = CSharpControlFlowGraph.Create(method.Body, semanticModel);
+            }
+            catch (Exception ex) when (semanticModel.Compilation.GetLanguageVersion() > supportedVersion && !Debugger.IsAttached)
+            {
+                // We don't want to fail when exception occurs for unsupported language version
+                writer.WriteLine($"// Skipping function {method.Identifier.ValueText}{GetAnonymousArgumentsString(method)}, failed to generate CFG: {ex.Message}");
+                writer.WriteLine();
+                return;
+            }
             blockCounter = 0;
             blockMap.Clear();
 
@@ -149,11 +164,10 @@ namespace SonarAnalyzer.CBDE
             writer.WriteLine($"func @{GetMangling(method)}{GetAnonymousArgumentsString(method)} -> {returnType} {GetLocation(method)} {{");
             CreateEntryBlock(method);
 
-            var cfg = CSharpControlFlowGraph.Create(method.Body, semanticModel);
-            foreach (var block in cfg.Blocks)
-            {
-                ExportBlock(block, method, returnType);
-            }
+                foreach (var block in cfg.Blocks)
+                {
+                    ExportBlock(block, method, returnType);
+                }
             writer.WriteLine("}");
         }
 

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/CbdeHandlerTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/CbdeHandlerTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 * SonarAnalyzer for .NET
 * Copyright (C) 2015-2020 SonarSource SA
 * mailto: contact AT sonarsource DOT com
@@ -42,6 +42,16 @@ namespace SonarAnalyzer.UnitTest.Rules
             System.Environment.SetEnvironmentVariable("SONAR_DOTNET_INTERNAL_LOG_CBDE", "true");
             Verifier.VerifyAnalyzer(@"TestCases\CbdeHandler.cs",
                 CS.CbdeHandlerRule.MakeUnitTestInstance(null, null));
+        }
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void CbdeHandler_CS_FromCSharp9()
+        {
+            System.Environment.SetEnvironmentVariable("SONAR_DOTNET_INTERNAL_LOG_CBDE", "true");
+            Verifier.VerifyAnalyzer(@"TestCases\CbdeHandler.CSharp9.cs",
+                CS.CbdeHandlerRule.MakeUnitTestInstance(null, null),
+                ParseOptionsHelper.FromCSharp9);
         }
 
         [TestMethod]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/CbdeHandlerTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/CbdeHandlerTest.cs
@@ -51,7 +51,8 @@ namespace SonarAnalyzer.UnitTest.Rules
             System.Environment.SetEnvironmentVariable("SONAR_DOTNET_INTERNAL_LOG_CBDE", "true");
             Verifier.VerifyAnalyzer(@"TestCases\CbdeHandler.CSharp9.cs",
                 CS.CbdeHandlerRule.MakeUnitTestInstance(null, null),
-                ParseOptionsHelper.FromCSharp9);
+                ParseOptionsHelper.FromCSharp9,
+                OutputKind.ConsoleApplication);
         }
 
         [TestMethod]

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/MlirExportTest.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.UnitTest.CBDE
         [TestMethod]
         public void SimpleMethod()
         {
-            var code = @"
+            const string code = @"
 class C
 {
     int Mult(int i, int j)
@@ -67,7 +67,7 @@ class C
         [TestMethod]
         public void IfThenElse()
         {
-            var code = @"
+            const string code = @"
 void UselessCondition(int i) {
     if (i == 0) {
         if (i != 0) {
@@ -90,7 +90,7 @@ int WithReturn(int i) {
         [TestMethod]
         public void WhileLoops()
         {
-            var code = @"
+            const string code = @"
 private int WhileLoop(int i)
 {
     while (i<100)
@@ -128,7 +128,7 @@ private int WhileLoopContinue(int i)
         [TestMethod]
         public void DoWhileLoops()
         {
-            var code = @"
+            const string code = @"
 private int WhileLoop(int i)
 {
     do
@@ -166,7 +166,7 @@ private int WhileLoopContinue(int i)
         [TestMethod]
         public void ForLoops()
         {
-            var code = @"
+            const string code = @"
 private int ForLoop(int i)
 {
     int total = 0;
@@ -208,7 +208,7 @@ private int ForLoopContinue(int i)
         [TestMethod]
         public void ForEachLoops()
         {
-            var code = @"
+            const string code = @"
 int ForEachLoop()
 {
     var a = new int [10];
@@ -227,7 +227,7 @@ int ForEachLoop()
         [TestMethod]
         public void WorkWithLong()
         {
-            var code = @"
+            const string code = @"
 long withLong()
 {
     long l = 10;
@@ -248,7 +248,7 @@ long withLong()
         [TestMethod]
         public void TryCatchFinally()
         {
-            var code = @"
+            const string code = @"
 int TryCatch(int i)
 {
     int j = 3;
@@ -349,7 +349,7 @@ int TryThrow(int i)
         [TestMethod]
         public void FuncCall()
         {
-            var code = @"
+            const string code = @"
 
 class S {
     public static void stat(){}
@@ -384,7 +384,7 @@ int g(A a, int i)
         [TestMethod]
         public void Using()
         {
-            var code = @"
+            const string code = @"
 using System;
 
 class Resource : IDisposable
@@ -406,7 +406,7 @@ class A {
         [TestMethod]
         public void Enum()
         {
-            var code = @"
+            const string code = @"
 using System;
 
 public enum Color { Red, Green, Blue };
@@ -456,7 +456,7 @@ class A {
         [TestMethod]
         public void EmptyBody()
         {
-            var code = @"
+            const string code = @"
 public static extern void Extern(int p1);
 ";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
@@ -465,7 +465,7 @@ public static extern void Extern(int p1);
         [TestMethod]
         public void CommentsWithNewLine()
         {
-            var code = @"
+            const string code = @"
 void f()
 {
     new A() { i = 3 }; // Noncompliant
@@ -478,7 +478,7 @@ void f()
         [TestMethod]
         public void ReturnNullLitteral()
         {
-            var code = @"
+            const string code = @"
 public Type f()
 {
     return null;
@@ -489,7 +489,7 @@ public Type f()
         [TestMethod]
         public void ReturnParenthesizedNullLitteral()
         {
-            var code = @"
+            const string code = @"
 public Type f()
 {
     return (null);
@@ -500,7 +500,7 @@ public Type f()
         [TestMethod]
         public void ParenthesizedExpressions()
         {
-            var code = @"
+            const string code = @"
 public void f(int i, int j)
 {
     var k = ((i) + j);
@@ -515,7 +515,7 @@ public void f(int i, int j)
         [TestMethod]
         public void UnknownMethodOnMultipleLines()
         {
-            var code = @"
+            const string code = @"
 void f(int i, int j)
 {
     g(i,
@@ -527,7 +527,7 @@ void f(int i, int j)
         [TestMethod]
         public void ForWithoutCondition()
         {
-            var code = @"
+            const string code = @"
 void f(int i)
 {
     for (;;)
@@ -541,7 +541,7 @@ void f(int i)
         [TestMethod]
         public void ChainingAssignments()
         {
-            var code = @"
+            const string code = @"
 void f(int i)
 {
     int j = i = 0;
@@ -553,7 +553,7 @@ void f(int i)
         [TestMethod]
         public void UseOfReadonlyClassField()
         {
-            var code = @"
+            const string code = @"
 public class A
 {
     readonly int a = 0;
@@ -569,7 +569,7 @@ public class A
         [TestMethod]
         public void UseOfConstantClassField()
         {
-            var code = @"
+            const string code = @"
 public class A
 {
     const int a = 0;
@@ -585,7 +585,7 @@ public class A
         [TestMethod]
         public void UnnamedFunctionParameter()
         {
-            var code = @"
+            const string code = @"
 int Func(int, int, int i)
 {
     return 2*i;
@@ -596,7 +596,7 @@ int Func(int, int, int i)
         [TestMethod]
         public void SimpleLambdaExpression()
         {
-            var code = @"
+            const string code = @"
 public System.Linq.Expressions.Expression<Func<int, int>> F()
 {
     return x => 2*x;
@@ -607,7 +607,7 @@ public System.Linq.Expressions.Expression<Func<int, int>> F()
         [TestMethod]
         public void ParenthesizedLambdaExpression()
         {
-            var code = @"
+            const string code = @"
 Action f()
 {
     return () => Y();
@@ -618,7 +618,7 @@ Action f()
         [TestMethod]
         public void SwitchStatement()
         {
-            var code = @"
+            const string code = @"
 int f(int i)
 {
     switch (i)
@@ -635,7 +635,7 @@ int f(int i)
         [TestMethod]
         public void NonASCIIEncodings()
         {
-            var code = @"
+            const string code = @"
 public void 你好() { }
 
 public void Łódź() { }
@@ -649,7 +649,7 @@ public int Łódźअनुلمرadım(int 你好) { return 2 * 你好; }";
         [TestMethod]
         public void Arglist()
         {
-            var code = @"
+            const string code = @"
 public void f(__arglist)
 {
 }";
@@ -659,7 +659,7 @@ public void f(__arglist)
         [TestMethod]
         public void ParamsKeyword()
         {
-            var code = @"
+            const string code = @"
 public void f(params int[] args)
         {
         }";
@@ -669,7 +669,7 @@ public void f(params int[] args)
         [TestMethod]
         public void CheckedUnchecked()
         {
-            var code = @"
+            const string code = @"
 public int CheckedStmt(int i)
 {
     checked
@@ -700,7 +700,7 @@ public int UncheckedExpr(int i)
         [TestMethod]
         public void Fixed()
         {
-            var code = @"
+            const string code = @"
 class Point
 {
     public int x;
@@ -721,7 +721,7 @@ unsafe private static void ModifyFixedStorage()
         [TestMethod]
         public void Namespace()
         {
-            var code = @"
+            const string code = @"
 namespace Tests
 {
     public static void f()
@@ -734,7 +734,7 @@ namespace Tests
         [TestMethod]
         public void Overloads()
         {
-            var code = @"
+            const string code = @"
 namespace N
 {
     class A {
@@ -758,7 +758,7 @@ class B {
         [TestMethod]
         public void NestedFunction()
         {
-            var code = @"
+            const string code = @"
 void f()
 {
     var s = g();
@@ -773,7 +773,7 @@ void f()
         [TestMethod]
         public void FieldAssignment()
         {
-            var code = @"
+            const string code = @"
 class Point
 {
     public int x;
@@ -790,7 +790,7 @@ void f(Point p)
         [TestMethod]
         public void FieldOfThisAssignment()
         {
-            var code = @"
+            const string code = @"
 class Point
 {
     public int x;
@@ -807,7 +807,7 @@ class Point
         [TestMethod]
         public void ArrayAssignment()
         {
-            var code = @"
+            const string code = @"
 void f()
 {
     int[] array = new int[5];
@@ -819,7 +819,7 @@ void f()
         [TestMethod]
         public void CastOnReturn()
         {
-            var code = @"
+            const string code = @"
 int f(char c)
 {
     return c;
@@ -840,7 +840,7 @@ char h(bool c)
         [TestMethod]
         public void IgnoreParenthesesInAssignment()
         {
-            var code = @"
+            const string code = @"
 void f(int a, int b)
 {
     a = (b = 2);
@@ -851,7 +851,7 @@ void f(int a, int b)
         [TestMethod]
         public void AssignmentInComparison()
         {
-            var code = @"
+            const string code = @"
 int f(int a, int b)
 {
     if ((a = 3) < (b = 2))
@@ -866,7 +866,7 @@ int f(int a, int b)
         [TestMethod]
         public void AssignmentInBinaryOperator()
         {
-            var code = @"
+            const string code = @"
 void f(int a, int b)
 {
     a = (b = 2) + 1;
@@ -877,7 +877,7 @@ void f(int a, int b)
         [TestMethod]
         public void Goto()
         {
-            var code = @"
+            const string code = @"
 void f()
 {
     goto Label;
@@ -890,7 +890,7 @@ Label:
         [TestMethod]
         public void UnknownConstant()
         {
-            var code = @"
+            const string code = @"
 class A
 {
         private const object NullConst = null;
@@ -905,7 +905,7 @@ class A
         [TestMethod]
         public void Property()
         {
-            var code = @"
+            const string code = @"
 class A {
     public void DoSomething1() { }
     public bool someCondition1 { get; set; }
@@ -929,7 +929,7 @@ class A {
         [TestMethod]
         public void AsyncFunction()
         {
-            var code = @"
+            const string code = @"
 class A {
     async System.Threading.Tasks.Task<int> FuncAsync()
     {
@@ -942,7 +942,7 @@ class A {
         [TestMethod]
         public void MethodGroup()
         {
-            var code = @"
+            const string code = @"
 public static Func<string, bool> CreateFilter()
 {
     return string.IsNullOrEmpty;
@@ -953,7 +953,7 @@ public static Func<string, bool> CreateFilter()
         [TestMethod]
         public void MemberFieldAccess()
         {
-            var code = @"
+            const string code = @"
 class M
 {
     public int[] Parameters => new int[12];
@@ -975,7 +975,7 @@ class A
         [TestMethod]
         public void BoolProperty()
         {
-            var code = @"
+            const string code = @"
 class A
 {
     public bool Toto => true;
@@ -995,7 +995,7 @@ class B
         [TestMethod]
         public void MethodsCallsOnMultipleLines()
         {
-            var code = @"
+            const string code = @"
 class A
 {
     public const string myString = ""Blabla"";
@@ -1014,7 +1014,7 @@ class A
         [TestMethod]
         public void AnonymousMethodExpression()
         {
-            var code = @"
+            const string code = @"
 class A
 {
     public delegate object anonymousMethod(params object[] args);
@@ -1030,7 +1030,7 @@ class A
         [TestMethod]
         public void AnonymousObjectCreation()
         {
-            var code = @"
+            const string code = @"
 public int f()
 {
     var v = new { a = 108, m = ""Hello"" };
@@ -1042,7 +1042,7 @@ public int f()
         [TestMethod]
         public void AssignmentInReturn()
         {
-            var code = @"
+            const string code = @"
 class A
 {
     protected int a;
@@ -1058,7 +1058,7 @@ class A
         [TestMethod]
         public void BooleanConstant()
         {
-            var code = @"
+            const string code = @"
 public class A
 {
     internal const bool myBool = true;
@@ -1074,7 +1074,7 @@ public class A
         [TestMethod]
         public void PropertyFromAnotherAssembly()
         {
-            var code = @"
+            const string code = @"
 
 using System;
 using System.Collections.ObjectModel;
@@ -1099,7 +1099,7 @@ public class A<T> : Collection<T>
         [TestMethod]
         public void InfiniteLoop()
         {
-            var code = @"
+            const string code = @"
 int InfiniteLoop(int i) {
     while (true) {
         if (++i == 42) {
@@ -1114,7 +1114,7 @@ int InfiniteLoop(int i) {
         [TestMethod]
         public void IfDynamic()
         {
-            var code = @"
+            const string code = @"
 internal class A
 {
     public dynamic HasValue => true;
@@ -1137,7 +1137,7 @@ internal class B
         [TestMethod]
         public void ModifyFieldParameterAndLocalVariable()
         {
-            var code = @"
+            const string code = @"
 class A
 {
     private int p;
@@ -1156,7 +1156,7 @@ class A
         [TestMethod]
         public void BinaryOperatorAssignment()
         {
-            var code = @"
+            const string code = @"
 public void f(int i)
 {
     i -= 1;
@@ -1182,7 +1182,7 @@ public void g(int[] array1, long[] array2)
         [TestMethod]
         public void NoIdentifier()
         {
-            var code = @"
+            const string code = @"
 public class A
 {
     public int count;
@@ -1207,7 +1207,7 @@ public int f()
         [TestMethod]
         public void IncompatibleAssignmentTypes()
         {
-            var code = @"
+            const string code = @"
 public int f(int i)
 {
     byte b = (byte)i;
@@ -1227,7 +1227,7 @@ public int f(int i)
         [TestMethod]
         public void UnaryNeg()
         {
-            var code = @"
+            const string code = @"
 public bool neg()
 {
     int i = -12;
@@ -1243,7 +1243,7 @@ public bool neg()
         [TestMethod]
         public void UnaryPlus()
         {
-            var code = @"
+            const string code = @"
 public bool plus()
 {
     int i = +12;
@@ -1259,7 +1259,7 @@ public bool plus()
         [TestMethod]
         public void MixingUintAndNeg()
         {
-            var code = @"
+            const string code = @"
 void f() {
   int j = -10u;
 }
@@ -1273,7 +1273,7 @@ void g() {
         [TestMethod]
         public void UnsafeStatement()
         {
-            var code = @"
+            const string code = @"
 int f() {
   int i = 0;
   unsafe
@@ -1289,7 +1289,7 @@ int f() {
         [TestMethod]
         public void UnsafeClass()
         {
-            var code = @"
+            const string code = @"
 unsafe class C {
   int f()
   {
@@ -1303,7 +1303,7 @@ unsafe class C {
         [TestMethod]
         public void BoolAssignmentInsideIfCondition()
         {
-            var code = @"
+            const string code = @"
 public class Derived {
 
 protected bool j;
@@ -1324,5 +1324,5 @@ protected bool j;
 }";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
-    } // Class
-} // Namespace
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/MlirExportTest.cs
@@ -1344,7 +1344,6 @@ public class TargetTypedNew
         StringBuilder sb2 = new(null);
         StringBuilder sb3 = new(length: 4, capacity: 3, startIndex: 1, value: ""fooBar"");
         Console.WriteLine(sb.ToString() + sb2.ToString() + sb3.ToString());
-        }
     }
 }";
             ValidateCodeGeneration(code);
@@ -1355,41 +1354,26 @@ public class TargetTypedNew
         {
             const string code = @"
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 public class LambdaDiscardParameters
 {
     public void Method()
     {
-        var items = Enumerable.Range(0, 2).SelectMany(_ => Enumerable.Range(0, 1).SelectMany(_ => Enumerable.Range(0, 1))).ToList(); // i don't need parameters in nested
-        items.ForEach(_ => Console.WriteLine($""Discard test { _}""));
+        var items = Enumerable.Range(0, 2).SelectMany((_, _) => Enumerable.Range(0, 1).SelectMany((_, _) => Enumerable.Range(0, 1))).ToList();
+        items.Select((_, _) => 0);
 
-        LinqQuery(items);
+        _ = InvokeFunc((_, _) => true);
+        _ = InvokeFunc((_, _) => { return true; });
 
-        _ = Bar(_ => { return true; });
-
-        Func<int, string, int> explicitTypes = (int _, string _) => 1;
-
-        LocalFunction(1, 1);
-
-        void LocalFunction(int _, int _2)
-        { }
+        Func<int, string, int> explicitTypes2 = (int _, string _) => 1;
+        Func<int, string, bool, int> explicitTypes3 = (int _, string _, bool _) => 1;
     }
 
-    public Func<int, Func<int, bool>> Nested = _ => _ => true;
+    public Func<int, int, Func<int, int, bool>> Nested = (_, _) => (_, _) => true;
 
-    private bool Bar(Func<bool, bool> func)
-    {
-        return func(true);
-    }
-
-    private IEnumerable<int> LinqQuery(List<int> list) =>
-        from _ in NoOp()
-        from k in list
-        select k;
-
-    private IEnumerable<int> NoOp() => new[] { 1 };
+    private bool InvokeFunc(Func<bool, bool, bool> func) =>
+        func(true, true);
 }";
             ValidateCodeGeneration(code);
         }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/MlirExportTest.cs
@@ -60,8 +60,7 @@ class C
         else
             return i*3 +1;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -84,8 +83,7 @@ int WithReturn(int i) {
         }
     }
     return i;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -123,8 +121,7 @@ private int WhileLoopContinue(int i)
         }
     }
     return i;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -162,8 +159,7 @@ private int WhileLoopContinue(int i)
         }
     } while (i < 100)
     return i;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -205,8 +201,7 @@ private int ForLoopContinue(int i)
         total += j;
     }
     return total;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -225,8 +220,7 @@ int ForEachLoop()
         }
     }
     return 0;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -247,8 +241,7 @@ long withLong()
         return total;
     }
     return total;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -349,8 +342,7 @@ int TryThrow(int i)
         i+= 12;
     }
     return 20;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -385,8 +377,7 @@ int g(A a, int i)
     a.log(result);
     return result;
 }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -408,8 +399,7 @@ class A {
             return i;
         }
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -459,8 +449,7 @@ class A {
             return ConsoleColor.Red;
         }
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -482,8 +471,7 @@ void f()
     new A() { i = 3 }; // Noncompliant
 //          ^^^^^^^^^
     new A() { i = 4 };
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -494,8 +482,7 @@ void f()
 public Type f()
 {
     return null;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -506,8 +493,7 @@ public Type f()
 public Type f()
 {
     return (null);
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -522,8 +508,7 @@ public void f(int i, int j)
     {
         (i = k);
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -535,8 +520,7 @@ void f(int i, int j)
 {
     g(i,
     j);
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -550,8 +534,7 @@ void f(int i)
     {
         i = i + 1;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -563,8 +546,7 @@ void f(int i)
 {
     int j = i = 0;
     i = j = 10;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -580,8 +562,7 @@ public class A
     {
         return a;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -597,8 +578,7 @@ public class A
     {
         return a;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -609,8 +589,7 @@ public class A
 int Func(int, int, int i)
 {
     return 2*i;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -621,8 +600,7 @@ int Func(int, int, int i)
 public System.Linq.Expressions.Expression<Func<int, int>> F()
 {
     return x => 2*x;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -633,8 +611,7 @@ public System.Linq.Expressions.Expression<Func<int, int>> F()
 Action f()
 {
     return () => Y();
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -651,8 +628,7 @@ int f(int i)
         default:
             return 1;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -666,8 +642,7 @@ public void Łódź() { }
 
 public void AsciiThen你好ThenAsciiAgain() { }
 
-public int Łódźअनुلمرadım(int 你好) { return 2 * 你好; }
-";
+public int Łódźअनुلمرadım(int 你好) { return 2 * 你好; }";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -677,8 +652,7 @@ public int Łódźअनुلمرadım(int 你好) { return 2 * 你好; }
             var code = @"
 public void f(__arglist)
 {
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -688,8 +662,7 @@ public void f(__arglist)
             var code = @"
 public void f(params int[] args)
         {
-        }
-";
+        }";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -720,8 +693,7 @@ public int UncheckedStmt(int i)
 public int UncheckedExpr(int i)
 {
     return unchecked(i * 2);
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -742,8 +714,7 @@ unsafe private static void ModifyFixedStorage()
     {
         *p = 1;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -757,8 +728,7 @@ namespace Tests
     {
         Tests.g();
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
         [TestMethod]
@@ -781,8 +751,7 @@ class A {
 
 class B {
     int F(int i) {return 2*i;}
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -797,8 +766,7 @@ void f()
     {
         return 0;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -815,8 +783,7 @@ class Point
 void f(Point p)
 {
     p.x = 2;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -833,8 +800,7 @@ class Point
     {
         this.x = a;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -846,8 +812,7 @@ void f()
 {
     int[] array = new int[5];
     array[0] = 2;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -868,8 +833,7 @@ short g(char c)
 char h(bool c)
 {
     return c;
-    }
-";
+    }";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -880,8 +844,7 @@ char h(bool c)
 void f(int a, int b)
 {
     a = (b = 2);
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -896,8 +859,7 @@ int f(int a, int b)
         return 0;
     }
     return 1;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -908,8 +870,7 @@ int f(int a, int b)
 void f(int a, int b)
 {
     a = (b = 2) + 1;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -922,8 +883,7 @@ void f()
     goto Label;
 Label:
     return;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -938,8 +898,7 @@ class A
         void f()
         {
             NullConst.ToString();
-        }
-";
+        }";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -963,8 +922,7 @@ class A {
             DoSomething1();
         }
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -977,8 +935,7 @@ class A {
     {
         return 3;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -989,8 +946,7 @@ class A {
 public static Func<string, bool> CreateFilter()
 {
     return string.IsNullOrEmpty;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1012,8 +968,7 @@ class A
         }
         return true;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1033,8 +988,7 @@ class B
         A a = new A();
         return a.Toto;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1053,8 +1007,7 @@ class A
             .Replace('d', 'e');
         return result;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1070,8 +1023,7 @@ class A
     {
         return delegate (object[] args) { return 0; };
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1083,8 +1035,7 @@ public int f()
 {
     var v = new { a = 108, m = ""Hello"" };
     return v.a;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1100,8 +1051,7 @@ class A
     {
         return a = 1;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1117,8 +1067,7 @@ public class A
     {
         var b = myBool;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1143,8 +1092,7 @@ public class A<T> : Collection<T>
             }
         }
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1159,8 +1107,7 @@ int InfiniteLoop(int i) {
         }
     }
     // No return here
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1183,8 +1130,7 @@ internal class B
         }
         return 3;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1203,8 +1149,7 @@ class A
         dim = 2;
         p = 3;
     }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1230,8 +1175,7 @@ public void g(int[] array1, long[] array2)
 {
     array1[0] += 2;
     array2[0] += 3;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1256,8 +1200,7 @@ public int f()
         return 1;
     }
     return 0;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1277,8 +1220,7 @@ public int f(int i)
     }
 
     return b;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1294,8 +1236,7 @@ public bool neg()
         return true;
     }
     return false;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1311,8 +1252,7 @@ public bool plus()
         return true;
     }
     return false;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1326,8 +1266,7 @@ void f() {
 
 void g() {
   int someInt = -2147483648;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1343,8 +1282,7 @@ int f() {
   }
   int j += i;
   return j;
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1358,8 +1296,7 @@ unsafe class C {
     int j = 1;
     return j+1;
   }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
 
@@ -1384,8 +1321,7 @@ protected bool j;
       k=2;
     }
   }
-}
-";
+}";
             MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
         }
     } // Class

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/MlirExportTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/CBDE/MlirExportTest.cs
@@ -61,7 +61,7 @@ class C
             return i*3 +1;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -84,7 +84,7 @@ int WithReturn(int i) {
     }
     return i;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -122,7 +122,7 @@ private int WhileLoopContinue(int i)
     }
     return i;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -160,7 +160,7 @@ private int WhileLoopContinue(int i)
     } while (i < 100)
     return i;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -202,7 +202,7 @@ private int ForLoopContinue(int i)
     }
     return total;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -221,7 +221,7 @@ int ForEachLoop()
     }
     return 0;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -242,7 +242,7 @@ long withLong()
     }
     return total;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -343,7 +343,7 @@ int TryThrow(int i)
     }
     return 20;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -378,7 +378,7 @@ int g(A a, int i)
     return result;
 }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -400,7 +400,7 @@ class A {
         }
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -450,7 +450,7 @@ class A {
         }
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -459,7 +459,7 @@ class A {
             const string code = @"
 public static extern void Extern(int p1);
 ";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -472,7 +472,7 @@ void f()
 //          ^^^^^^^^^
     new A() { i = 4 };
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -483,7 +483,7 @@ public Type f()
 {
     return null;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -494,7 +494,7 @@ public Type f()
 {
     return (null);
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -509,7 +509,7 @@ public void f(int i, int j)
         (i = k);
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -521,7 +521,7 @@ void f(int i, int j)
     g(i,
     j);
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -535,7 +535,7 @@ void f(int i)
         i = i + 1;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -547,7 +547,7 @@ void f(int i)
     int j = i = 0;
     i = j = 10;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -563,7 +563,7 @@ public class A
         return a;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -579,7 +579,7 @@ public class A
         return a;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -590,7 +590,7 @@ int Func(int, int, int i)
 {
     return 2*i;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -601,7 +601,7 @@ public System.Linq.Expressions.Expression<Func<int, int>> F()
 {
     return x => 2*x;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -612,7 +612,7 @@ Action f()
 {
     return () => Y();
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -629,7 +629,7 @@ int f(int i)
             return 1;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -643,7 +643,7 @@ public void Łódź() { }
 public void AsciiThen你好ThenAsciiAgain() { }
 
 public int Łódźअनुلمرadım(int 你好) { return 2 * 你好; }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -653,7 +653,7 @@ public int Łódźअनुلمرadım(int 你好) { return 2 * 你好; }";
 public void f(__arglist)
 {
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -663,7 +663,7 @@ public void f(__arglist)
 public void f(params int[] args)
         {
         }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -694,7 +694,7 @@ public int UncheckedExpr(int i)
 {
     return unchecked(i * 2);
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -715,7 +715,7 @@ unsafe private static void ModifyFixedStorage()
         *p = 1;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -729,7 +729,7 @@ namespace Tests
         Tests.g();
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
         [TestMethod]
         public void Overloads()
@@ -752,7 +752,7 @@ class A {
 class B {
     int F(int i) {return 2*i;}
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -767,7 +767,7 @@ void f()
         return 0;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -784,7 +784,7 @@ void f(Point p)
 {
     p.x = 2;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -801,7 +801,7 @@ class Point
         this.x = a;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -813,7 +813,7 @@ void f()
     int[] array = new int[5];
     array[0] = 2;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -834,7 +834,7 @@ char h(bool c)
 {
     return c;
     }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -845,7 +845,7 @@ void f(int a, int b)
 {
     a = (b = 2);
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -860,7 +860,7 @@ int f(int a, int b)
     }
     return 1;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -871,7 +871,7 @@ void f(int a, int b)
 {
     a = (b = 2) + 1;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -884,7 +884,7 @@ void f()
 Label:
     return;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -899,7 +899,7 @@ class A
         {
             NullConst.ToString();
         }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -923,7 +923,7 @@ class A {
         }
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -936,7 +936,7 @@ class A {
         return 3;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -947,7 +947,7 @@ public static Func<string, bool> CreateFilter()
 {
     return string.IsNullOrEmpty;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -969,7 +969,7 @@ class A
         return true;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -989,7 +989,7 @@ class B
         return a.Toto;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1008,7 +1008,7 @@ class A
         return result;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1024,7 +1024,7 @@ class A
         return delegate (object[] args) { return 0; };
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1036,7 +1036,7 @@ public int f()
     var v = new { a = 108, m = ""Hello"" };
     return v.a;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1052,7 +1052,7 @@ class A
         return a = 1;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1068,7 +1068,7 @@ public class A
         var b = myBool;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1093,7 +1093,7 @@ public class A<T> : Collection<T>
         }
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1108,7 +1108,7 @@ int InfiniteLoop(int i) {
     }
     // No return here
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1131,7 +1131,7 @@ internal class B
         return 3;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1150,7 +1150,7 @@ class A
         p = 3;
     }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1176,7 +1176,7 @@ public void g(int[] array1, long[] array2)
     array1[0] += 2;
     array2[0] += 3;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1201,7 +1201,7 @@ public int f()
     }
     return 0;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1221,7 +1221,7 @@ public int f(int i)
 
     return b;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1237,7 +1237,7 @@ public bool neg()
     }
     return false;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1253,7 +1253,7 @@ public bool plus()
     }
     return false;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1267,7 +1267,7 @@ void f() {
 void g() {
   int someInt = -2147483648;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1283,7 +1283,7 @@ int f() {
   int j += i;
   return j;
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1297,7 +1297,7 @@ unsafe class C {
     return j+1;
   }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
 
         [TestMethod]
@@ -1322,7 +1322,10 @@ protected bool j;
     }
   }
 }";
-            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
+            ValidateCodeGeneration(code);
         }
+
+        private void ValidateCodeGeneration(string code) =>
+            MlirTestUtilities.ValidateCodeGeneration(code, TestContext.TestName);
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/ControlFlowGraph/ControlFlowGraphTest.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/ControlFlowGraph/ControlFlowGraphTest.cs
@@ -5170,6 +5170,28 @@ b = x | 2;  b = x & 2;   b = x ^ 2;  c = ""c"" + 'c';  c = a - b;   c = a * b;  
 
         #endregion
 
+        #region Instance creation
+
+        [TestMethod]
+        [TestCategory("CFG")]
+        public void Cfg_New()
+        {
+            var cfg = Build(@"var x = new Object()");
+
+            VerifyMinimalCfg(cfg);
+            VerifyAllInstructions(cfg.EntryBlock, "new Object()", "x = new Object()");
+        }
+
+        [TestMethod]
+        [TestCategory("CFG")]
+        public void Cfg_New_TargetTyped()
+        {
+            Action a = () => Build(@"Object x = new()");
+            a.Should().Throw<NotSupportedException>(); // C# 9 ImplicitObjectCreationExpressionSyntax is not supported yet
+        }
+
+        #endregion
+
         #region Helpers to build the CFG for the tests
 
         internal const string TestInput = @"

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CbdeHandler.CSharp9.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CbdeHandler.CSharp9.cs
@@ -1,49 +1,103 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
-namespace Tests.Diagnostics
+int i = 2147483600;
+i += 100; // FN, Top level statements are not supported
+
+public class NativeInt
 {
-    public class Sample
+    public void PositiveOverflowNativeInt()
     {
-        public void PositiveOverflowNativeInt()
-        {
-            nint i = 2147483600;
-            i += 100; // FN, C# 9 native int is not supported yet
-        }
-        public void NegativeOverflowNativeInt()
-        {
-            nint i = -2147483600;
-            i -= 100; // FN, C# 9 native int is not supported yet
-        }
+        nint i = 2147483600;
+        i += 100; // Compliant, we can't tell what's the native MaxValue on the run machine
+
+        nuint ui = (nuint)18446744073709551615;
+        ui += 100; // Compliant, we can't tell what's the native MaxValue on the run machine
     }
 
-    public record SampleRecord
+    public void NegativeOverflowNativeInt()
     {
-        public void Inc()
+        nint i = -2147483600;
+        i -= 100;  // Compliant, we can't tell what's the native MinValue for the run machine
+    }
+
+    public void StaticLambda()
+    {
+        Action a = static () =>
+        {
+            int i = -2147483600;
+            i -= 100; // FN, lambdas are not supported
+        };
+    }
+
+    public void LambdaDiscard(IEnumerable<int> items)
+    {
+        var result = items.Select((_, _) =>
+        {
+            int i = -2147483600;
+            i -= 100; // FN, lambdas are not supported
+            return i;
+        });
+    }
+}
+
+public class Properties
+{
+    public int GetInit
+    {
+        get
         {
             int i = 2147483600;
-            i += 100; // Noncompliant
+            i += 100; // FN, properties are not supported
+            return i;
         }
-    }
-
-    public partial class Partial
-    {
-        public partial void Method();
-    }
-
-    public partial class Partial
-    {
-        public partial void Method()
+        init
         {
             int i = 2147483600;
-            i += 100; // Noncompliant
+            i += 100; // FN, properties are not supported
         }
     }
+}
 
-    public class TargetTypedNew
+public record SampleRecord
+{
+    public void Inc()
     {
-        public void Go()
-        {
-            Sample s = new(); // This was throwing CbdeException: Top level error in CBDE handling
-        }
+        int i = 2147483600;
+        i += 100; // Noncompliant
+    }
+}
+
+public partial class Partial
+{
+    public partial void Method();
+}
+
+public partial class Partial
+{
+    public partial void Method()
+    {
+        int i = 2147483600;
+        i += 100; // Noncompliant
+    }
+}
+
+public class TargetTypedNew
+{
+    public void Go()
+    {
+        TargetTypedNew s = new(); // This was throwing CbdeException: Top level error in CBDE handling
+    }
+}
+
+public unsafe class FunctionPointers
+{
+    public static void Log() { }
+
+    public void Method()
+    {
+        delegate*<void> ptr1 = &Log;
+        delegate*<void> ptr2 = &FunctionPointers.Log;
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CbdeHandler.CSharp9.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CbdeHandler.CSharp9.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace Tests.Diagnostics
+{
+    public class Sample
+    {
+        public void PositiveOverflowNativeInt()
+        {
+            nint i = 2147483600;
+            i += 100; // FN, C# 9 native int is not supported yet
+        }
+        public void NegativeOverflowNativeInt()
+        {
+            nint i = -2147483600;
+            i -= 100; // FN, C# 9 native int is not supported yet
+        }
+    }
+
+    public record SampleRecord
+    {
+        public void Inc()
+        {
+            int i = 2147483600;
+            i += 100; // Noncompliant
+        }
+    }
+
+    public partial class Partial
+    {
+        public partial void Method();
+    }
+
+    public partial class Partial
+    {
+        public partial void Method()
+        {
+            int i = 2147483600;
+            i += 100; // Noncompliant
+        }
+    }
+
+    public class TargetTypedNew
+    {
+        public void Go()
+        {
+            Sample s = new(); // This was throwing CbdeException: Top level error in CBDE handling
+        }
+    }
+}

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CbdeHandler.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CbdeHandler.cs
@@ -8,9 +8,37 @@ namespace Tests.Diagnostics
             int i = 2147483600;
             i +=100; // Noncompliant {{There is a path on which this operation always overflows}}
         }
+
         public void NegativeOverflow() {
             int i = -2147483600;
             i -=100; // Noncompliant {{There is a path on which this operation always overflows}}
+        }
+
+        public void Lambda()
+        {
+            Action a = () =>
+            {
+                int i = -2147483600;
+                i -= 100; // FN, lambdas are not supported
+            };
+        }
+    }
+
+    public class Properties
+    {
+        public int GetSet
+        {
+            get
+            {
+                int i = 2147483600;
+                i += 100; // FN, properties are not supported
+                return i;
+            }
+            set
+            {
+                int i = 2147483600;
+                i += 100; // FN, properties are not supported
+            }
         }
     }
 }

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CbdeHandler.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/CbdeHandler.cs
@@ -2,7 +2,7 @@
 
 namespace Tests.Diagnostics
 {
-    public class IfConditionalAlwaysTrueOrFalse
+    public class Sample
     {
         public void PositiveOverflow() {
             int i = 2147483600;


### PR DESCRIPTION
Fixes #3439
Fixes #3697

I did not add tests for top level statement, because test infrastructure and implementation works on `MethodDeclarationSyntax` level.