### PR TITLE
Refactor MetadataReferenceFacade

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/SecurityHotspotTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/SecurityHotspotTest.cs
@@ -111,9 +111,9 @@ namespace SonarAnalyzer.UnitTest.Common
                                   .Concat(DeliveringDebugFeaturesInProductionTest.AdditionalReferencesNetCore2)
                                   .Concat(ExpandingArchivesTest.AdditionalReferences)
                                   .Concat(DoNotHardcodeCredentialsTest.AdditionalReferences)
-                                  .Concat(MetadataReferenceFacade.GetSystemDiagnosticsProcess())
-                                  .Concat(MetadataReferenceFacade.GetRegularExpressions()) // Needed by UsingRegularExpressions
-                                  .Concat(MetadataReferenceFacade.GetSystemSecurityCryptography()) // Needed by DoNotUseRandom
+                                  .Concat(MetadataReferenceFacade.SystemDiagnosticsProcess)
+                                  .Concat(MetadataReferenceFacade.RegularExpressions) // Needed by UsingRegularExpressions
+                                  .Concat(MetadataReferenceFacade.SystemSecurityCryptography) // Needed by DoNotUseRandom
                                   .Concat(NuGetMetadataReference.Nancy()); // Needed by CookieShouldBeHttpOnly, CookiesShouldBeSecure
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/MethodSignatureHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/MethodSignatureHelperTest.cs
@@ -121,7 +121,7 @@ namespace Test
     }
 }
 ";
-            var snippet = new SnippetCompiler(code, MetadataReferenceFacade.GetSystemXml());
+            var snippet = new SnippetCompiler(code, MetadataReferenceFacade.SystemXml);
             CheckExactMatch_DoesNotMatchOverrides(snippet);
         }
 
@@ -140,7 +140,7 @@ Namespace Test
 End Namespace
 ";
             var snippet = new SnippetCompiler(code, false, AnalyzerLanguage.VisualBasic,
-                MetadataReferenceFacade.GetSystemXml());
+                MetadataReferenceFacade.SystemXml);
             CheckExactMatch_DoesNotMatchOverrides(snippet);
         }
 
@@ -179,7 +179,7 @@ namespace Test
     }
 }
 ";
-            var snippet = new SnippetCompiler(code, MetadataReferenceFacade.GetSystemXml());
+            var snippet = new SnippetCompiler(code, MetadataReferenceFacade.SystemXml);
             CheckIsMatch_AndCheckingOverrides_DoesMatchOverrides(snippet);
         }
 
@@ -197,7 +197,7 @@ Namespace Test
     End Class
 End Namespace
 ";
-            var snippet = new SnippetCompiler(code, false, AnalyzerLanguage.VisualBasic, MetadataReferenceFacade.GetSystemXml());
+            var snippet = new SnippetCompiler(code, false, AnalyzerLanguage.VisualBasic, MetadataReferenceFacade.SystemXml);
             CheckIsMatch_AndCheckingOverrides_DoesMatchOverrides(snippet);
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/NetFrameworkVersionProviderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/NetFrameworkVersionProviderTest.cs
@@ -138,7 +138,6 @@ namespace SonarAnalyzer.UnitTest.Helpers
         }
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.GetMsCorLib()
-                .Concat(MetadataReferenceFacade.GetSystemComponentModelComposition());
+            MetadataReferenceFacade.MsCorLib.Concat(MetadataReferenceFacade.SystemComponentModelComposition);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/SonarAnalysisContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/SonarAnalysisContextTest.cs
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
                     Verifier.VerifyNoIssueReported(testCase.Path,
                                                    testCase.Analyzer,
                                                    ParseOptionsHelper.FromCSharp8,
-                                                   additionalReferences: MetadataReferenceFacade.GetSystemComponentModelPrimitives());
+                                                   additionalReferences: MetadataReferenceFacade.SystemComponentModelPrimitives);
                 }
             }
             finally
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
                 Verifier.VerifyAnalyzer(testCase.Path,
                                         testCase.Analyzer,
                                         ParseOptionsHelper.FromCSharp8,
-                                        additionalReferences: MetadataReferenceFacade.GetSystemComponentModelPrimitives());
+                                        additionalReferences: MetadataReferenceFacade.SystemComponentModelPrimitives);
             }
         }
 
@@ -128,14 +128,14 @@ namespace SonarAnalyzer.UnitTest.Helpers
                             Verifier.VerifyNoIssueReported(testCase.Path,
                                                            testCase.Analyzer,
                                                            ParseOptionsHelper.FromCSharp8,
-                                                           additionalReferences: MetadataReferenceFacade.GetSystemComponentModelPrimitives());
+                                                           additionalReferences: MetadataReferenceFacade.SystemComponentModelPrimitives);
                         }
                         else
                         {
                             Verifier.VerifyAnalyzer(testCase.Path,
                                                     testCase.Analyzer,
                                                     ParseOptionsHelper.FromCSharp8,
-                                                    additionalReferences: MetadataReferenceFacade.GetSystemComponentModelPrimitives());
+                                                    additionalReferences: MetadataReferenceFacade.SystemComponentModelPrimitives);
                         }
                     }
                 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/MetadataReferences/MetadataReferenceFacade.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/MetadataReferences/MetadataReferenceFacade.cs
@@ -26,14 +26,14 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
 {
     internal static class MetadataReferenceFacade
     {
-        internal static References GetMsCorLib() =>
+        internal static References MsCorLib =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.Mscorlib;
 #else
             new[] {CoreMetadataReference.MsCorLib};
 #endif
 
-        internal static References GetMicrosoftVisualBasic() =>
+        internal static References MicrosoftVisualBasic =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.MicrosoftVisualBasic;
 #else
@@ -44,28 +44,28 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
             };
 #endif
 
-        internal static References GetMicrosoftWin32Registry() =>
+        internal static References MicrosoftWin32Registry =>
 #if NETFRAMEWORK
             Enumerable.Empty<MetadataReference>();
 #else
             new[] {CoreMetadataReference.MicrosoftWin32Registry};
 #endif
 
-        internal static References GetMicrosoftWin32Primitives() =>
+        internal static References MicrosoftWin32Primitives =>
 #if NETFRAMEWORK
             Enumerable.Empty<MetadataReference>();
 #else
             new[] {CoreMetadataReference.MicrosoftWin32Primitives};
 #endif
 
-        internal static References GetPresentationFramework() =>
+        internal static References PresentationFramework =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.PresentationFramework;
 #else
             Enumerable.Empty<MetadataReference>();
 #endif
 
-        internal static References GetSystemCollections() =>
+        internal static References SystemCollections =>
 #if NETFRAMEWORK
             Enumerable.Empty<MetadataReference>();
 #else
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
             };
 #endif
 
-        internal static References GetSystemData() =>
+        internal static References SystemData =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemData;
 #else
@@ -87,7 +87,7 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
             };
 #endif
 
-        internal static References GetSystemDiagnosticsProcess() =>
+        internal static References SystemDiagnosticsProcess =>
 #if NETFRAMEWORK
             Enumerable.Empty<MetadataReference>();
 #else
@@ -98,21 +98,21 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
             };
 #endif
 
-        internal static References GetSystemDrawing() =>
+        internal static References SystemDrawing =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemDrawing;
 #else
             NuGetMetadataReference.SystemDrawingCommon();
 #endif
 
-        internal static References GetSystemDirectoryServices() =>
+        internal static References SystemDirectoryServices =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemDirectoryServices;
 #else
             NuGetMetadataReference.SystemDDirectoryServices();
 #endif
 
-        internal static References GetSystemIoCompression() =>
+        internal static References SystemIoCompression =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemIOCompression
                 .Concat(FrameworkMetadataReference.SystemIOCompressionFileSystem);
@@ -124,7 +124,7 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
             };
 #endif
 
-        internal static References GetSystemServiceModel() =>
+        internal static References SystemServiceModel =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemServiceModel;
 #else
