### PR TITLE
GitHub workflow: Submit review

### DIFF
--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -1,0 +1,121 @@
+name: Submit Review
+
+on:
+  pull_request_review:
+    types: ["submitted"]
+
+jobs:
+  assign_and_move_card:
+    name: Assign issue to PR author and move Kanban card
+    runs-on: ubuntu-latest
+    # Single quotes must be used here https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#literals
+    if: |
+        github.event.review.state == 'approved'
+        || github.event.review.state == 'changes_requested'
+
+    steps:
+      # https://github.com/actions/github-script
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const TODO_COLUMN = 4971951;
+            const IN_PROGRESS_COLUMN = 4971952;
+            const REVIEW_IN_PROGRESS_COLUMN = 4971953;
+            const REVIEW_APPROVED_COLUMN = 4971954;
+            const DONE_COLUMN = 4971955;
+            //
+            async function getIssue(issue_number) {
+                try {
+                    return (await github.issues.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number
+                    })).data;
+                }
+                catch (error) {
+                    console.log(`Issue #${issue_number} not found: ${error}`);
+                    return null;
+                }
+            }
+            //
+            async function findCard(content_url) {
+                // Columns are searched from the most probable one
+                const allColumns = [REVIEW_IN_PROGRESS_COLUMN, REVIEW_APPROVED_COLUMN, IN_PROGRESS_COLUMN, TODO_COLUMN, DONE_COLUMN];
+                for (let i = 0; i < allColumns.length; i++) {
+                    let cards = await github.projects.listCards({ column_id: allColumns[i] });
+                    let card = cards.data.find(x => x.content_url == content_url);
+                    if (card) {
+                        return card;
+                    }
+                }
+                console.log("Card not found for: " + content_url);
+                return null;
+            }
+            //
+            async function removeAssignees(issue){
+                const oldAssignees = issue.assignees.map(x => x.login);
+                if (oldAssignees.length !== 0) {
+                    console.log("Removing assignees: " + oldAssignees.join(", "));
+                    await github.issues.removeAssignees({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: issue.number,
+                        assignees: oldAssignees
+                    });
+                }
+            }
+            //
+            async function addAssignee(issue, login) {
+                console.log("Assigning to: " + login);
+                await github.issues.addAssignees({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    assignees: [login]
+                });
+            }
+            //
+            async function processIssue(issue) {
+                if (issue.state == "open") {
+                    const pr = context.payload.pull_request;
+                    switch(pr.author_association){
+                        case "OWNER":
+                        case "MEMBER":
+                        case "COLLABORATOR":
+                            removeAssignees(issue);
+                            addAssignee(issue, pr.user.login);
+                            break;
+                        deafult:
+                            console.log("Skip assignment. Author association: " + pr.author_association);
+                    }
+                    const card = await findCard(issue.url);
+                    const newColumn = context.payload.review.state == "approved" ? REVIEW_APPROVED_COLUMN : IN_PROGRESS_COLUMN;
+                    if (card && card.column_id != newColumn) {
+                        console.log("Moving card");
+                        github.projects.moveCard({ card_id: card.id, position: "bottom", column_id: newColumn });
+                    }
+                }
+            }
+            //
+            let processPR = true;
+            const pr = context.payload.pull_request;
+            const matches = pr.body.match(/Fixes\s*#\d+/gi);
+            if (matches) {
+                for (let i = 0; i < matches.length; i++) {
+                    console.log("Processing linked issue: " + matches[i]);
+                    let linkedIssue = await getIssue(matches[i].split("#")[1]);
+                    if (linkedIssue) {
+                        processPR = false;
+                        processIssue(linkedIssue);
+                    }
+                }
+            }
+            if (processPR) {
+                console.log("Processing PR: #" + pr.number);
+                const issue = await getIssue(pr.number);
+                if (issue) {
+                    processIssue(issue);
+                }
+            }
+            console.log("Done");

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -9,9 +9,10 @@ jobs:
     name: Assign issue to PR author and move Kanban card
     runs-on: ubuntu-latest
     # Single quotes must be used here https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#literals
+    # PRs from forks don't have required token authorization
     if: |
-        github.event.review.state == 'approved'
-        || github.event.review.state == 'changes_requested'
+        github.event.pull_request.head.repo.full_name == github.repository
+        && (github.event.review.state == 'approved' || github.event.review.state == 'changes_requested')
 
     steps:
       # https://github.com/actions/github-script
@@ -78,17 +79,8 @@ jobs:
             //
             async function processIssue(issue) {
                 if (issue.state == "open") {
-                    const pr = context.payload.pull_request;
-                    switch(pr.author_association){
-                        case "OWNER":
-                        case "MEMBER":
-                        case "COLLABORATOR":
-                            removeAssignees(issue);
-                            addAssignee(issue, pr.user.login);
-                            break;
-                        deafult:
-                            console.log("Skip assignment. Author association: " + pr.author_association);
-                    }
+                    removeAssignees(issue);
+                    addAssignee(issue, context.payload.pull_request.user.login);
                     const card = await findCard(issue.url);
                     const newColumn = context.payload.review.state == "approved" ? REVIEW_APPROVED_COLUMN : IN_PROGRESS_COLUMN;
                     if (card && card.column_id != newColumn) {


### PR DESCRIPTION
Second baby step in Kanban automation. Most of the content is copy/paste from https://github.com/SonarSource/sonar-dotnet/blob/master/.github/workflows/RequestReview.yml This is intentional to keep the orchestration as simple as possible. I'll extract it to standalone reusable action into another repo after dogfooding.

Desired functionality when review is submitted:
* Find all cards with "Fixed #xxxx" and process referenced issue XOR
* Process PR itself, if no referenced issue is found
* Do not process closed issues/PRs

Submitted review is COMMENT:
* Do nothing

Submitted review is APPROVE:
* Move card to "Review approved" (GitHub does this for PRs, but doesn't do it for referenced issues)
* Assign card to PR author, remove others

Submitted review is REQUEST CHANGES:
* Move card to "In progress"
* Assign card to PR author, remove others

