### PR TITLE
Generate FilesToAnalyze.txt in .NET ITs

### DIFF
--- a/analyzers/its/SonarAnalyzer.Testing.ImportBefore.targets
+++ b/analyzers/its/SonarAnalyzer.Testing.ImportBefore.targets
@@ -14,6 +14,7 @@
       <SonarAnalyzerRegressionTestRunning Condition="$(SonarAnalyzerRegressionTestRunning) == ''">false</SonarAnalyzerRegressionTestRunning>
       <SonarProjectOutputPath>$(MSBuildStartupDirectory)\output\$(PROJECT)\$(AssemblyName)</SonarProjectOutputPath>
       <SonarProjectConfigFilePath>$(SonarProjectOutputPath)\SonarProjectConfig.xml</SonarProjectConfigFilePath>
+      <SonarFilesToAnalyzePath>$(SonarProjectOutputPath)\FilesToAnalyze.txt</SonarFilesToAnalyzePath>
       <!-- Only projects with explicit SonarQubeTestProject=true will be classified as test ones. -->
       <SonarProjectType Condition="$(SonarQubeTestProject) != 'true'">Product</SonarProjectType>
       <SonarProjectType Condition="$(SonarQubeTestProject) == 'true'">Test</SonarProjectType>
@@ -25,15 +26,16 @@
       <SonarProjectConfigLine Include="&lt;SonarProjectConfig xmlns=&quot;http://www.sonarsource.com/msbuild/analyzer/2021/1&quot;&gt;" />
       <SonarProjectConfigLine Include="  &lt;AnalysisConfigPath&gt;&lt;/AnalysisConfigPath&gt;" />
       <SonarProjectConfigLine Include="  &lt;ProjectPath&gt;$(MSBuildProjectFullPath)&lt;/ProjectPath&gt;" />
-      <SonarProjectConfigLine Include="  &lt;FilesToAnalyzePath&gt;&lt;/FilesToAnalyzePath&gt;" />
+      <SonarProjectConfigLine Include="  &lt;FilesToAnalyzePath&gt;$(SonarFilesToAnalyzePath)&lt;/FilesToAnalyzePath&gt;" />
       <SonarProjectConfigLine Include="  &lt;OutPath&gt;$(SonarProjectOutputPath)&lt;/OutPath&gt;" />
       <SonarProjectConfigLine Include="  &lt;ProjectType&gt;$(SonarProjectType)&lt;/ProjectType&gt;" />
       <SonarProjectConfigLine Include="  &lt;TargetFramework&gt;$(TargetFramework)&lt;/TargetFramework&gt;" />
       <SonarProjectConfigLine Include="&lt;/SonarProjectConfig&gt;" />
     </ItemGroup>
 
-    <MakeDir Condition="$(SonarAnalyzerRegressionTestRunning)"
-            Directories="$(SonarProjectOutputPath)"/>
+    <MakeDir Condition="$(SonarAnalyzerRegressionTestRunning)" Directories="$(SonarProjectOutputPath)"/>
+    <!-- First FINDSTR removes \bin\, \obj\ and \packages\ subdirectories from FilesToAnalyze.txt. Second FINDSTR includes only files with an extension, becase DIR lists also directories themlselves.-->
+    <Exec Command="dir &quot;$(MSBuildStartupDirectory)\sources\$(PROJECT)&quot; /s /b | findstr /v &quot;\\bin\\ \\obj\\ \\packages\\&quot; | findstr /e /r &quot;\\[^\\]*\.[^\\]*&quot; > &quot;$(SonarFilesToAnalyzePath)&quot;"/>
     <WriteLinesToFile Condition="$(SonarAnalyzerRegressionTestRunning)"
             File="$(SonarProjectConfigFilePath)"
             Lines="@(SonarProjectConfigLine)"

--- a/analyzers/its/SonarAnalyzer.Testing.ImportBefore.targets
+++ b/analyzers/its/SonarAnalyzer.Testing.ImportBefore.targets
@@ -20,7 +20,7 @@
       <SonarProjectType Condition="$(SonarQubeTestProject) == 'true'">Test</SonarProjectType>
     </PropertyGroup>
 