@@ -132,7 +132,7 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
                 .Concat(NuGetMetadataReference.SystemServiceModelPrimitives());
 #endif
 
-        internal static References GetSystemNetHttp() =>
+        internal static References SystemNetHttp =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemNetHttp;
 #else
@@ -149,7 +149,7 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
             };
 #endif
 
-        internal static References GetSystemSecurityCryptography() =>
+        internal static References SystemSecurityCryptography =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemSecurityCryptographyAlgorithms;
 #else
@@ -163,14 +163,14 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
             };
 #endif
 
-        internal static References GetSystemSecurityPermissions() =>
+        internal static References SystemSecurityPermissions =>
 #if NETFRAMEWORK
             Enumerable.Empty<MetadataReference>();
 #else
             NuGetMetadataReference.SystemSecurityPermissions();
 #endif
 
-        internal static References GetSystemThreadingTasks() =>
+        internal static References SystemThreadingTasks =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemThreadingTasks
                 .Concat(NuGetMetadataReference.SystemThreadingTasksExtensions("4.0.0"));
@@ -178,21 +178,21 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
             new[] {CoreMetadataReference.SystemThreadingTasks};
 #endif
 
-        internal static References GetSystemThreadingTasksExtensions(string version) =>
+        internal static References SystemThreadingTasksExtensions(string version) =>
 #if NETFRAMEWORK
             NuGetMetadataReference.SystemThreadingTasksExtensions(version);
 #else
             new[] {CoreMetadataReference.SystemThreadingTasks};
 #endif
 
-        internal static References GetRegularExpressions() =>
+        internal static References RegularExpressions =>
 #if NETFRAMEWORK
             Enumerable.Empty<MetadataReference>();
 #else
             NuGetMetadataReference.SystemTextRegularExpressions();
 #endif
 
-        internal static References GetSystemRuntimeSerialization() =>
+        internal static References SystemRuntimeSerialization =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemRuntimeSerialization;
 #else
@@ -203,7 +203,7 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
             };
 #endif
 
-        internal static References GetSystemXaml() =>
+        internal static References SystemXaml =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemXaml;
 #else
@@ -214,7 +214,7 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
             };
 #endif
 
-        internal static References GetSystemXml() =>
+        internal static References SystemXml =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemXml;
 #else
@@ -229,62 +229,62 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
             .Union(NuGetMetadataReference.SystemConfigurationConfigurationManager());
 #endif
 
-        internal static References GetSystemXmlLinq() =>
+        internal static References SystemXmlLinq =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemXmlLinq;
 #else
             new[] {CoreMetadataReference.SystemXmlLinq};
 #endif
 
-        internal static References GetSystemWeb() =>
+        internal static References SystemWeb =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemWeb;
 #else
             new[] {CoreMetadataReference.SystemWeb};
 #endif
 
-        internal static References GetSystemWindowsForms() =>
+        internal static References SystemWindowsForms =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemWindowsForms;
 #else
             Enumerable.Empty<MetadataReference>();
 #endif
 
-        internal static References GetSystemComponentModelComposition() =>
+        internal static References SystemComponentModelComposition =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.SystemComponentModelComposition;
 #else
             NuGetMetadataReference.SystemComponentModelComposition();
 #endif
 
-        internal static References GetSystemComponentModelPrimitives() =>
+        internal static References SystemComponentModelPrimitives =>
 #if NETFRAMEWORK
             Enumerable.Empty<MetadataReference>();
 #else
             new[] {CoreMetadataReference.SystemComponentModelPrimitives};
 #endif
 
-        internal static References GetSystemNetSockets() =>
+        internal static References SystemNetSockets =>
 #if NETFRAMEWORK
             Enumerable.Empty<MetadataReference>();
 #else
             new[] {CoreMetadataReference.SystemNetSockets};
 #endif
-        internal static References GetSystemNetPrimitives() =>
+        internal static References SystemNetPrimitives =>
 #if NETFRAMEWORK
             Enumerable.Empty<MetadataReference>();
 #else
             new[] {CoreMetadataReference.SystemNetPrimitives};
 #endif
 
-        internal static References GetWindowsBase() =>
+        internal static References WindowsBase =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.WindowsBase;
 #else
             Enumerable.Empty<MetadataReference>();
 #endif
 
-        internal static References GetProjectDefaultReferences() =>
+        internal static References ProjectDefaultReferences =>
 #if NETFRAMEWORK
             FrameworkMetadataReference.Mscorlib
                 .Concat(FrameworkMetadataReference.System)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AesManagedShouldBeWithSecureModeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AesManagedShouldBeWithSecureModeTest.cs
@@ -34,14 +34,14 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void AesManagedShouldBeWithSecureMode() =>
             Verifier.VerifyAnalyzer(@"TestCases\AesManagedShouldBeWithSecureMode.cs",
                                     new AesManagedShouldBeWithSecureMode(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemSecurityCryptography());
+                                    additionalReferences: MetadataReferenceFacade.SystemSecurityCryptography);
 #if NET
         [TestMethod]
         [TestCategory("Rule")]
         public void AesManagedShouldBeWithSecureMode_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\AesManagedShouldBeWithSecureMode.CSharp9.cs",
                             new AesManagedShouldBeWithSecureMode(),
-                            MetadataReferenceFacade.GetSystemSecurityCryptography());
+                            MetadataReferenceFacade.SystemSecurityCryptography);
 #endif
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CertificateValidationCheckTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CertificateValidationCheckTest.cs
@@ -84,8 +84,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         }
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.GetSystemNetHttp()
-                .Concat(MetadataReferenceFacade.GetSystemSecurityCryptography())
+            MetadataReferenceFacade.SystemNetHttp
+                .Concat(MetadataReferenceFacade.SystemSecurityCryptography)
                 .Concat(NetStandardMetadataReference.Netstandard);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ClearTextProtocolsAreSensitiveTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ClearTextProtocolsAreSensitiveTest.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 #endif
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.GetSystemNetHttp().Concat(MetadataReferenceFacade.GetSystemComponentModelPrimitives());
+            MetadataReferenceFacade.SystemNetHttp.Concat(MetadataReferenceFacade.SystemComponentModelPrimitives);
     }
 }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CollectionPropertiesShouldBeReadOnlyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CollectionPropertiesShouldBeReadOnlyTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void CollectionPropertiesShouldBeReadOnly() =>
             Verifier.VerifyAnalyzer(@"TestCases\CollectionPropertiesShouldBeReadOnly.cs",
                 new CollectionPropertiesShouldBeReadOnly(),
-                additionalReferences: MetadataReferenceFacade.GetSystemRuntimeSerialization());
+                additionalReferences: MetadataReferenceFacade.SystemRuntimeSerialization);
 
 #if NET
         [TestMethod]
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void CollectionPropertiesShouldBeReadOnly_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\CollectionPropertiesShouldBeReadOnly.CSharp9.cs",
                 new CollectionPropertiesShouldBeReadOnly(),
-                MetadataReferenceFacade.GetSystemRuntimeSerialization());
+                MetadataReferenceFacade.SystemRuntimeSerialization);
 #endif
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CollectionsShouldImplementGenericInterfaceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CollectionsShouldImplementGenericInterfaceTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void CollectionsShouldImplementGenericInterface() =>
             Verifier.VerifyAnalyzer(@"TestCases\CollectionsShouldImplementGenericInterface.cs",
                                     new CollectionsShouldImplementGenericInterface(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemCollections(),
+                                    additionalReferences: MetadataReferenceFacade.SystemCollections,
                                     checkMode:CompilationErrorBehavior.Ignore); // It would be too tedious to implement all those interfaces
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CommandPathTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CommandPathTest.cs
@@ -33,21 +33,21 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestMethod]
         [TestCategory("Rule")]
         public void CommandPath_CS() =>
