### PR TITLE
GitHub workflow: Milestone issue

### DIFF
--- a/.github/workflows/MilestoneIssue.yml
+++ b/.github/workflows/MilestoneIssue.yml
@@ -1,0 +1,22 @@
+name: Milesone Issue
+
+on:
+  issues:
+    types: ["milestoned"]
+
+jobs:
+  create_card:
+    name: Create card
+    runs-on: ubuntu-latest
+
+    steps:
+      # https://github.com/actions/github-script
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const TODO_COLUMN = 4971951;
+            console.log("Creating Issue card");
+            // Action will fail if a card already exists for this issue
+            github.projects.createCard({ column_id: TODO_COLUMN, content_id: context.payload.issue.id, content_type: "Issue" });
+            console.log("Done");

--- a/.github/workflows/MilestoneIssue.yml
+++ b/.github/workflows/MilestoneIssue.yml
@@ -1,4 +1,4 @@
-name: Milesone Issue
+name: Milestone Issue
 
 on:
   issues:


### PR DESCRIPTION
To work on a sprint, we need to add issues to ToDo column and set Milesones on all of them.

New intended process will be just adding milestones, as we have to do it anyway and choose the correct one. This action will automatically add the card to ToDo column for us.

Sprint issues without milestone needs to be added manually, as before.