### PR TITLE
Define &, |, and ! operators for Tracker Conditions

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/BuilderPatternDescriptor.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/BuilderPatternDescriptor.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Helpers
         }
 
         public bool IsMatch(InvocationContext context) =>
-            invocationConditions.All(x => x(context));
+            invocationConditions.All(x => x.Invoke(context));
 
         public bool IsValid(TInvocationSyntax invocation) =>
             isValid(invocation);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/CommandPathBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/CommandPathBase.cs
@@ -41,18 +41,18 @@ namespace SonarAnalyzer.Rules
             var inv = Language.Tracker.Invocation;
             inv.Track(input,
                 inv.MatchMethod(new MemberDescriptor(KnownType.System_Diagnostics_Process, "Start")),
-                c => IsInvalid(FirstArgument(c)));
+                new Condition(c => IsInvalid(FirstArgument(c))));
 
             var pa = Language.Tracker.PropertyAccess;
             pa.Track(input,
                 pa.MatchProperty(new MemberDescriptor(KnownType.System_Diagnostics_ProcessStartInfo, "FileName")),
                 pa.MatchSetter(),
-                c => IsInvalid((string)pa.AssignedValue(c)));
+                new Condition(c => IsInvalid((string)pa.AssignedValue(c))));
 
             var oc = Language.Tracker.ObjectCreation;
             oc.Track(input,
                 oc.MatchConstructor(KnownType.System_Diagnostics_ProcessStartInfo),
-                c => oc.ConstArgumentForParameter(c, "fileName") is string value && IsInvalid(value));
+                new Condition(c => oc.ConstArgumentForParameter(c, "fileName") is string value && IsInvalid(value)));
         }
 
         private bool IsInvalid(string path) =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/ExecutingSqlQueriesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/ExecutingSqlQueriesBase.cs
@@ -126,7 +126,7 @@ namespace SonarAnalyzer.Rules
             pa.Track(input,
                 pa.MatchProperty(properties),
                 pa.MatchSetter(),
-                c => IsTracked(GetSetValue(c), c),
+                new Condition(c => IsTracked(GetSetValue(c), c)),
                 pa.ExceptWhen(pa.AssignedValueIsConstant()));
 
             TrackObjectCreation(input, constructorsForFirstArgument, FirstArgumentIndex);
@@ -161,7 +161,7 @@ namespace SonarAnalyzer.Rules
             t.Track(input,
                 t.MatchConstructor(objectCreationTypes),
                 t.ArgumentAtIndexIs(argumentIndex, KnownType.System_String),
-                    c => IsTracked(GetArgumentAtIndex(c, argumentIndex), c),
+                    new Condition(c => IsTracked(GetArgumentAtIndex(c, argumentIndex), c)),
                 t.ExceptWhen(t.ArgumentAtIndexIsConst(argumentIndex)));
         }
 
@@ -175,7 +175,7 @@ namespace SonarAnalyzer.Rules
         }
 
         private TrackerBase<TSyntaxKind, InvocationContext>.Condition MethodHasRawSqlQueryParameter() =>
-            context =>
+            new Condition(context =>
             {
                 return Language.Syntax.NodeExpression(context.Node) is { } invocationExpression
                        && context.SemanticModel.GetSymbolInfo(invocationExpression).Symbol is IMethodSymbol methodSymbol
@@ -183,9 +183,9 @@ namespace SonarAnalyzer.Rules
 
                 static bool ParameterIsRawString(IMethodSymbol method, int index) =>
                     method.Parameters.Length > index && method.Parameters[index].IsType(KnownType.Microsoft_EntityFrameworkCore_RawSqlString);
-            };
+            });
 
         private TrackerBase<TSyntaxKind, InvocationContext>.Condition ArgumentAtIndexIsTracked(int index) =>