-            Verifier.VerifyAnalyzer(@"TestCases\CommandPath.cs", new CS.CommandPath(AnalyzerConfiguration.AlwaysEnabled), additionalReferences: MetadataReferenceFacade.GetSystemDiagnosticsProcess());
+            Verifier.VerifyAnalyzer(@"TestCases\CommandPath.cs", new CS.CommandPath(AnalyzerConfiguration.AlwaysEnabled), additionalReferences: MetadataReferenceFacade.SystemDiagnosticsProcess);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void CommandPath_VB() =>
-            Verifier.VerifyAnalyzer(@"TestCases\CommandPath.vb", new VB.CommandPath(AnalyzerConfiguration.AlwaysEnabled), additionalReferences: MetadataReferenceFacade.GetSystemDiagnosticsProcess());
+            Verifier.VerifyAnalyzer(@"TestCases\CommandPath.vb", new VB.CommandPath(AnalyzerConfiguration.AlwaysEnabled), additionalReferences: MetadataReferenceFacade.SystemDiagnosticsProcess);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void CommandPath_CS_Disabled() =>
-            Verifier.VerifyNoIssueReported(@"TestCases\CommandPath.cs", new CS.CommandPath(), additionalReferences: MetadataReferenceFacade.GetSystemDiagnosticsProcess());
+            Verifier.VerifyNoIssueReported(@"TestCases\CommandPath.cs", new CS.CommandPath(), additionalReferences: MetadataReferenceFacade.SystemDiagnosticsProcess);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void CommandPath_VB_Disabled() =>
-            Verifier.VerifyNoIssueReported(@"TestCases\CommandPath.vb", new VB.CommandPath(), additionalReferences: MetadataReferenceFacade.GetSystemDiagnosticsProcess());
+            Verifier.VerifyNoIssueReported(@"TestCases\CommandPath.vb", new VB.CommandPath(), additionalReferences: MetadataReferenceFacade.SystemDiagnosticsProcess);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConfiguringLoggersTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConfiguringLoggersTest.cs
@@ -127,7 +127,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         private static IEnumerable<MetadataReference> Log4NetReferences =>
             // See: https://github.com/SonarSource/sonar-dotnet/issues/3548
             NuGetMetadataReference.Log4Net("2.0.8", "net45-full")
-            .Concat(MetadataReferenceFacade.GetSystemXml());
+            .Concat(MetadataReferenceFacade.SystemXml);
 
         private static IEnumerable<MetadataReference> NLogReferences =>
             NuGetMetadataReference.NLog(Constants.NuGetLatestVersion);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConstructorArgumentValueShouldExistTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConstructorArgumentValueShouldExistTest.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void ConstructorArgumentValueShouldExist_CS() =>
             Verifier.VerifyAnalyzer(@"TestCases\ConstructorArgumentValueShouldExist.cs",
                 new ConstructorArgumentValueShouldExist(),
-                additionalReferences: MetadataReferenceFacade.GetSystemXaml());
+                additionalReferences: MetadataReferenceFacade.SystemXaml);
 #if NET
         [TestMethod]
         [TestCategory("Rule")]
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void ConstructorArgumentValueShouldExist_VB() =>
             Verifier.VerifyAnalyzer(@"TestCases\ConstructorArgumentValueShouldExist.vb",
                 new SonarAnalyzer.Rules.VisualBasic.ConstructorArgumentValueShouldExist(),
-                additionalReferences: MetadataReferenceFacade.GetSystemXaml());
+                additionalReferences: MetadataReferenceFacade.SystemXaml);
     }
 }
 #endif

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConsumeValueTaskCorrectlyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConsumeValueTaskCorrectlyTest.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         private static IEnumerable<MetadataReference> GetReferences() =>
             Enumerable.Empty<MetadataReference>()
-                .Concat(MetadataReferenceFacade.GetSystemThreadingTasks());
+                .Concat(MetadataReferenceFacade.SystemThreadingTasks);
     }
 }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CookieShouldBeHttpOnlyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CookieShouldBeHttpOnlyTest.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void CookiesShouldBeHttpOnly() =>
             Verifier.VerifyAnalyzer(@"TestCases\CookieShouldBeHttpOnly.cs",
                 new CookieShouldBeHttpOnly(AnalyzerConfiguration.AlwaysEnabled),
-                additionalReferences: MetadataReferenceFacade.GetSystemWeb());
+                additionalReferences: MetadataReferenceFacade.SystemWeb);
 #else
         [TestMethod]
         [TestCategory("Rule")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CookieShouldBeSecureTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CookieShouldBeSecureTest.cs
@@ -45,14 +45,14 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void CookiesShouldBeSecure() =>
             Verifier.VerifyAnalyzer(@"TestCases\CookieShouldBeSecure.cs",
                 new CookieShouldBeSecure(AnalyzerConfiguration.AlwaysEnabled),
-                additionalReferences: MetadataReferenceFacade.GetSystemWeb());
+                additionalReferences: MetadataReferenceFacade.SystemWeb);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void CookiesShouldBeSecure_Not_Enabled() =>
             Verifier.VerifyNoIssueReported(@"TestCases\CookieShouldBeSecure.cs",
                 new CookieShouldBeSecure(),
-                additionalReferences: MetadataReferenceFacade.GetSystemWeb());
+                additionalReferences: MetadataReferenceFacade.SystemWeb);
 
 #else
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CreatingHashAlgorithmsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CreatingHashAlgorithmsTest.cs
@@ -65,6 +65,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                 additionalReferences: GetAdditionalReferences());
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.GetSystemSecurityCryptography();
+            MetadataReferenceFacade.SystemSecurityCryptography;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CryptographicKeyShouldNotBeTooShortTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CryptographicKeyShouldNotBeTooShortTest.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 #endif
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.GetSystemSecurityCryptography()
+            MetadataReferenceFacade.SystemSecurityCryptography
                 .Concat(NuGetMetadataReference.SystemSecurityCryptographyOpenSsl())
                 .Concat(NuGetMetadataReference.BouncyCastle());
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DangerousGetHandleShouldNotBeCalledTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DangerousGetHandleShouldNotBeCalledTest.cs
@@ -34,14 +34,14 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void DangerousGetHandleShouldNotBeCalled_CS() =>
             Verifier.VerifyAnalyzer(@"TestCases\DangerousGetHandleShouldNotBeCalled.cs",
                 new csharp.DangerousGetHandleShouldNotBeCalled(),
-                additionalReferences: MetadataReferenceFacade.GetMicrosoftWin32Registry());
+                additionalReferences: MetadataReferenceFacade.MicrosoftWin32Registry);
 #if NET
         [TestMethod]
         [TestCategory("Rule")]
         public void DangerousGetHandleShouldNotBeCalled_CS_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\DangerousGetHandleShouldNotBeCalled.CSharp9.cs",
                 new csharp.DangerousGetHandleShouldNotBeCalled(),
-                MetadataReferenceFacade.GetMicrosoftWin32Registry());
+                MetadataReferenceFacade.MicrosoftWin32Registry);
 #endif
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DisposableNotDisposedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DisposableNotDisposedTest.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzer(@"TestCases\DisposableNotDisposed.cs",
                 new DisposableNotDisposed(),
                 ParseOptionsHelper.FromCSharp8,
-                additionalReferences: MetadataReferenceFacade.GetSystemNetHttp());
+                additionalReferences: MetadataReferenceFacade.SystemNetHttp);
 
 #if NET
         [TestMethod]
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void DisposableNotDisposed_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\DisposableNotDisposed.CSharp9.cs",
                 new DisposableNotDisposed(),
