### PR TITLE
Restore VSIX nuget packages

### DIFF
--- a/scripts/build/dev-build.ps1
+++ b/scripts/build/dev-build.ps1
@@ -61,6 +61,11 @@ try {
     Write-Host "MSBuild: ${msbuildVersion}"
 
     if ($build) {
+        # Restore VSIX (special project)
+        Push-Location "src\SonarAnalyzer.Vsix"
+        nuget restore .\packages.SonarAnalyzer.Vsix.config -PackagesDirectory "../../packages"
+        Pop-Location
+
         Invoke-MSBuild $msbuildVersion $solutionName /t:"Restore,Rebuild" `
             /consoleloggerparameters:Summary `
             /m `


### PR DESCRIPTION
When running 
- `git clean -dfx`
- `.\scripts\build\dev-build.ps1 -buildJava -build -test -release` 

The build fails for the VSIX project (at least on my machine). This should fix it.