-            context => IsTracked(GetArgumentAtIndex(context, index), context);
+            new Condition(context => IsTracked(GetArgumentAtIndex(context, index), context));
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/ReadingStandardInputBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/ReadingStandardInputBase.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules
             inv.Track(input, inv.MatchMethod(new MemberDescriptor(KnownType.System_Console, nameof(Console.OpenStandardInput))));
 
             inv.Track(input,
-                WhenResultIsNotIgnored, // This is syntax-only check and we can execute it first
+                new Condition(c => WhenResultIsNotIgnored(c)), // This is syntax-only check and we can execute it first
                 inv.MatchMethod(
                     new MemberDescriptor(KnownType.System_Console, nameof(Console.Read)),
                     new MemberDescriptor(KnownType.System_Console, nameof(Console.ReadKey)),

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/UsingRegularExpressionsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/UsingRegularExpressionsBase.cs
@@ -60,10 +60,10 @@ namespace SonarAnalyzer.Rules
         }
 
         private TrackerBase<TSyntaxKind, InvocationContext>.Condition SecondArgumentIsHardcodedRegex() =>
-            context => GetStringLiteralAtIndex(context, 1) is string hardcodedString && IsComplexRegex(hardcodedString);
+            new Condition(context => GetStringLiteralAtIndex(context, 1) is string hardcodedString && IsComplexRegex(hardcodedString));
 
         private TrackerBase<TSyntaxKind, ObjectCreationContext>.Condition FirstArgumentIsHardcodedRegex() =>
-            context => GetStringLiteralAtIndex(context, 0) is string hardcodedString && IsComplexRegex(hardcodedString);
+            new Condition(context => GetStringLiteralAtIndex(context, 0) is string hardcodedString && IsComplexRegex(hardcodedString));
 
         private bool IsComplexRegex(string s) =>
             s != null

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/BaseTypeTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/BaseTypeTracker.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Helpers.Trackers
         internal Condition MatchSubclassesOf(params KnownType[] types)
         {
             var immutableTypes = types.ToImmutableArray();
-            return context =>
+            return new Condition(context =>
             {
                 foreach (var baseTypeNode in context.AllBaseTypeNodes)
                 {
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Helpers.Trackers
                 }
 
                 return false;
-            };
+            });
         }
 
         protected override BaseTypeContext CreateContext(SyntaxNodeAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/ElementAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/ElementAccessTracker.cs
@@ -31,13 +31,13 @@ namespace SonarAnalyzer.Helpers.Trackers
         public abstract Condition MatchProperty(MemberDescriptor member);
 
         internal Condition ArgumentAtIndexIs(int index, params KnownType[] types) =>
-            context => context.InvokedPropertySymbol.Value != null
+            new Condition(context => context.InvokedPropertySymbol.Value != null
                        && context.InvokedPropertySymbol.Value.Parameters.Length > index
-                       && context.InvokedPropertySymbol.Value.Parameters[0].Type.DerivesOrImplements(types[index]);
+                       && context.InvokedPropertySymbol.Value.Parameters[0].Type.DerivesOrImplements(types[index]));
 
         internal Condition MatchIndexerIn(params KnownType[] types) =>
-            context => context.InvokedPropertySymbol.Value != null
-                       && context.InvokedPropertySymbol.Value.ContainingType.DerivesOrImplementsAny(types.ToImmutableArray());
+            new Condition(context => context.InvokedPropertySymbol.Value != null
+                       && context.InvokedPropertySymbol.Value.ContainingType.DerivesOrImplementsAny(types.ToImmutableArray()));
 
         protected override ElementAccessContext CreateContext(SyntaxNodeAnalysisContext context) =>
             new ElementAccessContext(context);

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/FieldAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/FieldAccessTracker.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Helpers.Trackers
         protected abstract bool IsIdentifierWithinMemberAccess(SyntaxNode expression);
 
         public Condition MatchField(params MemberDescriptor[] fields) =>
-            context => MemberDescriptor.MatchesAny(context.FieldName, context.InvokedFieldSymbol, false, Language.NameComparison, fields);
+            new Condition(context => MemberDescriptor.MatchesAny(context.FieldName, context.InvokedFieldSymbol, false, Language.NameComparison, fields));
 
         protected override FieldAccessContext CreateContext(SyntaxNodeAnalysisContext context)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/InvocationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/InvocationTracker.cs
@@ -33,48 +33,45 @@ namespace SonarAnalyzer.Helpers.Trackers
         protected abstract SyntaxToken? ExpectedExpressionIdentifier(SyntaxNode expression);
 
         public Condition MatchMethod(params MemberDescriptor[] methods) =>
-           context => MemberDescriptor.MatchesAny(context.MethodName, context.MethodSymbol, true, Language.NameComparison, methods);
+           new Condition(context => MemberDescriptor.MatchesAny(context.MethodName, context.MethodSymbol, true, Language.NameComparison, methods));
 
         public Condition MethodNameIs(string methodName) =>
-            context => context.MethodName == methodName;
+            new Condition(context => context.MethodName == methodName);
 
         public Condition MethodIsStatic() =>
-            context => context.MethodSymbol.Value != null
-                       && context.MethodSymbol.Value.IsStatic;
+            new Condition(context => context.MethodSymbol.Value != null
+                       && context.MethodSymbol.Value.IsStatic);
 
         public Condition MethodIsExtension() =>
-            context => context.MethodSymbol.Value != null
-                       && context.MethodSymbol.Value.IsExtensionMethod;
+            new Condition(context => context.MethodSymbol.Value != null
+                       && context.MethodSymbol.Value.IsExtensionMethod);
 
         public Condition MethodHasParameters(int count) =>
-            context => context.MethodSymbol.Value != null
-                       && context.MethodSymbol.Value.Parameters.Length == count;
+            new Condition(context => context.MethodSymbol.Value != null
+                       && context.MethodSymbol.Value.Parameters.Length == count);
 
         public Condition IsInvalidBuilderInitialization<TInvocationSyntax>(BuilderPatternCondition<TSyntaxKind, TInvocationSyntax> condition) where TInvocationSyntax : SyntaxNode =>
-            condition.IsInvalidBuilderInitialization;
+            new Condition(condition.IsInvalidBuilderInitialization);
 
-        public Condition ExceptWhen(Condition condition) =>
-            value => !condition(value);
+        public Condition ExceptWhen(Condition condition) => !condition;
 
-        public Condition And(Condition condition1, Condition condition2) =>
-            value => condition1(value) && condition2(value);
+        public Condition And(Condition condition1, Condition condition2) => condition1 & condition2;
 
-        public Condition Or(Condition condition1, Condition condition2) =>
-            value => condition1(value) || condition2(value);
+        public Condition Or(Condition condition1, Condition condition2) => condition1 | condition2;
 
         public Condition Or(Condition condition1, Condition condition2, Condition condition3) =>
-            value => condition1(value) || condition2(value) || condition3(value);
+            condition1 | condition2 | condition3;
 
         internal Condition MethodReturnTypeIs(KnownType returnType) =>
-            context => context.MethodSymbol.Value != null
-                       && context.MethodSymbol.Value.ReturnType.DerivesFrom(returnType);
+            new Condition(context => context.MethodSymbol.Value != null
+                       && context.MethodSymbol.Value.ReturnType.DerivesFrom(returnType));
 
         internal Condition ArgumentIsBoolConstant(string parameterName, bool expectedValue) =>
-            context => ConstArgumentForParameter(context, parameterName) is bool boolValue
-                       && boolValue == expectedValue;
+            new Condition(context => ConstArgumentForParameter(context, parameterName) is bool boolValue
+                       && boolValue == expectedValue);
 
         internal Condition IsIHeadersDictionary() =>
-            context =>
+           new Condition(context =>
             {
                 const int argumentsNumber = 2;
 
@@ -83,7 +80,7 @@ namespace SonarAnalyzer.Helpers.Trackers
                 return containingType.TypeArguments.Length == argumentsNumber
                        && containingType.TypeArguments[0].Is(KnownType.System_String)
                        && containingType.TypeArguments[1].Is(KnownType.Microsoft_Extensions_Primitives_StringValues);
-            };
+            });
 
         protected override InvocationContext CreateContext(SyntaxNodeAnalysisContext context) =>
             Language.Syntax.NodeExpression(context.Node) is { } expression

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/MethodDeclarationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/MethodDeclarationTracker.cs
@@ -59,28 +59,28 @@ namespace SonarAnalyzer.Helpers.Trackers
             bool IsTrackedMethod(IMethodSymbol methodSymbol, Compilation compilation)
             {
                 var conditionContext = new MethodDeclarationContext(methodSymbol, compilation);
-                return conditions.All(c => c(conditionContext));
+                return conditions.All(c => c.Invoke(conditionContext));
             }
         }
 
         public Condition MatchMethodName(params string[] methodNames) =>