-                MetadataReferenceFacade.GetSystemNetHttp());
+                MetadataReferenceFacade.SystemNetHttp);
 #endif
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotCallAssemblyLoadInvalidMethodsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotCallAssemblyLoadInvalidMethodsTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void DoNotCallAssemblyLoadInvalidMethods() =>
             Verifier.VerifyAnalyzer(@"TestCases\DoNotCallAssemblyLoadInvalidMethods.cs",
                                     new DoNotCallAssemblyLoadInvalidMethods(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemSecurityPermissions());
+                                    additionalReferences: MetadataReferenceFacade.SystemSecurityPermissions);
 
 #if NET
         [TestMethod]
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void DoNotCallAssemblyLoadInvalidMethods_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\DoNotCallAssemblyLoadInvalidMethods.CSharp9.cs",
                                     new DoNotCallAssemblyLoadInvalidMethods(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemSecurityPermissions());
+                                    additionalReferences: MetadataReferenceFacade.SystemSecurityPermissions);
 #endif
 
 #if NETFRAMEWORK // The overloads with Evidence are obsolete on .Net Framework 4.8 and not available on .Net Core

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotCallExitMethodsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotCallExitMethodsTest.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void DoNotCallExitMethods() =>
             Verifier.VerifyAnalyzer(@"TestCases\DoNotCallExitMethods.cs",
                 new DoNotCallExitMethods(),
-                additionalReferences: MetadataReferenceFacade.GetSystemWindowsForms());
+                additionalReferences: MetadataReferenceFacade.SystemWindowsForms);
 #endif
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotExposeListTTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotExposeListTTest.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void DoNotExposeListT() =>
             Verifier.VerifyAnalyzer(@"TestCases\DoNotExposeListT.cs", new DoNotExposeListT(),
-                additionalReferences: MetadataReferences.MetadataReferenceFacade.GetSystemXml());
+                additionalReferences: MetadataReferences.MetadataReferenceFacade.SystemXml);
 
         [TestMethod]
         [TestCategory("Rule")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotHardcodeCredentialsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotHardcodeCredentialsTest.cs
@@ -103,7 +103,6 @@ namespace SonarAnalyzer.UnitTest.Rules
         }
 
         internal static IEnumerable<MetadataReference> AdditionalReferences =>
-            MetadataReferenceFacade.GetSystemSecurityCryptography()
-                .Union(MetadataReferenceFacade.GetSystemNetHttp());
+            MetadataReferenceFacade.SystemSecurityCryptography.Concat(MetadataReferenceFacade.SystemNetHttp);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotInstantiateSharedClassesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotInstantiateSharedClassesTest.cs
@@ -60,6 +60,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                 GetAdditionalReferences());
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.GetSystemComponentModelComposition();
+            MetadataReferenceFacade.SystemComponentModelComposition;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseIifTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseIifTest.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void DoNotUseIif() =>
             Verifier.VerifyAnalyzer(@"TestCases\DoNotUseIif.vb",
                 new SonarAnalyzer.Rules.VisualBasic.DoNotUseIif(),
-                additionalReferences: MetadataReferenceFacade.GetMicrosoftVisualBasic());
+                additionalReferences: MetadataReferenceFacade.MicrosoftVisualBasic);
 
         [TestMethod]
         [TestCategory("CodeFix")]
@@ -42,6 +42,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                 @"TestCases\DoNotUseIif.Fixed.vb",
                 new SonarAnalyzer.Rules.VisualBasic.DoNotUseIif(),
                 new SonarAnalyzer.Rules.VisualBasic.DoNotUseIifCodeFixProvider(),
-                additionalReferences: MetadataReferenceFacade.GetMicrosoftVisualBasic());
+                additionalReferences: MetadataReferenceFacade.MicrosoftVisualBasic);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseRandomTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseRandomTest.cs
@@ -35,13 +35,13 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void DoNotUseRandom() =>
             Verifier.VerifyAnalyzer(@"TestCases\DoNotUseRandom.cs",
                 new DoNotUseRandom(AnalyzerConfiguration.AlwaysEnabled),
-                additionalReferences: MetadataReferenceFacade.GetSystemSecurityCryptography());
+                additionalReferences: MetadataReferenceFacade.SystemSecurityCryptography);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void DoNotUseRandom_Not_Enabled() =>
             Verifier.VerifyNoIssueReported(@"TestCases\DoNotUseRandom.cs",
                 new DoNotUseRandom(),
-                additionalReferences: MetadataReferenceFacade.GetSystemSecurityCryptography());
+                additionalReferences: MetadataReferenceFacade.SystemSecurityCryptography);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/EncryptingDataTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/EncryptingDataTest.cs
@@ -61,6 +61,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                 additionalReferences: GetAdditionalReferences());
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.GetSystemSecurityCryptography();
+            MetadataReferenceFacade.SystemSecurityCryptography;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/EncryptionAlgorithmsShouldBeSecureTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/EncryptionAlgorithmsShouldBeSecureTest.cs
@@ -69,6 +69,6 @@ namespace SonarAnalyzer.UnitTest.Rules
 #endif
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.GetSystemSecurityCryptography();
+            MetadataReferenceFacade.SystemSecurityCryptography;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpandingArchivesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpandingArchivesTest.cs
@@ -63,6 +63,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                                            additionalReferences: AdditionalReferences);
 
         internal static IEnumerable<MetadataReference> AdditionalReferences =>
-            MetadataReferenceFacade.GetSystemIoCompression();
+            MetadataReferenceFacade.SystemIoCompression;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/GenericTypeParameterEmptinessCheckingTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/GenericTypeParameterEmptinessCheckingTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void GenericTypeParameterEmptinessChecking() =>
             Verifier.VerifyAnalyzer(@"TestCases\GenericTypeParameterEmptinessChecking.cs",
                                     new GenericTypeParameterEmptinessChecking(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemCollections(),
+                                    additionalReferences: MetadataReferenceFacade.SystemCollections,
                                     checkMode: CompilationErrorBehavior.Ignore);
 
 #if NET
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void GenericTypeParameterEmptinessChecking_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\GenericTypeParameterEmptinessChecking.CSharp9.cs",
                                                       new GenericTypeParameterEmptinessChecking(),
-                                                      MetadataReferenceFacade.GetSystemCollections());
+                                                      MetadataReferenceFacade.SystemCollections);
 #endif
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/GetHashCodeEqualsOverrideTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/GetHashCodeEqualsOverrideTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void GetHashCodeEqualsOverride() =>
             Verifier.VerifyAnalyzer(@"TestCases\GetHashCodeEqualsOverride.cs",
                                     new GetHashCodeEqualsOverride(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemComponentModelPrimitives());
+                                    additionalReferences: MetadataReferenceFacade.SystemComponentModelPrimitives);
 
 #if NET
         [TestMethod]
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void GetHashCodeEqualsOverride_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\GetHashCodeEqualsOverride.CSharp9.cs",
                                                       new GetHashCodeEqualsOverride(),
-                                                      additionalReferences: MetadataReferenceFacade.GetSystemComponentModelPrimitives());
+                                                      additionalReferences: MetadataReferenceFacade.SystemComponentModelPrimitives);
 #endif
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/HashesShouldHaveUnpredictableSaltTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/HashesShouldHaveUnpredictableSaltTest.cs
@@ -39,14 +39,14 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzer(@"TestCases\HashesShouldHaveUnpredictableSalt.cs",
                                     GetAnalyzer(),
                                     ParseOptionsHelper.FromCSharp8,
-                                    additionalReferences: MetadataReferenceFacade.GetSystemSecurityCryptography());
+                                    additionalReferences: MetadataReferenceFacade.SystemSecurityCryptography);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void HashesShouldHaveUnpredictableSalt_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\HashesShouldHaveUnpredictableSalt.CSharp9.cs",
                                                       GetAnalyzer(),
