### PR TITLE
Rule S3329: IV is safe by default

### DIFF
--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues/NetFramework48/AesCngTest.cs
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues/NetFramework48/AesCngTest.cs
@@ -26,15 +26,9 @@ namespace NetFramework48
     {
         public static void TestCases()
         {
-            using (var sa = new AesCng())
-            {
-                sa.CreateEncryptor(); // Noncompliant (S3329) {{Use a dynamically-generated, random IV.}}
-                sa.CreateEncryptor(sa.Key, sa.IV); // Noncompliant
-
-                sa.GenerateKey();
-                sa.GenerateIV();
-                sa.CreateEncryptor(sa.Key, sa.IV);
-            }
+            var aes = new AesCng();
+            aes.CreateEncryptor();
+            aes.CreateEncryptor(aes.Key, new byte[16]); // Noncompliant (S3329) {{Use a dynamically-generated, random IV.}}
         }
     }
 }

--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues/NetFramework48/AesCryptoServiceProviderTest.cs
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues/NetFramework48/AesCryptoServiceProviderTest.cs
@@ -28,12 +28,8 @@ namespace NetFramework48
         {
             using (var sa = new AesCryptoServiceProvider())
             {
-                sa.CreateEncryptor(); // Noncompliant (S3329) {{Use a dynamically-generated, random IV.}}
-                sa.CreateEncryptor(sa.Key, sa.IV); // Noncompliant
-
-                sa.GenerateKey();
-                sa.GenerateIV();
-                sa.CreateEncryptor(sa.Key, sa.IV);
+                sa.CreateEncryptor();
+                sa.CreateEncryptor(sa.Key, new byte[16]); // Noncompliant (S3329) {{Use a dynamically-generated, random IV.}}
             }
         }
     }

--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues/NetFramework48/AesTest.cs
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues/NetFramework48/AesTest.cs
@@ -26,14 +26,10 @@ namespace NetFramework48
     {
         public static void TestCases()
         {
-            using (var sa = Aes.Create())
+            using (var aes = Aes.Create())
             {
-                sa.CreateEncryptor(); // Noncompliant (S3329) {{Use a dynamically-generated, random IV.}}
-                sa.CreateEncryptor(sa.Key, sa.IV); // Noncompliant
-
-                sa.GenerateKey();
-                sa.GenerateIV();
-                sa.CreateEncryptor(sa.Key, sa.IV);
+                aes.CreateEncryptor();
+                aes.CreateEncryptor(aes.Key, new byte[16]); // Noncompliant (S3329) {{Use a dynamically-generated, random IV.}}
             }
         }
     }

--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues/NetFramework48/SymmetricAlgorithmTest.cs
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues/NetFramework48/SymmetricAlgorithmTest.cs
@@ -26,14 +26,10 @@ namespace NetFramework48
     {
         public static void TestCases()
         {
-            using (var sa = SymmetricAlgorithm.Create("AES"))
+            using (var sa = SymmetricAlgorithm.Create("Rijndael"))
             {
-                sa.CreateEncryptor(); // Noncompliant (S3329) {{Use a dynamically-generated, random IV.}}
-                sa.CreateEncryptor(sa.Key, sa.IV); // Noncompliant
-
-                sa.GenerateKey();
-                sa.GenerateIV();
-                sa.CreateEncryptor(sa.Key, sa.IV);
+                sa.CreateEncryptor();
+                sa.CreateEncryptor(sa.Key, new byte[16]); // Noncompliant (S3329) {{Use a dynamically-generated, random IV.}}
             }
         }
     }

--- a/analyzers/rspec/cs/S3329_c#.html
+++ b/analyzers/rspec/cs/S3329_c#.html
@@ -15,24 +15,22 @@ twice will yield two different ciphertexts.</p>
 public void Encrypt(byte[] key, byte[] data, MemoryStream target)
 {
     byte[] initializationVector = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
-    using (AesCryptoServiceProvider aes = new AesCryptoServiceProvider())
-    {
-        ICryptoTransform encryptor = aes.CreateEncryptor(key, initializationVector); // Noncompliant, hardcoded value is used
-        using (CryptoStream cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write))
-        {
-            cryptoStream.Write(data);
-        }
-    }
+
+    using var aes = new AesCryptoServiceProvider();
+    var encryptor = aes.CreateEncryptor(key, initializationVector); // Noncompliant, hardcoded value is used
+
+    using var cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write);
+    cryptoStream.Write(data);
 }
 </pre>
 <h2>Compliant Solution</h2>
 <pre>
 public byte[] Encrypt(byte[] key, byte[] data, MemoryStream target)
 {
-    using AesCryptoServiceProvider aes = new AesCryptoServiceProvider();
-    var encryptor = aes.CreateEncryptor(key, aes.IV);
+    using var aes = new AesCryptoServiceProvider();
+    var encryptor = aes.CreateEncryptor(key, aes.IV); // aes.IV is automatically generated to random secure value
 
-    using CryptoStream cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write);
+    using var cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write);
     cryptoStream.Write(data);
 
     return aes.IV;

