### PR TITLE
Remove useless Helpers sub-namespaces

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Helpers
             Action<SyntaxNodeAnalysisContext> action,
             params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct
         {
-            context.RegisterSyntaxNodeActionInNonGenerated(CSharp.CSharpGeneratedCodeRecognizer.Instance, action,
+            context.RegisterSyntaxNodeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action,
                 syntaxKinds);
         }
 
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Helpers
             Action<SyntaxNodeAnalysisContext> action,
             params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct
         {
-            context.RegisterSyntaxNodeActionInNonGenerated(CSharp.CSharpGeneratedCodeRecognizer.Instance, action,
+            context.RegisterSyntaxNodeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action,
                 syntaxKinds);
         }
 
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Helpers
             Action<SyntaxNodeAnalysisContext> action,
             params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct
         {
-            context.RegisterSyntaxNodeActionInNonGenerated(CSharp.CSharpGeneratedCodeRecognizer.Instance, action,
+            context.RegisterSyntaxNodeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action,
                 syntaxKinds);
         }
 
@@ -59,21 +59,21 @@ namespace SonarAnalyzer.Helpers
             this SonarAnalysisContext context,
             Action<SyntaxTreeAnalysisContext> action)
         {
-            context.RegisterSyntaxTreeActionInNonGenerated(CSharp.CSharpGeneratedCodeRecognizer.Instance, action);
+            context.RegisterSyntaxTreeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action);
         }
 
         public static void RegisterSyntaxTreeActionInNonGenerated(
             this ParameterLoadingAnalysisContext context,
             Action<SyntaxTreeAnalysisContext> action)
         {
-            context.RegisterSyntaxTreeActionInNonGenerated(CSharp.CSharpGeneratedCodeRecognizer.Instance, action);
+            context.RegisterSyntaxTreeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action);
         }
 
         public static void RegisterCodeBlockStartActionInNonGenerated<TLanguageKindEnum>(
             this SonarAnalysisContext context,
             Action<CodeBlockStartAnalysisContext<TLanguageKindEnum>> action) where TLanguageKindEnum : struct
         {
-            context.RegisterCodeBlockStartActionInNonGenerated(CSharp.CSharpGeneratedCodeRecognizer.Instance, action);
+            context.RegisterCodeBlockStartActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action);
         }
 
         #endregion Register*ActionInNonGenerated
@@ -85,7 +85,7 @@ namespace SonarAnalyzer.Helpers
             Diagnostic diagnostic,
             Compilation compilation)
         {
-            context.ReportDiagnosticIfNonGenerated(CSharp.CSharpGeneratedCodeRecognizer.Instance, diagnostic, compilation);
+            context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic, compilation);
         }
 
         public static void ReportDiagnosticIfNonGenerated(
@@ -93,14 +93,14 @@ namespace SonarAnalyzer.Helpers
             Diagnostic diagnostic,
             Compilation compilation)
         {
-            context.ReportDiagnosticIfNonGenerated(CSharp.CSharpGeneratedCodeRecognizer.Instance, diagnostic, compilation);
+            context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic, compilation);
         }
 
         public static void ReportDiagnosticIfNonGenerated(
             this SymbolAnalysisContext context,
             Diagnostic diagnostic)
         {
-            context.ReportDiagnosticIfNonGenerated(CSharp.CSharpGeneratedCodeRecognizer.Instance, diagnostic,
+            context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic,
                 context.Compilation);
         }
 
@@ -109,7 +109,7 @@ namespace SonarAnalyzer.Helpers
         internal static bool ShouldAnalyze(this SyntaxTree tree, AnalyzerOptions options,
             Compilation compilation)
             // ToDo: PERF: do the global setting check before the per-file check.
