### PR TITLE
Rename "Promote Nuget on repox" pipeline step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -526,7 +526,7 @@ stages:
   condition: succeeded()
   jobs:
     - job: promoteRepox
-      displayName: 'Promote SonarAnalyzer.CFG.CSharp NuGet on repox'
+      displayName: 'SonarAnalyzer.CFG.CSharp'
       steps:
         - powershell: |
             # Calculate the file path


### PR DESCRIPTION
Currently, GitHub shows this full check name in CI check list:
`Sonar.Net (Promote NuGet on repox Promote SonarAnalyzer.CFG.CSharp NuGet on repox)`

this will fix it to
`Sonar.Net (Promote NuGet on repox SonarAnalyzer.CFG.CSharp)`
while still keeping the tree structure in AZP understandable.

This check is not marked as required. Renaming doesn't require to update GitHub settings.

Another PR is [on it's way](https://sonarsource.visualstudio.com/DotNetTeam%20Project/_git/pipelines-yaml-templates/pullrequest/14) in AZP to deal with 
`Sonar.Net (Promote artifacts on repox and notify Burgr Promote artifact on repox and notify Burgr)`
`Sonar.Net (Promote artifacts on repox and notify Burgr promoteBurgr)`
to
`Sonar.Net (Artifacts: Promote on repox)`
`Sonar.Net (Artifacts: Notify Burgr)`