--- a/analyzers/rspec/cs/S3329_c#.html
+++ b/analyzers/rspec/cs/S3329_c#.html
@@ -17,7 +17,7 @@ public void Encrypt(byte[] key, byte[] data, MemoryStream target)
     byte[] initializationVector = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
     using (AesCryptoServiceProvider aes = new AesCryptoServiceProvider())
     {
-        ICryptoTransform encryptor = aes.CreateEncryptor(key, initializationVector);     // Noncompliant, hardcoded value is used
+        ICryptoTransform encryptor = aes.CreateEncryptor(key, initializationVector); // Noncompliant, hardcoded value is used
         using (CryptoStream cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write))
         {
             cryptoStream.Write(data);
@@ -29,16 +29,13 @@ public void Encrypt(byte[] key, byte[] data, MemoryStream target)
 <pre>
 public byte[] Encrypt(byte[] key, byte[] data, MemoryStream target)
 {
-    using (AesCryptoServiceProvider aes = new AesCryptoServiceProvider())
-    {
-        aes.GenerateIV();
-        ICryptoTransform encryptor = aes.CreateEncryptor(key, aes.IV);
-        using (CryptoStream cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write))
-        {
-            cryptoStream.Write(data);
-        }
-        return aes.IV;
-    }
+    using AesCryptoServiceProvider aes = new AesCryptoServiceProvider();
+    var encryptor = aes.CreateEncryptor(key, aes.IV);
+
+    using CryptoStream cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write);
+    cryptoStream.Write(data);
+
+    return aes.IV;
 }
 </pre>
 <h2>See</h2>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InitializationVectorShouldBeRandom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InitializationVectorShouldBeRandom.cs
