### PR TITLE
Run tests for all platforms in dev build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -263,7 +263,7 @@ stages:
           Test-ExitCode "ERROR: Unit tests for .NET Core 3.1 FAILED."
 
           Write-Host "UTs .Net 5"
-          & dotnet test $testProjFileName -c $(BuildConfiguration) --no-build --no-restore --nologo -f net5
+          & dotnet test $testProjFileName -c $(BuildConfiguration) --no-build --no-restore --nologo -f net5.0
           Test-ExitCode "ERROR: Unit tests for .NET 5 FAILED."
 
           cd ..

--- a/scripts/build/build-utils.ps1
+++ b/scripts/build/build-utils.ps1
@@ -147,6 +147,15 @@ function Invoke-UnitTests([string]$binPath, [bool]$failsIfNotTest) {
 
     & (Get-VsTestPath) $testFiles /Parallel /Enablecodecoverage /InIsolation /Logger:trx /TestAdapterPath:$testDirs
     Test-ExitCode "ERROR: Unit Tests execution FAILED."
+
+    $testProjFileName = "tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj"
+    & dotnet build $testProjFileName
+
+    dotnet test  $testProjFileName --no-build --no-restore --nologo -f netcoreapp3.1
+    Test-ExitCode "ERROR: Unit tests for .NET Core 3.1 FAILED."
+
+    dotnet test  $testProjFileName --no-build --no-restore --nologo -f net5
+    Test-ExitCode "ERROR: Unit tests for .NET 5 FAILED."
 }
 
 function Invoke-IntegrationTests([ValidateSet("14.0", "15.0", "16.0", "Current")][string] $msbuildVersion) {

--- a/scripts/build/build-utils.ps1
+++ b/scripts/build/build-utils.ps1
@@ -127,7 +127,7 @@ function Invoke-MSBuild (
 }
 
 # Tests
-function Invoke-UnitTests([string]$binPath, [bool]$failsIfNotTest) {
+function Invoke-UnitTests([string]$binPath, [string]$buildConfiguration) {
     Write-Header "Running unit tests"
 
     $escapedPath = (Join-Path $binPath "net48") -Replace '\\', '\\'
@@ -145,16 +145,18 @@ function Invoke-UnitTests([string]$binPath, [bool]$failsIfNotTest) {
         }
     $testDirs = $testDirs | Select-Object -Uniq
 
-    & (Get-VsTestPath) $testFiles /Parallel /Enablecodecoverage /InIsolation /Logger:trx /TestAdapterPath:$testDirs
+    Write-Header "Running unit tests .NET Framework 4.8"
+    & (Get-VsTestPath) $testFiles /Logger:"console;verbosity=minimal"  /Parallel /Enablecodecoverage /InIsolation  /TestAdapterPath:$testDirs
     Test-ExitCode "ERROR: Unit Tests execution FAILED."
 
     $testProjFileName = "tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj"
-    & dotnet build $testProjFileName
 
-    dotnet test  $testProjFileName --no-build --no-restore --nologo -f netcoreapp3.1
+    Write-Header "Running unit tests .NET Core 3.1"
+    dotnet test  $testProjFileName -f netcoreapp3.1 -v minimal -c $buildConfiguration --no-build --no-restore
     Test-ExitCode "ERROR: Unit tests for .NET Core 3.1 FAILED."
 
-    dotnet test  $testProjFileName --no-build --no-restore --nologo -f net5
+    Write-Header "Running unit tests .NET 5"
+    dotnet test  $testProjFileName -f net5.0 -v minimal -c $buildConfiguration --no-build --no-restore
     Test-ExitCode "ERROR: Unit tests for .NET 5 FAILED."
 }
 

--- a/scripts/build/dev-build.ps1
+++ b/scripts/build/dev-build.ps1
@@ -75,7 +75,7 @@ try {
         # When running this script, we want to run all unit tests.
         # see sonaranalyzer-dotnet\tests\SonarAnalyzer.UnitTest\TestFramework\ParseOptionsHelper.cs
         $env:SYSTEM_DEFINITIONID="set"
-        Invoke-UnitTests $binPath $true
+        Invoke-UnitTests $binPath $buildConfiguration
     }
 
     if ($its) {


### PR DESCRIPTION
This should have been done in #3700 ... better late than never.

In #3700 I forced the same behavior as on AZP.

By running `.\scripts\build\dev-build.ps1 -build -test -release` before opening a PR we'll make sure we won't have surprises.