### PR TITLE
Improve S1144 for protected internal members

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
@@ -112,7 +112,7 @@ namespace SonarAnalyzer.Helpers
                 deconstructors.FirstOrDefault(m => m.GetParameters().Count() == numberOfArguments && IsAccessibleOutsideTheType(m.DeclaredAccessibility));
 
             static bool IsAccessibleOutsideTheType(Accessibility accessibility) =>
-                accessibility == Accessibility.Public || accessibility == Accessibility.Internal || accessibility == Accessibility.ProtectedAndInternal;
+                accessibility == Accessibility.Public || accessibility == Accessibility.Internal || accessibility == Accessibility.ProtectedOrInternal;
         }
 
         public override void VisitAttribute(AttributeSyntax node)

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpSymbolUsageCollector.cs
@@ -109,10 +109,7 @@ namespace SonarAnalyzer.Helpers
             }
 
             static ISymbol FindDeconstructor(IEnumerable<ISymbol> deconstructors, int numberOfArguments) =>
-                deconstructors.FirstOrDefault(m => m.GetParameters().Count() == numberOfArguments && IsAccessibleOutsideTheType(m.DeclaredAccessibility));
-
-            static bool IsAccessibleOutsideTheType(Accessibility accessibility) =>
-                accessibility == Accessibility.Public || accessibility == Accessibility.Internal || accessibility == Accessibility.ProtectedOrInternal;
+                deconstructors.FirstOrDefault(m => m.GetParameters().Count() == numberOfArguments && m.DeclaredAccessibility.IsAccessibleOutsideTheType());
         }
 
         public override void VisitAttribute(AttributeSyntax node)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldBeStatic.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldBeStatic.cs
@@ -134,12 +134,9 @@ namespace SonarAnalyzer.Rules.CSharp
             bool IsExcludedByEnclosingType() =>
                 methodOrPropertySymbol.ContainingType.IsInterface()
                 // Any generic type in nesting chain with member accessible from outside (through the whole nesting chain) is excluded.
-                || (methodOrPropertySymbol.ContainingType.IsGenericType && IsAccessibleOutsideTheType(methodOrPropertySymbol.GetEffectiveAccessibility()))
+                || (methodOrPropertySymbol.ContainingType.IsGenericType && methodOrPropertySymbol.GetEffectiveAccessibility().IsAccessibleOutsideTheType())
                 // Any nested private generic type with member accessible from outside that type (not the whole nesting chain) is also excluded.
-                || (methodOrPropertySymbol.ContainingType.TypeArguments.Any() && IsAccessibleOutsideTheType(methodOrPropertySymbol.DeclaredAccessibility));
-
-            bool IsAccessibleOutsideTheType(Accessibility accessibility) =>
-                accessibility == Accessibility.Public || accessibility == Accessibility.Internal || accessibility == Accessibility.ProtectedOrInternal;
+                || (methodOrPropertySymbol.ContainingType.TypeArguments.Any() && methodOrPropertySymbol.DeclaredAccessibility.IsAccessibleOutsideTheType());
         }
 
         private static bool IsIgnoredAttribute(AttributeData attribute) =>

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/AccessibilityExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/AccessibilityExtensions.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2020 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+
+namespace SonarAnalyzer.Helpers
+{
+    public static class AccessibilityExtensions
+    {
+        public static bool IsAccessibleOutsideTheType(this Accessibility accessibility) =>
+            accessibility == Accessibility.Public || accessibility == Accessibility.Internal || accessibility == Accessibility.ProtectedOrInternal;
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/AccessibilityExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/AccessibilityExtensions.cs
@@ -24,6 +24,11 @@ namespace SonarAnalyzer.Helpers
 {
     public static class AccessibilityExtensions
     {
+        /// <summary>
+        /// Beware of Accessibility members:
+        /// ProtectedOrInternal = C# "protected internal" or VB.NET "Protected Friend" syntax. Accessible from inheriting class OR the same assembly.
+        /// ProtectedAndInternal = C# "private protected" or VB.NET "Private Protected" syntax. Accessible only from inheriting class in the same assembly.
+        /// </summary>
         public static bool IsAccessibleOutsideTheType(this Accessibility accessibility) =>
             accessibility == Accessibility.Public || accessibility == Accessibility.Internal || accessibility == Accessibility.ProtectedOrInternal;
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberShouldBeStatic.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberShouldBeStatic.CSharp8.cs
@@ -17,4 +17,10 @@
             return a + b;
         }
     }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/3204
+    public class Repro_3204<TFirst, TSecond>
+    {
+        private protected int ProtectedInternal() => 42;    // Noncompliant, not accessible from outside this class
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.CSharp7.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.CSharp7.cs
@@ -92,9 +92,11 @@ namespace Tests.Diagnostics
             }
         }
 
-        internal class ProtectedInternalDeconstruct
+        private class ProtectedInternalDeconstruct
         {
             protected internal void Deconstruct(out object a, out object b) { a = b = null; }
+
+            protected internal void Deconstruct(out object a, out object b, out object c) { a = b = c = null; } // Noncompliant
         }
 
         private class Ambiguous


### PR DESCRIPTION
Related to #2478

Spin off from https://github.com/SonarSource/sonar-dotnet/pull/3843#discussion_r545271559

Having only public facing member, the rule didn't trigger.
Having only one Deconstruct, the code with access checking didn't run.