-            context => methodNames.Contains(context.MethodSymbol.Name);
+            new Condition(context => methodNames.Contains(context.MethodSymbol.Name));
 
         public Condition IsOrdinaryMethod() =>
-            context => context.MethodSymbol.MethodKind == MethodKind.Ordinary;
+            new Condition(context => context.MethodSymbol.MethodKind == MethodKind.Ordinary);
 
         public Condition IsMainMethod() =>
-            context => context.MethodSymbol.IsMainMethod();
+            new Condition(context => context.MethodSymbol.IsMainMethod());
 
         internal Condition AnyParameterIsOfType(params KnownType[] types)
         {
             var typesArray = types.ToImmutableArray();
-            return context =>
+            return new Condition(context =>
                 context.MethodSymbol.Parameters.Length > 0
-                && context.MethodSymbol.Parameters.Any(parameter => parameter.Type.DerivesOrImplementsAny(typesArray));
+                && context.MethodSymbol.Parameters.Any(parameter => parameter.Type.DerivesOrImplementsAny(typesArray)));
         }
 
         internal Condition DecoratedWithAnyAttribute(params KnownType[] attributeTypes) =>
-            context => context.MethodSymbol.GetAttributes().Any(a => a.AttributeClass.IsAny(attributeTypes));
+            new Condition(context => context.MethodSymbol.GetAttributes().Any(a => a.AttributeClass.IsAny(attributeTypes)));
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/ObjectCreationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/ObjectCreationTracker.cs
@@ -29,48 +29,45 @@ namespace SonarAnalyzer.Helpers.Trackers
         internal abstract Condition ArgumentAtIndexIsConst(int index);
         internal abstract object ConstArgumentForParameter(ObjectCreationContext context, string parameterName);
 
