### PR TITLE
Introduction of CountComparisonSyntax

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -31,6 +31,18 @@ namespace SonarAnalyzer.Helpers.Facade
     {
         public override SyntaxKind Kind(SyntaxNode node) => node.Kind();
 
+        public override ComparisonKind ComparisonKind(SyntaxNode node) =>
+           Kind(node) switch
+           {
+               SyntaxKind.EqualsExpression => Helpers.ComparisonKind.Equals,
+               SyntaxKind.NotEqualsExpression => Helpers.ComparisonKind.NotEquals,
+               SyntaxKind.LessThanExpression => Helpers.ComparisonKind.LessThan,
+               SyntaxKind.LessThanOrEqualExpression => Helpers.ComparisonKind.LessThanOrEqual,
+               SyntaxKind.GreaterThanExpression => Helpers.ComparisonKind.GreaterThan,
+               SyntaxKind.GreaterThanOrEqualExpression => Helpers.ComparisonKind.GreaterThanOrEqual,
+               _ => Helpers.ComparisonKind.None,
+           };
+
         public override bool IsKind(SyntaxNode node, SyntaxKind kind) => node.IsKind(kind);
 
         public override bool IsAnyKind(SyntaxNode node, ISet<SyntaxKind> syntaxKinds) => node.IsAnyKind(syntaxKinds);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ComparableInterfaceImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ComparableInterfaceImplementation.cs
@@ -60,17 +60,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "op_Equality",
             "op_Inequality"
         };
