### PR TITLE
Fix S3264 perf regression

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
@@ -73,8 +73,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var possiblyCopiedSymbols = GetPossiblyCopiedSymbols(removableDeclarationCollector);
 
             removableEventFields
-                .Where(x => !invokedSymbols.Contains(x.Symbol))
-                .Where(x => !possiblyCopiedSymbols.Contains(x.Symbol))
+                .Where(x => !invokedSymbols.Contains(x.Symbol) && !possiblyCopiedSymbols.Contains(x.Symbol))
                 .ToList()
                 .ForEach(x => context.ReportDiagnosticIfNonGenerated(
                     Diagnostic.Create(Rule, GetLocation(x.SyntaxNode), x.Symbol.Name)));

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
@@ -73,8 +73,8 @@ namespace SonarAnalyzer.Rules.CSharp
             var possiblyCopiedSymbols = GetPossiblyCopiedSymbols(removableDeclarationCollector);
 
             removableEventFields
-                .Where(tuple => !invokedSymbols.Contains(tuple.Symbol))
-                .Where(tuple => !possiblyCopiedSymbols.Contains(tuple.Symbol))
+                .Where(x => !invokedSymbols.Contains(x.Symbol))
+                .Where(x => !possiblyCopiedSymbols.Contains(x.Symbol))
                 .ToList()
                 .ForEach(x => context.ReportDiagnosticIfNonGenerated(
                     Diagnostic.Create(Rule, GetLocation(x.SyntaxNode), x.Symbol.Name)));


### PR DESCRIPTION
Fixes  #4498

- doing the same method call inside a loop is not optimal.
- this wouldn't have lead to a huge perf increase, but `GetInvokedEventSymbols()` does a `tuple.SemanticModel.GetSymbolInfo(tuple.SyntaxNode).Symbol` inside, so it can explode if there's lots of events inside a codebase