@@ -86,10 +86,10 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
 
             private ProgramState InvocationExpressionPostProcess(InvocationExpressionSyntax invocation, ProgramState programState)
             {
-                if (IsSymmetricAlgorithmGenerateIVMethod(invocation, semanticModel))
+                if (IsSymmetricAlgorithmGenerateIVMethod(invocation, semanticModel)
+                    && GetSymbolicValue(invocation, programState) is {} ivSymbolicValue)
                 {
-                    var symbolicValue = GetSymbolicValue(invocation, programState);
-                    programState = programState.SetConstraint(symbolicValue, CryptographyIVSymbolicValueConstraint.Initialized);
+                    programState = programState.SetConstraint(ivSymbolicValue, CryptographyIVSymbolicValueConstraint.Initialized);
                 }
                 else if (IsSanitizer(invocation, semanticModel)
                          && semanticModel.GetSymbolInfo(invocation.ArgumentList.Arguments[0].Expression).Symbol is {} symbol

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InitializationVectorShouldBeRandom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InitializationVectorShouldBeRandom.cs
@@ -78,34 +78,15 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
             public override ProgramState PostProcessInstruction(ProgramPoint programPoint, ProgramState programState) =>
                 programPoint.CurrentInstruction switch
                 {
-                    ObjectCreationExpressionSyntax objectCreation => ObjectCreationPostProcess(objectCreation, programState),
                     InvocationExpressionSyntax invocation => InvocationExpressionPostProcess(invocation, programState),
                     ArrayCreationExpressionSyntax arrayCreation => ArrayCreationPostProcess(arrayCreation, programState),
                     AssignmentExpressionSyntax assignment => AssignmentExpressionPostProcess(assignment, programState),
                     _ => programState
                 };
 
-            private ProgramState ObjectCreationPostProcess(ObjectCreationExpressionSyntax objectCreation, ProgramState programState)
-            {
-                if (semanticModel.GetSymbolInfo(objectCreation).Symbol is {} symbol
-                    && symbol.ContainingType is {} symbolType
-                    && symbolType.DerivesFrom(KnownType.System_Security_Cryptography_SymmetricAlgorithm))
-                {
-                    var symbolicValue = programState.PeekValue();
-                    programState = programState.SetConstraint(symbolicValue, CryptographyIVSymbolicValueConstraint.NotInitialized);
-                }
-
-                return programState;
-            }
-
             private ProgramState InvocationExpressionPostProcess(InvocationExpressionSyntax invocation, ProgramState programState)
             {
-                if (IsSymmetricAlgorithmCreateMethod(invocation, semanticModel))
-                {
-                    var symbolicValue = programState.PeekValue();
-                    programState = programState.SetConstraint(symbolicValue, CryptographyIVSymbolicValueConstraint.NotInitialized);
-                }
-                else if (IsSymmetricAlgorithmGenerateIVMethod(invocation, semanticModel))
+                if (IsSymmetricAlgorithmGenerateIVMethod(invocation, semanticModel))
                 {
                     var symbolicValue = GetSymbolicValue(invocation, programState);
                     programState = programState.SetConstraint(symbolicValue, CryptographyIVSymbolicValueConstraint.Initialized);
@@ -165,6 +146,7 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
                                                                  && HasNotInitializedIVConstraint(symbolicValue, programState),
                     IdentifierNameSyntax identifier => programState.GetSymbolValue(semanticModel.GetSymbolInfo(identifier).Symbol) is {} symbolicValue
                                                        && programState.HasConstraint(symbolicValue, ByteArraySymbolicValueConstraint.Constant),
+                    ArrayCreationExpressionSyntax _ => true,
                     _ => false
                 };
 
@@ -182,9 +164,6 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
 
             private static bool HasNotInitializedIVConstraint(SymbolicValue value, ProgramState programState) =>
                 programState.Constraints[value].HasConstraint(CryptographyIVSymbolicValueConstraint.NotInitialized);
-
-            private static bool IsSymmetricAlgorithmCreateMethod(InvocationExpressionSyntax invocation, SemanticModel semanticModel) =>
-                invocation.IsMemberAccessOnKnownType("Create", KnownType.System_Security_Cryptography_SymmetricAlgorithm, semanticModel);
 
             private static bool IsSymmetricAlgorithmCreateEncryptorMethod(InvocationExpressionSyntax invocation, SemanticModel semanticModel) =>
                 invocation.IsMemberAccessOnKnownType("CreateEncryptor", KnownType.System_Security_Cryptography_SymmetricAlgorithm, semanticModel);

--- a/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S3329.html
+++ b/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S3329.html
@@ -15,24 +15,22 @@ twice will yield two different ciphertexts.</p>
 public void Encrypt(byte[] key, byte[] data, MemoryStream target)
 {
     byte[] initializationVector = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
-    using (AesCryptoServiceProvider aes = new AesCryptoServiceProvider())
-    {
-        ICryptoTransform encryptor = aes.CreateEncryptor(key, initializationVector); // Noncompliant, hardcoded value is used
-        using (CryptoStream cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write))
-        {
-            cryptoStream.Write(data);
-        }
-    }
+
+    using var aes = new AesCryptoServiceProvider();
+    var encryptor = aes.CreateEncryptor(key, initializationVector); // Noncompliant, hardcoded value is used
+
+    using var cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write);
+    cryptoStream.Write(data);
 }
 </pre>
 <h2>Compliant Solution</h2>
 <pre>
 public byte[] Encrypt(byte[] key, byte[] data, MemoryStream target)
 {
-    using AesCryptoServiceProvider aes = new AesCryptoServiceProvider();
-    var encryptor = aes.CreateEncryptor(key, aes.IV);
+    using var aes = new AesCryptoServiceProvider();
+    var encryptor = aes.CreateEncryptor(key, aes.IV); // aes.IV is automatically generated to random secure value
 
-    using CryptoStream cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write);
+    using var cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write);
     cryptoStream.Write(data);
 
     return aes.IV;