-        public Condition ExceptWhen(Condition condition) =>
-            value => !condition(value);
+        public Condition ExceptWhen(Condition condition) => !condition;
 
-        public Condition And(Condition condition1, Condition condition2) =>
-            value => condition1(value) && condition2(value);
+        public Condition And(Condition condition1, Condition condition2) => condition1 & condition2;
 
-        public Condition Or(Condition condition1, Condition condition2) =>
-            value => condition1(value) || condition2(value);
+        public Condition Or(Condition condition1, Condition condition2) => condition1 | condition2;
 
         public Condition Or(Condition condition1, Condition condition2, Condition condition3) =>
-            value => condition1(value) || condition2(value) || condition3(value);
+            condition1 | condition2 | condition3;
 
         internal Condition ArgumentIsBoolConstant(string parameterName, bool expectedValue) =>
-            context => ConstArgumentForParameter(context, parameterName) is bool boolValue && boolValue == expectedValue;
+            new Condition(context => ConstArgumentForParameter(context, parameterName) is bool boolValue && boolValue == expectedValue);
 
         internal Condition ArgumentAtIndexIs(int index, KnownType type) =>
-            context => context.InvokedConstructorSymbol.Value != null
+            new Condition(context => context.InvokedConstructorSymbol.Value != null
                        && context.InvokedConstructorSymbol.Value.Parameters.Length > index
-                       && context.InvokedConstructorSymbol.Value.Parameters[index].Type.Is(type);
+                       && context.InvokedConstructorSymbol.Value.Parameters[index].Type.Is(type));
 
         internal Condition WhenDerivesOrImplementsAny(params KnownType[] types) =>
-            context => context.InvokedConstructorSymbol.Value != null
+            new Condition(context => context.InvokedConstructorSymbol.Value != null
                        && context.InvokedConstructorSymbol.Value.IsConstructor()
-                       && context.InvokedConstructorSymbol.Value.ContainingType.DerivesOrImplementsAny(types.ToImmutableArray());
+                       && context.InvokedConstructorSymbol.Value.ContainingType.DerivesOrImplementsAny(types.ToImmutableArray()));
 
         internal Condition MatchConstructor(params KnownType[] types) =>
             // We cannot do a syntax check first because a type name can be aliased with
             // a using Alias = Fully.Qualified.Name and we will generate false negative
             // for new Alias()
