### PR TITLE
Update SonarLint.xml and fix it's link in UTs

### DIFF
--- a/analyzers/.sonarlint/SonarAnalyzer.slconfig
+++ b/analyzers/.sonarlint/SonarAnalyzer.slconfig
@@ -9,7 +9,7 @@
   "Profiles": {
     "CSharp": {
       "ProfileKey": "AWT63_RpV-oLu4FdMlyI",
-      "ProfileTimestamp": "2020-12-04T10:55:38Z"
+      "ProfileTimestamp": "2020-12-28T10:06:24Z"
     }
   }
 }

--- a/analyzers/.sonarlint/sonaranalyzer-dotnetCSharp.ruleset
+++ b/analyzers/.sonarlint/sonaranalyzer-dotnetCSharp.ruleset
@@ -88,6 +88,7 @@
     <Rule Id="S1940" Action="Info" />
     <Rule Id="S1944" Action="Warning" />
     <Rule Id="S1994" Action="Warning" />
+    <Rule Id="S2053" Action="Warning" />
     <Rule Id="S2070" Action="None" />
     <Rule Id="S2114" Action="Warning" />
     <Rule Id="S2123" Action="Warning" />
@@ -118,7 +119,7 @@
     <Rule Id="S2306" Action="Warning" />
     <Rule Id="S2325" Action="Info" />
     <Rule Id="S2326" Action="Warning" />
-    <Rule Id="S2327" Action="Warning" />
+    <Rule Id="S2327" Action="None" />
     <Rule Id="S2328" Action="Info" />
     <Rule Id="S2330" Action="Warning" />
     <Rule Id="S2333" Action="Info" />
@@ -202,6 +203,7 @@
     <Rule Id="S3263" Action="Warning" />
     <Rule Id="S3264" Action="Warning" />
     <Rule Id="S3265" Action="Warning" />
+    <Rule Id="S3329" Action="Warning" />
     <Rule Id="S3343" Action="Warning" />
     <Rule Id="S3346" Action="Warning" />
     <Rule Id="S3353" Action="Warning" />
@@ -340,6 +342,7 @@
     <Rule Id="S4261" Action="Info" />
     <Rule Id="S4275" Action="Warning" />
     <Rule Id="S4277" Action="Warning" />
+    <Rule Id="S4423" Action="Warning" />
     <Rule Id="S4426" Action="Warning" />
     <Rule Id="S4428" Action="Warning" />
     <Rule Id="S4432" Action="None" />

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -84,9 +84,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\.sonarlint\SonarLint.xml">
-      <Link>Properties\SonarLint.xml</Link>
-    </AdditionalFiles>
+    <AdditionalFiles Include="..\..\.sonarlint\sonaranalyzer-dotnet\CSharp\SonarLint.xml" Link="Properties\SonarLint.xml" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Our UT project didn't have correct link to `sonarlint.xml` configuration file so it was locally complaining about nonexistent issues (like license headers).