### PR TITLE
Improve perf for S2291, S2971, S3346 and S3256

### DIFF
--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/BeginInvokePairedWithEndInvoke.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/BeginInvokePairedWithEndInvoke.cs
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     var invocation = (InvocationExpressionSyntax)c.Node;
                     const string BeginInvoke = "BeginInvoke";
-                    if (invocation.ToStringContains(BeginInvoke) &&
+                    if (invocation.Expression.ToStringContains(BeginInvoke) &&
                         GetCallbackArg(invocation) is { } callbackArg &&
                         GetMethodSymbol(invocation, c.SemanticModel) is { } methodSymbol &&
                         methodSymbol.Name == BeginInvoke &&

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
@@ -97,7 +97,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var invocation = (InvocationExpressionSyntax)context.Node;
             if (invocation.ArgumentList?.Arguments.Count == 0 &&
                 invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
-                invocation.ToStringContains(CountName) &&
+                memberAccess.Name.Identifier.ValueText == CountName &&
                 context.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol &&
                 methodSymbol.Name == CountName &&
                 methodSymbol.IsExtensionOn(KnownType.System_Collections_Generic_IEnumerable_T) &&

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
@@ -97,6 +97,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var invocation = (InvocationExpressionSyntax)context.Node;
             if (invocation.ArgumentList?.Arguments.Count == 0 &&
                 invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+                invocation.ToStringContains(CountName) &&
                 context.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol &&
                 methodSymbol.Name == CountName &&
                 methodSymbol.IsExtensionOn(KnownType.System_Collections_Generic_IEnumerable_T) &&

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/DebugAssertHasNoSideEffects.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/DebugAssertHasNoSideEffects.cs
@@ -53,7 +53,8 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     var invokedMethodSyntax = c.Node as InvocationExpressionSyntax;
 
-                    if (ContainsCallsWithSideEffects(invokedMethodSyntax) &&
+                    if (invokedMethodSyntax.ToStringContains("Assert") &&
+                        ContainsCallsWithSideEffects(invokedMethodSyntax) &&
                         IsDebugAssert(invokedMethodSyntax, c))
                     {
                         c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, invokedMethodSyntax.ArgumentList.GetLocation()));

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/EnumerableSumInUnchecked.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/EnumerableSumInUnchecked.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var invocation = (InvocationExpressionSyntax)c.Node;
                     var expression = invocation.Expression;
                     if (expression is MemberAccessExpressionSyntax memberAccess &&
-                        invocation.ToStringContains("Sum") &&
+                        memberAccess.Name.Identifier.ValueText == "Sum" &&
                         IsSumInsideUnchecked(invocation) &&
                         c.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol &&
                         IsSumOnInteger(methodSymbol))

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/EnumerableSumInUnchecked.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/EnumerableSumInUnchecked.cs
@@ -48,6 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var invocation = (InvocationExpressionSyntax)c.Node;
                     var expression = invocation.Expression;
                     if (expression is MemberAccessExpressionSyntax memberAccess &&
+                        invocation.ToStringContains("Sum") &&
                         IsSumInsideUnchecked(invocation) &&
                         c.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol &&
                         IsSumOnInteger(methodSymbol))

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/GetTypeWithIsAssignableFrom.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/GetTypeWithIsAssignableFrom.cs
@@ -59,7 +59,8 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    if (invocation.ToStringContainsEitherOr("IsInstanceOfType", "IsAssignableFrom") &&
+                    var methodName = memberAccess.Name.Identifier.ValueText;
+                    if ((methodName == "IsInstanceOfType" || methodName == "IsAssignableFrom") &&
                         c.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol &&
                         methodSymbol.IsInType(KnownType.System_Type))
                     {

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/RedundantToCharArrayCall.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/RedundantToCharArrayCall.cs
@@ -47,13 +47,13 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     var invocation = (InvocationExpressionSyntax)c.Node;
 
-                    if ((invocation.Parent is ElementAccessExpressionSyntax || invocation.Parent is ForEachStatementSyntax) &&
-                        invocation.ToStringContains("ToCharArray") &&
-                        invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
-                        c.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol &&
-                        methodSymbol.Name == "ToCharArray" &&
-                        methodSymbol.IsInType(KnownType.System_String) &&
-                        methodSymbol.Parameters.Length == 0)
+                    if ((invocation.Parent is ElementAccessExpressionSyntax || invocation.Parent is ForEachStatementSyntax)
+                        && invocation.Expression is MemberAccessExpressionSyntax memberAccess
+                        && memberAccess.Name.Identifier.ValueText == "ToCharArray"
+                        && c.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol
+                        && methodSymbol.Name == "ToCharArray"
+                        && methodSymbol.IsInType(KnownType.System_String)
+                        && methodSymbol.Parameters.Length == 0)
                     {
                         c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, memberAccess.Name.GetLocation()));
                     }

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TypeExaminationOnSystemType.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/TypeExaminationOnSystemType.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     var invocation = (InvocationExpressionSyntax)c.Node;
 
-                    if (invocation.ToStringContainsEitherOr("IsInstanceOfType", "GetType") &&
+                    if (invocation.Expression.ToStringContainsEitherOr("IsInstanceOfType", "GetType") &&
                         c.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol)
                     {
                         CheckGetTypeCallOnType(invocation, methodSymbol, c);

--- a/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UseStringIsNullOrEmpty.cs
+++ b/sonaranalyzer-dotnet/src/SonarAnalyzer.CSharp/Rules/UseStringIsNullOrEmpty.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -42,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
-        private static readonly ISet<string> ReservedMethods = new HashSet<string> { nameof(string.Equals) };
+        private const string EqualsName = nameof(string.Equals);
 
         protected override void Initialize(SonarAnalysisContext context)
         {
@@ -61,7 +60,8 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    if (!IsStringEqualsMethod(memberAccessExpression, c.SemanticModel))
+                    if (!memberAccessExpression.ToStringContains(EqualsName) ||
+                        !IsStringEqualsMethod(memberAccessExpression, c.SemanticModel))
                     {
                         return;
                     }
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var methodName = semanticModel.GetSymbolInfo(memberAccessExpression.Name);
 
             return methodName.Symbol.IsInType(KnownType.System_String) &&
-                   ReservedMethods.Contains(methodName.Symbol.Name);
+                   methodName.Symbol.Name == EqualsName;
         }
 
         private static bool IsStringIdentifier(ExpressionSyntax expression, SemanticModel semanticModel)

--- a/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EnumerableSumInUnchecked.cs
+++ b/sonaranalyzer-dotnet/tests/SonarAnalyzer.UnitTest/TestCases/EnumerableSumInUnchecked.cs
@@ -6,7 +6,7 @@ namespace Tests.Diagnostics
 {
     public class EnumerableSumInUnchecked
     {
-        public void Test(List<int> list)
+        public void Test(List<int> list, List<float> list2)
         {
             int a = list.Sum();  // Compliant
 
@@ -20,6 +20,8 @@ namespace Tests.Diagnostics
 
                 e = Enumerable.Sum(list); // Noncompliant
 //                             ^^^
+
+                float floatSum = list2.Sum(); // Compliant
             }
 
             checked
@@ -50,6 +52,16 @@ namespace Tests.Diagnostics
             {
                 var y = l2.Sum(ll => ll);  // Noncompliant
             }
+
+            // coverage
+            list.Count();
+            MySum();
+            unchecked
+            {
+                MySum();
+            }
         }
+
+        void MySum() { }
     }
 }


### PR DESCRIPTION
Related to #3731 (but a full fix)
Fixes #3768

(leftovers after #3771)

all these rules take several seconds and there wasn't a visible improvement in #3771 because we don't check the method name before getting the symbol