-
-        private static readonly IDictionary<string, string> OperatorNamesMap = new Dictionary<string, string>
-        {
-            { "op_LessThan", "<" },
-            { "op_GreaterThan", ">" },
-            { "op_LessThanOrEqual", "<=" },
-            { "op_GreaterThanOrEqual", ">=" },
-            { "op_Equality", "==" },
-            { "op_Inequality" , "!=" },
-        };
-
+                
         protected override void Initialize(SonarAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
@@ -147,7 +137,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             foreach (var op in RequiredOperators.Except(overridenOperators))
             {
-                yield return OperatorNamesMap[op];
+                yield return ComparisonKinds.OperatorName(op).CSharp();
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharp/CSharpExplodedGraph.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharp/CSharpExplodedGraph.cs
@@ -238,19 +238,19 @@ namespace SonarAnalyzer.SymbolicExecution
                     break;
 
                 case SyntaxKind.LessThanExpression:
-                    newProgramState = VisitComparisonBinaryOperator(newProgramState, (BinaryExpressionSyntax)instruction, (l, r) => new ComparisonSymbolicValue(ComparisonKind.Less, l, r));
+                    newProgramState = VisitComparisonBinaryOperator(newProgramState, (BinaryExpressionSyntax)instruction, (l, r) => new ComparisonSymbolicValue(ComparisonKind.LessThan, l, r));
                     break;
 
                 case SyntaxKind.LessThanOrEqualExpression:
-                    newProgramState = VisitComparisonBinaryOperator(newProgramState, (BinaryExpressionSyntax)instruction, (l, r) => new ComparisonSymbolicValue(ComparisonKind.LessOrEqual, l, r));
+                    newProgramState = VisitComparisonBinaryOperator(newProgramState, (BinaryExpressionSyntax)instruction, (l, r) => new ComparisonSymbolicValue(ComparisonKind.LessThanOrEqual, l, r));
                     break;
 
                 case SyntaxKind.GreaterThanExpression:
-                    newProgramState = VisitComparisonBinaryOperator(newProgramState, (BinaryExpressionSyntax)instruction, (l, r) => new ComparisonSymbolicValue(ComparisonKind.Less, r, l));
+                    newProgramState = VisitComparisonBinaryOperator(newProgramState, (BinaryExpressionSyntax)instruction, (l, r) => new ComparisonSymbolicValue(ComparisonKind.LessThan, r, l));
                     break;
 
                 case SyntaxKind.GreaterThanOrEqualExpression:
-                    newProgramState = VisitComparisonBinaryOperator(newProgramState, (BinaryExpressionSyntax)instruction, (l, r) => new ComparisonSymbolicValue(ComparisonKind.LessOrEqual, r, l));
+                    newProgramState = VisitComparisonBinaryOperator(newProgramState, (BinaryExpressionSyntax)instruction, (l, r) => new ComparisonSymbolicValue(ComparisonKind.LessThanOrEqual, r, l));
                     break;
 
                 case SyntaxKind.SubtractExpression:

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/ProgramState.cs
@@ -170,12 +170,12 @@ namespace SonarAnalyzer.SymbolicExecution
         private static void RemoveRedundantLessEquals(HashSet<BinaryRelationship> relationships)
         {
             // a <= b && a < b  ->  a < b
-            var leComparisions = GetComparisions(relationships, ComparisonKind.LessOrEqual);
-            var lComparisions = GetComparisions(relationships, ComparisonKind.Less);
+            var leComparisions = GetComparisions(relationships, ComparisonKind.LessThanOrEqual);
+            var lComparisions = GetComparisions(relationships, ComparisonKind.LessThan);
             relationships.ExceptWith(leComparisions.Where(le => lComparisions.Any(l => le.AreOperandsMatching(l))));
 
             // a <= b && a == b  ->  a == b
-            leComparisions = GetComparisions(relationships, ComparisonKind.LessOrEqual);
+            leComparisions = GetComparisions(relationships, ComparisonKind.LessThanOrEqual);
             var equals = relationships.OfType<EqualsRelationship>();
             relationships.ExceptWith(leComparisions.Where(le => equals.Any(e => le.AreOperandsMatching(e))));
         }
@@ -184,7 +184,7 @@ namespace SonarAnalyzer.SymbolicExecution
         {
             // a <= b && a != b  ->  a < b
 
-            var leComparisions = GetComparisions(relationships, ComparisonKind.LessOrEqual);
+            var leComparisions = GetComparisions(relationships, ComparisonKind.LessThanOrEqual);
             var notEquals = relationships.OfType<ValueNotEqualsRelationship>();
 
             var toChange = new List<ComparisonRelationship>();
@@ -202,7 +202,7 @@ namespace SonarAnalyzer.SymbolicExecution
             foreach (var item in toChange)
             {
                 relationships.Remove(item);
-                relationships.Add(new ComparisonRelationship(ComparisonKind.Less, item.LeftOperand, item.RightOperand));
+                relationships.Add(new ComparisonRelationship(ComparisonKind.LessThan, item.LeftOperand, item.RightOperand));
             }
         }
 
@@ -210,7 +210,7 @@ namespace SonarAnalyzer.SymbolicExecution
         {
             // a <= b && b <= a  ->  a == b
 
-            var leComparisions = GetComparisions(relationships, ComparisonKind.LessOrEqual);
+            var leComparisions = GetComparisions(relationships, ComparisonKind.LessThanOrEqual);
 
             var toChange = new List<ComparisonRelationship>();
             for (var i = 0; i < leComparisions.Count; i++)

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/Relationships/ValueEqualsRelationship.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/Relationships/ValueEqualsRelationship.cs
@@ -20,7 +20,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using SonarAnalyzer.SymbolicExecution.SymbolicValues;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.SymbolicExecution.Relationships
 {
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.SymbolicExecution.Relationships
 
             var isComparisonContradicting = relationships
                 .OfType<ComparisonRelationship>()
-                .Where(c => c.ComparisonKind == ComparisonKind.Less)
+                .Where(c => c.ComparisonKind == ComparisonKind.LessThan)
                 .Any(c => AreOperandsMatching(c));
 
             return isComparisonContradicting;

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/Relationships/ValueNotEqualsRelationship.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/Relationships/ValueNotEqualsRelationship.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.SymbolicExecution.Relationships
 
             var comparisons = relationships
                 .OfType<ComparisonRelationship>()
-                .Where(c => c.ComparisonKind == ComparisonKind.LessOrEqual)
+                .Where(c => c.ComparisonKind == ComparisonKind.LessThanOrEqual)
                 .Where(c => AreOperandsMatching(c));
 
             return comparisons.Count() == 2;

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/ComparisonSymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/ComparisonSymbolicValue.cs
@@ -20,6 +20,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using SonarAnalyzer.Helpers;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 using SonarAnalyzer.SymbolicExecution.Relationships;
 
@@ -62,12 +63,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
                 : relationship.Negate();
         }
 
-        public override string ToString()
-        {
-            var op = this.comparisonKind == ComparisonKind.Less
-                ? "<"
-                : "<=";
-            return $"{op}({LeftOperand}, {RightOperand})";
-        }
+        public override string ToString() =>
+            $"{comparisonKind.CSharp()}({LeftOperand}, {RightOperand})";
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
@@ -28,6 +28,8 @@ namespace SonarAnalyzer.Helpers.Facade
         where TSyntaxKind : struct
     {
         public abstract TSyntaxKind Kind(SyntaxNode node);
+        public abstract ComparisonKind ComparisonKind(SyntaxNode node);
+
         public abstract bool IsNullLiteral(SyntaxNode node);
         public abstract bool IsKind(SyntaxNode node, TSyntaxKind kind);
         public abstract bool IsAnyKind(SyntaxNode node, ISet<TSyntaxKind> syntaxKinds);

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/ComparisonKind.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/ComparisonKind.cs
@@ -18,11 +18,16 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
+namespace SonarAnalyzer.Helpers
 {
     public enum ComparisonKind
     {
-        Less,
-        LessOrEqual
+        None = 0,
+        Equals,
+        NotEquals,
+        LessThan,
+        LessThanOrEqual,
+        GreaterThan,
+        GreaterThanOrEqual,
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/ComparisonKinds.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/ComparisonKinds.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+
+namespace SonarAnalyzer.Helpers
+{
+    public static class ComparisonKinds
+    {
+        public static ComparisonKind OperatorName(string name) =>
+            name switch
+            {
+                "op_Equality" => ComparisonKind.Equals,
+                "op_Inequality" => ComparisonKind.NotEquals,
+                "op_LessThan" => ComparisonKind.LessThan,
+                "op_LessThanOrEqual" => ComparisonKind.LessThanOrEqual,
+                "op_GreaterThan" => ComparisonKind.GreaterThan,
+                "op_GreaterThanOrEqual" => ComparisonKind.GreaterThanOrEqual,
+                _ => throw new InvalidOperationException(),
+            };
+
+        public static ComparisonKind Mirror(this ComparisonKind comparison) =>
+           comparison switch
+           {
+               ComparisonKind.GreaterThan => ComparisonKind.LessThan,
+               ComparisonKind.GreaterThanOrEqual => ComparisonKind.LessThanOrEqual,
+               ComparisonKind.LessThan => ComparisonKind.GreaterThan,
+               ComparisonKind.LessThanOrEqual => ComparisonKind.GreaterThanOrEqual,
+               _ => comparison,
+           };
+
+        public static string CSharp(this ComparisonKind kind) =>
+            kind switch
+            {
+                ComparisonKind.Equals => "==",
+                ComparisonKind.NotEquals => "!=",
+                ComparisonKind.LessThan => "<",
+                ComparisonKind.LessThanOrEqual => "<=",
+                ComparisonKind.GreaterThan => ">",
+                ComparisonKind.GreaterThanOrEqual => ">=",
+                _ => throw new InvalidOperationException(),
+            };
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/CountComparisionKind.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/CountComparisionKind.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Helpers
+{
+    public enum CountComparisonKind
+    {
+        SizeDepedendent,
+        NotAny,
+        Any,
+        AlwaysFalse,
+        AlwaysTrue,
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/CountComparisonKinds.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/CountComparisonKinds.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Helpers
+{
+    public static class CountComparisonKinds
+    {
+        public static bool AnyOrNotAny(this CountComparisonKind comparison) =>
+            comparison == CountComparisonKind.Any || comparison == CountComparisonKind.NotAny;
+
+        public static CountComparisonKind Count(this ComparisonKind comparison, int count) =>
+            comparison switch
+            {
+                ComparisonKind.Equals => Equals(count),
+                ComparisonKind.NotEquals => NotEquals(count),
+
+                ComparisonKind.GreaterThanOrEqual => GreaterThanOrEqual(count),
+                ComparisonKind.GreaterThan => GreaterThan(count),
+
+                ComparisonKind.LessThan => LessThan(count),
+                ComparisonKind.LessThanOrEqual => LessThanOrEqual(count),
+
+                _ => CountComparisonKind.SizeDepedendent,
+            };
+
+        private static CountComparisonKind Equals(int count) =>
+            count > 0
+            ? CountComparisonKind.SizeDepedendent
+            : count == 0
+                ? CountComparisonKind.NotAny
+                : CountComparisonKind.AlwaysFalse;
+
+        private static CountComparisonKind NotEquals(int count) =>
+            count > 0
+            ? CountComparisonKind.SizeDepedendent
+            : count == 0
+                ? CountComparisonKind.Any
+                : CountComparisonKind.AlwaysTrue;
+
+        private static CountComparisonKind GreaterThan(int count) =>
+            count > 0
+            ? CountComparisonKind.SizeDepedendent
+            : count == 0
+                ? CountComparisonKind.Any
+                : CountComparisonKind.AlwaysTrue;
+
+        private static CountComparisonKind GreaterThanOrEqual(int count) =>
+            count > 1
+            ? CountComparisonKind.SizeDepedendent
+            : count == 1
+                ? CountComparisonKind.Any
+                : CountComparisonKind.AlwaysTrue;
+
+        private static CountComparisonKind LessThan(int count) =>
+            count > 1
+            ? CountComparisonKind.SizeDepedendent
+            : count == 1
+                ? CountComparisonKind.NotAny
+                : CountComparisonKind.AlwaysFalse;
+
+        private static CountComparisonKind LessThanOrEqual(int count) =>
+            count > 0
+            ? CountComparisonKind.SizeDepedendent
+            : count == 0
+                ? CountComparisonKind.NotAny
+                : CountComparisonKind.AlwaysFalse;
+    }
+}

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
@@ -33,6 +33,18 @@ namespace SonarAnalyzer.Helpers.Facade
 
         public override SyntaxKind Kind(SyntaxNode node) => node.Kind();
 
+        public override ComparisonKind ComparisonKind(SyntaxNode node) =>
+           Kind(node) switch
+           {
+               SyntaxKind.EqualsExpression => Helpers.ComparisonKind.Equals,
+               SyntaxKind.NotEqualsExpression => Helpers.ComparisonKind.NotEquals,
+               SyntaxKind.LessThanExpression => Helpers.ComparisonKind.LessThan,
+               SyntaxKind.LessThanOrEqualExpression => Helpers.ComparisonKind.LessThanOrEqual,
+               SyntaxKind.GreaterThanExpression => Helpers.ComparisonKind.GreaterThan,
+               SyntaxKind.GreaterThanOrEqualExpression => Helpers.ComparisonKind.GreaterThanOrEqual,
+               _ => Helpers.ComparisonKind.None,
+           };
+
         public override bool IsKind(SyntaxNode node, SyntaxKind kind) => node.IsKind(kind);
 
         public override bool IsAnyKind(SyntaxNode node, ISet<SyntaxKind> syntaxKinds) => node.IsAnyKind(syntaxKinds);


### PR DESCRIPTION
There are two rules involved for checking `Count`, `Length`, and `Count()`, on collections. Those are implemented for both languages and with a Fix for one on the way (#3857) the code duplication involved to do so, felt like a burden to me.

So with this helper syntax (struct), I tried to centralize the different types of Count comparisons we might be interested in:
* equivalent to Any()
* equivalent to !Any()
* Without meaning (`< 0`, `>= 0`, `!= -1`, `== -1`)

If a `BinaryExpressionSyntax` is a relavent count expression is not taken into account yet (up to the rule in play). Reason for that is that S1155 is not triggered by IList, ICollection, Array etc,  and S3981 is. It is beyond the scope of this proposal to decide on that here I think.

Just another remark: most of this code is already in #3857, but internal, C# only, and only taking Any() and !Any() into account.