### PR TITLE
Cleanup SymbolHelper

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
@@ -201,7 +201,7 @@ namespace SonarAnalyzer.Helpers
             method.MethodKind == MethodKind.Destructor;
 
         public static bool IsSameNamespace(this INamespaceSymbol namespace1, INamespaceSymbol namespace2) =>
-            namespace1.IsGlobalNamespace && namespace2.IsGlobalNamespace
+            (namespace1.IsGlobalNamespace && namespace2.IsGlobalNamespace)
             || (namespace1.Name.Equals(namespace2.Name)
                 && namespace1.ContainingNamespace != null
                 && namespace2.ContainingNamespace != null

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
@@ -35,27 +35,16 @@ namespace SonarAnalyzer.Helpers
                 yield break;
             }
 
-            foreach (var typeMember in @namespace.GetTypeMembers().SelectMany(t => GetAllNamedTypes(t)))
+            foreach (var typeMember in @namespace.GetTypeMembers().SelectMany(GetAllNamedTypes))
             {
                 yield return typeMember;
             }
 
-            foreach (var typeMember in @namespace.GetNamespaceMembers().SelectMany(t => GetAllNamedTypes(t)))
+            foreach (var typeMember in @namespace.GetNamespaceMembers().SelectMany(GetAllNamedTypes))
             {
                 yield return typeMember;
             }
         }
-
-        internal static IEnumerable<AttributeData> GetAttributes(this ISymbol symbol, KnownType attributeType) =>
-            symbol?.GetAttributes().Where(a => a.AttributeClass.Is(attributeType))
-                ?? Enumerable.Empty<AttributeData>();
-
-        internal static IEnumerable<AttributeData> GetAttributes(this ISymbol symbol, ImmutableArray<KnownType> attributeTypes) =>
-            symbol?.GetAttributes().Where(a => a.AttributeClass.IsAny(attributeTypes))
-                ?? Enumerable.Empty<AttributeData>();
-
-        internal static bool AnyAttributeDerivesFrom(this ISymbol symbol, KnownType attributeType) =>
-            symbol?.GetAttributes().Any(a => a.AttributeClass.DerivesFrom(attributeType)) ?? false;
 
         public static IEnumerable<INamedTypeSymbol> GetAllNamedTypes(this INamedTypeSymbol type)
         {
@@ -66,7 +55,7 @@ namespace SonarAnalyzer.Helpers
 
             yield return type;
 
-            foreach (var nestedType in type.GetTypeMembers().SelectMany(t => GetAllNamedTypes(t)))
+            foreach (var nestedType in type.GetTypeMembers().SelectMany(GetAllNamedTypes))
             {
                 yield return nestedType;
             }
@@ -86,10 +75,10 @@ namespace SonarAnalyzer.Helpers
             }
 
             return symbol.ContainingType
-                .AllInterfaces
-                .SelectMany(@interface => @interface.GetMembers())
-                .OfType<T>()
-                .FirstOrDefault(member => symbol.Equals(symbol.ContainingType.FindImplementationForInterfaceMember(member)));
+                         .AllInterfaces
+                         .SelectMany(@interface => @interface.GetMembers())
+                         .OfType<T>()
+                         .FirstOrDefault(member => symbol.Equals(symbol.ContainingType.FindImplementationForInterfaceMember(member)));
         }
 
         public static T GetOverriddenMember<T>(this T symbol)
@@ -105,28 +94,14 @@ namespace SonarAnalyzer.Helpers
                 return null;
             }
 
-            switch (symbol.Kind)
+            return symbol.Kind switch
             {
-                case SymbolKind.Method:
-                    return (T)((IMethodSymbol)symbol).OverriddenMethod;
-
-                case SymbolKind.Property:
-                    return (T)((IPropertySymbol)symbol).OverriddenProperty;
-
-                case SymbolKind.Event:
-                    return (T)((IEventSymbol)symbol).OverriddenEvent;
-
-                default:
-                    throw new ArgumentException(
-                        $"Only methods, properties and events can be overridden. {typeof(T).Name} was provided",
-                        nameof(symbol));
-            }
+                SymbolKind.Method => (T)((IMethodSymbol)symbol).OverriddenMethod,
+                SymbolKind.Property => (T)((IPropertySymbol)symbol).OverriddenProperty,
+                SymbolKind.Event => (T)((IEventSymbol)symbol).OverriddenEvent,
+                _ => throw new ArgumentException($"Only methods, properties and events can be overridden. {typeof(T).Name} was provided", nameof(symbol))
+            };
         }