-                                                      MetadataReferenceFacade.GetSystemSecurityCryptography());
+                                                      MetadataReferenceFacade.SystemSecurityCryptography);
 
         [TestMethod]
         [TestCategory("Rule")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/InsecureEncryptionAlgorithmTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/InsecureEncryptionAlgorithmTest.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 #endif
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.GetSystemSecurityCryptography()
+            MetadataReferenceFacade.SystemSecurityCryptography
                 .Concat(NuGetMetadataReference.BouncyCastle());
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/InsecureHashAlgorithmTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/InsecureHashAlgorithmTest.cs
@@ -42,12 +42,12 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestMethod]
         [TestCategory("Rule")]
         public void InsecureHashAlgorithm_CSharp9() =>
-            Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\InsecureHashAlgorithm.CSharp9.cs", new InsecureHashAlgorithm(), MetadataReferenceFacade.GetSystemSecurityCryptography());
+            Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\InsecureHashAlgorithm.CSharp9.cs", new InsecureHashAlgorithm(), MetadataReferenceFacade.SystemSecurityCryptography);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void InsecureHashAlgorithm() =>
-            Verifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\InsecureHashAlgorithm.cs", new InsecureHashAlgorithm(), MetadataReferenceFacade.GetSystemSecurityCryptography());
+            Verifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\InsecureHashAlgorithm.cs", new InsecureHashAlgorithm(), MetadataReferenceFacade.SystemSecurityCryptography);
 #endif
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/LdapConnectionShouldBeSecureTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/LdapConnectionShouldBeSecureTest.cs
@@ -35,9 +35,9 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzer(@"TestCases\LdapConnectionShouldBeSecure.cs",
                 new LdapConnectionShouldBeSecure(),
 #if NETFRAMEWORK
-                additionalReferences: MetadataReferenceFacade.GetSystemDirectoryServices().Concat(NuGetMetadataReference.NETStandardV2_1_0),
+                additionalReferences: MetadataReferenceFacade.SystemDirectoryServices.Concat(NuGetMetadataReference.NETStandardV2_1_0),
 #else
-                additionalReferences: MetadataReferenceFacade.GetSystemDirectoryServices(),
+                additionalReferences: MetadataReferenceFacade.SystemDirectoryServices,
 #endif
                 options: ParseOptionsHelper.FromCSharp8);
 
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void LdapConnectionsShouldBeSecure_FromCSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\LdapConnectionShouldBeSecure.CSharp9.cs",
                 new LdapConnectionShouldBeSecure(),
-                MetadataReferenceFacade.GetSystemDirectoryServices());
+                MetadataReferenceFacade.SystemDirectoryServices);
 #endif
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/LiteralsShouldNotBePassedAsLocalizedParametersTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/LiteralsShouldNotBePassedAsLocalizedParametersTest.cs
@@ -34,14 +34,14 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void LiteralsShouldNotBePassedAsLocalizedParameters() =>
             Verifier.VerifyAnalyzer(@"TestCases\LiteralsShouldNotBePassedAsLocalizedParameters.cs",
                                     new LiteralsShouldNotBePassedAsLocalizedParameters(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemComponentModelPrimitives());
+                                    additionalReferences: MetadataReferenceFacade.SystemComponentModelPrimitives);
 #if NET
         [TestMethod]
         [TestCategory("Rule")]
         public void LiteralsShouldNotBePassedAsLocalizedParameters_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\LiteralsShouldNotBePassedAsLocalizedParameters.CSharp9.cs",
                 new LiteralsShouldNotBePassedAsLocalizedParameters(),
-                additionalReferences: MetadataReferenceFacade.GetSystemComponentModelPrimitives());
+                additionalReferences: MetadataReferenceFacade.SystemComponentModelPrimitives);
 #endif
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MethodShouldBeNamedAccordingToSynchronicityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MethodShouldBeNamedAccordingToSynchronicityTest.cs
@@ -39,8 +39,8 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzer(@"TestCases\MethodShouldBeNamedAccordingToSynchronicity.cs",
                 new MethodShouldBeNamedAccordingToSynchronicity(),
                 additionalReferences:
-                MetadataReferenceFacade.GetSystemThreadingTasksExtensions(tasksVersion)
-                                       .Union(MetadataReferenceFacade.GetSystemComponentModelPrimitives())
+                MetadataReferenceFacade.SystemThreadingTasksExtensions(tasksVersion)
+                                       .Union(MetadataReferenceFacade.SystemComponentModelPrimitives)
                                        .Union(NuGetMetadataReference.MicrosoftAspNetSignalRCore()));
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/NonFlagsEnumInBitwiseOperationTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/NonFlagsEnumInBitwiseOperationTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void NonFlagsEnumInBitwiseOperation() =>
             Verifier.VerifyAnalyzer(@"TestCases\NonFlagsEnumInBitwiseOperation.cs",
                                     new NonFlagsEnumInBitwiseOperation(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemComponentModelPrimitives());
+                                    additionalReferences: MetadataReferenceFacade.SystemComponentModelPrimitives);
 
         [TestMethod]
         [TestCategory("CodeFix")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/NonStandardCryptographicAlgorithmsShouldNotBeUsedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/NonStandardCryptographicAlgorithmsShouldNotBeUsedTest.cs
@@ -37,27 +37,27 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void NonStandardCryptographicAlgorithmsShouldNotBeUsed_CSharp() =>
             Verifier.VerifyAnalyzer(@"TestCases\NonStandardCryptographicAlgorithmsShouldNotBeUsed.cs",
                                     new CSharp.NonStandardCryptographicAlgorithmsShouldNotBeUsed(AnalyzerConfiguration.AlwaysEnabled),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemSecurityCryptography());
+                                    additionalReferences: MetadataReferenceFacade.SystemSecurityCryptography);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void NonStandardCryptographicAlgorithmsShouldNotBeUsed_CSharp_Disabled() =>
             Verifier.VerifyNoIssueReported(@"TestCases\NonStandardCryptographicAlgorithmsShouldNotBeUsed.cs",
                                            new CSharp.NonStandardCryptographicAlgorithmsShouldNotBeUsed(),
-                                           additionalReferences: MetadataReferenceFacade.GetSystemSecurityCryptography());
+                                           additionalReferences: MetadataReferenceFacade.SystemSecurityCryptography);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void NonStandardCryptographicAlgorithmsShouldNotBeUsed_VB() =>
             Verifier.VerifyAnalyzer(@"TestCases\NonStandardCryptographicAlgorithmsShouldNotBeUsed.vb",
                                     new VisualBasic.NonStandardCryptographicAlgorithmsShouldNotBeUsed(AnalyzerConfiguration.AlwaysEnabled),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemSecurityCryptography());
+                                    additionalReferences: MetadataReferenceFacade.SystemSecurityCryptography);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void NonStandardCryptographicAlgorithmsShouldNotBeUsed_VB_Disabled() =>
             Verifier.VerifyNoIssueReported(@"TestCases\NonStandardCryptographicAlgorithmsShouldNotBeUsed.vb",
                                            new VisualBasic.NonStandardCryptographicAlgorithmsShouldNotBeUsed(),
-                                           additionalReferences: MetadataReferenceFacade.GetSystemSecurityCryptography());
+                                           additionalReferences: MetadataReferenceFacade.SystemSecurityCryptography);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/PartCreationPolicyShouldBeUsedWithExportAttributeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/PartCreationPolicyShouldBeUsedWithExportAttributeTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void PartCreationPolicyShouldBeUsedWithExportAttribute_CS() =>
             Verifier.VerifyAnalyzer(@"TestCases\PartCreationPolicyShouldBeUsedWithExportAttribute.cs",
                                     new csharp.PartCreationPolicyShouldBeUsedWithExportAttribute(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemComponentModelComposition());
+                                    additionalReferences: MetadataReferenceFacade.SystemComponentModelComposition);
 
 #if NET
         [TestMethod]
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void PartCreationPolicyShouldBeUsedWithExportAttribute_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\PartCreationPolicyShouldBeUsedWithExportAttribute.CSharp9.cs",
                                     new csharp.PartCreationPolicyShouldBeUsedWithExportAttribute(),
