### PR TITLE
Add .NET Standard 2.1 to allowed NuGet directories

### DIFF
--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/NugetMetadataFactory.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestFramework/NugetMetadataFactory.cs
@@ -38,6 +38,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
         private static readonly string[] allowedNugetLibDirectoriesInOrderOfPreference =
             new string[] {
+                "netstandard2.1",
                 "netstandard2.0",
                 "net47",
                 "net461",


### PR DESCRIPTION
`Microsoft.EntityFrameworkCore.SqlServer` NuGet package changed containted target framework to `netstandard2.1` in it's LATEST version.