### PR TITLE
Rule for using a testable (date) time provider

### DIFF
--- a/analyzers/its/expected/Ember-MM/EmberAPI-{208AA35E-C6AE-4D2D-A9DD-B6EFD19A4279}-S6354.json
+++ b/analyzers/its/expected/Ember-MM/EmberAPI-{208AA35E-C6AE-4D2D-A9DD-B6EFD19A4279}-S6354.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Ember-MM\EmberAPI\clsAPIErrorLog.vb",
+"region":  {
+"startLine":  60,
+"startColumn":  63,
+"endLine":  60,
+"endColumn":  75
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Ember-MM/generic.EmberCore.Extractor-{B413DEAF-4FDC-416A-B3E0-968C1C8F3F83}-S6354.json
+++ b/analyzers/its/expected/Ember-MM/generic.EmberCore.Extractor-{B413DEAF-4FDC-416A-B3E0-968C1C8F3F83}-S6354.json
@@ -1,0 +1,82 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Ember-MM\Addons\generic.EmberCore.Extractor\clsExtractor.vb",
+"region":  {
+"startLine":  185,
+"startColumn":  91,
+"endLine":  185,
+"endColumn":  105
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Ember-MM\Addons\generic.EmberCore.Extractor\clsExtractor.vb",
+"region":  {
+"startLine":  185,
+"startColumn":  145,
+"endLine":  185,
+"endColumn":  159
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Ember-MM\Addons\generic.EmberCore.Extractor\frmMovieExtractor.vb",
+"region":  {
+"startLine":  31,
+"startColumn":  67,
+"endLine":  31,
+"endColumn":  81
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Ember-MM\Addons\generic.EmberCore.Extractor\frmMovieExtractor.vb",
+"region":  {
+"startLine":  31,
+"startColumn":  121,
+"endLine":  31,
+"endColumn":  135
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Ember-MM\Addons\generic.EmberCore.Extractor\frmTVExtrator.vb",
+"region":  {
+"startLine":  62,
+"startColumn":  91,
+"endLine":  62,
+"endColumn":  105
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Ember-MM\Addons\generic.EmberCore.Extractor\frmTVExtrator.vb",
+"region":  {
+"startLine":  62,
+"startColumn":  145,
+"endLine":  62,
+"endColumn":  159
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Ember-MM/scraper.EmberCore.XML-{E567C031-1F7B-4637-9B3A-806988DE50CF}-S6354.json
+++ b/analyzers/its/expected/Ember-MM/scraper.EmberCore.XML-{E567C031-1F7B-4637-9B3A-806988DE50CF}-S6354.json
@@ -1,0 +1,56 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Ember-MM\Addons\scraper.EmberCore.XML\XMLScraper\MediaTags\MediaTag.vb",
+"region":  {
+"startLine":  59,
+"startColumn":  34,
+"endLine":  59,
+"endColumn":  46
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Ember-MM\Addons\scraper.EmberCore.XML\XMLScraper\ScraperLib\Scraper.vb",
+"region":  {
+"startLine":  69,
+"startColumn":  31,
+"endLine":  69,
+"endColumn":  43
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Ember-MM\Addons\scraper.EmberCore.XML\XMLScraper\ScraperLib\Scraper.vb",
+"region":  {
+"startLine":  290,
+"startColumn":  35,
+"endLine":  290,
+"endColumn":  47
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Ember-MM\Addons\scraper.EmberCore.XML\XMLScraper\ScraperLib\Scraper.vb",
+"region":  {
+"startLine":  511,
+"startColumn":  34,
+"endLine":  511,
+"endColumn":  46
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Nancy/Nancy--net452-S6354.json
+++ b/analyzers/its/expected/Nancy/Nancy--net452-S6354.json
@@ -1,0 +1,56 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Diagnostics\DiagnosticsHook.cs",
+"region":  {
+"startLine":  169,
+"startColumn":  106,
+"endLine":  169,
+"endColumn":  118
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Diagnostics\DiagnosticsHook.cs",
+"region":  {
+"startLine":  207,
+"startColumn":  30,
+"endLine":  207,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Diagnostics\DiagnosticsHook.cs",
+"region":  {
+"startLine":  283,
+"startColumn":  26,
+"endLine":  283,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\NancyEngine.cs",
+"region":  {
+"startLine":  215,
+"startColumn":  27,
+"endLine":  215,
+"endColumn":  39
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Nancy/Nancy--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/Nancy/Nancy--netstandard2.0-S6354.json
@@ -1,0 +1,56 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Diagnostics\DiagnosticsHook.cs",
+"region":  {
+"startLine":  169,
+"startColumn":  106,
+"endLine":  169,
+"endColumn":  118
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Diagnostics\DiagnosticsHook.cs",
+"region":  {
+"startLine":  207,
+"startColumn":  30,
+"endLine":  207,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\Diagnostics\DiagnosticsHook.cs",
+"region":  {
+"startLine":  283,
+"startColumn":  26,
+"endLine":  283,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\NancyEngine.cs",
+"region":  {
+"startLine":  215,
+"startColumn":  27,
+"endLine":  215,
+"endColumn":  39
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Nancy/Nancy.Authentication.Forms--net452-S6354.json
+++ b/analyzers/its/expected/Nancy/Nancy.Authentication.Forms--net452-S6354.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Authentication.Forms\FormsAuthentication.cs",
+"region":  {
+"startLine":  301,
+"startColumn":  120,
+"endLine":  301,
+"endColumn":  132
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Nancy/Nancy.Authentication.Forms--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/Nancy/Nancy.Authentication.Forms--netstandard2.0-S6354.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.Authentication.Forms\FormsAuthentication.cs",
+"region":  {
+"startLine":  301,
+"startColumn":  120,
+"endLine":  301,
+"endColumn":  132
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Nancy/Nancy.ViewEngines.Spark--net452-S6354.json
+++ b/analyzers/its/expected/Nancy/Nancy.ViewEngines.Spark--net452-S6354.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy.ViewEngines.Spark\NancyViewFolder.cs",
+"region":  {
+"startLine":  242,
+"startColumn":  40,
+"endLine":  242,
+"endColumn":  52
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Net5/jsonserializerrecords-38409230-12D6-462B-BFAC-33B3491365B5-net5.0-S6354.json
+++ b/analyzers/its/expected/Net5/jsonserializerrecords-38409230-12D6-462B-BFAC-33B3491365B5-net5.0-S6354.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Net5\Net5Samples\JsonSerializerRecords\Program.cs",
+"region":  {
+"startLine":  4,
+"startColumn":  25,
+"endLine":  4,
+"endColumn":  37
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Net5/recordswithstatichelper-541512C1-D79D-48B4-AE0B-D9A643E16D1F-net5.0-S6354.json
+++ b/analyzers/its/expected/Net5/recordswithstatichelper-541512C1-D79D-48B4-AE0B-D9A643E16D1F-net5.0-S6354.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\Net5\Net5Samples\RecordWithStaticHelper\Program.cs",
+"region":  {
+"startLine":  4,
+"startColumn":  37,
+"endLine":  4,
+"endColumn":  49
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka--netstandard2.0-S6354.json
@@ -1,0 +1,225 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Actor\ActorSystem.cs",
+"region":  {
+"startLine":  216,
+"startColumn":  46,
+"endLine":  216,
+"endColumn":  61
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Dispatch\Mailbox.cs",
+"region":  {
+"startLine":  535,
+"startColumn":  70,
+"endLine":  535,
+"endColumn":  82
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Event\DeadLetterListener.cs",
+"region":  {
+"startLine":  235,
+"startColumn":  38,
+"endLine":  235,
+"endColumn":  53
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Event\DeadLetterListener.cs",
+"region":  {
+"startLine":  240,
+"startColumn":  40,
+"endLine":  240,
+"endColumn":  55
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Event\DeadLetterListener.cs",
+"region":  {
+"startLine":  255,
+"startColumn":  60,
+"endLine":  255,
+"endColumn":  75
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Event\DeadLetterListener.cs",
+"region":  {
+"startLine":  274,
+"startColumn":  60,
+"endLine":  274,
+"endColumn":  66
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Event\DeadLetterListener.cs",
+"region":  {
+"startLine":  276,
+"startColumn":  56,
+"endLine":  276,
+"endColumn":  71
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Event\LogEvent.cs",
+"region":  {
+"startLine":  51,
+"startColumn":  25,
+"endLine":  51,
+"endColumn":  40
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\IO\SimpleDnsCache.cs",
+"region":  {
+"startLine":  40,
+"startColumn":  26,
+"endLine":  40,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\IO\SimpleDnsCache.cs",
+"region":  {
+"startLine":  59,
+"startColumn":  23,
+"endLine":  59,
+"endColumn":  35
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Pattern\CircuitBreakerState.cs",
+"region":  {
+"startLine":  40,
+"startColumn":  30,
+"endLine":  40,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Pattern\CircuitBreakerState.cs",
+"region":  {
+"startLine":  94,
+"startColumn":  23,
+"endLine":  94,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\AtomicState.cs",
+"region":  {
+"startLine":  87,
+"startColumn":  28,
+"endLine":  87,
+"endColumn":  43
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\AtomicState.cs",
+"region":  {
+"startLine":  105,
+"startColumn":  22,
+"endLine":  105,
+"endColumn":  37
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\AtomicState.cs",
+"region":  {
+"startLine":  130,
+"startColumn":  28,
+"endLine":  130,
+"endColumn":  43
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\Internal\AtomicState.cs",
+"region":  {
+"startLine":  148,
+"startColumn":  22,
+"endLine":  148,
+"endColumn":  37
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka\Util\TokenBucket.cs",
+"region":  {
+"startLine":  139,
+"startColumn":  45,
+"endLine":  139,
+"endColumn":  57
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.Cluster--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.Cluster--netstandard2.0-S6354.json
@@ -1,0 +1,147 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\ClusterHeartbeat.cs",
+"region":  {
+"startLine":  85,
+"startColumn":  30,
+"endLine":  85,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\ClusterHeartbeat.cs",
+"region":  {
+"startLine":  155,
+"startColumn":  34,
+"endLine":  155,
+"endColumn":  49
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\ClusterHeartbeat.cs",
+"region":  {
+"startLine":  241,
+"startColumn":  23,
+"endLine":  241,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\ClusterHeartbeat.cs",
+"region":  {
+"startLine":  253,
+"startColumn":  30,
+"endLine":  253,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\SBR\SplitBrainResolver.cs",
+"region":  {
+"startLine":  85,
+"startColumn":  42,
+"endLine":  85,
+"endColumn":  57
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\SBR\SplitBrainResolver.cs",
+"region":  {
+"startLine":  85,
+"startColumn":  59,
+"endLine":  85,
+"endColumn":  74
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\SBR\SplitBrainResolver.cs",
+"region":  {
+"startLine":  144,
+"startColumn":  23,
+"endLine":  144,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\SBR\SplitBrainResolver.cs",
+"region":  {
+"startLine":  171,
+"startColumn":  25,
+"endLine":  171,
+"endColumn":  40
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\SBR\SplitBrainResolver.cs",
+"region":  {
+"startLine":  298,
+"startColumn":  27,
+"endLine":  298,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\SBR\SplitBrainResolver.cs",
+"region":  {
+"startLine":  556,
+"startColumn":  23,
+"endLine":  556,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Cluster\SBR\SplitBrainResolver.cs",
+"region":  {
+"startLine":  732,
+"startColumn":  27,
+"endLine":  732,
+"endColumn":  42
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.Cluster.Metrics--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.Cluster.Metrics--netstandard2.0-S6354.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.Cluster.Metrics\Collectors\DefaultCollector.cs",
+"region":  {
+"startLine":  78,
+"startColumn":  50,
+"endLine":  78,
+"endColumn":  65
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.Cluster.Sharding--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.Cluster.Sharding--netstandard2.0-S6354.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.Cluster.Sharding\Shard.cs",
+"region":  {
+"startLine":  832,
+"startColumn":  85,
+"endLine":  832,
+"endColumn":  97
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.Cluster.Sharding\Shard.cs",
+"region":  {
+"startLine":  839,
+"startColumn":  28,
+"endLine":  839,
+"endColumn":  40
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.Cluster.Tools--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.Cluster.Tools--netstandard2.0-S6354.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.Cluster.Tools\PublishSubscribe\DistributedPubSubMediator.cs",
+"region":  {
+"startLine":  639,
+"startColumn":  27,
+"endLine":  639,
+"endColumn":  42
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.DistributedData--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.DistributedData--netstandard2.0-S6354.json
@@ -1,0 +1,186 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Internal\Internal.cs",
+"region":  {
+"startLine":  481,
+"startColumn":  31,
+"endLine":  481,
+"endColumn":  46
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\LWWRegister.cs",
+"region":  {
+"startLine":  91,
+"startColumn":  44,
+"endLine":  91,
+"endColumn":  59
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\LWWRegister.cs",
+"region":  {
+"startLine":  98,
+"startColumn":  45,
+"endLine":  98,
+"endColumn":  60
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Replicator.cs",
+"region":  {
+"startLine":  383,
+"startColumn":  34,
+"endLine":  383,
+"endColumn":  49
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Replicator.cs",
+"region":  {
+"startLine":  416,
+"startColumn":  30,
+"endLine":  416,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Replicator.cs",
+"region":  {
+"startLine":  474,
+"startColumn":  26,
+"endLine":  474,
+"endColumn":  41
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Replicator.cs",
+"region":  {
+"startLine":  1331,
+"startColumn":  23,
+"endLine":  1331,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Replicator.cs",
+"region":  {
+"startLine":  1420,
+"startColumn":  58,
+"endLine":  1420,
+"endColumn":  73
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Replicator.cs",
+"region":  {
+"startLine":  1421,
+"startColumn":  65,
+"endLine":  1421,
+"endColumn":  80
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Replicator.cs",
+"region":  {
+"startLine":  1450,
+"startColumn":  31,
+"endLine":  1450,
+"endColumn":  46
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Serialization\ReplicatorMessageSerializer.cs",
+"region":  {
+"startLine":  53,
+"startColumn":  29,
+"endLine":  53,
+"endColumn":  44
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Serialization\ReplicatorMessageSerializer.cs",
+"region":  {
+"startLine":  74,
+"startColumn":  29,
+"endLine":  74,
+"endColumn":  44
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Serialization\ReplicatorMessageSerializer.cs",
+"region":  {
+"startLine":  108,
+"startColumn":  21,
+"endLine":  108,
+"endColumn":  36
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Serialization\ReplicatorMessageSerializer.cs",
+"region":  {
+"startLine":  117,
+"startColumn":  29,
+"endLine":  117,
+"endColumn":  44
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner--net471-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner--net471-S6354.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner\Program.cs",
+"region":  {
+"startLine":  476,
+"startColumn":  23,
+"endLine":  476,
+"endColumn":  38
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner--net5.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner--net5.0-S6354.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner\Program.cs",
+"region":  {
+"startLine":  476,
+"startColumn":  23,
+"endLine":  476,
+"endColumn":  38
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner--netcoreapp3.1-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner--netcoreapp3.1-S6354.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner\Program.cs",
+"region":  {
+"startLine":  476,
+"startColumn":  23,
+"endLine":  476,
+"endColumn":  38
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner.Shared--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner.Shared--netstandard2.0-S6354.json
@@ -1,0 +1,420 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Persistence\FileNameGenerator.cs",
+"region":  {
+"startLine":  17,
+"startColumn":  76,
+"endLine":  17,
+"endColumn":  91
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\TestRunCoordinator.cs",
+"region":  {
+"startLine":  61,
+"startColumn":  44,
+"endLine":  61,
+"endColumn":  59
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\TestRunCoordinator.cs",
+"region":  {
+"startLine":  89,
+"startColumn":  95,
+"endLine":  89,
+"endColumn":  110
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\TestRunTree.cs",
+"region":  {
+"startLine":  61,
+"startColumn":  75,
+"endLine":  61,
+"endColumn":  90
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\TestRunTree.cs",
+"region":  {
+"startLine":  76,
+"startColumn":  27,
+"endLine":  76,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\TestRunTree.cs",
+"region":  {
+"startLine":  143,
+"startColumn":  30,
+"endLine":  143,
+"endColumn":  45
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\TestRunTree.cs",
+"region":  {
+"startLine":  196,
+"startColumn":  75,
+"endLine":  196,
+"endColumn":  90
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\TestRunTree.cs",
+"region":  {
+"startLine":  206,
+"startColumn":  27,
+"endLine":  206,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\TestRunTree.cs",
+"region":  {
+"startLine":  287,
+"startColumn":  85,
+"endLine":  287,
+"endColumn":  100
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\TestRunTree.cs",
+"region":  {
+"startLine":  350,
+"startColumn":  75,
+"endLine":  350,
+"endColumn":  90
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\TestRunTree.cs",
+"region":  {
+"startLine":  372,
+"startColumn":  27,
+"endLine":  372,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\ConsoleMessageSinkActor.cs",
+"region":  {
+"startLine":  49,
+"startColumn":  61,
+"endLine":  49,
+"endColumn":  76
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\ConsoleMessageSinkActor.cs",
+"region":  {
+"startLine":  143,
+"startColumn":  53,
+"endLine":  143,
+"endColumn":  68
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\ConsoleMessageSinkActor.cs",
+"region":  {
+"startLine":  150,
+"startColumn":  92,
+"endLine":  150,
+"endColumn":  107
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\ConsoleMessageSinkActor.cs",
+"region":  {
+"startLine":  157,
+"startColumn":  92,
+"endLine":  157,
+"endColumn":  107
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\MessageSink.cs",
+"region":  {
+"startLine":  145,
+"startColumn":  86,
+"endLine":  145,
+"endColumn":  101
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\MessageSink.cs",
+"region":  {
+"startLine":  164,
+"startColumn":  73,
+"endLine":  164,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\MessageSink.cs",
+"region":  {
+"startLine":  239,
+"startColumn":  82,
+"endLine":  239,
+"endColumn":  97
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\Spec.cs",
+"region":  {
+"startLine":  31,
+"startColumn":  25,
+"endLine":  31,
+"endColumn":  40
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\TeamCityMessageSinkActor.cs",
+"region":  {
+"startLine":  76,
+"startColumn":  73,
+"endLine":  76,
+"endColumn":  88
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\TeamCityMessageSinkActor.cs",
+"region":  {
+"startLine":  86,
+"startColumn":  67,
+"endLine":  86,
+"endColumn":  82
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\TestCoordinatorEnabledMessageSink.cs",
+"region":  {
+"startLine":  98,
+"startColumn":  62,
+"endLine":  98,
+"endColumn":  77
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\TestCoordinatorEnabledMessageSink.cs",
+"region":  {
+"startLine":  109,
+"startColumn":  62,
+"endLine":  109,
+"endColumn":  77
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\TimelineLogCollectorActor.cs",
+"region":  {
+"startLine":  100,
+"startColumn":  24,
+"endLine":  100,
+"endColumn":  39
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\TrxReporter\Models\Times.cs",
+"region":  {
+"startLine":  18,
+"startColumn":  23,
+"endLine":  18,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\TrxReporter\Models\UnitTestResult.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  23,
+"endLine":  26,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\TrxReporter\SpecSession.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  88,
+"endLine":  26,
+"endColumn":  103
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\TrxReporter\SpecSession.cs",
+"region":  {
+"startLine":  27,
+"startColumn":  129,
+"endLine":  27,
+"endColumn":  144
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\TrxReporter\SpecSession.cs",
+"region":  {
+"startLine":  28,
+"startColumn":  119,
+"endLine":  28,
+"endColumn":  134
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\TrxReporter\SpecSession.cs",
+"region":  {
+"startLine":  29,
+"startColumn":  122,
+"endLine":  29,
+"endColumn":  137
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\TrxReporter\SpecSession.cs",
+"region":  {
+"startLine":  30,
+"startColumn":  74,
+"endLine":  30,
+"endColumn":  89
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\TrxReporter\TrxSinkActor.cs",
+"region":  {
+"startLine":  102,
+"startColumn":  77,
+"endLine":  102,
+"endColumn":  92
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.Persistence--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.Persistence--netstandard2.0-S6354.json
@@ -1,0 +1,69 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\AtLeastOnceDeliverySemantic.cs",
+"region":  {
+"startLine":  408,
+"startColumn":  43,
+"endLine":  408,
+"endColumn":  58
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\AtLeastOnceDeliverySemantic.cs",
+"region":  {
+"startLine":  408,
+"startColumn":  81,
+"endLine":  408,
+"endColumn":  96
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\AtLeastOnceDeliverySemantic.cs",
+"region":  {
+"startLine":  437,
+"startColumn":  28,
+"endLine":  437,
+"endColumn":  43
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\AtLeastOnceDeliverySemantic.cs",
+"region":  {
+"startLine":  501,
+"startColumn":  23,
+"endLine":  501,
+"endColumn":  38
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence\Snapshot\SnapshotStore.cs",
+"region":  {
+"startLine":  78,
+"startColumn":  124,
+"endLine":  78,
+"endColumn":  139
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.Persistence.Sql.Common--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.Persistence.Sql.Common--netstandard2.0-S6354.json
@@ -1,0 +1,56 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\persistence\Akka.Persistence.Sql.Common\Journal\BatchingSqlJournal.cs",
+"region":  {
+"startLine":  1279,
+"startColumn":  66,
+"endLine":  1279,
+"endColumn":  81
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\persistence\Akka.Persistence.Sql.Common\Journal\ITimestampProvider.cs",
+"region":  {
+"startLine":  26,
+"startColumn":  83,
+"endLine":  26,
+"endColumn":  89
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\persistence\Akka.Persistence.Sql.Common\Journal\ITimestampProvider.cs",
+"region":  {
+"startLine":  35,
+"startColumn":  77,
+"endLine":  35,
+"endColumn":  92
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\contrib\persistence\Akka.Persistence.Sql.Common\Journal\QueryExecutor.cs",
+"region":  {
+"startLine":  687,
+"startColumn":  59,
+"endLine":  687,
+"endColumn":  74
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.Remote--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.Remote--netstandard2.0-S6354.json
@@ -1,0 +1,69 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Deadline.cs",
+"region":  {
+"startLine":  31,
+"startColumn":  26,
+"endLine":  31,
+"endColumn":  41
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Deadline.cs",
+"region":  {
+"startLine":  39,
+"startColumn":  26,
+"endLine":  39,
+"endColumn":  41
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Deadline.cs",
+"region":  {
+"startLine":  55,
+"startColumn":  56,
+"endLine":  55,
+"endColumn":  71
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Deadline.cs",
+"region":  {
+"startLine":  83,
+"startColumn":  56,
+"endLine":  83,
+"endColumn":  62
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Remote\Deadline.cs",
+"region":  {
+"startLine":  89,
+"startColumn":  37,
+"endLine":  89,
+"endColumn":  52
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.Streams--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.Streams--netstandard2.0-S6354.json
@@ -1,0 +1,251 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Dsl\Restart.cs",
+"region":  {
+"startLine":  603,
+"startColumn":  47,
+"endLine":  603,
+"endColumn":  62
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Dsl\Restart.cs",
+"region":  {
+"startLine":  605,
+"startColumn":  65,
+"endLine":  605,
+"endColumn":  80
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Extra\Timed.cs",
+"region":  {
+"startLine":  296,
+"startColumn":  36,
+"endLine":  296,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Fusing\Ops.cs",
+"region":  {
+"startLine":  3237,
+"startColumn":  90,
+"endLine":  3237,
+"endColumn":  105
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Fusing\Ops.cs",
+"region":  {
+"startLine":  3267,
+"startColumn":  34,
+"endLine":  3267,
+"endColumn":  49
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  212,
+"startColumn":  33,
+"endLine":  212,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  220,
+"startColumn":  33,
+"endLine":  220,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  234,
+"startColumn":  37,
+"endLine":  234,
+"endColumn":  52
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  295,
+"startColumn":  33,
+"endLine":  295,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  304,
+"startColumn":  33,
+"endLine":  304,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  322,
+"startColumn":  56,
+"endLine":  322,
+"endColumn":  71
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  383,
+"startColumn":  33,
+"endLine":  383,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  416,
+"startColumn":  37,
+"endLine":  416,
+"endColumn":  52
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  423,
+"startColumn":  58,
+"endLine":  423,
+"endColumn":  73
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  589,
+"startColumn":  33,
+"endLine":  589,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  597,
+"startColumn":  33,
+"endLine":  597,
+"endColumn":  48
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  626,
+"startColumn":  32,
+"endLine":  626,
+"endColumn":  47
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  641,
+"startColumn":  28,
+"endLine":  641,
+"endColumn":  43
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams\Implementation\Timers.cs",
+"region":  {
+"startLine":  645,
+"startColumn":  37,
+"endLine":  645,
+"endColumn":  52
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.Streams.TestKit--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.Streams.TestKit--netstandard2.0-S6354.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams.TestKit\TestSubscriber.cs",
+"region":  {
+"startLine":  490,
+"startColumn":  32,
+"endLine":  490,
+"endColumn":  47
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Streams.TestKit\TestSubscriber.cs",
+"region":  {
+"startLine":  498,
+"startColumn":  86,
+"endLine":  498,
+"endColumn":  101
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.TestKit--netstandard2.0-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.TestKit--netstandard2.0-S6354.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.TestKit\TestKitBase.cs",
+"region":  {
+"startLine":  235,
+"startColumn":  70,
+"endLine":  235,
+"endColumn":  85
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.Tests.Performance--netcoreapp3.1-S6354.json
+++ b/analyzers/its/expected/akka.net/Akka.Tests.Performance--netcoreapp3.1-S6354.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests.Performance\IO\TcpHorizontalScaleSpec.cs",
+"region":  {
+"startLine":  147,
+"startColumn":  27,
+"endLine":  147,
+"endColumn":  42
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Tests.Performance\IO\TcpHorizontalScaleSpec.cs",
+"region":  {
+"startLine":  148,
+"startColumn":  20,
+"endLine":  148,
+"endColumn":  35
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/PersistenceBenchmark--net471-S6354.json
+++ b/analyzers/its/expected/akka.net/PersistenceBenchmark--net471-S6354.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\benchmark\PersistenceBenchmark\Messages.cs",
+"region":  {
+"startLine":  49,
+"startColumn":  25,
+"endLine":  49,
+"endColumn":  37
+}
+}
+},
+{
+"id":  "S6354",
+"message":  "Use a testable (date) time provider instead.",
+"location":  {
+"uri":  "sources\akka.net\src\benchmark\PersistenceBenchmark\Messages.cs",
+"region":  {
+"startLine":  54,
+"startColumn":  25,
+"endLine":  54,
+"endColumn":  37
+}
+}
+}
+]
+}

--- a/analyzers/rspec/cs/S6354_c#.html
+++ b/analyzers/rspec/cs/S6354_c#.html
@@ -1,5 +1,5 @@
 <p>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes
-calls to static methods, and date/time functions are usually provided by system libraries as static methods.</p>
+calls to static methods, which cannot be changed or controlled. Date/time functions are usually provided by system libraries as static methods.</p>
 <p>This can be improved by wrapping the system calls in an object or service that can be controlled inside the unit test.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>

--- a/analyzers/rspec/cs/S6354_c#.html
+++ b/analyzers/rspec/cs/S6354_c#.html
@@ -1,0 +1,72 @@
+<p>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes
+calls to static methods, and date/time functions are usually provided by system libraries as static methods.</p>
+<p>This can be improved by wrapping the system calls in an object or service that can be controlled inside the unit test.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+public class Foo
+{
+    public string HelloTime() =&gt;
+        $"Hello at {DateTime.UtcNow}";
+}
+</pre>
+<h2>Compliant Solution</h2>
+<p>There are different approaches to solve this problem. One of them is suggested below. There are also open source libraries (such as NodaTime) which
+already implement an <code>IClock</code> interface and a <code>FakeClock</code> testing class.</p>
+<pre>
+public interface IClock
+{
+    DateTime UtcNow();
+}
+
+public class Foo
+{
+    public string HelloTime(IClock clock) =&gt;
+        $"Hello at {clock.UtcNow()}";
+}
+
+public class FooTest
+{
+    public record TestClock(DateTime now) : IClock
+    {
+        public DateTime UtcNow() =&gt; now;
+    }
+
+    [Fact]
+    public void HelloTime_Gives_CorrectTime()
+    {
+        var dateTime = new DateTime(2017, 06, 11);
+        Assert.Equal((new Foo()).HelloTime(new TestClock(dateTime)), $"Hello at {dateTime}");
+    }
+}
+</pre>
+<p>Another possible solution is using an adaptable static class, ideally supports an IDisposable method, that not only adjusts the time behaviour for
+the current thread only, but also for scope of the using.</p>
+<pre>
+public static class Clock
+{
+    public static DateTime UtcNow() { /* ... */ }
+    public static IDisposable SetTimeForCurrentThread(Func&lt;DateTime&gt; time) { /* ... */ }
+}
+
+public class Foo
+{
+    public string HelloTime() =&gt;
+        $"Hello at {Clock.UtcNow()}";
+}
+
+public class FooTest
+{
+    [Fact]
+    public void HelloTime_Gives_CorrectTime()
+    {
+        var dateTime = new DateTime(2017, 06, 11);
+        using (Clock.SetTimeForCurrentThread(() =&gt; dateTime))
+        {
+             Assert.Equal((new Foo()).HelloTime(), $"Hello at {dateTime}");
+        }
+    }
+}
+</pre>
+<h2>See</h2>
+<p><a href="https://nodatime.org/3.0.x/api/NodaTime.Testing.html">NodaTime testing</a></p>
+

--- a/analyzers/rspec/cs/S6354_c#.json
+++ b/analyzers/rspec/cs/S6354_c#.json
@@ -1,0 +1,15 @@
+{
+  "title": "Use a testable date\/time provider.",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "20min"
+  },
+  "tags": [],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-6354",
+  "sqKey": "S6354",
+  "scope": "Main",
+  "quickfix": "unknown"
+}

--- a/analyzers/rspec/vbnet/S6354_vb.net.html
+++ b/analyzers/rspec/vbnet/S6354_vb.net.html
@@ -1,5 +1,5 @@
 <p>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes
-calls to static methods, and date/time functions are usually provided by system libraries as static methods.</p>
+calls to static methods, which cannot be changed or controlled. Date/time functions are usually provided by system libraries as static methods.</p>
 <p>This can be improved by wrapping the system calls in an object or service that can be controlled inside the unit test.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>

--- a/analyzers/rspec/vbnet/S6354_vb.net.html
+++ b/analyzers/rspec/vbnet/S6354_vb.net.html
@@ -1,0 +1,69 @@
+<p>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes
+calls to static methods, and date/time functions are usually provided by system libraries as static methods.</p>
+<p>This can be improved by wrapping the system calls in an object or service that can be controlled inside the unit test.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+Public Class Foo
+    Public Function HelloTime() As String
+        Return $"Hello at {DateTime.UtcNow}"
+    End Function
+End Class
+</pre>
+<h2>Compliant Solution</h2>
+<p>There are different approaches to solve this problem. One of them is suggested below. There are also open source libraries (such as NodaTime) which
+already implement an <code>IClock</code> interface and a <code>FakeClock</code> testing class.</p>
+<pre>
+Public Interface IClock
+    Function UtcNow() As Date
+End Interface
+
+Public Class Foo
+    Public Function HelloTime(clock As IClock) As String
+        Return $"Hello at {clock.UtcNow()}"
+    End Function
+End Class
+
+Public Class FooTest
+    Public Class TestClock
+        Implements IClock
+        ' implement
+    End Class
+
+    &lt;Fact&gt;
+    Public Sub HelloTime_Gives_CorrectTime()
+        Dim dateTime = New DateTime(2017, 06, 11)
+        Assert.Equal((New Foo()).HelloTime(New TestClock(dateTime)), $"Hello at {dateTime}")
+    End Sub
+End Class
+</pre>
+<p>Another possible solution is using an adaptable module, ideally supports an IDisposable method, that not only adjusts the time behaviour for the
+current thread only, but also for scope of the using.</p>
+<pre>
+Public Module Clock
+    Public Function UtcNow() As Date
+    End Function
+
+    Public Function SetTimeForCurrentThread(time As Func(Of Date)) As IDisposable
+    End Function
+End Module
+
+Public Class Foo
+    Public Function HelloTime() As String
+        Return $"Hello at {Clock.UtcNow()}"
+    End Function
+End Class
+
+Public Class FooTest
+    &lt;Fact&gt;
+    Public Sub HelloTime_Gives_CorrectTime()
+        Dim dateTime = New DateTime(2017, 06, 11)
+
+        Using SetTimeForCurrentThread(Function() dateTime)
+            Assert.Equal((New Foo()).HelloTime(), $"Hello at {dateTime}")
+        End Using
+    End Sub
+End Class
+</pre>
+<h2>See</h2>
+<p><a href="https://nodatime.org/3.0.x/api/NodaTime.Testing.html">NodaTime testing</a></p>
+

--- a/analyzers/rspec/vbnet/S6354_vb.net.json
+++ b/analyzers/rspec/vbnet/S6354_vb.net.json
@@ -1,0 +1,15 @@
+{
+  "title": "Use a testable date\/time provider.",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "20min"
+  },
+  "tags": [],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-6354",
+  "sqKey": "S6354",
+  "scope": "Main",
+  "quickfix": "unknown"
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/analyzers/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -12811,6 +12811,39 @@
   <data name="S5773_Type" xml:space="preserve">
     <value>VULNERABILITY</value>
   </data>
+  <data name="S6354_Category" xml:space="preserve">
+    <value>Major Code Smell</value>
+  </data>
+  <data name="S6354_Description" xml:space="preserve">
+    <value>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes calls to static methods, and date/time functions are usually provided by system libraries as static methods.</value>
+  </data>
+  <data name="S6354_IsActivatedByDefault" xml:space="preserve">
+    <value>False</value>
+  </data>
+  <data name="S6354_Remediation" xml:space="preserve">
+    <value>Constant/Issue</value>
+  </data>
+  <data name="S6354_RemediationCost" xml:space="preserve">
+    <value>20min</value>
+  </data>
+  <data name="S6354_Scope" xml:space="preserve">
+    <value>Main</value>
+  </data>
+  <data name="S6354_Severity" xml:space="preserve">
+    <value>Major</value>
+  </data>
+  <data name="S6354_Status" xml:space="preserve">
+    <value>ready</value>
+  </data>
+  <data name="S6354_Tags" xml:space="preserve">
+    <value />
+  </data>
+  <data name="S6354_Title" xml:space="preserve">
+    <value>Use a testable date/time provider.</value>
+  </data>
+  <data name="S6354_Type" xml:space="preserve">
+    <value>CODE_SMELL</value>
+  </data>
   <data name="S818_Category" xml:space="preserve">
     <value>Minor Code Smell</value>
   </data>

--- a/analyzers/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/analyzers/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -12815,7 +12815,7 @@
     <value>Major Code Smell</value>
   </data>
   <data name="S6354_Description" xml:space="preserve">
-    <value>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes calls to static methods, and date/time functions are usually provided by system libraries as static methods.</value>
+    <value>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes calls to static methods, which cannot be changed or controlled. Date/time functions are usually provided by system libraries as static methods.</value>
   </data>
   <data name="S6354_IsActivatedByDefault" xml:space="preserve">
     <value>False</value>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseTestableTimeProvider.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseTestableTimeProvider.cs
@@ -18,10 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
@@ -30,10 +28,8 @@ namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     [Rule(DiagnosticId)]
-    public sealed class UseTestableTimeProvider : UseTestableTimeProviderBase<IdentifierNameSyntax, SyntaxKind>
+    public sealed class UseTestableTimeProvider : UseTestableTimeProviderBase<SyntaxKind>
     {
         protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
-
-        protected override string NameOf(IdentifierNameSyntax identifier) => identifier.Identifier.Text;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseTestableTimeProvider.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseTestableTimeProvider.cs
@@ -18,8 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
@@ -28,8 +30,10 @@ namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     [Rule(DiagnosticId)]
-    public sealed class UseTestableTimeProvider : UseTestableTimeProviderBase<SyntaxKind>
+    public sealed class UseTestableTimeProvider : UseTestableTimeProviderBase<IdentifierNameSyntax, SyntaxKind>
     {
         protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
+
+        protected override string NameOf(IdentifierNameSyntax identifier) => identifier.Identifier.Text;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseTestableTimeProvider.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseTestableTimeProvider.cs
@@ -21,7 +21,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
-using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseTestableTimeProvider.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseTestableTimeProvider.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * SonarAnalyzer for .NET
- * Copyright (C) 2015-2021 SonarSource SA
+ * Copyright (C) 2015-2022 SonarSource SA
  * mailto: contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseTestableTimeProvider.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseTestableTimeProvider.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.CSharp
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Rule(DiagnosticId)]
+    public sealed class UseTestableTimeProvider : UseTestableTimeProviderBase<SyntaxKind>
+    {
+        protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
+    }
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseTestableTimeProvider.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseTestableTimeProvider.cs
@@ -27,7 +27,6 @@ using SonarAnalyzer.Helpers;
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    [Rule(DiagnosticId)]
     public sealed class UseTestableTimeProvider : UseTestableTimeProviderBase<SyntaxKind>
     {
         protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -577,6 +577,8 @@ namespace SonarAnalyzer.Helpers
         public string TypeName { get; }
         public string ShortName => shortName.Value;
 
+        public static KnownType Microsoft_Net_Http_Headers_HeaderNames { get; internal set; }
+
         private KnownType(string typeName) : this(SpecialType.None, typeName) { }
 
         private KnownType(SpecialType specialType, string typeName)

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -87,7 +87,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType Microsoft_Extensions_Logging_EventSourceLoggerFactoryExtensions = new KnownType("Microsoft.Extensions.Logging.EventSourceLoggerFactoryExtensions");
         internal static readonly KnownType Microsoft_Extensions_Logging_ILoggerFactory = new KnownType("Microsoft.Extensions.Logging.ILoggerFactory");
         internal static readonly KnownType Microsoft_Extensions_Primitives_StringValues = new KnownType("Microsoft.Extensions.Primitives.StringValues");
-        internal static readonly KnownType Microsoft_Net_Http_Headers_HeaderNames = new KnownType("Microsoft.Net.Http.Headers.HeaderNames");
+        internal static readonly KnownType Microsoft_VisualBasic_DateAndTime = new KnownType("Microsoft.VisualBasic.DateAndTime");
         internal static readonly KnownType Microsoft_VisualBasic_Interaction = new KnownType("Microsoft.VisualBasic.Interaction");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_Assert = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.Assert");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_AssertFailedException = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException");

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -87,7 +87,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType Microsoft_Extensions_Logging_EventSourceLoggerFactoryExtensions = new KnownType("Microsoft.Extensions.Logging.EventSourceLoggerFactoryExtensions");
         internal static readonly KnownType Microsoft_Extensions_Logging_ILoggerFactory = new KnownType("Microsoft.Extensions.Logging.ILoggerFactory");
         internal static readonly KnownType Microsoft_Extensions_Primitives_StringValues = new KnownType("Microsoft.Extensions.Primitives.StringValues");
-        internal static readonly KnownType Microsoft_VisualBasic_DateAndTime = new KnownType("Microsoft.VisualBasic.DateAndTime");
+        internal static readonly KnownType Microsoft_Net_Http_Headers_HeaderNames = new KnownType("Microsoft.Net.Http.Headers.HeaderNames");
         internal static readonly KnownType Microsoft_VisualBasic_Interaction = new KnownType("Microsoft.VisualBasic.Interaction");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_Assert = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.Assert");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_AssertFailedException = new KnownType("Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException");
@@ -576,8 +576,6 @@ namespace SonarAnalyzer.Helpers
 
         public string TypeName { get; }
         public string ShortName => shortName.Value;
-
-        public static KnownType Microsoft_Net_Http_Headers_HeaderNames { get; internal set; }
 
         private KnownType(string typeName) : this(SpecialType.None, typeName) { }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseTestableTimeProviderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseTestableTimeProviderBase.cs
@@ -28,8 +28,8 @@ namespace SonarAnalyzer.Rules
     public abstract class UseTestableTimeProviderBase<TSyntaxKind> : SonarDiagnosticAnalyzer
          where TSyntaxKind : struct
     {
-        protected const string DiagnosticId = "S6354";
-        protected const string MessageFormat = "Use a testable (date) time provider instead.";
+        private const string DiagnosticId = "S6354";
+        private const string MessageFormat = "Use a testable (date) time provider instead.";
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
         private readonly DiagnosticDescriptor rule;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseTestableTimeProviderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseTestableTimeProviderBase.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules
     public abstract class UseTestableTimeProviderBase<TIdentifierNameSyntax, TSyntaxKind> : SonarDiagnosticAnalyzer
          where TSyntaxKind : struct
     {
-        protected const string DiagnosticId = "ToBeDecided";
+        protected const string DiagnosticId = "S6354";
         protected const string MessageFormat = "Use a testable (date) time provider instead.";
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseTestableTimeProviderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseTestableTimeProviderBase.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules
+{
+    public abstract class UseTestableTimeProviderBase<TSyntaxKind> : SonarDiagnosticAnalyzer
+         where TSyntaxKind : struct
+    {
+        protected const string DiagnosticId = "ToBedesided";
+        protected const string MessageFormat = "Use a testable (date) time provider instead.";
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        private readonly DiagnosticDescriptor rule;
+
+        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
+
+        protected UseTestableTimeProviderBase() =>
+            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+
+        protected sealed override void Initialize(SonarAnalysisContext context) =>
+            context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, c =>
+            {
+                if (c.SemanticModel.GetSymbolInfo(c.Node).Symbol is IMethodSymbol identifier
+                    && IsDateTimeProvider(identifier))
+                {
+                    c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, c.Node.GetLocation()));
+                }
+            },
+            Language.SyntaxKind.IdentifierName);
+
+        private bool IsDateTimeProvider(IMethodSymbol identifier) =>
+            identifier.IsInType(KnownType.System_DateTime)
+            && IsDateTimeProviderProperty(identifier.Name);
+
+        private bool IsDateTimeProviderProperty(string name)
+            => nameof(DateTime.Now).Equals(name, Language.NameComparison)
+            || nameof(DateTime.UtcNow).Equals(name, Language.NameComparison)
+            || nameof(DateTime.Today).Equals(name, Language.NameComparison);
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseTestableTimeProviderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseTestableTimeProviderBase.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * SonarAnalyzer for .NET
- * Copyright (C) 2015-2021 SonarSource SA
+ * Copyright (C) 2015-2022 SonarSource SA
  * mailto: contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseTestableTimeProviderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseTestableTimeProviderBase.cs
@@ -25,7 +25,7 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class UseTestableTimeProviderBase<TIdentifierNameSyntax, TSyntaxKind> : SonarDiagnosticAnalyzer
+    public abstract class UseTestableTimeProviderBase<TSyntaxKind> : SonarDiagnosticAnalyzer
          where TSyntaxKind : struct
     {
         protected const string DiagnosticId = "S6354";
@@ -42,17 +42,14 @@ namespace SonarAnalyzer.Rules
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, c =>
             {
-                if (c.Node is TIdentifierNameSyntax identifier
-                    && IsDateTimeProviderProperty(NameOf(identifier))
+                if (IsDateTimeProviderProperty(Language.Syntax.NodeIdentifier(c.Node).Value.Text)
                     && c.SemanticModel.GetSymbolInfo(c.Node).Symbol is IPropertySymbol property
                     && property.IsInType(KnownType.System_DateTime))
                 {
-                    c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, c.Node.Parent.GetLocation()));
+                    c.ReportIssue(Diagnostic.Create(rule, c.Node.Parent.GetLocation()));
                 }
             },
             Language.SyntaxKind.IdentifierName);
-
-        protected abstract string NameOf(TIdentifierNameSyntax identifier);
 
         private bool IsDateTimeProviderProperty(string name)
             => nameof(DateTime.Now).Equals(name, Language.NameComparison)

--- a/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S6354_cs.html
+++ b/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S6354_cs.html
@@ -1,5 +1,5 @@
 <p>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes
-calls to static methods, and date/time functions are usually provided by system libraries as static methods.</p>
+calls to static methods, which cannot be changed or controlled. Date/time functions are usually provided by system libraries as static methods.</p>
 <p>This can be improved by wrapping the system calls in an object or service that can be controlled inside the unit test.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>

--- a/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S6354_cs.html
+++ b/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S6354_cs.html
@@ -1,0 +1,72 @@
+<p>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes
+calls to static methods, and date/time functions are usually provided by system libraries as static methods.</p>
+<p>This can be improved by wrapping the system calls in an object or service that can be controlled inside the unit test.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+public class Foo
+{
+    public string HelloTime() =&gt;
+        $"Hello at {DateTime.UtcNow}";
+}
+</pre>
+<h2>Compliant Solution</h2>
+<p>There are different approaches to solve this problem. One of them is suggested below. There are also open source libraries (such as NodaTime) which
+already implement an <code>IClock</code> interface and a <code>FakeClock</code> testing class.</p>
+<pre>
+public interface IClock
+{
+    DateTime UtcNow();
+}
+
+public class Foo
+{
+    public string HelloTime(IClock clock) =&gt;
+        $"Hello at {clock.UtcNow()}";
+}
+
+public class FooTest
+{
+    public record TestClock(DateTime now) : IClock
+    {
+        public DateTime UtcNow() =&gt; now;
+    }
+
+    [Fact]
+    public void HelloTime_Gives_CorrectTime()
+    {
+        var dateTime = new DateTime(2017, 06, 11);
+        Assert.Equal((new Foo()).HelloTime(new TestClock(dateTime)), $"Hello at {dateTime}");
+    }
+}
+</pre>
+<p>Another possible solution is using an adaptable static class, ideally supports an IDisposable method, that not only adjusts the time behaviour for
+the current thread only, but also for scope of the using.</p>
+<pre>
+public static class Clock
+{
+    public static DateTime UtcNow() { /* ... */ }
+    public static IDisposable SetTimeForCurrentThread(Func&lt;DateTime&gt; time) { /* ... */ }
+}
+
+public class Foo
+{
+    public string HelloTime() =&gt;
+        $"Hello at {Clock.UtcNow()}";
+}
+
+public class FooTest
+{
+    [Fact]
+    public void HelloTime_Gives_CorrectTime()
+    {
+        var dateTime = new DateTime(2017, 06, 11);
+        using (Clock.SetTimeForCurrentThread(() =&gt; dateTime))
+        {
+             Assert.Equal((new Foo()).HelloTime(), $"Hello at {dateTime}");
+        }
+    }
+}
+</pre>
+<h2>See</h2>
+<p><a href="https://nodatime.org/3.0.x/api/NodaTime.Testing.html">NodaTime testing</a></p>
+

--- a/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S6354_vb.html
+++ b/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S6354_vb.html
@@ -1,5 +1,5 @@
 <p>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes
-calls to static methods, and date/time functions are usually provided by system libraries as static methods.</p>
+calls to static methods, which cannot be changed or controlled. Date/time functions are usually provided by system libraries as static methods.</p>
 <p>This can be improved by wrapping the system calls in an object or service that can be controlled inside the unit test.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>

--- a/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S6354_vb.html
+++ b/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S6354_vb.html
@@ -1,0 +1,69 @@
+<p>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes
+calls to static methods, and date/time functions are usually provided by system libraries as static methods.</p>
+<p>This can be improved by wrapping the system calls in an object or service that can be controlled inside the unit test.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+Public Class Foo
+    Public Function HelloTime() As String
+        Return $"Hello at {DateTime.UtcNow}"
+    End Function
+End Class
+</pre>
+<h2>Compliant Solution</h2>
+<p>There are different approaches to solve this problem. One of them is suggested below. There are also open source libraries (such as NodaTime) which
+already implement an <code>IClock</code> interface and a <code>FakeClock</code> testing class.</p>
+<pre>
+Public Interface IClock
+    Function UtcNow() As Date
+End Interface
+
+Public Class Foo
+    Public Function HelloTime(clock As IClock) As String
+        Return $"Hello at {clock.UtcNow()}"
+    End Function
+End Class
+
+Public Class FooTest
+    Public Class TestClock
+        Implements IClock
+        ' implement
+    End Class
+
+    &lt;Fact&gt;
+    Public Sub HelloTime_Gives_CorrectTime()
+        Dim dateTime = New DateTime(2017, 06, 11)
+        Assert.Equal((New Foo()).HelloTime(New TestClock(dateTime)), $"Hello at {dateTime}")
+    End Sub
+End Class
+</pre>
+<p>Another possible solution is using an adaptable module, ideally supports an IDisposable method, that not only adjusts the time behaviour for the
+current thread only, but also for scope of the using.</p>
+<pre>
+Public Module Clock
+    Public Function UtcNow() As Date
+    End Function
+
+    Public Function SetTimeForCurrentThread(time As Func(Of Date)) As IDisposable
+    End Function
+End Module
+
+Public Class Foo
+    Public Function HelloTime() As String
+        Return $"Hello at {Clock.UtcNow()}"
+    End Function
+End Class
+
+Public Class FooTest
+    &lt;Fact&gt;
+    Public Sub HelloTime_Gives_CorrectTime()
+        Dim dateTime = New DateTime(2017, 06, 11)
+
+        Using SetTimeForCurrentThread(Function() dateTime)
+            Assert.Equal((New Foo()).HelloTime(), $"Hello at {dateTime}")
+        End Using
+    End Sub
+End Class
+</pre>
+<h2>See</h2>
+<p><a href="https://nodatime.org/3.0.x/api/NodaTime.Testing.html">NodaTime testing</a></p>
+

--- a/analyzers/src/SonarAnalyzer.VisualBasic/RspecStrings.resx
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/RspecStrings.resx
@@ -5341,7 +5341,7 @@
     <value>Major Code Smell</value>
   </data>
   <data name="S6354_Description" xml:space="preserve">
-    <value>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes calls to static methods, and date/time functions are usually provided by system libraries as static methods.</value>
+    <value>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes calls to static methods, which cannot be changed or controlled. Date/time functions are usually provided by system libraries as static methods.</value>
   </data>
   <data name="S6354_IsActivatedByDefault" xml:space="preserve">
     <value>False</value>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/RspecStrings.resx
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/RspecStrings.resx
@@ -5337,6 +5337,39 @@
   <data name="S6146_Type" xml:space="preserve">
     <value>CODE_SMELL</value>
   </data>
+  <data name="S6354_Category" xml:space="preserve">
+    <value>Major Code Smell</value>
+  </data>
+  <data name="S6354_Description" xml:space="preserve">
+    <value>One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes calls to static methods, and date/time functions are usually provided by system libraries as static methods.</value>
+  </data>
+  <data name="S6354_IsActivatedByDefault" xml:space="preserve">
+    <value>False</value>
+  </data>
+  <data name="S6354_Remediation" xml:space="preserve">
+    <value>Constant/Issue</value>
+  </data>
+  <data name="S6354_RemediationCost" xml:space="preserve">
+    <value>20min</value>
+  </data>
+  <data name="S6354_Scope" xml:space="preserve">
+    <value>Main</value>
+  </data>
+  <data name="S6354_Severity" xml:space="preserve">
+    <value>Major</value>
+  </data>
+  <data name="S6354_Status" xml:space="preserve">
+    <value>ready</value>
+  </data>
+  <data name="S6354_Tags" xml:space="preserve">
+    <value />
+  </data>
+  <data name="S6354_Title" xml:space="preserve">
+    <value>Use a testable date/time provider.</value>
+  </data>
+  <data name="S6354_Type" xml:space="preserve">
+    <value>CODE_SMELL</value>
+  </data>
   <data name="S907_Category" xml:space="preserve">
     <value>Major Code Smell</value>
   </data>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseTestableTimeProvider.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseTestableTimeProvider.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.VisualBasic;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.VisualBasic
+{
+    [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+    [Rule(DiagnosticId)]
+    public sealed class UseTestableTimeProvider : UseTestableTimeProviderBase<SyntaxKind>
+    {
+        protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
+    }
+}

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseTestableTimeProvider.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseTestableTimeProvider.cs
@@ -27,7 +27,6 @@ using SonarAnalyzer.Helpers;
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    [Rule(DiagnosticId)]
     public sealed class UseTestableTimeProvider : UseTestableTimeProviderBase<SyntaxKind>
     {
         protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseTestableTimeProvider.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseTestableTimeProvider.cs
@@ -21,7 +21,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
-using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.VisualBasic

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseTestableTimeProvider.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseTestableTimeProvider.cs
@@ -18,11 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 
@@ -30,10 +28,8 @@ namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     [Rule(DiagnosticId)]
-    public sealed class UseTestableTimeProvider : UseTestableTimeProviderBase<IdentifierNameSyntax, SyntaxKind>
+    public sealed class UseTestableTimeProvider : UseTestableTimeProviderBase<SyntaxKind>
     {
         protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
-
-        protected override string NameOf(IdentifierNameSyntax identifier) => identifier.Identifier.Text;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseTestableTimeProvider.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseTestableTimeProvider.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * SonarAnalyzer for .NET
- * Copyright (C) 2015-2021 SonarSource SA
+ * Copyright (C) 2015-2022 SonarSource SA
  * mailto: contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseTestableTimeProvider.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseTestableTimeProvider.cs
@@ -18,9 +18,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 
@@ -28,8 +30,10 @@ namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     [Rule(DiagnosticId)]
-    public sealed class UseTestableTimeProvider : UseTestableTimeProviderBase<SyntaxKind>
+    public sealed class UseTestableTimeProvider : UseTestableTimeProviderBase<IdentifierNameSyntax, SyntaxKind>
     {
         protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
+
+        protected override string NameOf(IdentifierNameSyntax identifier) => identifier.Identifier.Text;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/CsRuleTypeMapping.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/CsRuleTypeMapping.cs
@@ -6351,7 +6351,7 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
                 //["6351"],
                 //["6352"],
                 //["6353"],
-                //["6354"],
+                ["6354"] = "CODE_SMELL",
                 //["6355"],
                 //["6356"],
                 //["6357"],

--- a/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/VbRuleTypeMapping.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/VbRuleTypeMapping.cs
@@ -6351,7 +6351,7 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
                 //["6351"],
                 //["6352"],
                 //["6353"],
-                //["6354"],
+                ["6354"] = "CODE_SMELL",
                 //["6355"],
                 //["6356"],
                 //["6357"],

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UseTestableTimeProviderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UseTestableTimeProviderTest.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * SonarAnalyzer for .NET
- * Copyright (C) 2015-2021 SonarSource SA
+ * Copyright (C) 2015-2022 SonarSource SA
  * mailto: contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UseTestableTimeProviderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UseTestableTimeProviderTest.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
+using CS = SonarAnalyzer.Rules.CSharp;
+using VB = SonarAnalyzer.Rules.VisualBasic;
+
+namespace SonarAnalyzer.UnitTest.Rules
+{
+    [TestClass]
+    public class UseTestableTimeProviderTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void UseTestableTimeProvider_CS() =>
+            Verifier.VerifyAnalyzer(@"TestCases\UseTestableTimeProvider.cs", new CS.UseTestableTimeProvider());
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void UseTestableTimeProvider_VB() =>
+            Verifier.VerifyAnalyzer(@"TestCases\UseTestableTimeProvider.vb", new VB.UseTestableTimeProvider());
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UseTestableTimeProviderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UseTestableTimeProviderTest.cs
@@ -31,11 +31,17 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestMethod]
         [TestCategory("Rule")]
         public void UseTestableTimeProvider_CS() =>
-            Verifier.VerifyAnalyzer(@"TestCases\UseTestableTimeProvider.cs", new CS.UseTestableTimeProvider());
+             new VerifierBuilder()
+                .AddAnalyzer(() => new CS.UseTestableTimeProvider())
+                .AddPaths("UseTestableTimeProvider.cs")
+                .Verify();
 
         [TestMethod]
         [TestCategory("Rule")]
         public void UseTestableTimeProvider_VB() =>
-            Verifier.VerifyAnalyzer(@"TestCases\UseTestableTimeProvider.vb", new VB.UseTestableTimeProvider());
+             new VerifierBuilder()
+                .AddAnalyzer(() => new VB.UseTestableTimeProvider())
+                .AddPaths("UseTestableTimeProvider.vb")
+                .Verify();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseTestableTimeProvider.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseTestableTimeProvider.cs
@@ -13,5 +13,14 @@ public class DateTimeAsProvider
     public void CompliantAre()
     {
         var other = DateTime.DaysInMonth(2000, 2); // Compliant
+        var noSystemDateTime = NotSystem.DateTime.Now; // Compliant
+    }
+}
+
+namespace NotSystem
+{
+    public class DateTime
+    {
+        public static DateTime Now => new DateTime();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseTestableTimeProvider.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseTestableTimeProvider.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+public class DateTimeAsProvider
+{
+    public void Noncompliant()
+    {
+        var now = DateTime.Now; // Noncompliant {{Use a testable (date) time provider instead.}}
+        //        ^^^^^^^^^^^^
+        var utc = DateTime.UtcNow; // Noncompliant
+        var today = DateTime.Today; // Noncompliant
+    }
+
+    public void CompliantAre()
+    {
+        var other = DateTime.DaysInMonth(2000, 2); // Compliant
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseTestableTimeProvider.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseTestableTimeProvider.vb
@@ -3,8 +3,8 @@
 Public Class DateTimeAsProvider
 
     Public Sub Noncompliant()
-        Dim now As Date = DateTime.Now ' Noncompliant {{Use a testable (Date) time provider instead.}}
-        '                     ^^^^^^^^^^^^
+        Dim now As Date = DateTime.Now ' Noncompliant {{Use a testable (date) time provider instead.}}
+        '                 ^^^^^^^^^^^^
         Dim utc As Date = DateTime.UtcNow ' Noncompliant
         Dim today As Date = DateTime.Today ' Noncompliant
     End Sub

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseTestableTimeProvider.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseTestableTimeProvider.vb
@@ -7,9 +7,29 @@ Public Class DateTimeAsProvider
         '                 ^^^^^^^^^^^^
         Dim utc As Date = DateTime.UtcNow ' Noncompliant
         Dim today As Date = DateTime.Today ' Noncompliant
+        Dim date As Date = Date.Now ' Noncompliant
     End Sub
 
     Public Sub CompliantAre()
         Dim other As Integer = DateTime.DaysInMonth(2000, 2) ' Compliant
+        Dim noSystemDateTime As NotSystem.DateTime = NotSystem.DateTime.Now ' Compliant
+        Dim noSystemtDate As NotSystem.Date = NotSystem.Date.Now ' Compliant
     End Sub
 End Class
+
+Namespace NotSystem
+    Public Class DateTime
+        Public Shared ReadOnly Property Now As DateTime
+            Get
+                Return New DateTime()
+            End Get
+        End Property
+    End Class
+    Public Class Date
+        Public Shared ReadOnly Property Now As NotSystem.Date
+            Get
+                Return New NotSystem.Date()
+            End Get
+        End Property
+    End Class
+End Namespace

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseTestableTimeProvider.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseTestableTimeProvider.vb
@@ -1,0 +1,15 @@
+﻿Imports System
+
+Public Class DateTimeAsProvider
+
+    Public Sub Noncompliant()
+        Dim now As Date = DateTime.Now ' Noncompliant {{Use a testable (Date) time provider instead.}}
+        '                     ^^^^^^^^^^^^
+        Dim utc As Date = DateTime.UtcNow ' Noncompliant
+        Dim today As Date = DateTime.Today ' Noncompliant
+    End Sub
+
+    Public Sub CompliantAre()
+        Dim other As Integer = DateTime.DaysInMonth(2000, 2) ' Compliant
+    End Sub
+End Class

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseTestableTimeProvider.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseTestableTimeProvider.vb
@@ -7,7 +7,7 @@ Public Class DateTimeAsProvider
         '                 ^^^^^^^^^^^^
         Dim utc As Date = DateTime.UtcNow ' Noncompliant
         Dim today As Date = DateTime.Today ' Noncompliant
-        Dim date As Date = Date.Now ' Noncompliant
+        Dim [date] As Date = Date.Now ' Noncompliant
     End Sub
 
     Public Sub CompliantAre()
@@ -25,7 +25,7 @@ Namespace NotSystem
             End Get
         End Property
     End Class
-    Public Class Date
+    Public Class [Date]
         Public Shared ReadOnly Property Now As NotSystem.Date
             Get
                 Return New NotSystem.Date()


### PR DESCRIPTION
As `DateTime.Now`, `DateTime.UtcNow` and `DateTime.Today` are not stub-able, usage should be discouraged. Detecting the usage is not the challenge obviously, writing down what to do instead in such a way that it helps developers might be.

-------------------------
# Description
One of the principles of a unit test is that it must have full control of the system under test. This is problematic when production code includes calls to the static references `DateTime.Now`, `DateTime.UtcNow` and `DateTime.Today`. There are two different approaches to solves this problem.

## A testable static reference
A static reference that can be adjusted, ideally supports an `IDisposable` method, that not only adjusts the time behaviour for the current thread only, but also for scope of the `using`.
``` C#
public static class Clock
{
    public static DateTime UtcNow();
    public static IDisposable SetTimeForCurrentThread(Func<DateTime> time);
}
```

## Interface
An interface that relies on the (UTC) time provided:
``` C#
public interface IClock
{
    DateTime UtcNow();
}
```

## Compliant code with static reference
``` C#
public class Cookie
{
    public DateTime? ExpirationDate { get; set; }
    public bool HasExpired() => ExpirationDate .HasValue && ExpirationDate .Value < Clock.UtcNow();
}

public class CookieTest
{
    [Test]
    public void Cookie_has_expired_when_expiration_date_in_past()
    {
        using (Clock.SetTimeForCurrentThread(() => new DateTime(2017, 06, 11)))
        {
             Assert.IsTrue(new Cookie { ExpirationDate = new DateTime(2017, 06, 10) }.HasExpired());
        }
    }
}
```

## Compliant code with interface
``` C#
public class Cookie
{
    public DateTime? ExpirationDate { get; set; }
    public bool HasExpired(IClock clock) => ExpirationDate .HasValue && ExpirationDate .Value < clock.UtcNow();
}

public class CookieTest
{
    [Test]
    public void Cookie_has_expired_when_expiration_date_in_past()
    {
        var clock = new TestClock(new DateTime(2017, 06, 11));
        Assert.IsTrue(new Cookie { ExpirationDate = new DateTime(2017, 06, 10) }.HasExpired(clock));
    }
}
```