-                                    MetadataReferenceFacade.GetSystemComponentModelComposition());
+                                    MetadataReferenceFacade.SystemComponentModelComposition);
 #endif
 
         [TestMethod]
@@ -50,6 +50,6 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void PartCreationPolicyShouldBeUsedWithExportAttribute_VB() =>
             Verifier.VerifyAnalyzer(@"TestCases\PartCreationPolicyShouldBeUsedWithExportAttribute.vb",
                                     new vbnet.PartCreationPolicyShouldBeUsedWithExportAttribute(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemComponentModelComposition());
+                                    additionalReferences: MetadataReferenceFacade.SystemComponentModelComposition);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/PropertiesAccessCorrectFieldTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/PropertiesAccessCorrectFieldTest.cs
@@ -64,8 +64,8 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         private static IEnumerable<MetadataReference> AdditionalReferences =>
             NuGetMetadataReference.MvvmLightLibs("5.4.1.1")
-                .Concat(MetadataReferenceFacade.GetWindowsBase())
-                .Concat(MetadataReferenceFacade.GetPresentationFramework());
+                .Concat(MetadataReferenceFacade.WindowsBase)
+                .Concat(MetadataReferenceFacade.PresentationFramework);
     }
 }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/PropertiesShouldBePreferredTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/PropertiesShouldBePreferredTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void PropertiesShouldBePreferred() =>
             Verifier.VerifyAnalyzer(@"TestCases\PropertiesShouldBePreferred.cs",
                                     new PropertiesShouldBePreferred(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemThreadingTasks());
+                                    additionalReferences: MetadataReferenceFacade.SystemThreadingTasks);
 
 #if NET
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ReturnEmptyCollectionInsteadOfNullTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ReturnEmptyCollectionInsteadOfNullTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void ReturnEmptyCollectionInsteadOfNull() =>
             Verifier.VerifyAnalyzer(@"TestCases\ReturnEmptyCollectionInsteadOfNull.cs",
                                     new ReturnEmptyCollectionInsteadOfNull(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemXml());
+                                    additionalReferences: MetadataReferenceFacade.SystemXml);
 
 #if NET
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SerializationConstructorsShouldBeSecuredTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SerializationConstructorsShouldBeSecuredTest.cs
@@ -83,6 +83,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                                     additionalReferences: GetAdditionalReferences());
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.GetSystemSecurityPermissions();
+            MetadataReferenceFacade.SystemSecurityPermissions;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SetLocaleForDataTypesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SetLocaleForDataTypesTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void SetLocaleForDataTypes() =>
             Verifier.VerifyAnalyzer(@"TestCases\SetLocaleForDataTypes.cs",
                                     new SetLocaleForDataTypes(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemData());
+                                    additionalReferences: MetadataReferenceFacade.SystemData);
 
 #if NET
         [TestMethod]
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void SetLocaleForDataTypes_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\SetLocaleForDataTypes.CSharp9.cs",
                                     new SetLocaleForDataTypes(),
-                                    MetadataReferenceFacade.GetSystemData());
+                                    MetadataReferenceFacade.SystemData);
 #endif
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ShouldImplementExportedInterfacesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ShouldImplementExportedInterfacesTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void ShouldImplementExportedInterfaces_CS() =>
             Verifier.VerifyAnalyzer(@"TestCases\ShouldImplementExportedInterfaces.cs",
                                     new ShouldImplementExportedInterfaces(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemComponentModelComposition());
+                                    additionalReferences: MetadataReferenceFacade.SystemComponentModelComposition);
 
 #if NET
         [TestMethod]
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void ShouldImplementExportedInterfaces_CSharp9() =>
            Verifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\ShouldImplementExportedInterfaces.CSharp9.cs",
                                               new ShouldImplementExportedInterfaces(),
-                                              MetadataReferenceFacade.GetSystemComponentModelComposition());
+                                              MetadataReferenceFacade.SystemComponentModelComposition);
 #endif
 
         [TestMethod]
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void ShouldImplementExportedInterfaces_VB() =>
             Verifier.VerifyAnalyzer(@"TestCases\ShouldImplementExportedInterfaces.vb",
                                     new SonarAnalyzer.Rules.VisualBasic.ShouldImplementExportedInterfaces(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemComponentModelComposition());
+                                    additionalReferences: MetadataReferenceFacade.SystemComponentModelComposition);
 
         [TestMethod]
         [TestCategory("Rule")]
@@ -61,6 +61,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                     @"TestCases\ShouldImplementExportedInterfaces_Part2.cs",
                 },
                 new ShouldImplementExportedInterfaces(),
-                additionalReferences: MetadataReferenceFacade.GetSystemComponentModelComposition());
+                additionalReferences: MetadataReferenceFacade.SystemComponentModelComposition);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SocketsCreationTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SocketsCreationTest.cs
@@ -62,6 +62,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                                            additionalReferences: GetAdditionalReferences());
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.GetSystemNetSockets().Concat(MetadataReferenceFacade.GetSystemNetPrimitives());
+            MetadataReferenceFacade.SystemNetSockets.Concat(MetadataReferenceFacade.SystemNetPrimitives);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SqlKeywordsDelimitedBySpaceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SqlKeywordsDelimitedBySpaceTest.cs
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void SqlKeywordsDelimitedBySpace_DotnetFramework(string sqlNamespace)
         {
-            var references = MetadataReferenceFacade.GetSystemData()
+            var references = MetadataReferenceFacade.SystemData
                 .Concat(NuGetMetadataReference.Dapper())
                 .Concat(NuGetMetadataReference.EntityFramework())
                 .Concat(NuGetMetadataReference.MicrosoftDataSqliteCore())
@@ -103,7 +103,7 @@ namespace TestNamespace
         [TestCategory("Rule")]
         public void SqlKeywordsDelimitedBySpace_DotnetCore(string sqlNamespace)
         {
-            var references = MetadataReferenceFacade.GetSystemData()
+            var references = MetadataReferenceFacade.SystemData
                 .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCore("2.2.0"))
                 .Concat(NuGetMetadataReference.ServiceStackOrmLite())
                 .Concat(NuGetMetadataReference.SystemDataSqlClient())

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InitializationVectorShouldBeRandomTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InitializationVectorShouldBeRandomTest.cs
@@ -36,14 +36,14 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
             Verifier.VerifyAnalyzer(@"TestCases\InitializationVectorShouldBeRandom.cs",
                                     GetAnalyzer(),
                                     ParseOptionsHelper.FromCSharp8,
-                                    additionalReferences: MetadataReferenceFacade.GetSystemSecurityCryptography());
+                                    additionalReferences: MetadataReferenceFacade.SystemSecurityCryptography);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void InitializationVectorShouldBeRandom_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\InitializationVectorShouldBeRandom.CSharp9.cs",
                                                       GetAnalyzer(),
-                                                      MetadataReferenceFacade.GetSystemSecurityCryptography());
+                                                      MetadataReferenceFacade.SystemSecurityCryptography);
 
         private static SonarDiagnosticAnalyzer GetAnalyzer() =>
             new SymbolicExecutionRunner(new InitializationVectorShouldBeRandom());

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
@@ -65,8 +65,8 @@ namespace SonarAnalyzer.UnitTest.Rules
                 additionalReferences: NuGetMetadataReference.MSTestTestFramework(testFwkVersion)
                     .Concat(NuGetMetadataReference.FluentAssertions(fluentVersion))
                     .Concat(NuGetMetadataReference.NSubstitute(nSubstituteVersion))
-                    .Concat(MetadataReferenceFacade.GetSystemXml())
-                    .Concat(MetadataReferenceFacade.GetSystemXmlLinq())
+                    .Concat(MetadataReferenceFacade.SystemXml)
+                    .Concat(MetadataReferenceFacade.SystemXmlLinq)
                     .ToArray());
 
         [DataTestMethod]
