### PR TITLE
SecurityHotspotTest: link only required references

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/CookieShouldBeHttpOnlyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/CookieShouldBeHttpOnlyTest.cs
@@ -18,11 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#if NET
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis;
-#endif
 using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.UnitTest.MetadataReferences;
@@ -41,8 +40,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Hotspot")]
         public void CookiesShouldBeHttpOnly_Nancy() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\CookieShouldBeHttpOnly_Nancy.cs",
-                new CS.CookieShouldBeHttpOnly(AnalyzerConfiguration.AlwaysEnabled),
-                NuGetMetadataReference.Nancy());
+                                    new CS.CookieShouldBeHttpOnly(AnalyzerConfiguration.AlwaysEnabled),
+                                    AdditionalReferences);
 
 #if NETFRAMEWORK // The analyzed code is valid only for .Net Framework
         [TestMethod]
@@ -50,8 +49,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Hotspot")]
         public void CookiesShouldBeHttpOnly() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\CookieShouldBeHttpOnly.cs",
-                new CS.CookieShouldBeHttpOnly(AnalyzerConfiguration.AlwaysEnabled),
-                MetadataReferenceFacade.SystemWeb);
+                                    new CS.CookieShouldBeHttpOnly(AnalyzerConfiguration.AlwaysEnabled),
+                                    MetadataReferenceFacade.SystemWeb);
 
         [DataTestMethod]
         [DataRow(@"TestCases\WebConfig\CookieShouldBeHttpOnly\HttpOnlyCookiesConfig")]
@@ -62,9 +61,9 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             var webConfigPath = Path.Combine(root, WebConfig);
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\CookieShouldBeHttpOnly_WithWebConfig.cs",
-                new CS.CookieShouldBeHttpOnly(AnalyzerConfiguration.AlwaysEnabled),
-                MetadataReferenceFacade.SystemWeb,
-                TestHelper.CreateSonarProjectConfig(root, TestHelper.CreateFilesToAnalyze(root, webConfigPath)));
+                                    new CS.CookieShouldBeHttpOnly(AnalyzerConfiguration.AlwaysEnabled),
+                                    MetadataReferenceFacade.SystemWeb,
+                                    TestHelper.CreateSonarProjectConfig(root, TestHelper.CreateFilesToAnalyze(root, webConfigPath)));
         }
 
         [TestMethod]
@@ -75,9 +74,9 @@ namespace SonarAnalyzer.UnitTest.Rules
             var root = @"TestCases\WebConfig\CookieShouldBeHttpOnly\NonHttpOnlyCookiesConfig";
             var webConfigPath = Path.Combine(root, WebConfig);
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\CookieShouldBeHttpOnly.cs",
-                new CS.CookieShouldBeHttpOnly(AnalyzerConfiguration.AlwaysEnabled),
-                MetadataReferenceFacade.SystemWeb,
-                TestHelper.CreateSonarProjectConfig(root, TestHelper.CreateFilesToAnalyze(root, webConfigPath)));
+                                    new CS.CookieShouldBeHttpOnly(AnalyzerConfiguration.AlwaysEnabled),
+                                    MetadataReferenceFacade.SystemWeb,
+                                    TestHelper.CreateSonarProjectConfig(root, TestHelper.CreateFilesToAnalyze(root, webConfigPath)));
         }
 
 #else
@@ -86,8 +85,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Hotspot")]
         public void CookiesShouldBeHttpOnly_NetCore() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\CookieShouldBeHttpOnly_NetCore.cs",
-                new CS.CookieShouldBeHttpOnly(AnalyzerConfiguration.AlwaysEnabled),
-                GetAdditionalReferences_NetCore());
+                                    new CS.CookieShouldBeHttpOnly(AnalyzerConfiguration.AlwaysEnabled),
+                                    GetAdditionalReferences_NetCore());
 
         [TestMethod]
         [TestCategory("Rule")]
@@ -99,5 +98,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         private static IEnumerable<MetadataReference> GetAdditionalReferences_NetCore() =>
             NuGetMetadataReference.MicrosoftAspNetCoreHttpFeatures(Constants.NuGetLatestVersion);
 #endif