--- a/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S3329.html
+++ b/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S3329.html
@@ -17,7 +17,7 @@ public void Encrypt(byte[] key, byte[] data, MemoryStream target)
     byte[] initializationVector = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
     using (AesCryptoServiceProvider aes = new AesCryptoServiceProvider())
     {
-        ICryptoTransform encryptor = aes.CreateEncryptor(key, initializationVector);     // Noncompliant, hardcoded value is used
+        ICryptoTransform encryptor = aes.CreateEncryptor(key, initializationVector); // Noncompliant, hardcoded value is used
         using (CryptoStream cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write))
         {
             cryptoStream.Write(data);
@@ -29,16 +29,13 @@ public void Encrypt(byte[] key, byte[] data, MemoryStream target)
 <pre>
 public byte[] Encrypt(byte[] key, byte[] data, MemoryStream target)
 {
-    using (AesCryptoServiceProvider aes = new AesCryptoServiceProvider())
-    {
-        aes.GenerateIV();
-        ICryptoTransform encryptor = aes.CreateEncryptor(key, aes.IV);
-        using (CryptoStream cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write))
-        {
-            cryptoStream.Write(data);
-        }
-        return aes.IV;
-    }
+    using AesCryptoServiceProvider aes = new AesCryptoServiceProvider();
+    var encryptor = aes.CreateEncryptor(key, aes.IV);
+
+    using CryptoStream cryptoStream = new CryptoStream(target, encryptor, CryptoStreamMode.Write);
+    cryptoStream.Write(data);
+
+    return aes.IV;
 }
 </pre>
 <h2>See</h2>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InitializationVectorShouldBeRandom.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InitializationVectorShouldBeRandom.CSharp9.cs
@@ -6,19 +6,14 @@ var constantIV = new byte[16];
 using var aes = new AesCng();
 using var rng = new RNGCryptoServiceProvider();
 
-aes.CreateEncryptor(); // FN
-aes.CreateEncryptor(aes.Key, constantIV); // FN
-
-aes.GenerateIV();
 aes.CreateEncryptor();
-aes.CreateEncryptor(aes.Key, aes.IV);
+aes.CreateEncryptor(aes.Key, new byte[16]); // FN
 
 void TopLevelLocalFunction()
 {
     using var aes = new AesCng();
-    aes.CreateEncryptor(); // FN
-    aes.GenerateIV();
     aes.CreateEncryptor();
+    aes.CreateEncryptor(aes.Key, new byte[16]); // FN
 }
 
 public class Sample
@@ -26,9 +21,8 @@ public class Sample
     public void TargetTypedNew()
     {
         AesCng aes = new();
-        aes.CreateEncryptor(); // FN
-        aes.GenerateIV();
         aes.CreateEncryptor();
+        aes.CreateEncryptor(aes.Key, new byte[16]); // FN
     }
 
     public void StaticLambda()
@@ -36,7 +30,8 @@ public class Sample
         Action a = static () =>
         {
             AesCng aes = new AesCng();
-            aes.CreateEncryptor(); // Noncompliant
+            aes.CreateEncryptor();
+            aes.CreateEncryptor(aes.Key, new byte[16]); // Noncompliant
         };
         a();
     }
@@ -59,9 +54,8 @@ public record Record
     public void Method()
     {
         AesCng aes = new AesCng();
-        aes.CreateEncryptor(); // Noncompliant
-        aes.GenerateIV();
         aes.CreateEncryptor();
+        aes.CreateEncryptor(aes.Key, new byte[16]); // Noncompliant
     }
 }
 
@@ -75,9 +69,8 @@ public partial class Partial
     public partial void Method()
     {
         AesCng aes = new AesCng();
-        aes.CreateEncryptor(); // Noncompliant
-        aes.GenerateIV();
         aes.CreateEncryptor();
+        aes.CreateEncryptor(aes.Key, new byte[16]); // Noncompliant
     }
 }
 
@@ -88,9 +81,8 @@ namespace TartetTypedConditional
         public void Go(bool condition)
         {
             SymmetricAlgorithm aes = condition ? new AesCng() : new AesCryptoServiceProvider();
-            aes.CreateEncryptor();  // Noncompliant
-            aes.GenerateIV();
             aes.CreateEncryptor();
+            aes.CreateEncryptor(aes.Key, new byte[16]); // Noncompliant
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InitializationVectorShouldBeRandom.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InitializationVectorShouldBeRandom.cs
@@ -29,6 +29,8 @@ namespace Tests.Diagnostics
                 sa.CreateEncryptor(sa.Key, new CustomAlg().Key);
 
                 sa.IV = initializationVectorConstant;
+                sa.GenerateKey();
+
                 var ivReplacedDefaultConstructor = sa.CreateEncryptor(); // Noncompliant
                 var ivReplaced = sa.CreateEncryptor(sa.Key, sa.IV); // Noncompliant
             }
@@ -266,7 +268,6 @@ namespace Tests.Diagnostics
         {
             algorithm = Aes.Create();
         }
