### PR TITLE
Update Java ITs MSBuild timeout

### DIFF
--- a/its/src/test/java/com/sonar/it/shared/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/shared/TestUtils.java
@@ -127,7 +127,7 @@ public class TestUtils {
 
     LOG.info(String.format("Running MSBuild in working directory '%s'", command.getDirectory()));
 
-    int r = CommandExecutor.create().execute(command, 60 * 1000);
+    int r = CommandExecutor.create().execute(command, 2 * 60 * 1000);
     assertThat(r).isEqualTo(0);
   }
 


### PR DESCRIPTION
We're having too much of [these failures](https://sonarsource.visualstudio.com/DotNetTeam%20Project/_build/results?buildId=25314&view=logs&jobId=5a0b2a7a-818d-5a4c-a639-e2568d087f6b&j=5a0b2a7a-818d-5a4c-a639-e2568d087f6b&t=407cbd3b-4ba1-5b9c-259b-e19d650c77d2) in CI

```
[ERROR] Tests run: 102, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 551.258 s <<< FAILURE! - in com.sonar.it.csharp.Tests
[ERROR] visual_studio_on_MultipleProjects(com.sonar.it.csharp.CoverageTest)  Time elapsed: 73.875 s  <<< ERROR!

com.sonar.orchestrator.util.CommandException: Timeout exceeded: 60000 ms [command: cmd /c ""C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" "/t:Restore,Rebuild""]
	at com.sonar.it.csharp.CoverageTest.analyzeMultipleProjectsTestProject(CoverageTest.java:171)
	at com.sonar.it.csharp.CoverageTest.visual_studio_on_MultipleProjects(CoverageTest.java:127)
Caused by: java.util.concurrent.TimeoutException
	at com.sonar.it.csharp.CoverageTest.analyzeMultipleProjectsTestProject(CoverageTest.java:171)
	at com.sonar.it.csharp.CoverageTest.visual_studio_on_MultipleProjects(CoverageTest.java:127)
```