-            => DiagnosticAnalyzerContextHelper.ShouldAnalyze(CSharp.CSharpGeneratedCodeRecognizer.Instance,
+            => DiagnosticAnalyzerContextHelper.ShouldAnalyze(CSharpGeneratedCodeRecognizer.Instance,
                 tree,
                 compilation,
                 options);

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpEquivalenceChecker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpEquivalenceChecker.cs
@@ -23,7 +23,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SonarAnalyzer.Helpers.CSharp
+namespace SonarAnalyzer.Helpers
 {
     internal static class CSharpEquivalenceChecker
     {

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpGeneratedCodeRecognizer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpGeneratedCodeRecognizer.cs
@@ -25,9 +25,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace SonarAnalyzer.Helpers.CSharp
+namespace SonarAnalyzer.Helpers
 {
-    internal class CSharpGeneratedCodeRecognizer : Helpers.GeneratedCodeRecognizer
+    internal class CSharpGeneratedCodeRecognizer : GeneratedCodeRecognizer
     {
         #region Singleton implementation
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpOverloadHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpOverloadHelper.cs
@@ -25,7 +25,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace SonarAnalyzer.Helpers.CSharp
+namespace SonarAnalyzer.Helpers
 {
     internal static class CSharpOverloadHelper
     {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AssignmentInsideSubExpression.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AssignmentInsideSubExpression.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 using SonarAnalyzer.ShimLayer.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BinaryOperationWithIdenticalExpressions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BinaryOperationWithIdenticalExpressions.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BooleanLiteralUnnecessary.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BooleanLiteralUnnecessary.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BooleanLiteralUnnecessaryCodeFixProvider.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BooleanLiteralUnnecessaryCodeFixProvider.cs
@@ -28,7 +28,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CatchRethrow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CatchRethrow.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CertificateValidationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CertificateValidationCheck.cs
@@ -81,7 +81,7 @@ namespace SonarAnalyzer.Rules.CSharp
         }
 
         protected override IEqualityComparer<ExpressionSyntax> CreateNodeEqualityComparer() =>
-            new Helpers.CSharp.CSharpSyntaxNodeEqualityComparer<ExpressionSyntax>();
+            new CSharpSyntaxNodeEqualityComparer<ExpressionSyntax>();
 
         protected override SyntaxNode FindRootClassOrModule(SyntaxNode node)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassAndMethodName.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassAndMethodName.cs
@@ -117,7 +117,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (symbol.DeclaringSyntaxReferences.Length > 1 &&
                 symbol.DeclaringSyntaxReferences.Any(syntax =>
-                    Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance.IsGenerated(syntax.SyntaxTree)))
+                    CSharpGeneratedCodeRecognizer.Instance.IsGenerated(syntax.SyntaxTree)))
             {
                 return;
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentKeyword.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentKeyword.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalSimplification.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalSimplification.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 using SonarAnalyzer.ShimLayer.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalSimplificationCodeFixProvider.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalSimplificationCodeFixProvider.cs
@@ -28,7 +28,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameCondition.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameImplementation.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
@@ -28,7 +28,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCheckZeroSizeCollection.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCheckZeroSizeCollection.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static readonly DiagnosticDescriptor rule =
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
         protected override SyntaxKind GreaterThanOrEqualExpression => SyntaxKind.GreaterThanOrEqualExpression;
         protected override SyntaxKind LessThanOrEqualExpression => SyntaxKind.LessThanOrEqualExpression;
         protected override ExpressionSyntax GetLeftNode(BinaryExpressionSyntax binaryExpression) => binaryExpression.Left;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotPassSameValueAsMultipleArguments.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotPassSameValueAsMultipleArguments.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+            CSharpGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxKind InvocationExpressionSyntaxKind =>
             SyntaxKind.InvocationExpression;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseCollectionInItsOwnMethodCalls.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseCollectionInItsOwnMethodCalls.cs
@@ -28,7 +28,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyMethod.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } =
-            Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+            CSharpGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxKind[] SyntaxKinds { get; } = new []
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumNameHasEnumSuffix.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumNameHasEnumSuffix.cs
@@ -40,6 +40,6 @@ namespace SonarAnalyzer.Rules.CSharp
         public override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest => kindsOfInterest;
         protected override SyntaxToken GetIdentifier(SyntaxNode node) => ((EnumDeclarationSyntax)node).Identifier;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumNameShouldFollowRegex.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumNameShouldFollowRegex.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override SyntaxKind EnumStatementSyntaxKind => SyntaxKind.EnumDeclaration;
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
         protected override SyntaxToken GetIdentifier(EnumDeclarationSyntax declaration) => declaration.Identifier;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExpressionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExpressionComplexity.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [Rule(DiagnosticId)]
     public sealed class ExpressionComplexity : ExpressionComplexityBase<ExpressionSyntax>
     {
-        public override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        public override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
 
         public ExpressionComplexity() : base(RspecStrings.ResourceManager) { }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShouldNotBePublic.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShouldNotBePublic.cs
@@ -44,6 +44,6 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override IEnumerable<VariableDeclaratorSyntax> GetVariables(FieldDeclarationSyntax fieldDeclaration) =>
             fieldDeclaration.Declaration.Variables;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FileLines.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FileLines.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
 
         protected override bool IsEndOfFileToken(SyntaxToken token) => token.IsKind(SyntaxKind.EndOfFileToken);
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FlagsEnumWithoutInitializer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FlagsEnumWithoutInitializer.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override SyntaxToken GetIdentifier(EnumDeclarationSyntax declaration) => declaration.Identifier;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
 
         protected override IList<EnumMemberDeclarationSyntax> GetMembers(EnumDeclarationSyntax declaration)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FlagsEnumZeroMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FlagsEnumZeroMember.cs
@@ -48,6 +48,6 @@ namespace SonarAnalyzer.Rules.CSharp
             return node.Members;
         }
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterEmptinessChecking.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterEmptinessChecking.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeEqualsOverride.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeEqualsOverride.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetTypeWithIsAssignableFrom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetTypeWithIsAssignableFrom.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GotoStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GotoStatement.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         };
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-           Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+           CSharpGeneratedCodeRecognizer.Instance;
 
         protected override string GoToLabel => "goto";
     }        

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/HardcodedIpAddress.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/HardcodedIpAddress.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementSerializationMethodsCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementSerializationMethodsCorrectly.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public ImplementSerializationMethodsCorrectly() : base(RspecStrings.ResourceManager) { }
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
 
         protected override string MethodStaticMessage => ProblemStatic;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LineLength.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LineLength.cs
@@ -36,6 +36,6 @@ namespace SonarAnalyzer.Rules.CSharp
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+            CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializedToDefault.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializedToDefault.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 using SonarAnalyzer.ShimLayer.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveIdenticalImplementations.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveIdenticalImplementations.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
         private static readonly DiagnosticDescriptor rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxKind ClassDeclarationSyntaxKind => SyntaxKind.ClassDeclaration;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveTooManyLines.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveTooManyLines.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+            CSharpGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxKind[] SyntaxKinds { get; } =
             new[]

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MultipleVariableDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MultipleVariableDeclaration.cs
@@ -49,6 +49,6 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override IEnumerable<SyntaxToken> GetIdentifiers(LocalDeclarationStatementSyntax node) =>
             node.Declaration.Variables.Select(v => v.Identifier);
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NonStandardCryptographicAlgorithmsShouldNotBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NonStandardCryptographicAlgorithmsShouldNotBeUsed.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameter.cs
@@ -51,6 +51,6 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override Location GetReportLocation(ParameterSyntax parameter) =>
             parameter.Default.GetLocation();
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterAssignedTo.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterAssignedTo.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public ParameterAssignedTo() : base(RspecStrings.ResourceManager) { }
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxKind SyntaxKindOfInterest => SyntaxKind.SimpleAssignmentExpression;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyGetterWithThrow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyGetterWithThrow.cs
@@ -48,6 +48,6 @@ namespace SonarAnalyzer.Rules.CSharp
             ((ThrowStatementSyntax)syntaxNode).Expression;
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+            CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyWriteOnly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyWriteOnly.cs
@@ -54,6 +54,6 @@ namespace SonarAnalyzer.Rules.CSharp
             return accessors.Accessors.First().IsKind(SyntaxKind.SetAccessorDeclaration);
         }
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicConstantField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicConstantField.cs
@@ -47,6 +47,6 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override IEnumerable<VariableDeclaratorSyntax> GetVariables(FieldDeclarationSyntax node) =>
             node.Declaration.Variables;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicMethodWithMultidimensionalArray.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicMethodWithMultidimensionalArray.cs
@@ -43,6 +43,6 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override SyntaxToken GetIdentifier(MethodDeclarationSyntax method) => method.Identifier;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 using SonarAnalyzer.ShimLayer.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheckCodeFixProvider.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheckCodeFixProvider.cs
@@ -28,7 +28,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantParentheses.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantParentheses.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SelfAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SelfAssignment.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 using SonarAnalyzer.ShimLayer.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ShortCircuitNullPointerDereference.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ShortCircuitNullPointerDereference.cs
@@ -28,7 +28,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SingleStatementPerLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SingleStatementPerLine.cs
@@ -63,6 +63,6 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static bool StatementIsBlock(StatementSyntax st) => st is BlockSyntax;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyIFormatProviderOrCultureInfo.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyIFormatProviderOrCultureInfo.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyStringComparison.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyStringComparison.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringConcatenationInLoop.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringConcatenationInLoop.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
@@ -78,7 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override ImmutableArray<SyntaxKind> CompoundAssignmentKinds => compoundAssignmentKinds;
 
-        protected override Helpers.GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override Helpers.GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
 
         protected override bool IsAddExpression(BinaryExpressionSyntax rightExpression) =>
             rightExpression != null &&

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchWithoutDefault.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchWithoutDefault.cs
@@ -53,6 +53,6 @@ namespace SonarAnalyzer.Rules.CSharp
             return false;
         }
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TabCharacter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TabCharacter.cs
@@ -37,6 +37,6 @@ namespace SonarAnalyzer.Rules.CSharp
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TernaryOperatorPointless.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TernaryOperatorPointless.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyLabelsInSwitch.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyLabelsInSwitch.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
             new[] { SyntaxKind.SwitchStatement };
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+            CSharpGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxNode GetExpression(SwitchStatementSyntax statement) =>
             statement.Expression;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyParameters.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 using SonarAnalyzer.ShimLayer.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnaryPrefixOperatorRepeated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnaryPrefixOperatorRepeated.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
         };
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } =
-            Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+            CSharpGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxNode GetOperand(PrefixUnaryExpressionSyntax unarySyntax) =>
             unarySyntax.Operand;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnconditionalJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnconditionalJumpStatement.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
         protected override ISet<SyntaxKind> LoopStatements { get; } = new HashSet<SyntaxKind>
         {
             SyntaxKind.ForEachStatement,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryUsings.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryUsings.cs
@@ -28,7 +28,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 using SonarAnalyzer.ShimLayer.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -29,7 +29,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UriShouldNotBeHardcoded.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UriShouldNotBeHardcoded.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
         protected override SyntaxKind StringLiteralSyntaxKind { get; } = SyntaxKind.StringLiteralExpression;
         protected override SyntaxKind[] StringConcatenateExpressions { get; } = new[] { SyntaxKind.AddExpression };
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
         protected override string GetLiteralText(LiteralExpressionSyntax literalExpression) => literalExpression?.Token.ValueText;
         protected override ExpressionSyntax GetLeftNode(BinaryExpressionSyntax binaryExpression) => binaryExpression.Left;
         protected override ExpressionSyntax GetRightNode(BinaryExpressionSyntax binaryExpression) => binaryExpression.Right;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseShortCircuitingOperator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseShortCircuitingOperator.cs
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.Rules.CSharp
         }.ToImmutableDictionary();
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-             Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+             CSharpGeneratedCodeRecognizer.Instance;
 
         protected override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest => ImmutableArray.Create<SyntaxKind>(
             SyntaxKind.BitwiseAndExpression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/CopyPasteTokenAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/CopyPasteTokenAnalyzer.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class CopyPasteTokenAnalyzer : CopyPasteTokenAnalyzerBase
     {
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
 
         protected override bool IsUsingDirective(SyntaxNode node) => node is UsingDirectiveSyntax;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/FileMetadataAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/FileMetadataAnalyzer.cs
@@ -28,6 +28,6 @@ namespace SonarAnalyzer.Rules.CSharp
     public class FileMetadataAnalyzer : FileMetadataAnalyzerBase
     {
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+            CSharpGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/MetricsAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/MetricsAnalyzer.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class MetricsAnalyzer : MetricsAnalyzerBase
     {
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
 
         protected override MetricsBase GetMetrics(SyntaxTree syntaxTree, SemanticModel semanticModel)
             => new Metrics.CSharp.CSharpMetrics(syntaxTree, semanticModel);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/SymbolReferenceAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/SymbolReferenceAnalyzer.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class SymbolReferenceAnalyzer : SymbolReferenceAnalyzerBase
     {
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
 
         protected override bool IsIdentifier(SyntaxToken token) => token.IsKind(SyntaxKind.IdentifierToken);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public class TokenTypeAnalyzer : TokenTypeAnalyzerBase
     {
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+            CSharpGeneratedCodeRecognizer.Instance;
 
         protected override TokenClassifierBase GetTokenClassifier(SyntaxToken token, SemanticModel semanticModel) =>
             new TokenClassifier(token, semanticModel);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ValuesUselesslyIncremented.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ValuesUselesslyIncremented.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfNonVoidOneWay.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfNonVoidOneWay.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance;
+            CSharpGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxKind MethodDeclarationKind =>
             SyntaxKind.MethodDeclaration;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/WeakSslTlsProtocols.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/WeakSslTlsProtocols.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpBaseTypeTracker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpBaseTypeTracker.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Helpers
     public class CSharpBaseTypeTracker : BaseTypeTracker<SyntaxKind>
     {
         protected override SyntaxKind[] TrackedSyntaxKinds { get; } = new[] { SyntaxKind.BaseList };
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = CSharpGeneratedCodeRecognizer.Instance;
 
         public CSharpBaseTypeTracker(IAnalyzerConfiguration analyzerConfiguration, DiagnosticDescriptor rule)
             : base(analyzerConfiguration, rule)

--- a/analyzers/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpElementAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpElementAccessTracker.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpFieldAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpFieldAccessTracker.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Helpers
                 SyntaxKind.MemberBindingExpression,
                 SyntaxKind.IdentifierName
             };
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = CSharpGeneratedCodeRecognizer.Instance;
 
         public CSharpFieldAccessTracker(IAnalyzerConfiguration analyzerConfiguration, DiagnosticDescriptor rule) : base(analyzerConfiguration, rule) { }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpInvocationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpInvocationTracker.cs
@@ -23,7 +23,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpObjectCreationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpObjectCreationTracker.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers.CSharp;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpPropertyAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SyntaxTrackers/CSharpPropertyAccessTracker.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Helpers
                 SyntaxKind.MemberBindingExpression,
                 SyntaxKind.IdentifierName
             };
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = CSharp.CSharpGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = CSharpGeneratedCodeRecognizer.Instance;
 
         public CSharpPropertyAccessTracker(IAnalyzerConfiguration analyzerConfiguration, DiagnosticDescriptor rule) : base(analyzerConfiguration, rule) { }
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Helpers
             Action<SyntaxNodeAnalysisContext> action,
             params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct
         {
-            context.RegisterSyntaxNodeActionInNonGenerated(VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
+            context.RegisterSyntaxNodeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
         }
 
         public static void RegisterSyntaxNodeActionInNonGenerated<TLanguageKindEnum>(
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Helpers
             Action<SyntaxNodeAnalysisContext> action,
             params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct
         {
-            context.RegisterSyntaxNodeActionInNonGenerated(VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
+            context.RegisterSyntaxNodeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
         }
 
         public static void RegisterSyntaxNodeActionInNonGenerated<TLanguageKindEnum>(
@@ -49,28 +49,28 @@ namespace SonarAnalyzer.Helpers
             Action<SyntaxNodeAnalysisContext> action,
             params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct
         {
-            context.RegisterSyntaxNodeActionInNonGenerated(VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
+            context.RegisterSyntaxNodeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
         }
 
         public static void RegisterSyntaxTreeActionInNonGenerated(
             this SonarAnalysisContext context,
             Action<SyntaxTreeAnalysisContext> action)
         {
-            context.RegisterSyntaxTreeActionInNonGenerated(VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance, action);
+            context.RegisterSyntaxTreeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action);
         }
 
         public static void RegisterSyntaxTreeActionInNonGenerated(
             this ParameterLoadingAnalysisContext context,
             Action<SyntaxTreeAnalysisContext> action)
         {
-            context.RegisterSyntaxTreeActionInNonGenerated(VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance, action);
+            context.RegisterSyntaxTreeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action);
         }
 
         public static void RegisterCodeBlockStartActionInNonGenerated<TLanguageKindEnum>(
             this SonarAnalysisContext context,
             Action<CodeBlockStartAnalysisContext<TLanguageKindEnum>> action) where TLanguageKindEnum : struct
         {
-            context.RegisterCodeBlockStartActionInNonGenerated(VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance, action);
+            context.RegisterCodeBlockStartActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action);
         }
 
         #endregion Register*ActionInNonGenerated
@@ -82,7 +82,7 @@ namespace SonarAnalyzer.Helpers
             Diagnostic diagnostic,
             Compilation compilation)
         {
-            context.ReportDiagnosticIfNonGenerated(VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance, diagnostic, compilation);
+            context.ReportDiagnosticIfNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic, compilation);
         }
 
         public static void ReportDiagnosticIfNonGenerated(
@@ -90,14 +90,14 @@ namespace SonarAnalyzer.Helpers
             Diagnostic diagnostic,
             Compilation compilation)
         {
-            context.ReportDiagnosticIfNonGenerated(VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance, diagnostic, compilation);
+            context.ReportDiagnosticIfNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic, compilation);
         }
 
         public static void ReportDiagnosticIfNonGenerated(
             this SymbolAnalysisContext context,
             Diagnostic diagnostic)
         {
-            context.ReportDiagnosticIfNonGenerated(VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance, diagnostic,
+            context.ReportDiagnosticIfNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic,
                 context.Compilation);
         }
         #endregion ReportDiagnosticIfNonGenerated

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicEquivalenceChecker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicEquivalenceChecker.cs
@@ -23,7 +23,7 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SonarAnalyzer.Helpers.VisualBasic
+namespace SonarAnalyzer.Helpers
 {
     internal static class VisualBasicEquivalenceChecker
     {
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Helpers.VisualBasic
                 (n1, n2) => SyntaxFactory.AreEquivalent(n1, n2));
         }
     }
-    
+
     internal class VisualBasicSyntaxNodeEqualityComparer<T> : IEqualityComparer<T>, IEqualityComparer<SyntaxList<T>>
         where T : SyntaxNode
     {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicGeneratedCodeRecognizer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicGeneratedCodeRecognizer.cs
@@ -23,7 +23,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
-namespace SonarAnalyzer.Helpers.VisualBasic
+namespace SonarAnalyzer.Helpers
 {
     public sealed class VisualBasicGeneratedCodeRecognizer : Helpers.GeneratedCodeRecognizer
     {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
@@ -26,7 +26,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
-namespace SonarAnalyzer.Helpers.VisualBasic
+namespace SonarAnalyzer.Helpers
 {
     internal static class VisualBasicSyntaxHelper
     {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Metrics/VisualBasicCognitiveComplexityMetric.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Metrics/VisualBasicCognitiveComplexityMetric.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Metrics.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Metrics/VisualBasicMetrics.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Metrics/VisualBasicMetrics.cs
@@ -26,7 +26,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers.VisualBasic;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Metrics.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/AllBranchesShouldNotHaveSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/AllBranchesShouldNotHaveSameImplementation.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BinaryOperationWithIdenticalExpressions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BinaryOperationWithIdenticalExpressions.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanCheckInverted.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanCheckInverted.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanLiteralUnnecessary.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanLiteralUnnecessary.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CatchRethrow.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CatchRethrow.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CertificateValidationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CertificateValidationCheck.cs
@@ -28,7 +28,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CommentKeyword.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CommentKeyword.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameCondition.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameImplementation.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DangerousGetHandleShouldNotBeCalled.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DangerousGetHandleShouldNotBeCalled.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotCheckZeroSizeCollection.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotCheckZeroSizeCollection.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {
@@ -36,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private static readonly DiagnosticDescriptor rule =
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
 
-        protected override Helpers.GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
         protected override SyntaxKind GreaterThanOrEqualExpression => SyntaxKind.GreaterThanOrEqualExpression;
         protected override SyntaxKind LessThanOrEqualExpression => SyntaxKind.LessThanOrEqualExpression;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotOverwriteCollectionElements.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotOverwriteCollectionElements.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotPassSameValueAsMultipleArguments.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotPassSameValueAsMultipleArguments.cs
@@ -40,8 +40,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxKind InvocationExpressionSyntaxKind =>
             SyntaxKind.InvocationExpression;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyMethod.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyMethod.cs
@@ -37,8 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private static readonly DiagnosticDescriptor rule =
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } =
-            Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxKind[] SyntaxKinds { get; } = new []
         {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyNestedBlock.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyNestedBlock.cs
@@ -28,7 +28,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EncryptionAlgorithmsShouldBeSecure.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EncryptionAlgorithmsShouldBeSecure.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EnumNameHasEnumSuffix.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EnumNameHasEnumSuffix.cs
@@ -43,6 +43,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         protected override SyntaxToken GetIdentifier(SyntaxNode node) => ((EnumStatementSyntax)node).Identifier;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExpressionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExpressionComplexity.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [Rule(DiagnosticId)]
     public sealed class ExpressionComplexity : ExpressionComplexityBase<ExpressionSyntax>
     {
-        public override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        public override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         public ExpressionComplexity() : base(RspecStrings.ResourceManager) { }
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FieldShouldNotBePublic.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FieldShouldNotBePublic.cs
@@ -48,6 +48,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
         protected override IEnumerable<ModifiedIdentifierSyntax> GetVariables(FieldDeclarationSyntax fieldDeclaration) =>
             fieldDeclaration.Declarators.SelectMany(d => d.Names);
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FileLines.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FileLines.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override bool IsEndOfFileToken(SyntaxToken token) => token.IsKind(SyntaxKind.EndOfFileToken);
     }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FlagsEnumWithoutInitializer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FlagsEnumWithoutInitializer.cs
@@ -62,6 +62,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         protected override SyntaxToken GetIdentifier(EnumStatementSyntax declaration) => declaration.Identifier;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FlagsEnumZeroMember.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FlagsEnumZeroMember.cs
@@ -51,6 +51,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
             return parent?.ChildNodes().OfType<EnumMemberDeclarationSyntax>() ?? new EnumMemberDeclarationSyntax[0];
         }
 
-        protected sealed override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected sealed override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FunctionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FunctionComplexity.cs
@@ -66,7 +66,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
         protected override int GetComplexity(SyntaxNode node, SemanticModel semanticModel) =>
             new Metrics.VisualBasic.VisualBasicMetrics(node.SyntaxTree, semanticModel).GetCyclomaticComplexity(node);
 
-        protected sealed override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected sealed override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/GotoStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/GotoStatement.cs
@@ -32,8 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     {
         public GotoStatement() : base(RspecStrings.ResourceManager) { }
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-           Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxKind[] GotoSyntaxKinds => new[] { SyntaxKind.GoToStatement };
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/HardcodedIpAddress.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/HardcodedIpAddress.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/CommandPath.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/CommandPath.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DeliveringDebugFeaturesInProduction.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DeliveringDebugFeaturesInProduction.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DoNotHardcodeCredentials.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DoNotHardcodeCredentials.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/ExecutingSqlQueries.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/ExecutingSqlQueries.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/UsingRegularExpressions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/UsingRegularExpressions.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ImplementSerializationMethodsCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ImplementSerializationMethodsCorrectly.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         public ImplementSerializationMethodsCorrectly() : base(RspecStrings.ResourceManager) { }
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override string MethodStaticMessage => ProblemStatic;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/JwtSigned.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/JwtSigned.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LineLength.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LineLength.cs
@@ -36,6 +36,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+            VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodsShouldNotHaveIdenticalImplementations.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodsShouldNotHaveIdenticalImplementations.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodsShouldNotHaveTooManyLines.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodsShouldNotHaveTooManyLines.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MultipleVariableDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MultipleVariableDeclaration.cs
@@ -51,6 +51,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
         protected override IEnumerable<SyntaxToken> GetIdentifiers(LocalDeclarationStatementSyntax node) =>
             node.Declarators.SelectMany(d => d.Names.Select(n => n.Identifier));
 
-        protected sealed override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected sealed override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NameOfShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NameOfShouldBeUsed.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EnumNameShouldFollowRegex.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EnumNameShouldFollowRegex.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
         protected override SyntaxKind EnumStatementSyntaxKind => SyntaxKind.EnumStatement;
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxToken GetIdentifier(EnumStatementSyntax declaration) => declaration.Identifier;
     }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NonAsyncTaskShouldNotReturnNull.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NonAsyncTaskShouldNotReturnNull.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NonStandardCryptographicAlgorithmsShouldNotBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NonStandardCryptographicAlgorithmsShouldNotBeUsed.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameter.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameter.cs
@@ -54,6 +54,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
         protected override bool IsOptional(ParameterSyntax parameter) =>
             parameter.Modifiers.Any(SyntaxKind.OptionalKeyword);
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameterNotPassedToBaseCall.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameterNotPassedToBaseCall.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParameterAssignedTo.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParameterAssignedTo.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         public ParameterAssignedTo() : base(RspecStrings.ResourceManager) { }
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxKind SyntaxKindOfInterest => SyntaxKind.SimpleAssignmentStatement;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertiesAccessCorrectField.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertiesAccessCorrectField.cs
@@ -25,7 +25,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers.VisualBasic;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyGetterWithThrow.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyGetterWithThrow.cs
@@ -58,6 +58,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
             ((ThrowStatementSyntax)syntaxNode).Expression;
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+            VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyWriteOnly.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyWriteOnly.cs
@@ -46,6 +46,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         protected override bool IsWriteOnlyProperty(PropertyStatementSyntax prop) => prop.Modifiers.Any(SyntaxKind.WriteOnlyKeyword);
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicConstantField.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicConstantField.cs
@@ -49,6 +49,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
         protected override IEnumerable<ModifiedIdentifierSyntax> GetVariables(FieldDeclarationSyntax node) =>
             node.Declarators.SelectMany(d => d.Names);
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicMethodWithMultidimensionalArray.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicMethodWithMultidimensionalArray.cs
@@ -43,6 +43,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         protected override SyntaxToken GetIdentifier(MethodStatementSyntax method) => method.Identifier;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantNullCheck.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantNullCheck.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantParentheses.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantParentheses.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SelfAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SelfAssignment.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SingleStatementPerLine.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SingleStatementPerLine.cs
@@ -81,6 +81,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
             st is InheritsOrImplementsStatementSyntax ||
             st is SelectBlockSyntax;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringConcatenationInLoop.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringConcatenationInLoop.cs
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         protected override ImmutableArray<SyntaxKind> CompoundAssignmentKinds => compoundAssignmentKinds;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override bool IsAddExpression(BinaryExpressionSyntax rightExpression) =>
             rightExpression != null;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchWithoutDefault.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchWithoutDefault.cs
@@ -60,6 +60,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
             return node.CaseBlocks.Any(SyntaxKind.CaseElseBlock);
         }
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TabCharacter.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TabCharacter.cs
@@ -38,6 +38,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ThreadResumeOrSuspendShouldNotBeCalled.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ThreadResumeOrSuspendShouldNotBeCalled.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TooManyLabelsInSwitch.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TooManyLabelsInSwitch.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             new[] { SyntaxKind.SelectStatement };
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+            VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxNode GetExpression(SelectStatementSyntax statement) =>
             statement.Expression;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TooManyParameters.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TooManyParameters.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnaryPrefixOperatorRepeated.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnaryPrefixOperatorRepeated.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } =
-            Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+            VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxNode GetOperand(UnaryExpressionSyntax unarySyntax) =>
              unarySyntax.Operand;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnconditionalJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnconditionalJumpStatement.cs
@@ -27,7 +27,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {
@@ -39,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
-        protected override Helpers.GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override ISet<SyntaxKind> LoopStatements { get; } = new HashSet<SyntaxKind>
         {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UriShouldNotBeHardcoded.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UriShouldNotBeHardcoded.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             SyntaxKind.AddExpression,
             SyntaxKind.ConcatenateExpression };
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override string GetLiteralText(LiteralExpressionSyntax literalExpression) => literalExpression?.Token.ValueText;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperator.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperator.cs
@@ -69,7 +69,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         }.ToImmutableDictionary();
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-             Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+             VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest => ImmutableArray.Create<SyntaxKind>(
             SyntaxKind.AndExpression,

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
@@ -28,7 +28,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/CopyPasteTokenAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/CopyPasteTokenAnalyzer.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class CopyPasteTokenAnalyzer : CopyPasteTokenAnalyzerBase
     {
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override bool IsUsingDirective(SyntaxNode node) => node is ImportsStatementSyntax;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/FileMetadataAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/FileMetadataAnalyzer.cs
@@ -27,6 +27,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class FileMetadataAnalyzer : FileMetadataAnalyzerBase
     {
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/MetricsAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/MetricsAnalyzer.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class MetricsAnalyzer : MetricsAnalyzerBase
     {
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override MetricsBase GetMetrics(SyntaxTree syntaxTree, SemanticModel semanticModel) =>
             new Metrics.VisualBasic.VisualBasicMetrics(syntaxTree, semanticModel);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/SymbolReferenceAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/SymbolReferenceAnalyzer.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class SymbolReferenceAnalyzer : SymbolReferenceAnalyzerBase
     {
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override bool IsIdentifier(SyntaxToken token) => token.IsKind(SyntaxKind.IdentifierToken);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class TokenTypeAnalyzer : TokenTypeAnalyzerBase
     {
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+            VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override TokenClassifierBase GetTokenClassifier(SyntaxToken token, SemanticModel semanticModel) =>
             new TokenClassifier(token, semanticModel);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/WcfNonVoidOneWay.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/WcfNonVoidOneWay.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-            Helpers.VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+            VisualBasicGeneratedCodeRecognizer.Instance;
 
         protected override SyntaxKind MethodDeclarationKind =>
             SyntaxKind.FunctionStatement;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/WeakSslTlsProtocols.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/WeakSslTlsProtocols.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicAssignmentFinder.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicAssignmentFinder.cs
@@ -22,7 +22,7 @@ using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
-using SonarAnalyzer.Helpers.VisualBasic;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicAssignmentFinder.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicAssignmentFinder.cs
@@ -22,7 +22,6 @@ using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
-using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicBaseTypeTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicBaseTypeTracker.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Helpers
     public class VisualBasicBaseTypeTracker : BaseTypeTracker<SyntaxKind>
     {
         protected override SyntaxKind[] TrackedSyntaxKinds { get; } = new[] { SyntaxKind.InheritsStatement, SyntaxKind.ImplementsStatement };
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = VisualBasic.VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = VisualBasicGeneratedCodeRecognizer.Instance;
 
         public VisualBasicBaseTypeTracker(IAnalyzerConfiguration analyzerConfiguration, DiagnosticDescriptor rule) : base(analyzerConfiguration, rule) { }
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicBuilderPatternCondition.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicBuilderPatternCondition.cs
@@ -20,7 +20,6 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
-using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicBuilderPatternCondition.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicBuilderPatternCondition.cs
@@ -20,7 +20,7 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
-using SonarAnalyzer.Helpers.VisualBasic;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicElementAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicElementAccessTracker.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicElementAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicElementAccessTracker.cs
@@ -22,7 +22,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers.VisualBasic;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicFieldAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicFieldAccessTracker.cs
@@ -23,7 +23,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicFieldAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicFieldAccessTracker.cs
@@ -23,7 +23,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers.VisualBasic;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicInvocationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicInvocationTracker.cs
@@ -23,7 +23,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicInvocationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicInvocationTracker.cs
@@ -23,7 +23,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers.VisualBasic;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicObjectCreationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicObjectCreationTracker.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicObjectCreationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicObjectCreationTracker.cs
@@ -22,7 +22,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers.VisualBasic;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicPropertyAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicPropertyAccessTracker.cs
@@ -23,7 +23,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicPropertyAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SyntaxTrackers/VisualBasicPropertyAccessTracker.cs
@@ -23,7 +23,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Helpers.VisualBasic;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticAnalyzerContextHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticAnalyzerContextHelperTest.cs
@@ -238,7 +238,7 @@ End Module";
     }
 }";
 
-            var result = IsGenerated(source, SonarAnalyzer.Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance);
+            var result = IsGenerated(source, CSharpGeneratedCodeRecognizer.Instance);
             result.Should().BeTrue();
         }
 
@@ -261,7 +261,7 @@ End Module";
         }
     }
 }";
-            var result = IsGenerated(source, SonarAnalyzer.Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance);
+            var result = IsGenerated(source, CSharpGeneratedCodeRecognizer.Instance);
             result.Should().BeTrue();
         }
 
@@ -276,7 +276,7 @@ End Module";
     }
 }";
 
-            var result = IsGenerated(source, SonarAnalyzer.Helpers.CSharp.CSharpGeneratedCodeRecognizer.Instance);
+            var result = IsGenerated(source, CSharpGeneratedCodeRecognizer.Instance);
             result.Should().BeFalse();
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/EquivalenceCheckerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/EquivalenceCheckerTest.cs
@@ -25,8 +25,7 @@ using Microsoft.CodeAnalysis;
 using CSharp = Microsoft.CodeAnalysis.CSharp.Syntax;
 using VisualBasic = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarAnalyzer.Helpers.CSharp;
-using SonarAnalyzer.Helpers.VisualBasic;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.UnitTest.Helpers
 {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/MethodSignatureHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/MethodSignatureHelperTest.cs
@@ -373,7 +373,7 @@ End Namespace
             else
             {
                 invocation_identifierPairs = snippet.GetNodes<VBSyntax.InvocationExpressionSyntax>()
-                    .Select(n => ((SyntaxNode)n, vbnet::SonarAnalyzer.Helpers.VisualBasic.VisualBasicSyntaxHelper.GetIdentifier(n.Expression)?.Identifier.ValueText));
+                    .Select(n => ((SyntaxNode)n, VisualBasicSyntaxHelper.GetIdentifier(n.Expression)?.Identifier.ValueText));
             }
 
             foreach (var (invocation, methodName) in invocation_identifierPairs)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/SyntaxHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/SyntaxHelperTest.cs
@@ -23,7 +23,6 @@ using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 
 using CSharp = Microsoft.CodeAnalysis.CSharp.Syntax;
 using VisualBasic = Microsoft.CodeAnalysis.VisualBasic.Syntax;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/ResourceTests/GeneratedResourcesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/ResourceTests/GeneratedResourcesTest.cs
@@ -28,7 +28,6 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 using SonarAnalyzer.Rules;
 using SonarAnalyzer.Utilities;
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SyntaxTrackers/BuilderPatternConditionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SyntaxTrackers/BuilderPatternConditionTest.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Helpers.VisualBasic;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CSharpSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
 using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;


### PR DESCRIPTION
Remove useless suffixes from
* `SonarAnalyzer.Helpers.CSharp`
* `SonarAnalyzer.Helpers.VisualBasic`
to
* `SonarAnalyzer.Helpers`
because all nested classes are prefixes with the language name anyway