-            context => context.InvokedConstructorSymbol.Value != null
+            new Condition(context => context.InvokedConstructorSymbol.Value != null
                        && context.InvokedConstructorSymbol.Value.IsConstructor()
-                       && context.InvokedConstructorSymbol.Value.ContainingType.IsAny(types);
+                       && context.InvokedConstructorSymbol.Value.ContainingType.IsAny(types));
 
         internal Condition WhenDerivesFrom(KnownType baseType) =>
-            context => context.InvokedConstructorSymbol.Value != null
+            new Condition(context => context.InvokedConstructorSymbol.Value != null
                        && context.InvokedConstructorSymbol.Value.IsConstructor()
-                       && context.InvokedConstructorSymbol.Value.ContainingType.DerivesFrom(baseType);
+                       && context.InvokedConstructorSymbol.Value.ContainingType.DerivesFrom(baseType));
 
         internal Condition WhenImplements(KnownType baseType) =>
-            context => context.InvokedConstructorSymbol.Value != null
+            new Condition(context => context.InvokedConstructorSymbol.Value != null
                        && context.InvokedConstructorSymbol.Value.IsConstructor()
-                       && context.InvokedConstructorSymbol.Value.ContainingType.Implements(baseType);
+                       && context.InvokedConstructorSymbol.Value.ContainingType.Implements(baseType));
 
         protected override ObjectCreationContext CreateContext(SyntaxNodeAnalysisContext context) =>
             new ObjectCreationContext(context);

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessTracker.cs
@@ -33,19 +33,18 @@ namespace SonarAnalyzer.Helpers.Trackers
         protected abstract bool IsIdentifierWithinMemberAccess(SyntaxNode expression);
 
         public Condition MatchProperty(params MemberDescriptor[] properties) =>
-            context => MemberDescriptor.MatchesAny(context.PropertyName, context.PropertySymbol, false, Language.NameComparison, properties);
+            new Condition(context => MemberDescriptor.MatchesAny(context.PropertyName, context.PropertySymbol, false, Language.NameComparison, properties));
 
-        public Condition ExceptWhen(Condition condition) =>
-            value => !condition(value);
+        public Condition ExceptWhen(Condition condition) => !condition;
 
         public Condition And(Condition condition1, Condition condition2) =>
-            value => condition1(value) && condition2(value);
+            condition1 & condition2;
 
         public Condition Or(Condition condition1, Condition condition2) =>
-            value => condition1(value) || condition2(value);
+            condition1 | condition2;
 
         public Condition Or(Condition condition1, Condition condition2, Condition condition3) =>
