### PR TITLE
Make contact email consistent with other licence headers

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
@@ -1,7 +1,7 @@
 ﻿/*
  * SonarAnalyzer for .NET
  * Copyright (C) 2015-2021 SonarSource SA
- * mailto:contact@sonarsource.com
+ * mailto: contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
When checking the following commit: https://github.com/SonarSource/sonar-dotnet/commit/1af2e34548c0873aa437a11d02f9d51373ed7177,  that bumps the year to 2021 I spotted that the mailto was different in the `CSharpDiagnosticAnalyzerContextHelper.cs` file.

This commit makes it consistent with the files in the following directory: https://github.com/SonarSource/sonar-dotnet/tree/master/analyzers/src/SonarAnalyzer.CSharp/Rules
