### PR TITLE
Remove redundant parameters from ReportDiagnosticIfNonGenerated

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
@@ -53,11 +53,8 @@ namespace SonarAnalyzer.Helpers
         public static void ReportDiagnosticIfNonGenerated(this CompilationAnalysisContext context, Diagnostic diagnostic) =>
             context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
 
-        public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, Diagnostic diagnostic, Compilation compilation) =>
-            context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic, compilation);
-
         public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, Diagnostic diagnostic) =>
-            context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic, context.Compilation);
+            context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
 
         internal static bool ShouldAnalyze(this SyntaxTree tree, AnalyzerOptions options, Compilation compilation) =>
             // ToDo: PERF: do the global setting check before the per-file check.

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
@@ -50,8 +50,8 @@ namespace SonarAnalyzer.Helpers
             where TSyntaxKind : struct =>
             context.RegisterCodeBlockStartActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action);
 
-        public static void ReportDiagnosticIfNonGenerated(this CompilationAnalysisContext context, Diagnostic diagnostic, Compilation compilation) =>
-            context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic, compilation);
+        public static void ReportDiagnosticIfNonGenerated(this CompilationAnalysisContext context, Diagnostic diagnostic) =>
+            context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
 
         public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, Diagnostic diagnostic, Compilation compilation) =>
             context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic, compilation);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeAbstract.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeAbstract.cs
@@ -97,9 +97,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 if (declaringSyntaxReference.GetSyntax() is ClassDeclarationSyntax classDeclaration)
                 {
-                    context.ReportDiagnosticIfNonGenerated(
-                        Diagnostic.Create(rule, classDeclaration.Identifier.GetLocation(), message),
-                        context.Compilation);
+                    context.ReportDiagnosticIfNonGenerated(Diagnostic.Create(rule, classDeclaration.Identifier.GetLocation(), message));
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithOnlyStaticMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithOnlyStaticMember.cs
@@ -75,9 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 if (syntaxReference.GetSyntax() is ClassDeclarationSyntax classDeclarationSyntax)
                 {
-                    context.ReportDiagnosticIfNonGenerated(
-                        Diagnostic.Create(rule, classDeclarationSyntax.Identifier.GetLocation(), reportMessage),
-                        context.Compilation);
+                    context.ReportDiagnosticIfNonGenerated(Diagnostic.Create(rule, classDeclarationSyntax.Identifier.GetLocation(), reportMessage));
                 }
             }
         }
@@ -108,9 +106,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     if (syntaxReference.GetSyntax() is ConstructorDeclarationSyntax constructorDeclaration)
                     {
-                        context.ReportDiagnosticIfNonGenerated(
-                            Diagnostic.Create(rule, constructorDeclaration.Identifier.GetLocation(), reportMessage),
-                            context.Compilation);
+                        context.ReportDiagnosticIfNonGenerated(Diagnostic.Create(rule, constructorDeclaration.Identifier.GetLocation(), reportMessage));
                     }
                 }
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableNotDisposed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableNotDisposed.cs
@@ -116,7 +116,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         {
                             if (!excludedSymbols.Contains(trackedNodeAndSymbol.Symbol))
                             {
-                                c.ReportDiagnosticIfNonGenerated(Diagnostic.Create(rule, trackedNodeAndSymbol.Node.GetLocation(), trackedNodeAndSymbol.Symbol.Name), c.Compilation);
+                                c.ReportDiagnosticIfNonGenerated(Diagnostic.Create(rule, trackedNodeAndSymbol.Node.GetLocation(), trackedNodeAndSymbol.Symbol.Name));
                             }
                         }
                     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -131,7 +131,7 @@ namespace SonarAnalyzer.Rules.CSharp
                             var diagnostics = GetDiagnosticsForUnusedPrivateMembers(usageCollector, removableInternalTypes.ToHashSet(), "internal", new BidirectionalDictionary<ISymbol, SyntaxNode>());
                             foreach (var diagnostic in diagnostics)
                             {
-                                cc.ReportDiagnosticIfNonGenerated(diagnostic, cc.Compilation);
+                                cc.ReportDiagnosticIfNonGenerated(diagnostic);
                             }
                         });
                 });

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -108,7 +108,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                                     .Concat(GetDiagnosticsForUsedButUnreadFields(usageCollector, removableSymbolsCollector.PrivateSymbols));
                             foreach (var diagnostic in diagnostics)
                             {
-                                cc.ReportDiagnosticIfNonGenerated(diagnostic, cc.Compilation);
+                                cc.ReportDiagnosticIfNonGenerated(diagnostic);
                             }
                         },
                         SymbolKind.NamedType);

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/DiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/DiagnosticAnalyzerContextHelper.cs
@@ -108,16 +108,13 @@ namespace SonarAnalyzer.Helpers
             }
         }
 