@@ -80,8 +80,8 @@ namespace SonarAnalyzer.UnitTest.Rules
                 additionalReferences: NuGetMetadataReference.NUnit(testFwkVersion)
                     .Concat(NuGetMetadataReference.FluentAssertions(fluentVersion))
                     .Concat(NuGetMetadataReference.NSubstitute(nSubstituteVersion))
-                    .Concat(MetadataReferenceFacade.GetSystemXml())
-                    .Concat(MetadataReferenceFacade.GetSystemXmlLinq())
+                    .Concat(MetadataReferenceFacade.SystemXml)
+                    .Concat(MetadataReferenceFacade.SystemXmlLinq)
                     .ToArray());
 
         [DataTestMethod]
@@ -126,8 +126,8 @@ public class Foo
 }",
                 new TestMethodShouldContainAssertion(),
                 additionalReferences: NuGetMetadataReference.NUnit(testFwkVersion)
-                    .Concat(MetadataReferenceFacade.GetSystemXml())
-                    .Concat(MetadataReferenceFacade.GetSystemXmlLinq())
+                    .Concat(MetadataReferenceFacade.SystemXml)
+                    .Concat(MetadataReferenceFacade.SystemXmlLinq)
                     .ToArray());
 
         [DataTestMethod]
@@ -140,8 +140,8 @@ public class Foo
                 additionalReferences: NuGetMetadataReference.XunitFramework(testFwkVersion)
                     .Concat(NuGetMetadataReference.FluentAssertions(fluentVersion))
                     .Concat(NuGetMetadataReference.NSubstitute(nSubstituteVersion))
-                    .Concat(MetadataReferenceFacade.GetSystemXml())
-                    .Concat(MetadataReferenceFacade.GetSystemXmlLinq())
+                    .Concat(MetadataReferenceFacade.SystemXml)
+                    .Concat(MetadataReferenceFacade.SystemXmlLinq)
                     .ToArray());
 
         [TestMethod]
@@ -151,8 +151,8 @@ public class Foo
                 new TestMethodShouldContainAssertion(),
                 additionalReferences: NuGetMetadataReference.XunitFrameworkV1
                     .Concat(NuGetMetadataReference.FluentAssertions(Constants.NuGetLatestVersion))
-                    .Concat(MetadataReferenceFacade.GetSystemXml())
-                    .Concat(MetadataReferenceFacade.GetSystemXmlLinq())
+                    .Concat(MetadataReferenceFacade.SystemXml)
+                    .Concat(MetadataReferenceFacade.SystemXmlLinq)
                     .ToArray());
 
         [DataTestMethod]
@@ -192,7 +192,7 @@ public class Foo
                 additionalReferences:
                 NuGetMetadataReference.NUnit(testFwkVersion)
                     .Concat(NuGetMetadataReference.FluentAssertions(fluentVersion))
-                    .Concat(MetadataReferenceFacade.GetSystemThreadingTasks()));
+                    .Concat(MetadataReferenceFacade.SystemThreadingTasks));
 
         [TestMethod]
         [TestCategory("Rule")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TypesShouldNotExtendOutdatedBaseTypesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TypesShouldNotExtendOutdatedBaseTypesTest.cs
@@ -35,6 +35,6 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void TypesShouldNotExtendOutdatedBaseTypes() =>
             Verifier.VerifyAnalyzer(@"TestCases\TypesShouldNotExtendOutdatedBaseTypes.cs",
                                     new TypesShouldNotExtendOutdatedBaseTypes(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemXml().Concat(MetadataReferenceFacade.GetSystemCollections()));
+                                    additionalReferences: MetadataReferenceFacade.SystemXml.Concat(MetadataReferenceFacade.SystemCollections));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UnnecessaryUsingsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UnnecessaryUsingsTest.cs
@@ -97,8 +97,6 @@ namespace SonarAnalyzer.UnitTest.Rules
         }
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.GetMicrosoftWin32Primitives()
-                                   .Union(MetadataReferenceFacade.GetSystemSecurityCryptography());
+            MetadataReferenceFacade.MicrosoftWin32Primitives.Concat(MetadataReferenceFacade.SystemSecurityCryptography);
     }
 }
-

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UriShouldNotBeHardcodedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UriShouldNotBeHardcodedTest.cs
@@ -46,8 +46,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void UriShouldNotBeHardcoded_CSharp_VirtualPath_AspNet(string aspNetMvcVersion) =>
             Verifier.VerifyAnalyzer(@"TestCases\UriShouldNotBeHardcoded.AspNet.cs",
                                     new UriShouldNotBeHardcoded(),
-                                    additionalReferences: MetadataReferenceFacade.GetSystemWeb()
-                                        .Concat(NuGetMetadataReference.MicrosoftAspNetMvc(aspNetMvcVersion)));
+                                    additionalReferences: MetadataReferenceFacade.SystemWeb.Concat(NuGetMetadataReference.MicrosoftAspNetMvc(aspNetMvcVersion)));
 #endif
 
         [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UseUriInsteadOfStringTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UseUriInsteadOfStringTest.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void UseUriInsteadOfString() =>
             Verifier.VerifyAnalyzer(@"TestCases\UseUriInsteadOfString.cs",
                 new UseUriInsteadOfString(),
-                additionalReferences: MetadataReferenceFacade.GetSystemDrawing());
+                additionalReferences: MetadataReferenceFacade.SystemDrawing);
 
 #if NET
         [TestMethod]
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void UseUriInsteadOfString_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\UseUriInsteadOfString.CSharp9.cs",
                 new UseUriInsteadOfString(),
-                MetadataReferenceFacade.GetSystemDrawing());
+                MetadataReferenceFacade.SystemDrawing);
 #endif
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UsingRegularExpressionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UsingRegularExpressionsTest.cs
@@ -35,27 +35,27 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void UsingRegularExpressions_CS() =>
             Verifier.VerifyAnalyzer(@"TestCases\UsingRegularExpressions.cs",
                 new CS.UsingRegularExpressions(AnalyzerConfiguration.AlwaysEnabled),
-                additionalReferences: MetadataReferenceFacade.GetRegularExpressions());
+                additionalReferences: MetadataReferenceFacade.RegularExpressions);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void UsingRegularExpressions_CS_Disabled() =>
             Verifier.VerifyNoIssueReported(@"TestCases\UsingRegularExpressions.cs",
                 new CS.UsingRegularExpressions(),
-                additionalReferences: MetadataReferenceFacade.GetRegularExpressions());
+                additionalReferences: MetadataReferenceFacade.RegularExpressions);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void UsingRegularExpressions_VB() =>
             Verifier.VerifyAnalyzer(@"TestCases\UsingRegularExpressions.vb",
                 new VB.UsingRegularExpressions(AnalyzerConfiguration.AlwaysEnabled),
-                additionalReferences: MetadataReferenceFacade.GetRegularExpressions());
+                additionalReferences: MetadataReferenceFacade.RegularExpressions);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void UsingRegularExpressions_VB_Disabled() =>
             Verifier.VerifyNoIssueReported(@"TestCases\UsingRegularExpressions.vb",
                 new VB.UsingRegularExpressions(),
-                additionalReferences: MetadataReferenceFacade.GetRegularExpressions());
+                additionalReferences: MetadataReferenceFacade.RegularExpressions);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/WcfMissingContractAttributeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/WcfMissingContractAttributeTest.cs
@@ -35,6 +35,6 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzer(
                 @"TestCases\WcfMissingContractAttribute.cs",
                 new WcfMissingContractAttribute(),
-                additionalReferences: MetadataReferenceFacade.GetSystemServiceModel());
+                additionalReferences: MetadataReferenceFacade.SystemServiceModel);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/WcfNonVoidOneWayTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/WcfNonVoidOneWayTest.cs
@@ -34,13 +34,13 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void WcfNonVoidOneWay_CS() =>
             Verifier.VerifyAnalyzer(@"TestCases\WcfNonVoidOneWay.cs",
                 new WcfNonVoidOneWay(),
-                additionalReferences: MetadataReferenceFacade.GetSystemServiceModel());
+                additionalReferences: MetadataReferenceFacade.SystemServiceModel);
 
         [TestMethod]
         [TestCategory("Rule")]
         public void WcfNonVoidOneWay_VB() =>
             Verifier.VerifyAnalyzer(@"TestCases\WcfNonVoidOneWay.vb",
                 new SonarAnalyzer.Rules.VisualBasic.WcfNonVoidOneWay(),
-                additionalReferences: MetadataReferenceFacade.GetSystemServiceModel());
+                additionalReferences: MetadataReferenceFacade.SystemServiceModel);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/WeakSslTlsProtocolsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/WeakSslTlsProtocolsTest.cs
@@ -49,7 +49,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                                     additionalReferences: GetAdditionalReferences());
 
         private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-           MetadataReferenceFacade.GetSystemNetHttp()