-
 
         public void GenerateIV()
         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InitializationVectorShouldBeRandom.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InitializationVectorShouldBeRandom.cs
@@ -257,4 +257,25 @@ namespace Tests.Diagnostics
 
         public override void GenerateKey() => throw new NotImplementedException();
     }
+
+    public class SymmetricalEncryptorWrapper
+    {
+        private readonly SymmetricAlgorithm algorithm;
+
+        public SymmetricalEncryptorWrapper()
+        {
+            algorithm = Aes.Create();
+        }
+
+
+        public void GenerateIV()
+        {
+            algorithm.GenerateIV();
+        }
+
+        public ICryptoTransform CreateEncryptor()
+        {
+            return algorithm.CreateEncryptor();
+        }
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InitializationVectorShouldBeRandom.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InitializationVectorShouldBeRandom.cs
@@ -11,15 +11,13 @@ namespace Tests.Diagnostics
 
             using (SymmetricAlgorithm sa = SymmetricAlgorithm.Create("AES"))
             {
-                ICryptoTransform notInitialized = sa.CreateEncryptor(); // Noncompliant {{Use a dynamically-generated, random IV.}}
-//                                                ^^^^^^^^^^^^^^^^^^^^
-
-                var keyAndIVareNotInitialized = sa.CreateEncryptor(sa.Key, sa.IV); // Noncompliant - iv is not generated
-//                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                ICryptoTransform noParams = sa.CreateEncryptor(); // Compliant - IV is automatically generated
+                var defaultKeyAndIV = sa.CreateEncryptor(sa.Key, sa.IV); // Compliant
 
                 sa.GenerateKey();
-                var ivIsNotInitialized = sa.CreateEncryptor(sa.Key, sa.IV); // Noncompliant - iv is not generated
-                var constantVector = sa.CreateEncryptor(sa.Key, initializationVectorConstant); // Noncompliant
+                var generateIVNotCalled = sa.CreateEncryptor(sa.Key, sa.IV);
+                var constantVector = sa.CreateEncryptor(sa.Key, initializationVectorConstant); // Noncompliant {{Use a dynamically-generated, random IV.}}
+//                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
                 sa.GenerateIV();
                 var defaultConstructor = sa.CreateEncryptor(); // Compliant
@@ -42,9 +40,6 @@ namespace Tests.Diagnostics
             new Random().NextBytes(initializationVectorWeakBytes);
 
             var sa = SymmetricAlgorithm.Create("AES");
-            sa.GenerateKey();
-            sa.GenerateIV();
-
             var encryptor = sa.CreateEncryptor(sa.Key, initializationVectorWeakBytes); // Noncompliant
         }
 
@@ -59,9 +54,6 @@ namespace Tests.Diagnostics
             }
 
             var sa = SymmetricAlgorithm.Create("AES");
-            sa.GenerateKey();
-            sa.GenerateIV();
-
             sa.CreateEncryptor(sa.Key, initializationVectorWeakFor); // Noncompliant
         }
 
@@ -116,16 +108,14 @@ namespace Tests.Diagnostics
             using var aes = new AesCryptoServiceProvider();
             using var rng = new RNGCryptoServiceProvider();
 
-            var noParamsNoKeyAndNoIV = aes.CreateEncryptor(); // Noncompliant
-
-            aes.GenerateKey();
-            var noParamsNoIV = aes.CreateEncryptor(); // Noncompliant
+            var noParams = aes.CreateEncryptor(); // Compliant
 
             var constantIV = new byte[16];
             var withConstant = aes.CreateEncryptor(aes.Key, constantIV); // Noncompliant
 
+            aes.GenerateKey();
             aes.GenerateIV();
-            var noParams = aes.CreateEncryptor();
+            aes.CreateEncryptor();
             var withGeneratedKeyAndIV = aes.CreateEncryptor(aes.Key, aes.IV);
 
             aes.CreateDecryptor(aes.Key, constantIV); // Compliant, we do not check CreateDecryptor
@@ -139,16 +129,16 @@ namespace Tests.Diagnostics
             using var aes = Aes.Create();
             using var rng = new RNGCryptoServiceProvider();
 
-            var noParamsNoKeyAndNoIV = aes.CreateEncryptor(); // Noncompliant
+            var noParams = aes.CreateEncryptor(); // Compliant
 
             aes.GenerateKey();