-
-        public static bool CanSymbolBeInterfaceMemberOrOverride(ISymbol symbol) =>
-            symbol?.Kind == SymbolKind.Method
-            || symbol?.Kind == SymbolKind.Property
-            || symbol?.Kind == SymbolKind.Event;
 
         public static IEnumerable<INamedTypeSymbol> GetSelfAndBaseTypes(this ITypeSymbol type)
         {
@@ -143,18 +118,15 @@ namespace SonarAnalyzer.Helpers
             }
         }
 
-        public static bool IsChangeable(this ISymbol symbol)
-        {
-            return !symbol.IsAbstract &&
-                !symbol.IsVirtual &&
-                symbol.GetInterfaceMember() == null &&
-                symbol.GetOverriddenMember() == null;
-        }
+        public static bool IsChangeable(this ISymbol symbol) =>
+            !symbol.IsAbstract
+            && !symbol.IsVirtual
+            && symbol.GetInterfaceMember() == null
+            && symbol.GetOverriddenMember() == null;
 
         public static bool IsExtensionOn(this IMethodSymbol methodSymbol, KnownType type)
         {
-            if (methodSymbol == null ||
-                !methodSymbol.IsExtensionMethod)
+            if (!(methodSymbol is {IsExtensionMethod: true}))
             {
                 return false;
             }
@@ -170,52 +142,19 @@ namespace SonarAnalyzer.Helpers
             return constructedFrom.Is(type);
         }
 
