### PR TITLE
Fix project count logic - filter out global module

### DIFF
--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/ProjectTypeCollector.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/ProjectTypeCollector.java
@@ -40,8 +40,7 @@ public class ProjectTypeCollector {
   // modules that have both MAIN and TEST files
   private int mixed = 0;
   // modules that have no files
-  // there is always the top-level (global) module which has no files and has no equivalent "real" MSBuild project (module)
-  private int noFiles = -1;
+  private int noFiles = 0;
 
   void addProjectInfo(boolean hasMainFiles, boolean hasTestFiles) {
     if (hasMainFiles && hasTestFiles) {
@@ -61,7 +60,7 @@ public class ProjectTypeCollector {
 
   private static Optional<String> createMessage(int onlyMain, int onlyTest, int mixed, int noFiles) {
     int projectsCount = onlyMain + onlyTest + mixed + noFiles;
-    if (projectsCount <= 0) {
+    if (projectsCount == 0) {
       return Optional.empty();
     }
     StringBuilder stringBuilder = new StringBuilder(String.format("Found %d MSBuild %s.", projectsCount, pluralize(PROJECT, projectsCount)));

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/ProjectTypeCollectorTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/ProjectTypeCollectorTest.java
@@ -23,124 +23,118 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// These tests use "SUT" (System Under Test) to name the object being tested.
 public class ProjectTypeCollectorTest {
 
   @Test
   public void withNoProjects() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
-    assertThat(underTest.getSummary()).isEmpty();
+    ProjectTypeCollector sut = new ProjectTypeCollector();
+    assertThat(sut.getSummary()).isEmpty();
   }
 
   @Test
-  public void withNoFiles_skip() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
+  public void withNoFiles() {
+    ProjectTypeCollector sut = new ProjectTypeCollector();
 
-    assertThat(underTest.getSummary()).isEmpty();
-  }
+    addProjectWithNoFiles(sut);
 
-  @Test
-  public void withNoFiles_twoModules_logOne() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
-
-    addProjectWithNoFiles(underTest);
-
-    assertThat(underTest.getSummary()).hasValue("Found 1 MSBuild project. 1 with no MAIN nor TEST files.");
+    assertThat(sut.getSummary()).hasValue("Found 1 MSBuild project. 1 with no MAIN nor TEST files.");
   }
 
   @Test
   public void withOnlyMainFiles() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
+    ProjectTypeCollector sut = new ProjectTypeCollector();
 
-    addMainProject(underTest);
+    addMainProject(sut);
 
-    assertThat(underTest.getSummary()).hasValue("Found 1 MSBuild project. 1 MAIN project.");
+    assertThat(sut.getSummary()).hasValue("Found 1 MSBuild project. 1 MAIN project.");
   }
 
   @Test
   public void withOnlyTestFile() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
+    ProjectTypeCollector sut = new ProjectTypeCollector();
 
-    addTestProject(underTest);
-    addTestProject(underTest);
-    addTestProject(underTest);
+    addTestProject(sut);
+    addTestProject(sut);
+    addTestProject(sut);
 
-    assertThat(underTest.getSummary()).hasValue("Found 3 MSBuild projects. 3 TEST projects.");
+    assertThat(sut.getSummary()).hasValue("Found 3 MSBuild projects. 3 TEST projects.");
   }
 
   @Test
-  public void withBothTypes_calledOnce_returnsEmpty() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
+  public void withBothTypes() {
+    ProjectTypeCollector sut = new ProjectTypeCollector();
 
-    addMixedProject(underTest);
+    addProjectWithBothTypes(sut);
 
-    assertThat(underTest.getSummary()).hasValue("Found 1 MSBuild project. 1 with both MAIN and TEST files.");
+    assertThat(sut.getSummary()).hasValue("Found 1 MSBuild project. 1 with both MAIN and TEST files.");
   }
 
   @Test
   public void mixedProjects_test_and_main() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
+    ProjectTypeCollector sut = new ProjectTypeCollector();
 
-    addTestProject(underTest);
-    addMainProject(underTest);
-    addTestProject(underTest);
+    addTestProject(sut);
+    addMainProject(sut);
+    addTestProject(sut);
 
-    assertThat(underTest.getSummary()).hasValue("Found 3 MSBuild projects. 1 MAIN project. 2 TEST projects.");
+    assertThat(sut.getSummary()).hasValue("Found 3 MSBuild projects. 1 MAIN project. 2 TEST projects.");
   }
 
   @Test
   public void mixedProjects_test_and_both() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
+    ProjectTypeCollector sut = new ProjectTypeCollector();
 
-    addTestProject(underTest);
-    addMixedProject(underTest);
-    addTestProject(underTest);
+    addTestProject(sut);
+    addProjectWithBothTypes(sut);
+    addTestProject(sut);
 
-    assertThat(underTest.getSummary()).hasValue("Found 3 MSBuild projects. 2 TEST projects. 1 with both MAIN and TEST files.");
+    assertThat(sut.getSummary()).hasValue("Found 3 MSBuild projects. 2 TEST projects. 1 with both MAIN and TEST files.");
   }
 
   @Test
   public void mixedProjects_main_and_both() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
+    ProjectTypeCollector sut = new ProjectTypeCollector();
 
-    addMainProject(underTest);
-    addMixedProject(underTest);
-    addMainProject(underTest);
+    addMainProject(sut);
+    addProjectWithBothTypes(sut);
+    addMainProject(sut);
 
-    assertThat(underTest.getSummary()).hasValue("Found 3 MSBuild projects. 2 MAIN projects. 1 with both MAIN and TEST files.");
+    assertThat(sut.getSummary()).hasValue("Found 3 MSBuild projects. 2 MAIN projects. 1 with both MAIN and TEST files.");
   }
 
   @Test
   public void mixedProjects_test_none() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
