### PR TITLE
Fix S1155 FN: Count() != 0

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionEmptinessChecking.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionEmptinessChecking.cs
@@ -83,6 +83,14 @@ namespace SonarAnalyzer.Rules.CSharp
                     CheckCountZero(binary.Right, binary.Left, c);
                 },
                 SyntaxKind.EqualsExpression);
+            context.RegisterSyntaxNodeActionInNonGenerated(
+                c =>
+                {
+                    var binary = (BinaryExpressionSyntax)c.Node;
+                    CheckCountZero(binary.Left, binary.Right, c);
+                    CheckCountZero(binary.Right, binary.Left, c);
+                },
+                SyntaxKind.NotEqualsExpression);
         }
 
         private static void CheckCountZero(ExpressionSyntax zero, ExpressionSyntax count, SyntaxNodeAnalysisContext context)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CollectionEmptinessCheckingTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CollectionEmptinessCheckingTest.cs
@@ -30,9 +30,7 @@ namespace SonarAnalyzer.UnitTest.Rules
     {
         [TestMethod]
         [TestCategory("Rule")]
-        public void CollectionEmptinessChecking()
-        {
+        public void CollectionEmptinessChecking() =>
             Verifier.VerifyAnalyzer(@"TestCases\CollectionEmptinessChecking.cs", new CollectionEmptinessChecking());
-        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CollectionEmptinessChecking.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CollectionEmptinessChecking.cs
@@ -28,6 +28,14 @@ namespace Tests.Diagnostics
         {
             return l.Any();
         }
+        private static bool IsNotEmpty1(List<string> l)
+        {
+            return l.Count() != 0; // Noncompliant
+        }
+        private static bool IsNotEmpty2(List<string> l)
+        {
+            return 0 != l.Count(); // Noncompliant
+        }
         private static bool IsEmpty1(List<string> l)
         {
             return l.Count() == 0; // Noncompliant
@@ -51,6 +59,14 @@ namespace Tests.Diagnostics
         private static bool IsEmpty4b(List<string> l)
         {
             return 1 > l.Count(); // Noncompliant
+        }
+        private static bool HasContentWithCondition(List<int> numbers)
+        {
+            return numbers.Count(n => n % 2 == 0) > 0; // Noncompliant
+        }
+        private static bool IsEmptyWithCondition(List<int> numbers)
+        {
+            return numbers.Count(n => n % 2 == 0) == 0; // Noncompliant
         }
     }
 }


### PR DESCRIPTION
Will working on #2334 , I noticed that both `enumerable.Count() != 0` and `enumerable.Count(condition) ?? 0|1` where not covered by tests. The second already worked, but the first one didn't, so hence a simple fix.