### PR TITLE
Cleanup around NuGetMetadataFactory

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/MetadataReferences/NuGetMetadataFactory.Package.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/MetadataReferences/NuGetMetadataFactory.Package.cs
@@ -84,8 +84,10 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
             {
                 var versionArgument = Version == Constants.NuGetLatestVersion ? string.Empty : $"-Version {Version}";
                 var configFile = ValidatedNuGetConfigPath();
-                // Explicitly specify the NuGet config to use to avoid being impacted by the NuGet config on the machine running the tests
-                var args = $"install {Id} {versionArgument} -OutputDirectory \"{PackagesFolder}\" -NonInteractive -ForceEnglishOutput -ConfigFile {configFile}";
+                // Explicitly specify the NuGet config to use to avoid being impacted by the NuGet config on the machine running the tests.
+                // If the unit tests are failing since the nuget packages cannot be installed (nuget.exe: ERROR: Illegal characters in path.)
+                // please ensure that the PackagesFolder does not end with a separator.
+                var args = $"install {Id} {versionArgument} -OutputDirectory \"{Path.GetFullPath(PackagesFolder)}\" -NonInteractive -ForceEnglishOutput -ConfigFile \"{configFile}\"";
                 LogMessage($"Installing package using nuget.exe {args}");
                 var startInfo = new ProcessStartInfo
                 {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/MetadataReferences/NuGetMetadataFactory.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/MetadataReferences/NuGetMetadataFactory.cs
@@ -33,8 +33,11 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
     {
         private const string NuGetConfigFileRelativePath = @"..\..\..\nuget.config";
 
-        private static readonly string PackagesFolder = Environment.GetEnvironmentVariable("NUGET_PACKAGES") ?? @"..\..\..\..\..\packages\";
-        private static readonly PackageManager PackageManager = new PackageManager(CreatePackageRepository(), PackagesFolder);
+        // We use the global nuget cache for storing our packages if the NUGET_PACKAGES environment variable is defined.
+        // This is especially helpful on the build agents where the packages are precached
+        // (since we don't need to spawn a new process for calling the nuget.exe to install or copy them from global cache)
+        private static readonly string PackagesFolder = Environment.GetEnvironmentVariable("NUGET_PACKAGES") ?? @"..\..\..\..\..\packages";
+        private static readonly PackageManager PackageManager = new (CreatePackageRepository(), PackagesFolder);
 
         private static readonly string[] SortedAllowedDirectories =
         {


### PR DESCRIPTION
- remove separator at the end of the path
- add comments
- Path.GetFullPath() to always provide full path (useful when debugging)