-        public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, GeneratedCodeRecognizer generatedCodeRecognizer, Diagnostic diagnostic, Compilation compilation)
+        public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, GeneratedCodeRecognizer generatedCodeRecognizer, Diagnostic diagnostic)
         {
-            if (ShouldAnalyze(generatedCodeRecognizer, diagnostic.Location.SourceTree, compilation, context.Options))
+            if (ShouldAnalyze(generatedCodeRecognizer, diagnostic.Location.SourceTree, context.Compilation, context.Options))
             {
                 context.ReportDiagnosticWhenActive(diagnostic);
             }
         }
-
-        public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, GeneratedCodeRecognizer generatedCodeRecognizer, Diagnostic diagnostic) =>
-            context.ReportDiagnosticIfNonGenerated(generatedCodeRecognizer, diagnostic, context.Compilation);
 
         public static bool ShouldAnalyze(GeneratedCodeRecognizer generatedCodeRecognizer, SyntaxTree syntaxTree, Compilation c, AnalyzerOptions options) =>
             options.ShouldAnalyzeGeneratedCode(c.Language) || !syntaxTree.IsGenerated(generatedCodeRecognizer, c);

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/DiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/DiagnosticAnalyzerContextHelper.cs
@@ -100,8 +100,7 @@ namespace SonarAnalyzer.Helpers
                     }
                 });
 
-        // ToDo: Remove unused parameters
-        public static void ReportDiagnosticIfNonGenerated(this CompilationAnalysisContext context, GeneratedCodeRecognizer generatedCodeRecognizer, Diagnostic diagnostic, Compilation compilation)
+        public static void ReportDiagnosticIfNonGenerated(this CompilationAnalysisContext context, GeneratedCodeRecognizer generatedCodeRecognizer, Diagnostic diagnostic)
         {
             if (ShouldAnalyze(context, generatedCodeRecognizer, diagnostic.Location.SourceTree, context.Compilation, context.Options))
             {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
@@ -51,8 +51,8 @@ namespace SonarAnalyzer.Helpers
             where TSyntaxKind : struct =>
             context.RegisterCodeBlockStartActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-        public static void ReportDiagnosticIfNonGenerated(this CompilationAnalysisContext context, Diagnostic diagnostic, Compilation compilation) =>
-            context.ReportDiagnosticIfNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic, compilation);
+        public static void ReportDiagnosticIfNonGenerated(this CompilationAnalysisContext context, Diagnostic diagnostic) =>
+            context.ReportDiagnosticIfNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic);
 
         public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, Diagnostic diagnostic, Compilation compilation) =>
             context.ReportDiagnosticIfNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic, compilation);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
@@ -54,10 +54,7 @@ namespace SonarAnalyzer.Helpers
         public static void ReportDiagnosticIfNonGenerated(this CompilationAnalysisContext context, Diagnostic diagnostic) =>
             context.ReportDiagnosticIfNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic);
 
-        public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, Diagnostic diagnostic, Compilation compilation) =>
-            context.ReportDiagnosticIfNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic, compilation);
-
         public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, Diagnostic diagnostic) =>
-            context.ReportDiagnosticIfNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic, context.Compilation);
+            context.ReportDiagnosticIfNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic);
     }
 }


### PR DESCRIPTION
Remove redundant `Compilation` argument from `ReportDiagnosticIfNonGenerated` extensions

Rebase will be needed after #4060 is merged. The `Squash #4048` commit doesn't need a review.