+    ProjectTypeCollector sut = new ProjectTypeCollector();
 
-    addTestProject(underTest);
-    addTestProject(underTest);
-    addProjectWithNoFiles(underTest);
+    addTestProject(sut);
+    addTestProject(sut);
+    addProjectWithNoFiles(sut);
 
-    assertThat(underTest.getSummary()).hasValue("Found 3 MSBuild projects. 2 TEST projects. 1 with no MAIN nor TEST files.");
+    assertThat(sut.getSummary()).hasValue("Found 3 MSBuild projects. 2 TEST projects. 1 with no MAIN nor TEST files.");
   }
 
   @Test
   public void mixedProjects_main_none() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
+    ProjectTypeCollector sut = new ProjectTypeCollector();
 
-    addProjectWithNoFiles(underTest);
-    addMainProject(underTest);
-    addMainProject(underTest);
-    addMainProject(underTest);
+    addProjectWithNoFiles(sut);
+    addMainProject(sut);
+    addMainProject(sut);
+    addMainProject(sut);
 
-    assertThat(underTest.getSummary()).hasValue("Found 4 MSBuild projects. 3 MAIN projects. 1 with no MAIN nor TEST files.");
+    assertThat(sut.getSummary()).hasValue("Found 4 MSBuild projects. 3 MAIN projects. 1 with no MAIN nor TEST files.");
   }
 
   @Test
   public void mixedProjects_all_types() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
+    ProjectTypeCollector sut = new ProjectTypeCollector();
 
-    addTestProject(underTest);
-    addMainProject(underTest);
-    addMixedProject(underTest);
+    addTestProject(sut);
+    addMainProject(sut);
+    addProjectWithBothTypes(sut);
 
