### PR TITLE
GitHub workflow: Create PR

### DIFF
--- a/.github/workflows/CreatePullRequest.yml
+++ b/.github/workflows/CreatePullRequest.yml
@@ -1,0 +1,38 @@
+name: Create Pull Request
+
+on:
+  pull_request:
+    types: ["opened"]
+
+jobs:
+  assign_and_create_card:
+    name: Assign issue to sender and create Kanban card
+    runs-on: ubuntu-latest
+    # PRs from forks don't have required token authorization
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      # https://github.com/actions/github-script
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const IN_PROGRESS_COLUMN = 4971952;
+            //
+            async function addAssignee(issue, login) {
+                console.log("Assigning to: " + login);
+                await github.issues.addAssignees({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    assignees: [login]
+                });
+            }
+            //
+            if(context.payload.pull_request.body.match(/Fixes\s*#\d+/gi)) {
+                console.log("Skip, contains 'Fixes'");  // There should already be a card with original issue
+            } else {
+                addAssignee(context.payload.pull_request, context.payload.sender.login);
+                github.projects.createCard({ column_id: IN_PROGRESS_COLUMN, content_id: context.payload.pull_request.id, content_type: "PullRequest" });
+                console.log("Done");
+            }

--- a/.github/workflows/CreatePullRequest.yml
+++ b/.github/workflows/CreatePullRequest.yml
@@ -29,8 +29,9 @@ jobs:
                 });
             }
             //
-            if(context.payload.pull_request.body.match(/Fixes\s*#\d+/gi)) {
-                console.log("Skip, contains 'Fixes'");  // There should already be a card with original issue
+            const matches = context.payload.pull_request.body.match(/(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*#\d+/gi);
+            if(matches) {
+                console.log("Skip, contains '" + matches[0] + "'");
             } else {
                 addAssignee(context.payload.pull_request, context.payload.sender.login);
                 github.projects.createCard({ column_id: IN_PROGRESS_COLUMN, content_id: context.payload.pull_request.id, content_type: "PullRequest" });

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -94,7 +94,7 @@ jobs:
             //
             let processPR = true;
             const pr = context.payload.pull_request;
-            const matches = pr.body.match(/Fixes\s*#\d+/gi);
+            const matches = pr.body.match(/(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*#\d+/gi);
             if (matches) {
                 for (let i = 0; i < matches.length; i++) {
                     console.log("Processing linked issue: " + matches[i]);

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -92,7 +92,7 @@ jobs:
             //
             let processPR = true;
             const pr = context.payload.pull_request;
-            const matches = pr.body.match(/Fixes\s*#\d+/gi);
+            const matches = pr.body.match(/(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*#\d+/gi);
             if (matches) {
                 for (let i = 0; i < matches.length; i++) {
                     console.log("Processing linked issue: " + matches[i]);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: sonar-release
 # This workflow is triggered when publishing a new github release
-on: 
+on:
   release:
     types:
       - published
@@ -8,14 +8,14 @@ on:
 env:
   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
   PYTHONUNBUFFERED: 1
-  
+
 jobs:
   sonar_release:
     runs-on: ubuntu-latest
     name: Start release process
     steps:
       - name: LT release
-        id: lt_release        
+        id: lt_release
         with:
           publish_to_binaries: true
           distribute: true
@@ -49,7 +49,7 @@ jobs:
       - name: Notify success on Slack
         uses: Ilshidur/action-slack@2.0.0
         with:
-          args: "Release successful for {{ GITHUB_REPOSITORY }} by {{ GITHUB_ACTOR }}"        
+          args: "Release successful for {{ GITHUB_REPOSITORY }} by {{ GITHUB_ACTOR }}"
       - name: Notify failures on Slack
         uses: Ilshidur/action-slack@2.0.0
         if: failure()


### PR DESCRIPTION
We should provide early visibility to PRs & draft PRs as they are a WIP and consume time.

If PR contains "Fixes #xxx", this action does nothing as there should already exist a card on Kanban with the original issue.

For standalone PRs, it creates the card in "In progress" column and assigns PR to sender.