+
+        internal static IEnumerable<MetadataReference> AdditionalReferences =>
+            NetStandardMetadataReference.Netstandard.Concat(NuGetMetadataReference.Nancy());
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/CookieShouldBeSecureTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/CookieShouldBeSecureTest.cs
@@ -18,10 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#if NET
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis;
-#endif
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.UnitTest.MetadataReferences;
@@ -38,8 +37,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Hotspot")]
         public void CookiesShouldBeSecure_Nancy() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\CookieShouldBeSecure_Nancy.cs",
-                new CS.CookieShouldBeSecure(AnalyzerConfiguration.AlwaysEnabled),
-                NuGetMetadataReference.Nancy());
+                                    new CS.CookieShouldBeSecure(AnalyzerConfiguration.AlwaysEnabled),
+                                    AdditionalReferences);
 
 #if NETFRAMEWORK // HttpCookie is not available on .Net Core
 
@@ -48,8 +47,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Hotspot")]
         public void CookiesShouldBeSecure() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\CookieShouldBeSecure.cs",
-                new CS.CookieShouldBeSecure(AnalyzerConfiguration.AlwaysEnabled),
-                MetadataReferenceFacade.SystemWeb);
+                                    new CS.CookieShouldBeSecure(AnalyzerConfiguration.AlwaysEnabled),
+                                    MetadataReferenceFacade.SystemWeb);
 
 #else
 
@@ -58,8 +57,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Hotspot")]
         public void CookiesShouldBeSecure_NetCore() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\CookieShouldBeSecure_NetCore.cs",
-                new CS.CookieShouldBeSecure(AnalyzerConfiguration.AlwaysEnabled),
-                GetAdditionalReferences_NetCore());
+                                    new CS.CookieShouldBeSecure(AnalyzerConfiguration.AlwaysEnabled),
+                                    GetAdditionalReferences_NetCore());
 
         [TestMethod]
         [TestCategory("Rule")]
@@ -73,6 +72,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             NuGetMetadataReference.MicrosoftAspNetCoreHttpFeatures(Constants.NuGetLatestVersion);
 
 #endif
-
+        internal static IEnumerable<MetadataReference> AdditionalReferences =>
+            NetStandardMetadataReference.Netstandard.Concat(NuGetMetadataReference.Nancy());
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/ExecutingSqlQueriesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/ExecutingSqlQueriesTest.cs
@@ -40,26 +40,26 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Hotspot")]
         public void ExecutingSqlQueries_CS_Net46() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\ExecutingSqlQueries_Net46.cs",
-                new CS.ExecutingSqlQueries(AnalyzerConfiguration.AlwaysEnabled),
-                GetReferencesNet46(Constants.NuGetLatestVersion));
+                                    new CS.ExecutingSqlQueries(AnalyzerConfiguration.AlwaysEnabled),
+                                    GetReferencesNet46(Constants.NuGetLatestVersion));
 
         [TestMethod]
         [TestCategory("Rule")]
         [TestCategory("Hotspot")]
         public void ExecutingSqlQueries_VB_Net46() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\ExecutingSqlQueries_Net46.vb",
-                new VB.ExecutingSqlQueries(AnalyzerConfiguration.AlwaysEnabled),
-                ParseOptionsHelper.FromVisualBasic15,
-                GetReferencesNet46(Constants.NuGetLatestVersion));
+                                    new VB.ExecutingSqlQueries(AnalyzerConfiguration.AlwaysEnabled),
+                                    ParseOptionsHelper.FromVisualBasic15,
+                                    GetReferencesNet46(Constants.NuGetLatestVersion));
 
         internal static IEnumerable<MetadataReference> GetReferencesNet46(string sqlServerCeVersion) =>
-            Enumerable.Empty<MetadataReference>()
-                .Concat(FrameworkMetadataReference.SystemData)
-                .Concat(FrameworkMetadataReference.SystemDataOracleClient)
-                .Concat(NuGetMetadataReference.SystemDataSqlServerCe(sqlServerCeVersion)
-                .Concat(NuGetMetadataReference.MySqlData("8.0.22"))
-                .Concat(NuGetMetadataReference.MicrosoftDataSqliteCore())
-                .Concat(NuGetMetadataReference.SystemDataSQLiteCore()));
+            NetStandardMetadataReference.Netstandard
+                                        .Concat(FrameworkMetadataReference.SystemData)
+                                        .Concat(FrameworkMetadataReference.SystemDataOracleClient)
+                                        .Concat(NuGetMetadataReference.SystemDataSqlServerCe(sqlServerCeVersion))
+                                        .Concat(NuGetMetadataReference.MySqlData("8.0.22"))
+                                        .Concat(NuGetMetadataReference.MicrosoftDataSqliteCore())
+                                        .Concat(NuGetMetadataReference.SystemDataSQLiteCore());
 
 #else
 