-            var noParamsNoIV = aes.CreateEncryptor(); // Noncompliant
+            var reGeneratedKey = aes.CreateEncryptor(); // Compliant
 
             var constantIV = new byte[16];
             var withConstant = aes.CreateEncryptor(aes.Key, constantIV); // Noncompliant
 
             aes.GenerateIV();
-            var noParams = aes.CreateEncryptor();
+            aes.CreateEncryptor();
             var withGeneratedKeyAndIV = aes.CreateEncryptor(aes.Key, aes.IV);
 
             aes.CreateDecryptor(aes.Key, constantIV); // Compliant, we do not check CreateDecryptor
@@ -162,16 +152,16 @@ namespace Tests.Diagnostics
             using var aes = new AesCng();
             using var rng = new RNGCryptoServiceProvider();
 
-            var noParamsNoKeyAndNoIV = aes.CreateEncryptor(); // Noncompliant
+            var noParams = aes.CreateEncryptor(); // Compliant
 
             aes.GenerateKey();
-            var noParamsNoIV = aes.CreateEncryptor(); // Noncompliant
+            var withGeneratedKey = aes.CreateEncryptor(); // Compliant
 
             var constantIV = new byte[16];
             var withConstant = aes.CreateEncryptor(aes.Key, constantIV); // Noncompliant
 
             aes.GenerateIV();
-            var noParams = aes.CreateEncryptor();
+            aes.CreateEncryptor();
             var withGeneratedKeyAndIV = aes.CreateEncryptor(aes.Key, aes.IV);
 
             aes.CreateDecryptor(aes.Key, constantIV); // Compliant, we do not check CreateDecryptor
@@ -185,16 +175,16 @@ namespace Tests.Diagnostics
             using var aes = new CustomAes();
             using var rng = new RNGCryptoServiceProvider();
 
-            var noParamsNoKeyAndNoIV = aes.CreateEncryptor(); // Noncompliant
+            var noParams = aes.CreateEncryptor(); // Compliant
 
             aes.GenerateKey();
-            var noParamsNoIV = aes.CreateEncryptor(); // Noncompliant
+            var withGeneratedKey = aes.CreateEncryptor(); // Compliant
 
             var constantIV = new byte[16];
             var withConstant = aes.CreateEncryptor(aes.Key, constantIV); // Noncompliant
 
             aes.GenerateIV();
-            var noParams = aes.CreateEncryptor();
+            aes.CreateEncryptor();
             var withGeneratedKeyAndIV = aes.CreateEncryptor(aes.Key, aes.IV);
 
             aes.CreateDecryptor(aes.Key, constantIV); // Compliant, we do not check CreateDecryptor
@@ -205,31 +195,28 @@ namespace Tests.Diagnostics
 
         public void InConditionals(int a)
         {
-            using var aesNotInitialized = new AesCng();
-            using var rng = new RNGCryptoServiceProvider();
+            var constantIV = new byte[16];
 
-            using var aesInitialized = Aes.Create();
-            aesInitialized.GenerateKey();
-            aesInitialized.GenerateIV();
+            using var aes = new AesCng();
+            using var rng = new RNGCryptoServiceProvider();
 
             var e = a switch
             {
-                1 => aesNotInitialized.CreateEncryptor(), // Noncompliant
-                2 => aesNotInitialized.CreateEncryptor(aesNotInitialized.Key, aesNotInitialized.IV), // Noncompliant
-                3 => aesInitialized.CreateEncryptor(),
+                1 => aes.CreateEncryptor(), // Compliant
+                2 => aes.CreateEncryptor(aes.Key, constantIV), // Noncompliant
                 _ => null
             };
+
+            var iv = new byte[16];
 
             using var aes2 = new AesCng();
             if (a == 1)
             {
-                aes2.GenerateKey();
-                aes2.GenerateIV();
-                aes2.CreateEncryptor();
+                aes2.IV = iv; // Set IV to constant
             }
             aes2.CreateEncryptor(); // Noncompliant
 
-            var aes3 = a == 2 ? aesInitialized : aesNotInitialized;
+            var aes3 = a == 2 ? aes2 : aes;
             aes3.CreateEncryptor(); // Noncompliant
         }
 


### PR DESCRIPTION
Related to #3724

This updates the current implementation to consider the IV safe by default.

According to the [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.symmetricalgorithm.createencryptor?view=net-5.0#System_Security_Cryptography_SymmetricAlgorithm_CreateEncryptor):
> If the current Key property is null, the GenerateKey method is called to create a new random Key. If the current IV property is null, the GenerateIV method is called to create a new random IV.