### PR TITLE
Fix S4049 FP: Do not raise on methods with attributes that are not allowed on properties

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PropertiesShouldBePreferred.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PropertiesShouldBePreferred.cs
@@ -147,7 +147,7 @@ namespace MyLibrary
         public string GetBothSupportedAndNotSupportedPropertyUsage() => ""; // Compliant
 
         [PropertyOrMethod]
-        public int GetUsageIncludingProperty => 42; // Noncompliant
+        public int GetUsageIncludingProperty() => 42; // Noncompliant
 
         [AllTargets]
         public int GetUsageForAll() => 17; // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PropertiesShouldBePreferred.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PropertiesShouldBePreferred.cs
@@ -140,7 +140,7 @@ namespace MyLibrary
         private static readonly Random rnd = new Random();
 
         [NoProperty]
-        public int GetRandom() => rnd.Next(); // Noncompliant FP, attribute is needed and cannot be applied to property (Web API Controller)
+        public int GetRandom() => rnd.Next(); // Compliant
 
         [AttributeUsage(AttributeTargets.All ^ AttributeTargets.Property)]
         private class NoPropertyAttribute : Attribute { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PropertiesShouldBePreferred.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PropertiesShouldBePreferred.cs
@@ -142,7 +142,28 @@ namespace MyLibrary
         [NoProperty]
         public int GetRandom() => rnd.Next(); // Compliant
 
+        [NoProperty]
+        [PropertyOrMethod]
+        public string GetBothSupportedAndNotSupportedPropertyUsage() => ""; // Compliant
+
+        [PropertyOrMethod]
+        public int GetUsageIncludingProperty => 42; // Noncompliant
+
+        [AllTargets]
+        public int GetUsageForAll() => 17; // Noncompliant
+
+        [AllTargets]
+        [PropertyOrMethod]
+        public int GetUsageForAll2() => 17; // Noncompliant
+
+
+        [AttributeUsage(AttributeTargets.All)]
+        private sealed class AllTargetsAttribute : Attribute { }
+
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method)]
+        private sealed class PropertyOrMethodAttribute : Attribute { }
+
         [AttributeUsage(AttributeTargets.All ^ AttributeTargets.Property)]
-        private class NoPropertyAttribute : Attribute { }
+        private sealed class NoPropertyAttribute : Attribute { }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PropertiesShouldBePreferred.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PropertiesShouldBePreferred.cs
@@ -156,6 +156,8 @@ namespace MyLibrary
         [PropertyOrMethod]
         public int GetUsageForAll2() => 17; // Noncompliant
 
+        [NoUsageDefined]
+        public int GetNoUsagedDefined() => 666; // Noncompliant
 
         [AttributeUsage(AttributeTargets.All)]
         private sealed class AllTargetsAttribute : Attribute { }
@@ -165,5 +167,7 @@ namespace MyLibrary
 
         [AttributeUsage(AttributeTargets.All ^ AttributeTargets.Property)]
         private sealed class NoPropertyAttribute : Attribute { }
+
+        private sealed class NoUsageDefinedAttribute : Attribute { }
     }
 }


### PR DESCRIPTION
Fix for FP on Consider making method '{0}' a property; when there is any attribute on the method not supported on properties.

Fixes #3140