-    assertThat(underTest.getSummary()).hasValue("Found 3 MSBuild projects. 1 MAIN project. 1 TEST project. 1 with both MAIN and TEST files.");
+    assertThat(sut.getSummary()).hasValue("Found 3 MSBuild projects. 1 MAIN project. 1 TEST project. 1 with both MAIN and TEST files.");
   }
 
   private void addProjectWithNoFiles(ProjectTypeCollector projectTypeCollector) {
@@ -155,7 +149,7 @@ public class ProjectTypeCollectorTest {
     projectTypeCollector.addProjectInfo(true, false);
   }
 
-  private void addMixedProject(ProjectTypeCollector projectTypeCollector) {
+  private void addProjectWithBothTypes(ProjectTypeCollector projectTypeCollector) {
     projectTypeCollector.addProjectInfo(true, true);
   }
 }

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/ProjectTypeCollectorTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/ProjectTypeCollectorTest.java
@@ -35,47 +35,21 @@ public class ProjectTypeCollectorTest {
   public void withNoFiles_skip() {
     ProjectTypeCollector underTest = new ProjectTypeCollector();
 
-    // this will be skipped, considered as top-level module
-    addProjectWithNoFiles(underTest);
-
     assertThat(underTest.getSummary()).isEmpty();
-  }
-
-  @Test
-  public void withNoTopLevelModule_behavesIncorrect() {
-    ProjectTypeCollector underTest = new ProjectTypeCollector();
-
-    addMainProject(underTest);
-
-    // There is an assumption that the scanner will always run the sensor on the top-level module which has no files.
-    // If that doesn't happen, it returns empty string.
-    assertThat(underTest.getSummary()).isEmpty();
-
-    addMainProject(underTest);
-    addMainProject(underTest);
-    assertThat(underTest.getSummary()).hasValue("Found 2 MSBuild projects. 3 MAIN projects.");
   }
 
   @Test
   public void withNoFiles_twoModules_logOne() {
     ProjectTypeCollector underTest = new ProjectTypeCollector();
 
-
-    // this will be skipped, considered as top-level module
-    addProjectWithNoFiles(underTest);
-
     addProjectWithNoFiles(underTest);
 
     assertThat(underTest.getSummary()).hasValue("Found 1 MSBuild project. 1 with no MAIN nor TEST files.");
   }
 
-
   @Test
   public void withOnlyMainFiles() {
     ProjectTypeCollector underTest = new ProjectTypeCollector();
-
-    // this will be skipped, considered as top-level module
-    addProjectWithNoFiles(underTest);
 
     addMainProject(underTest);
 
@@ -85,9 +59,6 @@ public class ProjectTypeCollectorTest {
   @Test
   public void withOnlyTestFile() {
     ProjectTypeCollector underTest = new ProjectTypeCollector();
-
-    // this will be skipped, considered as top-level module
-    addProjectWithNoFiles(underTest);
 
     addTestProject(underTest);
     addTestProject(underTest);
@@ -100,9 +71,6 @@ public class ProjectTypeCollectorTest {
   public void withBothTypes_calledOnce_returnsEmpty() {
     ProjectTypeCollector underTest = new ProjectTypeCollector();
 
-    // this will be skipped, considered as top-level module
-    addProjectWithNoFiles(underTest);
-
     addMixedProject(underTest);
 
     assertThat(underTest.getSummary()).hasValue("Found 1 MSBuild project. 1 with both MAIN and TEST files.");
@@ -111,9 +79,6 @@ public class ProjectTypeCollectorTest {
   @Test
   public void mixedProjects_test_and_main() {
     ProjectTypeCollector underTest = new ProjectTypeCollector();
-
-    // this will be skipped, considered as top-level module
-    addProjectWithNoFiles(underTest);
 
     addTestProject(underTest);
     addMainProject(underTest);
@@ -126,9 +91,6 @@ public class ProjectTypeCollectorTest {
   public void mixedProjects_test_and_both() {
     ProjectTypeCollector underTest = new ProjectTypeCollector();
 
-    // this will be skipped, considered as top-level module
-    addProjectWithNoFiles(underTest);
-
     addTestProject(underTest);
     addMixedProject(underTest);
     addTestProject(underTest);
@@ -139,9 +101,6 @@ public class ProjectTypeCollectorTest {
   @Test
   public void mixedProjects_main_and_both() {
     ProjectTypeCollector underTest = new ProjectTypeCollector();
-
-    // this will be skipped, considered as top-level module
-    addProjectWithNoFiles(underTest);
 
     addMainProject(underTest);
     addMixedProject(underTest);
@@ -154,9 +113,6 @@ public class ProjectTypeCollectorTest {
   public void mixedProjects_test_none() {
     ProjectTypeCollector underTest = new ProjectTypeCollector();
 
-    // this will be skipped - considered as top-level module
-    addProjectWithNoFiles(underTest);
-
     addTestProject(underTest);
     addTestProject(underTest);
     addProjectWithNoFiles(underTest);
@@ -167,9 +123,6 @@ public class ProjectTypeCollectorTest {
   @Test
   public void mixedProjects_main_none() {
     ProjectTypeCollector underTest = new ProjectTypeCollector();
-
-    // this will be skipped, considered as top-level
-    addProjectWithNoFiles(underTest);
 
     addProjectWithNoFiles(underTest);
     addMainProject(underTest);
@@ -182,9 +135,6 @@ public class ProjectTypeCollectorTest {
   @Test
   public void mixedProjects_all_types() {
     ProjectTypeCollector underTest = new ProjectTypeCollector();
-
-    // this will be skipped, considered as top-level module
-    addProjectWithNoFiles(underTest);
 
     addTestProject(underTest);
     addMainProject(underTest);


### PR DESCRIPTION
Fixes  #4054 

TL;DR;:
- we now count the MSBuild projects and show statistics - how many are MAIN, how many are TEST etc. Each MSBuild project has an equivalent scanner module.
- the global module is an artificial scanner module which has no files and no MSBuild equivalent.
- the global module has `projectName` and `projectKey` properties like all other module; to filter it out, this PR uses `projectOutPath` which is a property just for "real project" modules.

The IT,  `MultipleProjectsTest#projectTypesInfoIsLogged`, hasn't changed.