### PR TITLE
S3216 RSPEC update

### DIFF
--- a/analyzers/rspec/cs/S3216_c#.html
+++ b/analyzers/rspec/cs/S3216_c#.html
@@ -1,8 +1,9 @@
 <p>After an <code>await</code>ed <code>Task</code> has executed, you can continue execution in the original, calling thread or any arbitrary thread.
 Unless the rest of the code needs the context from which the <code>Task</code> was spawned, <code>Task.ConfigureAwait(false)</code> should be used to
 keep execution in the <code>Task</code> thread to avoid the need for context switching and the possibility of deadlocks.</p>
-<p>This rule raises an issue when code in a class library <code>await</code>s a <code>Task</code> and continues execution in the original calling
-thread.</p>
+<p>This rule raises an issue when code in a class library targeting .Net Framework <code>await</code>s a <code>Task</code> and continues execution in
+the original calling thread.</p>
+<p>The rule does not raise for .Net Core libraries as there is no <code>SynchronizationContext</code> in .Net Core.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
 var response = await httpClient.GetAsync(url);  // Noncompliant

--- a/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S3216.html
+++ b/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S3216.html
@@ -1,8 +1,9 @@
 <p>After an <code>await</code>ed <code>Task</code> has executed, you can continue execution in the original, calling thread or any arbitrary thread.
 Unless the rest of the code needs the context from which the <code>Task</code> was spawned, <code>Task.ConfigureAwait(false)</code> should be used to
 keep execution in the <code>Task</code> thread to avoid the need for context switching and the possibility of deadlocks.</p>
-<p>This rule raises an issue when code in a class library <code>await</code>s a <code>Task</code> and continues execution in the original calling
-thread.</p>
+<p>This rule raises an issue when code in a class library targeting .Net Framework <code>await</code>s a <code>Task</code> and continues execution in
+the original calling thread.</p>
+<p>The rule does not raise for .Net Core libraries as there is no <code>SynchronizationContext</code> in .Net Core.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
 var response = await httpClient.GetAsync(url);  // Noncompliant


### PR DESCRIPTION
As it can be seen in the following [blog post](https://devblogs.microsoft.com/dotnet/configureawait-faq/), ConfigureAwait(false) is not necessary in most cases in .Net Core as  there is no SynchronizationContext in most cases.
The rule was already raising only for .Net Framework but that was not mentioned in the rule description.