### PR TITLE
CFG generation throws StackOverlowException when syntax tree is too deep

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/ControlFlowGraph/CSharpControlFlowGraphBuilder.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ControlFlowGraph/CSharpControlFlowGraphBuilder.cs
@@ -220,7 +220,7 @@ namespace SonarAnalyzer.ControlFlowGraph.CSharp
             {
                 return currentBlock;
             }
-            if (!IsTooComplex(expression))
+            if (IsTooComplex(expression))
             {
                 throw new NotSupportedException("Too complex expression");
             }
@@ -537,7 +537,7 @@ namespace SonarAnalyzer.ControlFlowGraph.CSharp
         private static bool IsTooComplex(SyntaxNode node)
         {
             var count = 0;  // Limit descending for performance reasons
-            return node.DescendantNodes(x => ++count < SupportedExpressionNodeCountLimit).Count() < SupportedExpressionNodeCountLimit;
+            return node.DescendantNodes(x => ++count < SupportedExpressionNodeCountLimit).Count() >= SupportedExpressionNodeCountLimit;
         }
 
         #endregion Top level Build*

--- a/analyzers/tests/SonarAnalyzer.UnitTest/ControlFlowGraph/ControlFlowGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/ControlFlowGraph/ControlFlowGraphTest.cs
@@ -178,7 +178,8 @@ namespace NS
         public void Cfg_ExtremelyNestedExpression_NotSupported_FromExpression()
         {
             var method = CompileWithMethodBody(string.Format(TestInput, $"var x = {ExtremelyNestedExpression()};"), "Bar", out var semanticModel);
-            Action a = () => CSharpControlFlowGraph.Create(method.Body, semanticModel);
+            var equalsValueSyntax = method.DescendantNodes(x => !(x is ExpressionSyntax)).OfType<EqualsValueClauseSyntax>().Single();
+            Action a = () => CSharpControlFlowGraph.Create(equalsValueSyntax.Value, semanticModel);
 
             a.Should().Throw<NotSupportedException>().WithMessage("Too complex expression");
             CSharpControlFlowGraph.TryGet(method.Body, semanticModel, out _).Should().BeFalse();


### PR DESCRIPTION
Fixes #3630
