### PR TITLE
Refactor ReportDiagnosticWhenActive methods to not check diagnostic scope by default

### DIFF
--- a/analyzers/rspec/cs/S2053_c#.json
+++ b/analyzers/rspec/cs/S2053_c#.json
@@ -14,7 +14,7 @@
   "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-2053",
   "sqKey": "S2053",
-  "scope": "All",
+  "scope": "Main",
   "securityStandards": {
     "CWE": [
       759,

--- a/analyzers/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/analyzers/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -3025,7 +3025,7 @@
     <value>30min</value>
   </data>
   <data name="S2053_Scope" xml:space="preserve">
-    <value>All</value>
+    <value>Main</value>
   </data>
   <data name="S2053_Severity" xml:space="preserve">
     <value>Critical</value>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShadowsParentField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShadowsParentField.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         foreach (var diagnostics in fieldDeclaration.Declaration.Variables.SelectMany(x => CheckFields(c.SemanticModel, x)))
                         {
-                            c.ReportDiagnosticWhenActive(diagnostics);
+                            c.ReportDiagnosticWhenActive(diagnostics, context);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
@@ -65,13 +65,13 @@ namespace SonarAnalyzer.Helpers
             ReportDiagnostic(new ReportingContext(context, diagnostic, null));
 
         public static void ReportDiagnosticWhenActive(this CompilationAnalysisContext context, Diagnostic diagnostic) =>
-            ReportDiagnostic(new ReportingContext(context, diagnostic, null) { IsTestProject = SonarAnalysisContext.IsTestProject(context)});
+            ReportDiagnostic(new ReportingContext(context, diagnostic, null) { IsTestProject = SonarAnalysisContext.IsTestProject(context) });
 
         public static void ReportDiagnosticWhenActive(this SymbolAnalysisContext context, Diagnostic diagnostic) =>
-            ReportDiagnostic(new ReportingContext(context, diagnostic, null) { IsTestProject = SonarAnalysisContext.IsTestProjectNoCache(context.Compilation, context.Options)});
+            ReportDiagnostic(new ReportingContext(context, diagnostic, null) { IsTestProject = SonarAnalysisContext.IsTestProjectNoCache(context.Compilation, context.Options) });
 
         public static void ReportDiagnosticWhenActive(this CodeBlockAnalysisContext context, Diagnostic diagnostic) =>
-            ReportDiagnostic(new ReportingContext(context, diagnostic, null) { IsTestProject = SonarAnalysisContext.IsTestProjectNoCache(context.SemanticModel?.Compilation, context.Options)});
+            ReportDiagnostic(new ReportingContext(context, diagnostic, null) { IsTestProject = SonarAnalysisContext.IsTestProjectNoCache(context.SemanticModel?.Compilation, context.Options) });
 
         private static void ReportDiagnostic(ReportingContext reportingContext)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.Helpers
         public static void ReportDiagnosticWhenActive(this SyntaxNodeAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext = null) =>
             ReportDiagnostic(new ReportingContext(context, diagnostic, verifyScopeContext));
 
-        // SyntaxTreeAnalysisContext doesn't have a Compilation => verifyScopeContext is never needed
+        // SyntaxTreeAnalysisContext doesn't have a Compilation => verifyScopeContext is never needed, because IsAnalysisScopeMatching returns always true.
         public static void ReportDiagnosticWhenActive(this SyntaxTreeAnalysisContext context, Diagnostic diagnostic) =>
             ReportDiagnostic(new ReportingContext(context, diagnostic, null));
 
@@ -71,8 +71,9 @@ namespace SonarAnalyzer.Helpers
         public static void ReportDiagnosticWhenActive(this SymbolAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext = null) =>
             ReportDiagnostic(new ReportingContext(context, diagnostic, verifyScopeContext));
 
-        public static void ReportDiagnosticWhenActive(this CodeBlockAnalysisContext context, Diagnostic diagnostic) =>
-            ReportDiagnostic(new ReportingContext(context, diagnostic, null) { IsTestProject = SonarAnalysisContext.IsTestProjectNoCache(context.SemanticModel?.Compilation, context.Options) });
+        /// <param name="verifyScopeContext">Provide value for this argument only if the class has more than one SupportedDiagnostics.</param>
+        public static void ReportDiagnosticWhenActive(this CodeBlockAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext = null) =>
+            ReportDiagnostic(new ReportingContext(context, diagnostic, verifyScopeContext));
 
         private static void ReportDiagnostic(ReportingContext reportingContext)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
@@ -60,8 +60,9 @@ namespace SonarAnalyzer.Helpers
         public static void ReportDiagnosticWhenActive(this SyntaxNodeAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext = null) =>
             ReportDiagnostic(new ReportingContext(context, diagnostic, verifyScopeContext));
 
+        // SyntaxTreeAnalysisContext doesn't have a Compilation => verifyScopeContext is never needed
         public static void ReportDiagnosticWhenActive(this SyntaxTreeAnalysisContext context, Diagnostic diagnostic) =>
-            ReportDiagnostic(new ReportingContext(context, diagnostic, null) { IsTestProject = SonarAnalysisContext.IsTestProjectNoCache(null, context.Options) });
+            ReportDiagnostic(new ReportingContext(context, diagnostic, null));
 
         public static void ReportDiagnosticWhenActive(this CompilationAnalysisContext context, Diagnostic diagnostic) =>
             ReportDiagnostic(new ReportingContext(context, diagnostic, null) { IsTestProject = SonarAnalysisContext.IsTestProject(context)});

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
@@ -67,8 +67,9 @@ namespace SonarAnalyzer.Helpers
         public static void ReportDiagnosticWhenActive(this CompilationAnalysisContext context, Diagnostic diagnostic) =>
             ReportDiagnostic(new ReportingContext(context, diagnostic, null) { IsTestProject = SonarAnalysisContext.IsTestProject(context) });
 
-        public static void ReportDiagnosticWhenActive(this SymbolAnalysisContext context, Diagnostic diagnostic) =>
-            ReportDiagnostic(new ReportingContext(context, diagnostic, null) { IsTestProject = SonarAnalysisContext.IsTestProjectNoCache(context.Compilation, context.Options) });
+        /// <param name="verifyScopeContext">Provide value for this argument only if the class has more than one SupportedDiagnostics.</param>
+        public static void ReportDiagnosticWhenActive(this SymbolAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext = null) =>
+            ReportDiagnostic(new ReportingContext(context, diagnostic, verifyScopeContext));
 
         public static void ReportDiagnosticWhenActive(this CodeBlockAnalysisContext context, Diagnostic diagnostic) =>
             ReportDiagnostic(new ReportingContext(context, diagnostic, null) { IsTestProject = SonarAnalysisContext.IsTestProjectNoCache(context.SemanticModel?.Compilation, context.Options) });

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/ReportingContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/ReportingContext.cs
@@ -31,26 +31,23 @@ namespace SonarAnalyzer.Helpers
         public SyntaxTree SyntaxTree { get; }
         public Diagnostic Diagnostic { get; }
         public Compilation Compilation { get; }
-        public bool? IsTestProject { get; set; }
 
-        public ReportingContext(SyntaxNodeAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext)
-            : this(diagnostic, verifyScopeContext, context.Options, context.ReportDiagnostic, context.Compilation, context.GetSyntaxTree()) { }
+        public ReportingContext(SyntaxNodeAnalysisContext context, Diagnostic diagnostic)
+            : this(diagnostic, context.ReportDiagnostic, context.Compilation, context.GetSyntaxTree()) { }
 
-        public ReportingContext(SyntaxTreeAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext)
-            : this(diagnostic, verifyScopeContext, context.Options, context.ReportDiagnostic, null, context.GetSyntaxTree()) { }
+        public ReportingContext(SyntaxTreeAnalysisContext context, Diagnostic diagnostic)
+            : this(diagnostic, context.ReportDiagnostic, null, context.GetSyntaxTree()) { }
 
-        public ReportingContext(CompilationAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext)
-            : this(diagnostic, verifyScopeContext, context.Options, context.ReportDiagnostic, context.Compilation, context.GetFirstSyntaxTree()) { }
+        public ReportingContext(CompilationAnalysisContext context, Diagnostic diagnostic)
+            : this(diagnostic, context.ReportDiagnostic, context.Compilation, context.GetFirstSyntaxTree()) { }
 
-        public ReportingContext(SymbolAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext)
-            : this(diagnostic, verifyScopeContext, context.Options, context.ReportDiagnostic, context.Compilation, context.GetFirstSyntaxTree()) { }
+        public ReportingContext(SymbolAnalysisContext context, Diagnostic diagnostic)
+            : this(diagnostic, context.ReportDiagnostic, context.Compilation, context.GetFirstSyntaxTree()) { }
 
-        public ReportingContext(CodeBlockAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext)
-            : this(diagnostic, verifyScopeContext, context.Options, context.ReportDiagnostic, context.SemanticModel.Compilation, context.GetSyntaxTree()) { }
+        public ReportingContext(CodeBlockAnalysisContext context, Diagnostic diagnostic)
+            : this(diagnostic, context.ReportDiagnostic, context.SemanticModel.Compilation, context.GetSyntaxTree()) { }
 
         private ReportingContext(Diagnostic diagnostic,
-                                 SonarAnalysisContext verifyScopeContext,
-                                 AnalyzerOptions options,
                                  Action<Diagnostic> contextSpecificReport,
                                  Compilation compilation,
                                  SyntaxTree syntaxTree)
@@ -59,10 +56,6 @@ namespace SonarAnalyzer.Helpers
             SyntaxTree = syntaxTree;
             Compilation = compilation;
             this.contextSpecificReport = contextSpecificReport;
-            if (verifyScopeContext != null)
-            {
-                IsTestProject = verifyScopeContext.IsTestProject(compilation, options);
-            }
         }
 
         public void ReportDiagnostic(Diagnostic diagnostic) =>

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/ReportingContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/ReportingContext.cs
@@ -28,52 +28,44 @@ namespace SonarAnalyzer.Helpers
     {
         private readonly Action<Diagnostic> contextSpecificReport;
 
-        public ReportingContext(SyntaxNodeAnalysisContext context, Diagnostic diagnostic)
-        {
-            SyntaxTree = context.GetSyntaxTree();
-            Compilation = context.Compilation;
-            Diagnostic = diagnostic;
-            this.contextSpecificReport = context.ReportDiagnostic;
-        }
-
-        public ReportingContext(SyntaxTreeAnalysisContext context, Diagnostic diagnostic)
-        {
-            SyntaxTree = context.GetSyntaxTree();
-            Compilation = null;
-            Diagnostic = diagnostic;
-            this.contextSpecificReport = context.ReportDiagnostic;
-        }
-
-        public ReportingContext(CompilationAnalysisContext context, Diagnostic diagnostic)
-        {
-            SyntaxTree = context.GetFirstSyntaxTree();
-            Compilation = context.Compilation;
-            Diagnostic = diagnostic;
-            this.contextSpecificReport = context.ReportDiagnostic;
-        }
-
-        public ReportingContext(SymbolAnalysisContext context, Diagnostic diagnostic)
-        {
-            SyntaxTree = context.GetFirstSyntaxTree();
-            Compilation = context.Compilation;
-            Diagnostic = diagnostic;
-            this.contextSpecificReport = context.ReportDiagnostic;
-        }
-
-        public ReportingContext(CodeBlockAnalysisContext context, Diagnostic diagnostic)
-        {
-            SyntaxTree = context.GetSyntaxTree();
-            Compilation = context.SemanticModel.Compilation;
-            Diagnostic = diagnostic;
-            this.contextSpecificReport = context.ReportDiagnostic;
-        }
-
         public SyntaxTree SyntaxTree { get; }
-
         public Diagnostic Diagnostic { get; }
-
         public Compilation Compilation { get; }
+        public bool? IsTestProject { get; set; }    //FIXME: Get only
 
-        public void ReportDiagnostic(Diagnostic diagnostic) => this.contextSpecificReport(diagnostic);
+        public ReportingContext(SyntaxNodeAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext)
+            : this(diagnostic, verifyScopeContext, context.Options, context.ReportDiagnostic, context.Compilation, context.GetSyntaxTree()) { }
+
+        public ReportingContext(SyntaxTreeAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext)
+            : this(diagnostic, verifyScopeContext, context.Options, context.ReportDiagnostic, null, context.GetSyntaxTree()) { }
+
+        public ReportingContext(CompilationAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext)
+            : this(diagnostic, verifyScopeContext, context.Options, context.ReportDiagnostic, context.Compilation, context.GetFirstSyntaxTree()) { }
+
+        public ReportingContext(SymbolAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext)
+            : this(diagnostic, verifyScopeContext, context.Options, context.ReportDiagnostic, context.Compilation, context.GetFirstSyntaxTree()) { }
+
+        public ReportingContext(CodeBlockAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext)
+            : this(diagnostic, verifyScopeContext, context.Options, context.ReportDiagnostic, context.SemanticModel.Compilation, context.GetSyntaxTree()) { }
+
+        private ReportingContext(Diagnostic diagnostic,
+                                 SonarAnalysisContext verifyScopeContext,
+                                 AnalyzerOptions options,
+                                 Action<Diagnostic> contextSpecificReport,
+                                 Compilation compilation,
+                                 SyntaxTree syntaxTree)
+        {
+            Diagnostic = diagnostic;
+            SyntaxTree = syntaxTree;
+            Compilation = compilation;
+            this.contextSpecificReport = contextSpecificReport;
+            if (verifyScopeContext != null)
+            {
+                IsTestProject = verifyScopeContext.IsTestProject(compilation, options);
+            }
+        }
+
+        public void ReportDiagnostic(Diagnostic diagnostic) =>
+            contextSpecificReport(diagnostic);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/ReportingContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/ReportingContext.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Helpers
         public SyntaxTree SyntaxTree { get; }
         public Diagnostic Diagnostic { get; }
         public Compilation Compilation { get; }
-        public bool? IsTestProject { get; set; }    //FIXME: Get only
+        public bool? IsTestProject { get; set; }
 
         public ReportingContext(SyntaxNodeAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext)
             : this(diagnostic, verifyScopeContext, context.Options, context.ReportDiagnostic, context.Compilation, context.GetSyntaxTree()) { }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/SonarAnalysisContext.cs
@@ -101,6 +101,7 @@ namespace SonarAnalyzer.Helpers
         private static bool IsTestProject(TryGetValueDelegate<ProjectConfigReader> tryGetValue, Compilation c, AnalyzerOptions options) =>
             IsTest(ProjectConfiguration(tryGetValue, options).ProjectType, c);
 
+        [Obsolete] //FIXME: REMOVE
         public static bool IsTestProjectNoCache(Compilation c, AnalyzerOptions options)
         {
             var projectType = ProjectType.Unknown;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FieldShadowsParentField.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FieldShadowsParentField.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     {
                         foreach (var diagnostics in fieldDeclaration.Declarators.SelectMany(x => x.Names).SelectMany(x => CheckFields(c.SemanticModel, x)))
                         {
-                            c.ReportDiagnosticWhenActive(diagnostics);
+                            c.ReportDiagnosticWhenActive(diagnostics, context);
                         }
                     }
                 },

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CBDE/CbdeHandlerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CBDE/CbdeHandlerTest.cs
@@ -131,7 +131,8 @@ namespace SonarAnalyzer.UnitTest.Rules
             IEnumerable<MetadataReference> additionalReferences = null)
         {
             var compilation = SolutionBuilder.Create()
-                .AddTestProject(AnalyzerLanguage.FromPath(path))
+                .AddProject(AnalyzerLanguage.FromPath(path))
+                .AddTestReferences()
                 .AddReferences(additionalReferences)
                 .AddDocument(path)
                 .GetCompilation();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ClassAndMethodNameTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ClassAndMethodNameTest.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestMethod]
         [TestCategory("Rule")]
         public void ClassName_InTestProject_CS() =>
-            Verifier.VerifyAnalyzerInTest(@"TestCases\ClassName.Tests.cs", new CS.ClassAndMethodName(), ParseOptionsHelper.FromCSharp8);
+            Verifier.VerifyAnalyzer(@"TestCases\ClassName.Tests.cs", new CS.ClassAndMethodName(), ParseOptionsHelper.FromCSharp8, NuGetMetadataReference.MSTestTestFrameworkV1);
 
 #if NET
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ClassAndMethodNameTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ClassAndMethodNameTest.cs
@@ -21,6 +21,7 @@
 using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Helpers;
 using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CS = SonarAnalyzer.Rules.CSharp;
@@ -72,14 +73,18 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyNoIssueReportedFromCSharp9InTest(@"TestCases\RecordName.cs", new CS.ClassAndMethodName());
 #endif
 
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void ClassName_VB() =>
-            Verifier.VerifyAnalyzer(@"TestCases\ClassName.vb", new VB.ClassName());
+        public void ClassName_VB(ProjectType projectType) =>
+            Verifier.VerifyAnalyzer(@"TestCases\ClassName.vb", new VB.ClassName(), TestHelper.ProjectTypeReference(projectType));
 
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void MethodName_CS() =>
+        public void MethodName(ProjectType projectType) =>
             Verifier.VerifyAnalyzer(
                 new[]
                 {
@@ -87,20 +92,8 @@ namespace SonarAnalyzer.UnitTest.Rules
                     @"TestCases\MethodName.Partial.cs",
                 },
                 new CS.ClassAndMethodName(),
-                ParseOptionsHelper.FromCSharp8);
-
-        // ToDo fix conflict with PR #4179
-        [TestMethod]
-        [TestCategory("Rule")]
-        public void MethodName_InTestProject_CS() =>
-            Verifier.VerifyAnalyzerInTest(
-                new[]
-                {
-                    @"TestCases\MethodName.cs",
-                    @"TestCases\MethodName.Partial.cs",
-                },
-                new CS.ClassAndMethodName(),
-                ParseOptionsHelper.FromCSharp8);
+                ParseOptionsHelper.FromCSharp8,
+                TestHelper.ProjectTypeReference(projectType));
 
 #if NET
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CommentKeywordTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CommentKeywordTest.cs
@@ -19,6 +19,7 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Helpers;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CS = SonarAnalyzer.Rules.CSharp;
 using VB = SonarAnalyzer.Rules.VisualBasic;
@@ -28,28 +29,32 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class CommentKeywordTest
     {
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void CommentTodo_CS() =>
-            Verifier.VerifyAnalyzer(@"TestCases\CommentTodo.cs",
-                new CS.CommentKeyword());
+        public void CommentTodo_CS(ProjectType projectType) =>
+            Verifier.VerifyAnalyzer(@"TestCases\CommentTodo.cs", new CS.CommentKeyword(), TestHelper.ProjectTypeReference(projectType));
 
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void CommentFixme_CS() =>
-            Verifier.VerifyAnalyzer(@"TestCases\CommentFixme.cs",
-                new CS.CommentKeyword());
+        public void CommentFixme_CS(ProjectType projectType) =>
+            Verifier.VerifyAnalyzer(@"TestCases\CommentFixme.cs", new CS.CommentKeyword(), TestHelper.ProjectTypeReference(projectType));
 
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void CommentTodo_VB() =>
-            Verifier.VerifyAnalyzer(@"TestCases\CommentTodo.vb",
-                new VB.CommentKeyword());
+        public void CommentTodo_VB(ProjectType projectType) =>
+            Verifier.VerifyAnalyzer(@"TestCases\CommentTodo.vb", new VB.CommentKeyword(), TestHelper.ProjectTypeReference(projectType));
 
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void CommentFixme_VB() =>
-            Verifier.VerifyAnalyzer(@"TestCases\CommentFixme.vb",
-                new VB.CommentKeyword());
+        public void CommentFixme_VB(ProjectType projectType) =>
+            Verifier.VerifyAnalyzer(@"TestCases\CommentFixme.vb", new VB.CommentKeyword(), TestHelper.ProjectTypeReference(projectType));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/EmptyMethodTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/EmptyMethodTest.cs
@@ -56,12 +56,12 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestMethod]
         [TestCategory("CodeFix")]
         public void EmptyMethod_CodeFix_Throw() =>
-        Verifier.VerifyCodeFix(
-            @"TestCases\EmptyMethod.cs",
-            @"TestCases\EmptyMethod.Throw.Fixed.cs",
-            new CS.EmptyMethod(),
-            new CS.EmptyMethodCodeFixProvider(),
-            CS.EmptyMethodCodeFixProvider.TitleThrow);
+            Verifier.VerifyCodeFix(
+                @"TestCases\EmptyMethod.cs",
+                @"TestCases\EmptyMethod.Throw.Fixed.cs",
+                new CS.EmptyMethod(),
+                new CS.EmptyMethodCodeFixProvider(),
+                CS.EmptyMethodCodeFixProvider.TitleThrow);
 
         [TestMethod]
         [TestCategory("CodeFix")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/EmptyMethodTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/EmptyMethodTest.cs
@@ -53,15 +53,15 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\EmptyMethod.CSharp9.cs", new CS.EmptyMethod());
 #endif
 
-            [TestMethod]
+        [TestMethod]
         [TestCategory("CodeFix")]
         public void EmptyMethod_CodeFix_Throw() =>
-            Verifier.VerifyCodeFix(
-                @"TestCases\EmptyMethod.cs",
-                @"TestCases\EmptyMethod.Throw.Fixed.cs",
-                new CS.EmptyMethod(),
-                new CS.EmptyMethodCodeFixProvider(),
-                CS.EmptyMethodCodeFixProvider.TitleThrow);
+        Verifier.VerifyCodeFix(
+            @"TestCases\EmptyMethod.cs",
+            @"TestCases\EmptyMethod.Throw.Fixed.cs",
+            new CS.EmptyMethod(),
+            new CS.EmptyMethodCodeFixProvider(),
+            CS.EmptyMethodCodeFixProvider.TitleThrow);
 
         [TestMethod]
         [TestCategory("CodeFix")]
@@ -78,45 +78,20 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void EmptyMethod_VB() =>
             Verifier.VerifyAnalyzer(@"TestCases\EmptyMethod.vb", new VB.EmptyMethod());
 
-        [DataTestMethod]
-        [DataRow(ProjectType.Product)]
-        [DataRow(ProjectType.Unknown)]
-        public void EmptyMethod_WithVirtualOverride_RaisesIssueForMainAndUnknownProject_CS(ProjectType projectType) =>
-            Verifier.VerifyAnalyzer(@"TestCases\EmptyMethod.OverrideVirtual.cs",
-                new CS.EmptyMethod(),
-                options: ParseOptionsHelper.FromCSharp8,
-                additionalReferences: null,
-                sonarProjectConfigPath: TestHelper.CreateSonarProjectConfig(
-                    nameof(EmptyMethod_WithVirtualOverride_RaisesIssueForMainAndUnknownProject_CS),
-                    projectType));
+        [TestMethod]
+        public void EmptyMethod_WithVirtualOverride_RaisesIssueForMainProject_CS() =>
+            Verifier.VerifyAnalyzer(@"TestCases\EmptyMethod.OverrideVirtual.cs", new CS.EmptyMethod());
 
         [TestMethod]
         public void EmptyMethod_WithVirtualOverride_DoesNotRaiseIssuesForTestProject_CS() =>
-            Verifier.VerifyNoIssueReported(@"TestCases\EmptyMethod.OverrideVirtual.cs",
-                new CS.EmptyMethod(),
-                ParseOptionsHelper.FromCSharp8,
-                sonarProjectConfigPath: TestHelper.CreateSonarProjectConfig(
-                    nameof(EmptyMethod_WithVirtualOverride_DoesNotRaiseIssuesForTestProject_CS),
-                    ProjectType.Test));
+            Verifier.VerifyNoIssueReportedInTest(@"TestCases\EmptyMethod.OverrideVirtual.cs", new CS.EmptyMethod());
 
-        [DataTestMethod]
-        [DataRow(ProjectType.Product)]
-        [DataRow(ProjectType.Unknown)]
-        public void EmptyMethod_WithVirtualOverride_RaisesIssueForMainAndUnknownProject_VB(ProjectType projectType) =>
-            Verifier.VerifyAnalyzer(@"TestCases\EmptyMethod.OverrideVirtual.vb",
-                new VB.EmptyMethod(),
-                options: ParseOptionsHelper.FromCSharp8,
-                additionalReferences: null,
-                sonarProjectConfigPath: TestHelper.CreateSonarProjectConfig(
-                    nameof(EmptyMethod_WithVirtualOverride_RaisesIssueForMainAndUnknownProject_VB),
-                    projectType));
+        [TestMethod]
+        public void EmptyMethod_WithVirtualOverride_RaisesIssueForMainProject_VB() =>
+            Verifier.VerifyAnalyzer(@"TestCases\EmptyMethod.OverrideVirtual.vb", new VB.EmptyMethod());
 
         [TestMethod]
         public void EmptyMethod_WithVirtualOverride_DoesNotRaiseIssuesForTestProject_VB() =>
-            Verifier.VerifyNoIssueReported(@"TestCases\EmptyMethod.OverrideVirtual.vb",
-                new VB.EmptyMethod(),
-                sonarProjectConfigPath: TestHelper.CreateSonarProjectConfig(
-                    nameof(EmptyMethod_WithVirtualOverride_DoesNotRaiseIssuesForTestProject_VB),
-                    ProjectType.Test));
+            Verifier.VerifyNoIssueReportedInTest(@"TestCases\EmptyMethod.OverrideVirtual.vb", new VB.EmptyMethod());
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/FieldShadowsParentFieldTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/FieldShadowsParentFieldTest.cs
@@ -19,6 +19,7 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CS = SonarAnalyzer.Rules.CSharp;
 using VB = SonarAnalyzer.Rules.VisualBasic;
@@ -37,6 +38,16 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void FieldShadowsParentField_VB() =>
             Verifier.VerifyAnalyzer(@"TestCases\FieldShadowsParentField.vb", new VB.FieldShadowsParentField());
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void FieldShadowsParentField_DoesNotRaiseIssuesForTestProject_CS() =>
+            Verifier.VerifyNoIssueReportedInTest(@"TestCases\FieldShadowsParentField.cs", new CS.FieldShadowsParentField());
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void FieldShadowsParentField_DoesNotRaiseIssuesForTestProject_VB() =>
+            Verifier.VerifyNoIssueReportedInTest(@"TestCases\FieldShadowsParentField.vb", new VB.FieldShadowsParentField());
 
 #if NET
         [TestMethod]
@@ -59,5 +70,15 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Rule")]
         public void FieldsShouldNotDifferByCapitalization_VB() =>
             Verifier.VerifyAnalyzer(@"TestCases\FieldsShouldNotDifferByCapitalization.vb", new VB.FieldShadowsParentField());
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void FieldsShouldNotDifferByCapitalization_RaisesIssueForTestProject_CS() =>
+            Verifier.VerifyAnalyzer(@"TestCases\FieldsShouldNotDifferByCapitalization.cs", new CS.FieldShadowsParentField(), NuGetMetadataReference.MSTestTestFrameworkV1);
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void FieldsShouldNotDifferByCapitalization_RaisesIssueForTestProject_VB() =>
+            Verifier.VerifyAnalyzer(@"TestCases\FieldsShouldNotDifferByCapitalization.vb", new VB.FieldShadowsParentField(), NuGetMetadataReference.MSTestTestFrameworkV1);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/FieldShadowsParentFieldTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/FieldShadowsParentFieldTest.cs
@@ -19,6 +19,7 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Helpers;
 using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CS = SonarAnalyzer.Rules.CSharp;
@@ -61,24 +62,18 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\FieldsShouldNotDifferByCapitalization.CSharp9.cs", new CS.FieldShadowsParentField());
 #endif
 
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void FieldsShouldNotDifferByCapitalization_CS() =>
-            Verifier.VerifyAnalyzer(@"TestCases\FieldsShouldNotDifferByCapitalization.cs", new CS.FieldShadowsParentField());
+        public void FieldsShouldNotDifferByCapitalization_CS(ProjectType projectType) =>
+            Verifier.VerifyAnalyzer(@"TestCases\FieldsShouldNotDifferByCapitalization.cs", new CS.FieldShadowsParentField(), TestHelper.ProjectTypeReference(projectType));
 
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void FieldsShouldNotDifferByCapitalization_VB() =>
-            Verifier.VerifyAnalyzer(@"TestCases\FieldsShouldNotDifferByCapitalization.vb", new VB.FieldShadowsParentField());
-
-        [TestMethod]
-        [TestCategory("Rule")]
-        public void FieldsShouldNotDifferByCapitalization_RaisesIssueForTestProject_CS() =>
-            Verifier.VerifyAnalyzer(@"TestCases\FieldsShouldNotDifferByCapitalization.cs", new CS.FieldShadowsParentField(), NuGetMetadataReference.MSTestTestFrameworkV1);
-
-        [TestMethod]
-        [TestCategory("Rule")]
-        public void FieldsShouldNotDifferByCapitalization_RaisesIssueForTestProject_VB() =>
-            Verifier.VerifyAnalyzer(@"TestCases\FieldsShouldNotDifferByCapitalization.vb", new VB.FieldShadowsParentField(), NuGetMetadataReference.MSTestTestFrameworkV1);
+        public void FieldsShouldNotDifferByCapitalization_VB(ProjectType projectType) =>
+            Verifier.VerifyAnalyzer(@"TestCases\FieldsShouldNotDifferByCapitalization.vb", new VB.FieldShadowsParentField(), TestHelper.ProjectTypeReference(projectType));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/FieldShadowsParentFieldTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/FieldShadowsParentFieldTest.cs
@@ -20,7 +20,6 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CS = SonarAnalyzer.Rules.CSharp;
 using VB = SonarAnalyzer.Rules.VisualBasic;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/InsecureEncryptionAlgorithmTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/InsecureEncryptionAlgorithmTest.cs
@@ -34,8 +34,13 @@ namespace SonarAnalyzer.UnitTest.Rules
     {
         [TestMethod]
         [TestCategory("Rule")]
-        public void InsecureEncryptionAlgorithm_CS() =>
+        public void InsecureEncryptionAlgorithm_MainProject_CS() =>
             Verifier.VerifyAnalyzer(@"TestCases\InsecureEncryptionAlgorithm.cs", new CS.InsecureEncryptionAlgorithm(), GetAdditionalReferences());
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void InsecureEncryptionAlgorithm_DoesNotRaiseIssuesForTestProject_CS() =>
+            Verifier.VerifyNoIssueReportedInTest(@"TestCases\InsecureEncryptionAlgorithm.cs", new CS.InsecureEncryptionAlgorithm(), GetAdditionalReferences());
 
 #if NET
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/StringFormatValidatorTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/StringFormatValidatorTest.cs
@@ -19,6 +19,7 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Helpers;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CS = SonarAnalyzer.Rules.CSharp;
 
@@ -27,15 +28,19 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class StringFormatValidatorTest
     {
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void StringFormatRuntimeExceptionFreeValidator() =>
-            Verifier.VerifyAnalyzer(@"TestCases\StringFormatRuntimeExceptionFreeValidator.cs", new CS.StringFormatValidator());
+        public void StringFormatRuntimeExceptionFreeValidator(ProjectType projectType) =>
+            Verifier.VerifyAnalyzer(@"TestCases\StringFormatRuntimeExceptionFreeValidator.cs", new CS.StringFormatValidator(), TestHelper.ProjectTypeReference(projectType));
 
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void StringFormatTypoFreeValidator() =>
-            Verifier.VerifyAnalyzer(@"TestCases\StringFormatTypoFreeValidator.cs", new CS.StringFormatValidator());
+        public void StringFormatTypoFreeValidator(ProjectType projectType) =>
+            Verifier.VerifyAnalyzer(@"TestCases\StringFormatTypoFreeValidator.cs", new CS.StringFormatValidator(), TestHelper.ProjectTypeReference(projectType));
 
         [TestMethod]
         [TestCategory("Rule")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ConditionEvaluatesToConstantTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ConditionEvaluatesToConstantTest.cs
@@ -18,10 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-extern alias csharp;
-using csharp::SonarAnalyzer.Rules.CSharp;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
+using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.Rules.SymbolicExecution;
 using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
@@ -32,11 +32,14 @@ namespace SonarAnalyzer.UnitTest.Rules
     public class ConditionEvaluatesToConstantTest
     {
         [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void ConditionEvaluatesToConstant() =>
+        public void ConditionEvaluatesToConstant(ProjectType projectType) =>
             Verifier.VerifyAnalyzer(@"TestCases\ConditionEvaluatesToConstant.cs",
                 GetAnalyzer(),
-                NuGetMetadataReference.MicrosoftExtensionsPrimitives("3.1.7"));
+                NuGetMetadataReference.MicrosoftExtensionsPrimitives("3.1.7").Concat(TestHelper.ProjectTypeReference(projectType)));
 
         [TestMethod]
         [TestCategory("Rule")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyCollectionsShouldNotBeEnumeratedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyCollectionsShouldNotBeEnumeratedTest.cs
@@ -18,8 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-extern alias csharp;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Helpers;
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.Rules.SymbolicExecution;
 #if NETFRAMEWORK
@@ -32,17 +33,19 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
     [TestClass]
     public class EmptyCollectionsShouldNotBeEnumeratedTest
     {
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void EmptyCollectionsShouldNotBeEnumerated() =>
+        public void EmptyCollectionsShouldNotBeEnumerated(ProjectType projectType) =>
             Verifier.VerifyAnalyzer(
                 @"TestCases\EmptyCollectionsShouldNotBeEnumerated.cs",
                 new SymbolicExecutionRunner(new EmptyCollectionsShouldNotBeEnumerated()),
-#if NETFRAMEWORK
                 ParseOptionsHelper.FromCSharp8,
-                NuGetMetadataReference.NETStandardV2_1_0);
+#if NETFRAMEWORK
+                TestHelper.ProjectTypeReference(projectType).Concat(NuGetMetadataReference.NETStandardV2_1_0));
 #else
-                ParseOptionsHelper.FromCSharp8);
+                TestHelper.ProjectTypeReference(projectType));
 #endif
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyNullableValueAccessTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyNullableValueAccessTest.cs
@@ -18,8 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-extern alias csharp;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Helpers;
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.Rules.SymbolicExecution;
 using SonarAnalyzer.UnitTest.MetadataReferences;
@@ -30,16 +31,18 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
     [TestClass]
     public class EmptyNullableValueAccessTest
     {
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void EmptyNullableValueAccess() =>
+        public void EmptyNullableValueAccess(ProjectType projectType) =>
             Verifier.VerifyAnalyzer(@"TestCases\EmptyNullableValueAccess.cs",
                 new SymbolicExecutionRunner(new EmptyNullableValueAccess()),
-#if NETFRAMEWORK
                 ParseOptionsHelper.FromCSharp8,
-                NuGetMetadataReference.NETStandardV2_1_0);
+#if NETFRAMEWORK
+                TestHelper.ProjectTypeReference(projectType).Concat(NuGetMetadataReference.NETStandardV2_1_0));
 #else
-                ParseOptionsHelper.FromCSharp8);
+                TestHelper.ProjectTypeReference(projectType));
 #endif
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/HashesShouldHaveUnpredictableSaltTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/HashesShouldHaveUnpredictableSaltTest.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
@@ -32,13 +33,15 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class HashesShouldHaveUnpredictableSaltTest
     {
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void HashesShouldHaveUnpredictableSalt() =>
+        public void HashesShouldHaveUnpredictableSalt(ProjectType projectType) =>
             Verifier.VerifyAnalyzer(@"TestCases\HashesShouldHaveUnpredictableSalt.cs",
                                     GetAnalyzer(),
                                     ParseOptionsHelper.FromCSharp8,
-                                    MetadataReferenceFacade.SystemSecurityCryptography);
+                                    MetadataReferenceFacade.SystemSecurityCryptography.Concat(TestHelper.ProjectTypeReference(projectType)));
 
         [TestMethod]
         [TestCategory("Rule")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/HashesShouldHaveUnpredictableSaltTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/HashesShouldHaveUnpredictableSaltTest.cs
@@ -33,15 +33,21 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class HashesShouldHaveUnpredictableSaltTest
     {
-        [DataTestMethod]
-        [DataRow(ProjectType.Product)]
-        [DataRow(ProjectType.Test)]
+        [TestMethod]
         [TestCategory("Rule")]
-        public void HashesShouldHaveUnpredictableSalt(ProjectType projectType) =>
+        public void HashesShouldHaveUnpredictableSalt() =>
             Verifier.VerifyAnalyzer(@"TestCases\HashesShouldHaveUnpredictableSalt.cs",
                                     GetAnalyzer(),
                                     ParseOptionsHelper.FromCSharp8,
-                                    MetadataReferenceFacade.SystemSecurityCryptography.Concat(TestHelper.ProjectTypeReference(projectType)));
+                                    MetadataReferenceFacade.SystemSecurityCryptography);
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void HashesShouldHaveUnpredictableSalt_DoesNotRaiseIssuesForTestProject() =>
+            Verifier.VerifyNoIssueReportedInTest(@"TestCases\HashesShouldHaveUnpredictableSalt.cs",
+                                                 GetAnalyzer(),
+                                                 ParseOptionsHelper.FromCSharp8,
+                                                 MetadataReferenceFacade.SystemSecurityCryptography);
 
         [TestMethod]
         [TestCategory("Rule")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InitializationVectorShouldBeRandomTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InitializationVectorShouldBeRandomTest.cs
@@ -40,6 +40,14 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
 
         [TestMethod]
         [TestCategory("Rule")]
+        public void InitializationVectorShouldBeRandom_DoesNotRaiseIssuesForTestProject() =>
+            Verifier.VerifyNoIssueReportedInTest(@"TestCases\InitializationVectorShouldBeRandom.cs",
+                                                   GetAnalyzer(),
+                                                   ParseOptionsHelper.FromCSharp8,
+                                                   MetadataReferenceFacade.SystemSecurityCryptography);
+
+        [TestMethod]
+        [TestCategory("Rule")]
         public void InitializationVectorShouldBeRandom_CSharp9() =>
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\InitializationVectorShouldBeRandom.CSharp9.cs",
                                                       GetAnalyzer(),

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InvalidCastToInterfaceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InvalidCastToInterfaceTest.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-extern alias csharp;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.Rules.CSharp;
@@ -31,13 +31,17 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
     [TestClass]
     public class InvalidCastToInterfaceTest
     {
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void InvalidCastToInterface() =>
+        public void InvalidCastToInterface(ProjectType projectType) =>
             Verifier.VerifyAnalyzer(@"TestCases\InvalidCastToInterface.cs",
                 GetAnalyzers(),
 #if NETFRAMEWORK
-                additionalReferences: NuGetMetadataReference.NETStandardV2_1_0,
+                additionalReferences: TestHelper.ProjectTypeReference(projectType).Concat(NuGetMetadataReference.NETStandardV2_1_0),
+#else
+                additionalReferences: TestHelper.ProjectTypeReference(projectType),
 #endif
                 options: ParseOptionsHelper.FromCSharp8);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/NullPointerDereferenceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/NullPointerDereferenceTest.cs
@@ -69,6 +69,11 @@ public static class Utils
 
         [TestMethod]
         [TestCategory("Rule")]
+        public void NullPointerDereference_DoesNotRaiseIssuesForTestProject() =>
+            Verifier.VerifyNoIssueReportedInTest(@"TestCases\NullPointerDereference.cs", GetAnalyzer());
+
+        [TestMethod]
+        [TestCategory("Rule")]
         public void NullPointerDereference_CSharp6() =>
             Verifier.VerifyAnalyzer(@"TestCases\NullPointerDereference.CSharp6.cs",
                 GetAnalyzer(),

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnceTest.cs
@@ -18,8 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-extern alias csharp;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Helpers;
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.Rules.SymbolicExecution;
 using SonarAnalyzer.UnitTest.MetadataReferences;
@@ -30,16 +31,18 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class ObjectsShouldNotBeDisposedMoreThanOnceTest
     {
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void ObjectsShouldNotBeDisposedMoreThanOnce() =>
+        public void ObjectsShouldNotBeDisposedMoreThanOnce(ProjectType projectType) =>
             Verifier.VerifyAnalyzer(@"TestCases\ObjectsShouldNotBeDisposedMoreThanOnce.cs",
                 new SymbolicExecutionRunner(new ObjectsShouldNotBeDisposedMoreThanOnce()),
-#if NETFRAMEWORK
                 ParseOptionsHelper.FromCSharp8,
-                NuGetMetadataReference.NETStandardV2_1_0);
+#if NETFRAMEWORK
+                TestHelper.ProjectTypeReference(projectType).Concat(NuGetMetadataReference.NETStandardV2_1_0));
 #else
-                ParseOptionsHelper.FromCSharp8);
+                TestHelper.ProjectTypeReference(projectType));
 #endif
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNullTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNullTest.cs
@@ -18,9 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-extern alias csharp;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using csharp::SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.Helpers;
+using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.Rules.SymbolicExecution;
 using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
@@ -30,16 +31,18 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class PublicMethodArgumentsShouldBeCheckedForNullTest
     {
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void PublicMethodArgumentsShouldBeCheckedForNull() =>
+        public void PublicMethodArgumentsShouldBeCheckedForNull(ProjectType projectType) =>
             Verifier.VerifyAnalyzer(@"TestCases\PublicMethodArgumentsShouldBeCheckedForNull.cs",
                 new SymbolicExecutionRunner(new PublicMethodArgumentsShouldBeCheckedForNull()),
-#if NETFRAMEWORK
                 ParseOptionsHelper.FromCSharp8,
-                NuGetMetadataReference.NETStandardV2_1_0);
+#if NETFRAMEWORK
+                TestHelper.ProjectTypeReference(projectType).Concat(NuGetMetadataReference.NETStandardV2_1_0));
 #else
-                ParseOptionsHelper.FromCSharp8);
+                TestHelper.ProjectTypeReference(projectType));
 #endif
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/RestrictDeserializedTypesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/RestrictDeserializedTypesTest.cs
@@ -47,6 +47,14 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         [TestCategory("Rule")]
+        public void RestrictDeserializedTypes_DoesNotRaiseIssuesForTestProject() =>
+            Verifier.VerifyNoIssueReportedInTest(@"TestCases\RestrictDeserializedTypes.cs",
+                GetAnalyzer(),
+                ParseOptionsHelper.FromCSharp8,
+                GetAdditionalReferences());
+
+        [TestMethod]
+        [TestCategory("Rule")]
         public void RestrictDeserializedTypesJavaScriptSerializer() =>
             Verifier.VerifyAnalyzer(@"TestCases\RestrictDeserializedTypes.JavaScriptSerializer.cs",
                 GetAnalyzer(),

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
@@ -25,6 +25,7 @@ using FluentAssertions;
 using FluentAssertions.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Helpers;
 using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CS = SonarAnalyzer.Rules.CSharp;
@@ -176,11 +177,14 @@ namespace EntityFrameworkMigrations
 }
 ", new CS.UnusedPrivateMember(), additionalReferences: GetEntityFrameworkCoreReferences(Constants.NuGetLatestVersion));
 
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void UnusedPrivateMember() =>
+        public void UnusedPrivateMember(ProjectType projectType) =>
             Verifier.VerifyAnalyzer(@"TestCases\UnusedPrivateMember.cs",
-                                    new CS.UnusedPrivateMember());
+                                    new CS.UnusedPrivateMember(),
+                                    TestHelper.ProjectTypeReference(projectType));
 
         [TestMethod]
         [TestCategory("Rule")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UseUriInsteadOfStringTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UseUriInsteadOfStringTest.cs
@@ -18,7 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Helpers;
 using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
 using CS = SonarAnalyzer.Rules.CSharp;
@@ -28,12 +30,14 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class UseUriInsteadOfStringTest
     {
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         [TestCategory("Rule")]
-        public void UseUriInsteadOfString() =>
+        public void UseUriInsteadOfString(ProjectType projectType) =>
             Verifier.VerifyAnalyzer(@"TestCases\UseUriInsteadOfString.cs",
                 new CS.UseUriInsteadOfString(),
-                MetadataReferenceFacade.SystemDrawing);
+                MetadataReferenceFacade.SystemDrawing.Concat(TestHelper.ProjectTypeReference(projectType)));
 
 #if NET
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/ProjectBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/ProjectBuilder.cs
@@ -24,6 +24,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 
 namespace SonarAnalyzer.UnitTest.TestFramework
 {
@@ -63,6 +64,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
         public Document FindDocument(string name) =>
             Project.Documents.Single(d => d.Name == name);
+
+        public ProjectBuilder AddTestReferences() =>
+            AddReferences(NuGetMetadataReference.MSTestTestFrameworkV1);    // Any reference to detect a test project
 
         public ProjectBuilder AddReferences(IEnumerable<MetadataReference> references)
         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
@@ -44,9 +44,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             Solution = solution;
         }
 
-        public ProjectBuilder AddTestProject(AnalyzerLanguage language, bool createExtraEmptyFile = true) =>
-            AddProject(language, $"{GeneratedAssemblyName}{ProjectIds.Count}.Tests", createExtraEmptyFile);
-
         public ProjectBuilder AddProject(AnalyzerLanguage language, bool createExtraEmptyFile = true, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary) =>
             AddProject(language, $"{GeneratedAssemblyName}{ProjectIds.Count}", createExtraEmptyFile, outputKind);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/TestHelper.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/TestHelper.cs
@@ -32,6 +32,7 @@ using Microsoft.CodeAnalysis.Text;
 using Moq;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
+using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.PackagingTests;
 using SonarAnalyzer.UnitTest.TestFramework;
 
@@ -196,6 +197,11 @@ namespace SonarAnalyzer.UnitTest
             var type = CsRuleTypeMapping.RuleTypesCs.GetValueOrDefault(key) ?? VbRuleTypeMapping.RuleTypesVb.GetValueOrDefault(key);
             return type == "SECURITY_HOTSPOT";
         }
+
+        public static IEnumerable<MetadataReference> ProjectTypeReference(ProjectType projectType) =>
+            projectType == ProjectType.Test
+                ? NuGetMetadataReference.MSTestTestFrameworkV1  // Any reference to detect a test project
+                : Enumerable.Empty<MetadataReference>();
 
         public static AnalyzerOptions CreateOptions(string relativePath)
         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
@@ -164,22 +164,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                           IEnumerable<MetadataReference> additionalReferences = null) =>
             VerifyAnalyzer(paths, new[] { diagnosticAnalyzer }, options, CompilationErrorBehavior.Default, OutputKind.DynamicallyLinkedLibrary, additionalReferences);
 
-        public static void VerifyAnalyzerInTest(string path,
-                          DiagnosticAnalyzer diagnosticAnalyzer,
-                          IEnumerable<ParseOptions> options = null,
-                          CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
-                          OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary,
-                          IEnumerable<MetadataReference> additionalReferences = null) =>
-            VerifyAnalyzerInTest(new[] { path }, diagnosticAnalyzer, options, checkMode, outputKind, additionalReferences);
-
-        public static void VerifyAnalyzerInTest(IEnumerable<string> paths,
-                                  DiagnosticAnalyzer diagnosticAnalyzer,
-                                  IEnumerable<ParseOptions> options = null,
-                                  CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
-                                  OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary,
-                                  IEnumerable<MetadataReference> additionalReferences = null) =>
-            VerifyAnalyzer(paths, new[] { diagnosticAnalyzer }, options, checkMode, outputKind, AddTestReference(additionalReferences));
-
         public static void VerifyUtilityAnalyzer<TMessage>(IEnumerable<string> paths,
                                                            UtilityAnalyzerBase diagnosticAnalyzer,
                                                            string protobufPath,
@@ -214,8 +198,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                        IEnumerable<MetadataReference> additionalReferences = null)
         {
             var builder = SolutionBuilder.Create()
-                .AddTestProject(AnalyzerLanguage.FromPath(path))
-                .AddReferences(NuGetMetadataReference.MSTestTestFrameworkV1)    // Any reference to detect a test project
+                .AddProject(AnalyzerLanguage.FromPath(path))
+                .AddTestReferences()
                 .AddReferences(additionalReferences)
                 .AddDocument(path);
 


### PR DESCRIPTION
Fixes #4173