-    <!-- This section builds content of SonarProjectConfig.xml additional file -->
+    <!-- This section builds content of SonarProjectConfig.xml additional file. We need to simulate S4MSB behavior to configure the analyzer. -->
     <ItemGroup>
       <SonarProjectConfigLine Include="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;" />
       <SonarProjectConfigLine Include="&lt;SonarProjectConfig xmlns=&quot;http://www.sonarsource.com/msbuild/analyzer/2021/1&quot;&gt;" />
@@ -34,7 +34,7 @@
     </ItemGroup>
 
     <MakeDir Condition="$(SonarAnalyzerRegressionTestRunning)" Directories="$(SonarProjectOutputPath)"/>
-    <!-- First FINDSTR removes \bin\, \obj\ and \packages\ subdirectories from FilesToAnalyze.txt. Second FINDSTR includes only files with an extension, becase DIR lists also directories themlselves.-->
+    <!-- First FINDSTR removes \bin\, \obj\ and \packages\ subdirectories from FilesToAnalyze.txt. Second FINDSTR includes only files with an extension, because DIR lists also directories themselves.-->
     <Exec Command="dir &quot;$(MSBuildStartupDirectory)\sources\$(PROJECT)&quot; /s /b | findstr /v &quot;\\bin\\ \\obj\\ \\packages\\&quot; | findstr /e /r &quot;\\[^\\]*\.[^\\]*&quot; > &quot;$(SonarFilesToAnalyzePath)&quot;"/>
     <WriteLinesToFile Condition="$(SonarAnalyzerRegressionTestRunning)"
             File="$(SonarProjectConfigFilePath)"

--- a/analyzers/its/expected/WebConfig/Framework48-{6AC7E627-A21A-459C-8831-C45B6058E24D}-S5753.json
+++ b/analyzers/its/expected/WebConfig/Framework48-{6AC7E627-A21A-459C-8831-C45B6058E24D}-S5753.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S5753",
+"message":  "Make sure disabling ASP.NET Request Validation feature is safe here.",
+"location":  {
+"uri":  "sources\WebConfig\Views\Web.config",
+"region":  {
+"startLine":  35,
+"startColumn":  12,
+"endLine":  35,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S5753",
+"message":  "Make sure disabling ASP.NET Request Validation feature is safe here.",
+"location":  {
+"uri":  "sources\WebConfig\Web.config",
+"region":  {
+"startLine":  16,
+"startColumn":  18,
+"endLine":  16,
+"endColumn":  45
+}
+}
+}
+]
+}


### PR DESCRIPTION
Generate artificial `FilesToAnalyze.txt` for .NET ITs and link it from `SonarProjectConfig.xml` file, because S4MSB is not used.

`dir /s /b` produces output like this. `findstr` is used to remove
* \bin\
* \obj\
* \packages\
* all directories (and also files) without an extension, becase `dir /a -d` to exclude directories throws an error `File not found`
```
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\App_Start
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\bin
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\Controllers
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\Global.asax
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\Global.asax.cs
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\Web.config
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\Web.Debug.config
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\WebConfig.csproj
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\WebConfig.sln
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\App_Start\RouteConfig.cs
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\bin\Framework48.dll
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\bin\Framework48.dll.config
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\bin\Framework48.pdb
...
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\obj\Debug\Framework48.dll
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\obj\Debug\Framework48.pdb
...
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\packages\Microsoft.AspNet.Mvc.5.2.7
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\packages\Microsoft.AspNet.Razor.3.2.7
c:\Projects\sonar-dotnet\analyzers\its\sources\WebConfig\packages\Microsoft.AspNet.WebPages.3.2.7
```

Rebase will be needed after #4138 is merged. First `Squash UseOutPath` commit doesn't need a review. ~~.NET ITs are expected to fail in current state, this should be fixed in other PRs before rebase.~~

_Edit:_ It's rebased now, expected issues reappeared as expected