-        public static IEnumerable<IParameterSymbol> GetParameters(this ISymbol symbol)
-        {
-            switch (symbol.Kind)
+        public static IEnumerable<IParameterSymbol> GetParameters(this ISymbol symbol) =>
+            symbol.Kind switch
             {
-                case SymbolKind.Method:
-                    return ((IMethodSymbol)symbol).Parameters;
+                SymbolKind.Method => ((IMethodSymbol)symbol).Parameters,
+                SymbolKind.Property => ((IPropertySymbol)symbol).Parameters,
+                _ => Enumerable.Empty<IParameterSymbol>()
+            };
 
-                case SymbolKind.Property:
-                    return ((IPropertySymbol)symbol).Parameters;
+        public static bool IsAnyAttributeInOverridingChain(IPropertySymbol propertySymbol) =>
+            IsAnyAttributeInOverridingChain(propertySymbol, property => property.OverriddenProperty);
 
-                default:
-                    return Enumerable.Empty<IParameterSymbol>();
-            }
-        }
-
-        public static bool IsAnyAttributeInOverridingChain(IPropertySymbol propertySymbol)
-        {
-            return IsAnyAttributeInOverridingChain(propertySymbol, property => property.OverriddenProperty);
-        }
-
-        public static bool IsAnyAttributeInOverridingChain(IMethodSymbol methodSymbol)
-        {
-            return IsAnyAttributeInOverridingChain(methodSymbol, method => method.OverriddenMethod);
-        }
-
-        private static bool IsAnyAttributeInOverridingChain<TSymbol>(TSymbol symbol, Func<TSymbol, TSymbol> getOverriddenMember)
-            where TSymbol : class, ISymbol
-        {
-            var currentSymbol = symbol;
-            while (currentSymbol != null)
-            {
-                if (currentSymbol.GetAttributes().Any())
-                {
-                    return true;
-                }
-
-                if (!currentSymbol.IsOverride)
-                {
-                    return false;
-                }
-
-                currentSymbol = getOverriddenMember(currentSymbol);
-            }
-
-            return false;
-        }
+        public static bool IsAnyAttributeInOverridingChain(IMethodSymbol methodSymbol) =>
+            IsAnyAttributeInOverridingChain(methodSymbol, method => method.OverriddenMethod);
 
         public static Accessibility GetEffectiveAccessibility(this ISymbol symbol)
         {
@@ -250,20 +189,38 @@ namespace SonarAnalyzer.Helpers
         {
             var effectiveAccessibility = GetEffectiveAccessibility(symbol);
 
-            return effectiveAccessibility == Accessibility.Public ||
-                effectiveAccessibility == Accessibility.Protected ||
-                effectiveAccessibility == Accessibility.ProtectedOrInternal;
+            return effectiveAccessibility == Accessibility.Public
+                   || effectiveAccessibility == Accessibility.Protected
+                   || effectiveAccessibility == Accessibility.ProtectedOrInternal;
         }
 
-        public static bool IsConstructor(this ISymbol symbol)
-        {
-            return symbol.Kind == SymbolKind.Method && symbol.Name == ".ctor";
-        }
+        public static bool IsConstructor(this ISymbol symbol) =>
+            symbol.Kind == SymbolKind.Method && symbol.Name == ".ctor";
 
-        public static bool IsDestructor(this IMethodSymbol method)
-        {
-            return method.MethodKind == MethodKind.Destructor;
-        }
+        public static bool IsDestructor(this IMethodSymbol method) =>
+            method.MethodKind == MethodKind.Destructor;
+
+        public static bool IsSameNamespace(this INamespaceSymbol namespace1, INamespaceSymbol namespace2) =>
+            namespace1.IsGlobalNamespace && namespace2.IsGlobalNamespace
+            || (namespace1.Name.Equals(namespace2.Name)
+                && namespace1.ContainingNamespace != null
+                && namespace2.ContainingNamespace != null
+                && IsSameNamespace(namespace1.ContainingNamespace, namespace2.ContainingNamespace));
+
+        public static bool IsSameOrAncestorOf(this INamespaceSymbol thisNamespace, INamespaceSymbol namespaceToCheck) =>
+            IsSameNamespace(thisNamespace, namespaceToCheck)
+            || (namespaceToCheck.ContainingNamespace != null && IsSameOrAncestorOf(thisNamespace, namespaceToCheck.ContainingNamespace));
+
+        internal static IEnumerable<AttributeData> GetAttributes(this ISymbol symbol, KnownType attributeType) =>
+            symbol?.GetAttributes().Where(a => a.AttributeClass.Is(attributeType))
+            ?? Enumerable.Empty<AttributeData>();
+
+        internal static IEnumerable<AttributeData> GetAttributes(this ISymbol symbol, ImmutableArray<KnownType> attributeTypes) =>
+            symbol?.GetAttributes().Where(a => a.AttributeClass.IsAny(attributeTypes))
+            ?? Enumerable.Empty<AttributeData>();
+
+        internal static bool AnyAttributeDerivesFrom(this ISymbol symbol, KnownType attributeType) =>
+            symbol?.GetAttributes().Any(a => a.AttributeClass.DerivesFrom(attributeType)) ?? false;
 
         internal static bool IsKnownType(this SyntaxNode syntaxNode, KnownType knownType, SemanticModel semanticModel)
         {
@@ -278,19 +235,31 @@ namespace SonarAnalyzer.Helpers
             return symbolType.Is(knownType);
         }
 
-        public static bool IsSameNamespace(this INamespaceSymbol namespace1, INamespaceSymbol namespace2)
-        {
-            return namespace1.IsGlobalNamespace && namespace2.IsGlobalNamespace
-                || (namespace1.Name.Equals(namespace2.Name)
-                && namespace1.ContainingNamespace != null
-                && namespace2.ContainingNamespace != null
-                && IsSameNamespace(namespace1.ContainingNamespace, namespace2.ContainingNamespace));
-        }
+        private static bool CanSymbolBeInterfaceMemberOrOverride(ISymbol symbol) =>
+            symbol?.Kind == SymbolKind.Method
+            || symbol?.Kind == SymbolKind.Property
+            || symbol?.Kind == SymbolKind.Event;
 
-        public static bool IsSameOrAncestorOf(this INamespaceSymbol thisNamespace, INamespaceSymbol namespaceToCheck)
+        private static bool IsAnyAttributeInOverridingChain<TSymbol>(TSymbol symbol, Func<TSymbol, TSymbol> getOverriddenMember)
+            where TSymbol : class, ISymbol
         {
-            return IsSameNamespace(thisNamespace, namespaceToCheck)
-                || (namespaceToCheck.ContainingNamespace != null && IsSameOrAncestorOf(thisNamespace, namespaceToCheck.ContainingNamespace));
+            var currentSymbol = symbol;
+            while (currentSymbol != null)
+            {
+                if (currentSymbol.GetAttributes().Any())
+                {
+                    return true;
+                }
+
+                if (!currentSymbol.IsOverride)
+                {
+                    return false;
+                }
+
+                currentSymbol = getOverriddenMember(currentSymbol);
+            }
+
+            return false;
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
@@ -64,12 +64,9 @@ namespace SonarAnalyzer.Helpers
         public static T GetInterfaceMember<T>(this T symbol)
             where T : class, ISymbol
         {
-            if (!CanSymbolBeInterfaceMemberOrOverride(symbol))
-            {
-                return null;
-            }
-
-            if (symbol.IsOverride)
+            if (symbol == null
+                || symbol.IsOverride
+                || !CanBeInterfaceMember(symbol))
             {
                 return null;
             }
@@ -84,12 +81,7 @@ namespace SonarAnalyzer.Helpers
         public static T GetOverriddenMember<T>(this T symbol)
             where T : class, ISymbol
         {
-            if (!CanSymbolBeInterfaceMemberOrOverride(symbol))
-            {
-                return null;
-            }
-
-            if (!symbol.IsOverride)
+            if (!(symbol is {IsOverride: true}))
             {
                 return null;
             }
@@ -235,11 +227,6 @@ namespace SonarAnalyzer.Helpers
             return symbolType.Is(knownType);
         }
 
-        private static bool CanSymbolBeInterfaceMemberOrOverride(ISymbol symbol) =>
-            symbol?.Kind == SymbolKind.Method
-            || symbol?.Kind == SymbolKind.Property
-            || symbol?.Kind == SymbolKind.Event;
-
         private static bool IsAnyAttributeInOverridingChain<TSymbol>(TSymbol symbol, Func<TSymbol, TSymbol> getOverriddenMember)
             where TSymbol : class, ISymbol
         {
@@ -261,5 +248,10 @@ namespace SonarAnalyzer.Helpers
 
             return false;
         }
+
+        private static bool CanBeInterfaceMember(ISymbol symbol) =>
+            symbol.Kind == SymbolKind.Method
+            || symbol.Kind == SymbolKind.Property
+            || symbol.Kind == SymbolKind.Event;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/SymbolHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/SymbolHelperTest.cs
@@ -18,11 +18,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Collections.Immutable;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.UnitTest.TestFramework;
@@ -227,5 +229,37 @@ namespace NS
                 .IsKnownType(KnownType.System_Collections_Generic_List_T, testCode.SemanticModel)
                 .Should().BeFalse();
         }
+
+        [TestMethod]
+        public void IsAnyAttributeInOverridingChain_WhenMethodSymbolIsNull_ReturnsFalse() =>
+            SymbolHelper.IsAnyAttributeInOverridingChain((IMethodSymbol)null).Should().BeFalse();
+
+        [TestMethod]
+        public void IsAnyAttributeInOverridingChain_WhenPropertySymbolIsNull_ReturnsFalse() =>
+            SymbolHelper.IsAnyAttributeInOverridingChain((IPropertySymbol)null).Should().BeFalse();
+
+        [TestMethod]
+        public void AnyAttributeDerivesFrom_WhenSymbolIsNull_ReturnsFalse() =>
+            SymbolHelper.AnyAttributeDerivesFrom(null, KnownType.Void).Should().BeFalse();
+
+        [TestMethod]
+        public void GetAttributesForKnownType_WhenSymbolIsNull_ReturnsEmpty() =>
+            SymbolHelper.GetAttributes(null, KnownType.Void).Should().BeEmpty();
+
+        [TestMethod]
+        public void GetAttributesForKnownTypes_WhenSymbolIsNull_ReturnsEmpty() =>
+            SymbolHelper.GetAttributes(null, ImmutableArray.Create(KnownType.Void)).Should().BeEmpty();
+
+        [TestMethod]
+        public void GetParameters_WhenSymbolIsNotMethodOrProperty_ReturnsEmpty() =>
+            Mock.Of<ISymbol>(x => x.Kind == SymbolKind.Alias).GetParameters().Should().BeEmpty();
+
+        [TestMethod]
+        public void GetInterfaceMember_WhenSymbolIsNull_ReturnsEmpty() =>
+            ((ISymbol)null).GetInterfaceMember().Should().BeNull();
+
+        [TestMethod]
+        public void GetOverriddenMember_WhenSymbolIsNull_ReturnsEmpty() =>
+            ((ISymbol)null).GetOverriddenMember().Should().BeNull();
     }
 }


### PR DESCRIPTION
- moved methods to respect our convention
- use arrow methods where possible
- fix alignment
- use switch expressions
- re-arrange operators where needed
