### PR TITLE
Update rspec.ps1 encoding

### DIFF
--- a/scripts/rspec/rspec.ps1
+++ b/scripts/rspec/rspec.ps1
@@ -127,7 +127,7 @@ function UpdateTestEntry($rule) {
     $ruleTypeTestCase = "${sonaranalyzerPath}\\tests\\SonarAnalyzer.UnitTest\\PackagingTests\\$fileToEdit.cs"
     $ruleId = $ruleKey.Substring(1)
     (Get-Content "${ruleTypeTestCase}") -replace "//\[`"$ruleId`"\]", "[`"$ruleId`"] = `"$ruleType`"" |
-        Set-Content "${ruleTypeTestCase}" -Encoding utf8BOM
+        Set-Content "${ruleTypeTestCase}" -Encoding UTF8
 }
 
 function GetRulesInfo($lang, $rules) {


### PR DESCRIPTION
Revert of this https://github.com/SonarSource/sonar-dotnet/pull/3859#discussion_r545825263

`utf8BOM` produces this error (contrary [docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-content?view=powershell-7.1)):

>C:\Projects\sonar-dotnet\scripts\rspec\rspec.ps1 : Cannot bind parameter 'Encoding'. Cannot convert value "utf8BOM" to
type "Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding". Error: "Unable to match the identifier name
utf8BOM to a valid enumerator name. Specify one of the following enumerator names and try again:
Unknown, String, Unicode, Byte, BigEndianUnicode, UTF8, UTF7, UTF32, Ascii, Default, Oem, BigEndianUTF32"
>At line:1 char:1
>+ .\scripts\rspec\rspec.ps1 cs S4036 CommandPath
>+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>    + CategoryInfo          : InvalidArgument: (:) [rspec.ps1], ParameterBindingException
>    + FullyQualifiedErrorId : CannotConvertArgumentNoMessage,rspec.ps1