@@ -68,23 +68,23 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Hotspot")]
         public void ExecutingSqlQueries_CS_NetCore() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\ExecutingSqlQueries_NetCore.cs",
-                new CS.ExecutingSqlQueries(AnalyzerConfiguration.AlwaysEnabled),
-                ParseOptionsHelper.FromCSharp8,
-                GetReferencesNetCore(Constants.DotNetCore220Version));
+                                    new CS.ExecutingSqlQueries(AnalyzerConfiguration.AlwaysEnabled),
+                                    ParseOptionsHelper.FromCSharp8,
+                                    GetReferencesNetCore(Constants.DotNetCore220Version));
 
         [TestMethod]
         [TestCategory("Rule")]
         [TestCategory("Hotspot")]
         public void ExecutingSqlQueries_VB_NetCore() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\ExecutingSqlQueries_NetCore.vb",
-                new VB.ExecutingSqlQueries(AnalyzerConfiguration.AlwaysEnabled),
-                ParseOptionsHelper.FromVisualBasic15,
-                GetReferencesNetCore(Constants.DotNetCore220Version));
+                                    new VB.ExecutingSqlQueries(AnalyzerConfiguration.AlwaysEnabled),
+                                    ParseOptionsHelper.FromVisualBasic15,
+                                    GetReferencesNetCore(Constants.DotNetCore220Version));
 
         internal static IEnumerable<MetadataReference> GetReferencesNetCore(string entityFrameworkVersion) =>
             Enumerable.Empty<MetadataReference>()
-                .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCore(entityFrameworkVersion))
-                .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCoreRelational(entityFrameworkVersion));
+                      .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCore(entityFrameworkVersion))
+                      .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCoreRelational(entityFrameworkVersion));
 #endif
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/RequestsWithExcessiveLengthTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/RequestsWithExcessiveLengthTest.cs
@@ -76,7 +76,8 @@ namespace SonarAnalyzer.UnitTest.Rules
                 GetAdditionalReferences());
 
         internal static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(Constants.NuGetLatestVersion)
-                .Concat(NuGetMetadataReference.MicrosoftAspNetCoreMvcViewFeatures(Constants.NuGetLatestVersion));
+            NetStandardMetadataReference.Netstandard
+                                        .Concat(NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(Constants.NuGetLatestVersion))
+                                        .Concat(NuGetMetadataReference.MicrosoftAspNetCoreMvcViewFeatures(Constants.NuGetLatestVersion));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/UsingRegularExpressionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/UsingRegularExpressionsTest.cs
@@ -35,15 +35,15 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestCategory("Hotspot")]
         public void UsingRegularExpressions_CS() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\UsingRegularExpressions.cs",
-                new CS.UsingRegularExpressions(AnalyzerConfiguration.AlwaysEnabled),
-                MetadataReferenceFacade.RegularExpressions);
+                                    new CS.UsingRegularExpressions(AnalyzerConfiguration.AlwaysEnabled),
+                                    MetadataReferenceFacade.RegularExpressions);
 
         [TestMethod]
         [TestCategory("Rule")]
         [TestCategory("Hotspot")]
         public void UsingRegularExpressions_VB() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\UsingRegularExpressions.vb",
-                new VB.UsingRegularExpressions(AnalyzerConfiguration.AlwaysEnabled),
-                MetadataReferenceFacade.RegularExpressions);
+                                    new VB.UsingRegularExpressions(AnalyzerConfiguration.AlwaysEnabled),
+                                    MetadataReferenceFacade.RegularExpressions);
     }
 }


### PR DESCRIPTION
When running the hotspots, link only the required references instead of doing a union of all the references needed by all hotspots