-            value => condition1(value) || condition2(value) || condition3(value);
+            condition1 | condition2 | condition3;
 
         protected override PropertyAccessContext CreateContext(SyntaxNodeAnalysisContext context)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/SyntaxTrackerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/SyntaxTrackerBase.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Helpers
             void TrackAndReportIfNecessary(SyntaxNodeAnalysisContext c)
             {
                 if (CreateContext(c) is { } trackingContext
-                    && conditions.All(c => c(trackingContext))
+                    && conditions.All(c => c.Invoke(trackingContext))
                     && trackingContext.PrimaryLocation != null
                     && trackingContext.PrimaryLocation != Location.None)
                 {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/ConditionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/ConditionTest.cs
@@ -1,0 +1,66 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Condition = SonarAnalyzer.Helpers.Trackers.CSharpBaseTypeTracker.Condition;
+
+namespace SonarAnalyzer.UnitTest.Helpers
+{
+    public class ConditionTest
+    {
+        public static readonly Condition True = new Condition(context => true);
+        public static readonly Condition False = new Condition(context => false);
+
+        [TestMethod]
+        public void True_and_True_is_True()
+        {
+            var combined = True & True;
+            Assert.IsTrue(combined.Invoke(null));
+        }
+
+        [TestMethod]
+        public void True_and_False_is_False()
+        {
+            var combined = True & False;
+            Assert.IsFalse(combined.Invoke(null));
+        }
+
+        [TestMethod]
+        public void False_or_False_is_False()
+        {
+            var combined = False | False;
+            Assert.IsFalse(combined.Invoke(null));
+        }
+
+        [TestMethod]
+        public void True_or_False_is_True()
+        {
+            var combined = True | False;
+            Assert.IsTrue(combined.Invoke(null));
+        }
+
+        [TestMethod]
+        public void Not_True_is_False()
+        {
+            var negated = !True;
+            Assert.IsFalse(negated.Invoke(null));
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/BaseTypeTrackerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/BaseTypeTrackerTest.cs
@@ -50,14 +50,14 @@ End Class";
             var tracker = new CSharpBaseTypeTracker();
 
             var context = CreateContext<CSharpSyntax.BaseListSyntax>(TestInputCS, AnalyzerLanguage.CSharp, x => Enumerable.Empty<SyntaxNode>());
-            tracker.MatchSubclassesOf(KnownType.System_Exception)(context).Should().BeFalse();
+            tracker.MatchSubclassesOf(KnownType.System_Exception).Invoke(context).Should().BeFalse();
 
             context = CreateContext<CSharpSyntax.BaseListSyntax>(TestInputCS, AnalyzerLanguage.CSharp, x => null);
-            tracker.MatchSubclassesOf(KnownType.System_Exception)(context).Should().BeFalse();
+            tracker.MatchSubclassesOf(KnownType.System_Exception).Invoke(context).Should().BeFalse();
 
             context = CreateContext<CSharpSyntax.BaseListSyntax>(TestInputCS, AnalyzerLanguage.CSharp, x => x.Types.Select(x => x.Type));
-            tracker.MatchSubclassesOf(KnownType.System_Exception)(context).Should().BeTrue();
-            tracker.MatchSubclassesOf(KnownType.System_Attribute)(context).Should().BeFalse();
+            tracker.MatchSubclassesOf(KnownType.System_Exception).Invoke(context).Should().BeTrue();
+            tracker.MatchSubclassesOf(KnownType.System_Attribute).Invoke(context).Should().BeFalse();
         }
 
         [TestMethod]
@@ -65,14 +65,14 @@ End Class";
         {
             var tracker = new VisualBasicBaseTypeTracker();
             var context = CreateContext<VBSyntax.InheritsStatementSyntax>(TestInputVB, AnalyzerLanguage.VisualBasic, x => Enumerable.Empty<SyntaxNode>());
-            tracker.MatchSubclassesOf(KnownType.System_Exception)(context).Should().BeFalse();
+            tracker.MatchSubclassesOf(KnownType.System_Exception).Invoke(context).Should().BeFalse();
 
             context = CreateContext<VBSyntax.InheritsStatementSyntax>(TestInputVB, AnalyzerLanguage.VisualBasic, x => null);
-            tracker.MatchSubclassesOf(KnownType.System_Exception)(context).Should().BeFalse();
+            tracker.MatchSubclassesOf(KnownType.System_Exception).Invoke(context).Should().BeFalse();
 
             context = CreateContext<VBSyntax.InheritsStatementSyntax>(TestInputVB, AnalyzerLanguage.VisualBasic, x => x.Types);
-            tracker.MatchSubclassesOf(KnownType.System_Exception)(context).Should().BeTrue();
-            tracker.MatchSubclassesOf(KnownType.System_Attribute)(context).Should().BeFalse();
+            tracker.MatchSubclassesOf(KnownType.System_Exception).Invoke(context).Should().BeTrue();
+            tracker.MatchSubclassesOf(KnownType.System_Attribute).Invoke(context).Should().BeFalse();
         }
 
         private static BaseTypeContext CreateContext<TSyntaxNodeType>(string testInput, AnalyzerLanguage language, Func<TSyntaxNodeType, IEnumerable<SyntaxNode>> baseTypeNodes)


### PR DESCRIPTION
Fixes #4305.

- [ ] There are still places left where the delegates have to be converted to a `Condition` instance.