-               .Concat(MetadataReferenceFacade.GetSystemSecurityCryptography());
+           MetadataReferenceFacade.SystemNetHttp.Concat(MetadataReferenceFacade.SystemSecurityCryptography);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/XmlExternalEntityShouldNotBeParsedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/XmlExternalEntityShouldNotBeParsedTest.cs
@@ -42,9 +42,9 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void XmlExternalEntityShouldNotBeParsed_XmlDocument(NetFrameworkVersion version, string testFilePath) =>
             Verifier.VerifyAnalyzer(testFilePath,
                 new CS.XmlExternalEntityShouldNotBeParsed(GetVersionProviderMock(version)),
-                additionalReferences: MetadataReferenceFacade.GetSystemXml()
-                    .Concat(MetadataReferenceFacade.GetSystemData())
-                    .Concat(MetadataReferenceFacade.GetSystemXmlLinq())
+                additionalReferences: MetadataReferenceFacade.SystemXml
+                    .Concat(MetadataReferenceFacade.SystemData)
+                    .Concat(MetadataReferenceFacade.SystemXmlLinq)
                     .Concat(NuGetMetadataReference.MicrosoftWebXdt())
                     .ToArray());
 
@@ -54,9 +54,9 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void XmlExternalEntityShouldNotBeParsed_XmlDocument_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\XmlExternalEntityShouldNotBeParsed_XmlDocument_CSharp9.cs",
                 new CS.XmlExternalEntityShouldNotBeParsed(GetVersionProviderMock(NetFrameworkVersion.After452)),
-                MetadataReferenceFacade.GetSystemXml()
-                    .Concat(MetadataReferenceFacade.GetSystemData())
-                    .Concat(MetadataReferenceFacade.GetSystemXmlLinq())
+                MetadataReferenceFacade.SystemXml
+                    .Concat(MetadataReferenceFacade.SystemData)
+                    .Concat(MetadataReferenceFacade.SystemXmlLinq)
                     .Concat(NuGetMetadataReference.MicrosoftWebXdt())
                     .ToArray());
 #endif
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void XmlExternalEntityShouldNotBeParsed_XmlTextReader(NetFrameworkVersion version, string testFilePath) =>
             Verifier.VerifyAnalyzer(testFilePath, new CS.XmlExternalEntityShouldNotBeParsed(GetVersionProviderMock(version)),
                 ParseOptionsHelper.FromCSharp8,
-                additionalReferences: MetadataReferenceFacade.GetSystemXml().ToArray());
+                additionalReferences: MetadataReferenceFacade.SystemXml.ToArray());
 
 #if NET
         [TestMethod]
@@ -78,7 +78,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void XmlExternalEntityShouldNotBeParsed_XmlTextReader_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\XmlExternalEntityShouldNotBeParsed_XmlTextReader_CSharp9.cs",
                 new CS.XmlExternalEntityShouldNotBeParsed(GetVersionProviderMock(NetFrameworkVersion.After452)),
-                MetadataReferenceFacade.GetSystemXml().ToArray());
+                MetadataReferenceFacade.SystemXml.ToArray());
 #endif
 
         [DataRow(NetFrameworkVersion.After452, @"TestCases\XmlExternalEntityShouldNotBeParsed_AlwaysSafe.cs")]
@@ -103,9 +103,9 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void XmlExternalEntityShouldNotBeParsed_XmlReader_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\XmlExternalEntityShouldNotBeParsed_XmlReader_CSharp9.cs",
                                                       new CS.XmlExternalEntityShouldNotBeParsed(GetVersionProviderMock(NetFrameworkVersion.After452)),
-                                                      MetadataReferenceFacade.GetSystemXml()
-                                                          .Concat(MetadataReferenceFacade.GetSystemData())
-                                                          .Concat(MetadataReferenceFacade.GetSystemXmlLinq())
+                                                      MetadataReferenceFacade.SystemXml
+                                                          .Concat(MetadataReferenceFacade.SystemData)
+                                                          .Concat(MetadataReferenceFacade.SystemXmlLinq)
                                                           .ToArray());
 
         [TestMethod]
@@ -113,9 +113,9 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void XmlExternalEntityShouldNotBeParsed_XPathDocument_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\XmlExternalEntityShouldNotBeParsed_XPathDocument_CSharp9.cs",
                                                       new CS.XmlExternalEntityShouldNotBeParsed(GetVersionProviderMock(NetFrameworkVersion.After452)),
-                                                      MetadataReferenceFacade.GetSystemXml()
-                                                          .Concat(MetadataReferenceFacade.GetSystemData())
-                                                          .Concat(MetadataReferenceFacade.GetSystemXmlLinq())
+                                                      MetadataReferenceFacade.SystemXml
+                                                          .Concat(MetadataReferenceFacade.SystemData)
+                                                          .Concat(MetadataReferenceFacade.SystemXmlLinq)
                                                           .ToArray());
 #endif
 
@@ -138,14 +138,14 @@ namespace SonarAnalyzer.UnitTest.Rules
                     @"TestCases\XmlExternalEntityShouldNotBeParsed_XmlReader_ParameterProvider.cs"
                 },
                 new CS.XmlExternalEntityShouldNotBeParsed(GetVersionProviderMock(NetFrameworkVersion.After452)),
-                additionalReferences: MetadataReferenceFacade.GetSystemXml());
+                additionalReferences: MetadataReferenceFacade.SystemXml);
 
         private static void VerifyRule(NetFrameworkVersion version, string testFilePath, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary, IEnumerable<ParseOptions> options = null) =>
             Verifier.VerifyAnalyzer(testFilePath,
                 new CS.XmlExternalEntityShouldNotBeParsed(GetVersionProviderMock(version)),
-                additionalReferences: MetadataReferenceFacade.GetSystemXml()
-                    .Concat(MetadataReferenceFacade.GetSystemData())
-                    .Concat(MetadataReferenceFacade.GetSystemXmlLinq())
+                additionalReferences: MetadataReferenceFacade.SystemXml
+                    .Concat(MetadataReferenceFacade.SystemData)
+                    .Concat(MetadataReferenceFacade.SystemXmlLinq)
                     .ToArray(),
                 outputKind: outputKind,
                 options: options);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
@@ -67,12 +67,12 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
             var projectBuilder = ProjectBuilder
                 .FromProject(project)
-                .AddReferences(MetadataReferenceFacade.GetProjectDefaultReferences());
+                .AddReferences(MetadataReferenceFacade.ProjectDefaultReferences);
 
             if (language == AnalyzerLanguage.VisualBasic)
             {
                 // Need a reference to the VB dll to be able to use the Module keyword
-                projectBuilder = projectBuilder.AddReferences(MetadataReferenceFacade.GetMicrosoftVisualBasic());
+                projectBuilder = projectBuilder.AddReferences(MetadataReferenceFacade.MicrosoftVisualBasic);
             }
 
             if (createExtraEmptyFile)


### PR DESCRIPTION
Remove `Get` prefix and `()` suffix to align with source members.