### PR TITLE
Disable analysis during dev build (keep only live source analysis in the IDE)

### DIFF
--- a/analyzers/its/ReviewDiffs/ReviewDiffs.csproj
+++ b/analyzers/its/ReviewDiffs/ReviewDiffs.csproj
@@ -6,6 +6,7 @@
     <LangVersion>8.0</LangVersion>
     <SonarQubeExclude>true</SonarQubeExclude>
     <ProjectGuid>{7e3adcd6-01d7-44e2-b12f-c485c35c8a9c}</ProjectGuid>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
+++ b/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
@@ -38,6 +38,7 @@
   <PropertyGroup>
     <WarningsAsErrors />
     <NoWarn>NU1605</NoWarn>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -54,6 +54,7 @@
   <PropertyGroup>
     <WarningsAsErrors />
     <NoWarn>NU1605</NoWarn>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -59,6 +59,7 @@
   <PropertyGroup>
     <WarningsAsErrors />
     <NoWarn>NU1605</NoWarn>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/analyzers/src/SonarAnalyzer.Utilities/SonarAnalyzer.Utilities.csproj
+++ b/analyzers/src/SonarAnalyzer.Utilities/SonarAnalyzer.Utilities.csproj
@@ -34,6 +34,7 @@
   <PropertyGroup>
     <WarningsAsErrors />
     <NoWarn>NU1605</NoWarn>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
@@ -33,6 +33,7 @@
   <PropertyGroup>
     <WarningsAsErrors />
     <NoWarn>NU1605</NoWarn>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -21,6 +21,7 @@
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\SonarAnalyzer.Test.ruleset</CodeAnalysisRuleSet>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">

--- a/azure-pipelines-external.yml
+++ b/azure-pipelines-external.yml
@@ -68,7 +68,7 @@ stages:
           solution: '$(solution)'
           platform: '$(buildPlatform)'
           configuration: '$(buildConfiguration)'
-          msbuildArgs: '/p:DeployExtension=false /p:Sha1=$(Build.SourceVersion) /p:BuildNumber=$(Build.BuildId)'
+          msbuildArgs: '/p:RunAnalyzers=true /p:DeployExtension=false /p:Sha1=$(Build.SourceVersion) /p:BuildNumber=$(Build.BuildId)'
 
       - task: VSTest@2
         displayName: ".NET UTs"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,7 +203,7 @@ stages:
           Get-Content -Path $testProjFileName
 
           Write-Host "Build UnitTest project"
-          & dotnet build $testProjFileName -c $(BuildConfiguration)
+          & dotnet build /p:RunAnalyzers=true $testProjFileName -c $(BuildConfiguration)
           Test-ExitCode "ERROR: UnitTest project build FAILED."
 
           $supportedFrameworks = @('net48', 'net5.0')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ stages:
           solution: '$(solution)'
           platform: '$(buildPlatform)'
           configuration: '$(buildConfiguration)'
-          msbuildArgs: '/p:DeployExtension=false /p:SignAssembly=true /p:AssemblyOriginatorKeyFile="$(snk.secureFilePath)" /p:Sha1=$(Build.SourceVersion) /p:BuildNumber=$(Build.BuildId) /p:WarningLevel=0'
+          msbuildArgs: '/p:RunAnalyzers=true /p:DeployExtension=false /p:SignAssembly=true /p:AssemblyOriginatorKeyFile="$(snk.secureFilePath)" /p:Sha1=$(Build.SourceVersion) /p:BuildNumber=$(Build.BuildId) /p:WarningLevel=0'
 
       - task: PublishPipelineArtifact@1
         displayName: 'Publish analyzer binaries as pipeline artifact'

--- a/scripts/build/dev-build.ps1
+++ b/scripts/build/dev-build.ps1
@@ -70,7 +70,6 @@ try {
 
         Invoke-MSBuild $msbuildVersion $solutionName /t:"Restore,Rebuild" `
             /consoleloggerparameters:Summary `
-            /p:WarningLevel=0 `
             /m `
             /p:configuration=$buildConfiguration `
             /p:DeployExtension=false `
@@ -103,7 +102,7 @@ try {
             $skipTests = ""
         }
         Invoke-InLocation ".." {
-            Exec { & mvn clean install --batch-mode -P local-analyzer -D analyzer.configuration=$buildConfiguration $skipTests }
+            Exec { & mvn clean install -P local-analyzer -D analyzer.configuration=$buildConfiguration $skipTests }
         }
     }
 
@@ -115,7 +114,7 @@ try {
 
     $EndDate=(Get-Date)
     $Time=(New-TimeSpan -Start $StartDate -End $EndDate)
-    Write-Host "Time spent: $Time (start at $StartDate, end at $EndDate)"
+    Write-Host "Time spent: $Time"
 
     Write-Host -ForegroundColor Green "SUCCESS: script was successful!"
     exit 0

--- a/scripts/build/dev-build.ps1
+++ b/scripts/build/dev-build.ps1
@@ -60,6 +60,8 @@ try {
     Write-Host "Bin folder to use: $binPath"
     Write-Host "MSBuild: ${msbuildVersion}"
 
+    $StartDate=(Get-Date)
+
     if ($build) {
         # Restore VSIX (special project)
         Push-Location "src\SonarAnalyzer.Vsix"
@@ -68,6 +70,7 @@ try {
 
         Invoke-MSBuild $msbuildVersion $solutionName /t:"Restore,Rebuild" `
             /consoleloggerparameters:Summary `
+            /p:WarningLevel=0 `
             /m `
             /p:configuration=$buildConfiguration `
             /p:DeployExtension=false `
@@ -100,7 +103,7 @@ try {
             $skipTests = ""
         }
         Invoke-InLocation ".." {
-            Exec { & mvn clean install -P local-analyzer -D analyzer.configuration=$buildConfiguration $skipTests }
+            Exec { & mvn clean install --batch-mode -P local-analyzer -D analyzer.configuration=$buildConfiguration $skipTests }
         }
     }
 
@@ -109,6 +112,10 @@ try {
             Exec { & mvn clean install }
         }
     }
+
+    $EndDate=(Get-Date)
+    $Time=(New-TimeSpan -Start $StartDate -End $EndDate)
+    Write-Host "Time spent: $Time (start at $StartDate, end at $EndDate)"
 
     Write-Host -ForegroundColor Green "SUCCESS: script was successful!"
     exit 0


### PR DESCRIPTION
- currently StyleCop warnings pollute the logs, better no warnings at all
- maven batch mode avoids some unnecessary logs when downloading (see https://stackoverflow.com/a/48929096)

