### PR TITLE
Rule S2612: Add support for target typed new expressions

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/LooseFilePermissionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/LooseFilePermissionsTest.cs
@@ -47,7 +47,12 @@ namespace SonarAnalyzer.UnitTest.Rules.Hotspots
 #if NET
         [TestMethod]
         [TestCategory("Rule")]
-        public void LooseFilePermissions_Unix() =>
+        public void LooseFilePermissions_Windows_CSharp9() =>
+            Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\Hotspots\LooseFilePermissions.Windows.CSharp9.cs", new LooseFilePermissions(AnalyzerConfiguration.AlwaysEnabled));
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void LooseFilePermissions_Unix_CS() =>
             Verifier.VerifyAnalyzer(@"TestCases\Hotspots\LooseFilePermissions.Unix.cs",
                                     new LooseFilePermissions(AnalyzerConfiguration.AlwaysEnabled),
                                     NuGetMetadataReference.MonoPosixNetStandard());

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/LooseFilePermissions.Windows.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/LooseFilePermissions.Windows.CSharp9.cs
@@ -10,18 +10,20 @@ fileSecurity.AddAccessRule(new ("User", FileSystemRights.ListDirectory, AccessCo
 fileSecurity.AddAccessRule(new ("User", FileSystemRights.ListDirectory, AccessControlType.Deny));
 fileSecurity.AddAccessRule(new ("Everyone", FileSystemRights.ListDirectory, AccessControlType.Deny));
 fileSecurity.RemoveAccessRule(new ("Everyone", FileSystemRights.ListDirectory, AccessControlType.Allow));
-fileSecurity.SetAccessRule(new ("Everyone", FileSystemRights.Write, AccessControlType.Allow)); // FN
-fileSecurity.AddAccessRule(new ("Everyone", FileSystemRights.Write, AccessControlType.Allow)); // FN
+fileSecurity.SetAccessRule(new ("Everyone", FileSystemRights.Write, AccessControlType.Allow)); // Noncompliant
+fileSecurity.AddAccessRule(new ("Everyone", FileSystemRights.Write, AccessControlType.Allow)); // Noncompliant
 
 void InVariable(FileSecurity fileSecurity)
 {
     FileSystemAccessRule unsafeAccessRule = new ("Everyone", FileSystemRights.FullControl, AccessControlType.Allow);
-
+    //                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Secondary
+    //                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Secondary@-1
 
     fileSecurity.RemoveAccessRule(unsafeAccessRule);
 
-    fileSecurity.AddAccessRule(unsafeAccessRule); // FN
-    fileSecurity.SetAccessRule(unsafeAccessRule); // FN
+    fileSecurity.AddAccessRule(unsafeAccessRule); // Noncompliant
+    fileSecurity.SetAccessRule(unsafeAccessRule); // Noncompliant
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     FileSystemAccessRule safeAccessRule = new ("Everyone", FileSystemRights.FullControl, AccessControlType.Deny);
     fileSecurity.AddAccessRule(safeAccessRule);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/LooseFilePermissions.Windows.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/LooseFilePermissions.Windows.CSharp9.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+FileSecurity fileSecurity = null;
+DirectorySecurity directorySecurity = null;
+
+fileSecurity.SetAccessRule(new ("User", FileSystemRights.ListDirectory, AccessControlType.Allow));
+fileSecurity.AddAccessRule(new ("User", FileSystemRights.ListDirectory, AccessControlType.Allow));
+fileSecurity.AddAccessRule(new ("User", FileSystemRights.ListDirectory, AccessControlType.Deny));
+fileSecurity.AddAccessRule(new ("Everyone", FileSystemRights.ListDirectory, AccessControlType.Deny));
+fileSecurity.RemoveAccessRule(new ("Everyone", FileSystemRights.ListDirectory, AccessControlType.Allow));
+fileSecurity.SetAccessRule(new ("Everyone", FileSystemRights.Write, AccessControlType.Allow)); // FN
+fileSecurity.AddAccessRule(new ("Everyone", FileSystemRights.Write, AccessControlType.Allow)); // FN
+
+void InVariable(FileSecurity fileSecurity)
+{
+    FileSystemAccessRule unsafeAccessRule = new ("Everyone", FileSystemRights.FullControl, AccessControlType.Allow);
+
+
+    fileSecurity.RemoveAccessRule(unsafeAccessRule);
+
+    fileSecurity.AddAccessRule(unsafeAccessRule); // FN
+    fileSecurity.SetAccessRule(unsafeAccessRule); // FN
+
+    FileSystemAccessRule safeAccessRule = new ("Everyone", FileSystemRights.FullControl, AccessControlType.Deny);
+    fileSecurity.AddAccessRule(safeAccessRule);
+    fileSecurity.SetAccessRule(safeAccessRule);
+
+    FileSystemAccessRule rule = new ("User", FileSystemRights.Read, AccessControlType.Allow);
+    rule = new ("Everyone", FileSystemRights.Read, AccessControlType.Allow);
+
+    fileSecurity.AddAccessRule(rule); // Compliant - FN, we look only at the object creation and don't track state changes.
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/ObjectCreationFactoryTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/ObjectCreationFactoryTest.cs
@@ -56,7 +56,6 @@ namespace SonarAnalyzer.UnitTest.Wrappers
             wrapper.Expression.Should().BeEquivalentTo(objectCreation);
             wrapper.Initializer.Should().BeEquivalentTo(objectCreation.Initializer);
             wrapper.ArgumentList.Should().BeEquivalentTo(objectCreation.ArgumentList);
-            wrapper.InitializerExpressions.Should().BeEquivalentTo(objectCreation.Initializer.Expressions);
             wrapper.TypeAsString(snippet.SemanticModel).Should().Be("A");
             wrapper.TypeSymbol(snippet.SemanticModel).Name.Should().Be("A");
         }
@@ -81,7 +80,6 @@ namespace SonarAnalyzer.UnitTest.Wrappers
             var objectCreation = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<ObjectCreationExpressionSyntax>().First();
             var wrapper = ObjectCreationFactory.Create(objectCreation);
             wrapper.Initializer.Should().BeNull();
-            wrapper.InitializerExpressions.Should().BeNull();
         }
 
         [TestMethod]
@@ -107,7 +105,6 @@ namespace SonarAnalyzer.UnitTest.Wrappers
             wrapper.Expression.Should().BeEquivalentTo(objectCreation.SyntaxNode);
             wrapper.Initializer.Should().BeEquivalentTo(objectCreation.Initializer);
             wrapper.ArgumentList.Should().BeEquivalentTo(objectCreation.ArgumentList);
-            wrapper.InitializerExpressions.Should().BeEquivalentTo(objectCreation.Initializer.Expressions);
             wrapper.TypeAsString(snippet.SemanticModel).Should().Be("A");
             wrapper.TypeSymbol(snippet.SemanticModel).Name.Should().Be("A");
         }
@@ -132,7 +129,6 @@ namespace SonarAnalyzer.UnitTest.Wrappers
             var objectCreation = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<ImplicitObjectCreationExpressionSyntax>().First();
             var wrapper = ObjectCreationFactory.Create(objectCreation);
             wrapper.Initializer.Should().BeNull();
-            wrapper.InitializerExpressions.Should().BeNull();
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/ObjectCreationFactoryTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/ObjectCreationFactoryTest.cs
@@ -56,8 +56,32 @@ namespace SonarAnalyzer.UnitTest.Wrappers
             wrapper.Expression.Should().BeEquivalentTo(objectCreation);
             wrapper.Initializer.Should().BeEquivalentTo(objectCreation.Initializer);
             wrapper.ArgumentList.Should().BeEquivalentTo(objectCreation.ArgumentList);
+            wrapper.InitializerExpressions.Should().BeEquivalentTo(objectCreation.Initializer.Expressions);
             wrapper.TypeAsString(snippet.SemanticModel).Should().Be("A");
             wrapper.TypeSymbol(snippet.SemanticModel).Name.Should().Be("A");
+        }
+
+        [TestMethod]
+        public void ObjectCreationEmptyInitializerSyntax()
+        {
+            const string code = @"
+                public class A
+                {
+                    public int X;
+                    public A(int y) { }
+                }
+                public class B
+                {
+                    void Foo()
+                    {
+                        var bar = new A(1);
+                    }
+                }";
+            var snippet = new SnippetCompiler(code);
+            var objectCreation = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<ObjectCreationExpressionSyntax>().First();
+            var wrapper = ObjectCreationFactory.Create(objectCreation);
+            wrapper.Initializer.Should().BeNull();
+            wrapper.InitializerExpressions.Should().BeNull();
         }
 
         [TestMethod]
@@ -83,8 +107,32 @@ namespace SonarAnalyzer.UnitTest.Wrappers
             wrapper.Expression.Should().BeEquivalentTo(objectCreation.SyntaxNode);
             wrapper.Initializer.Should().BeEquivalentTo(objectCreation.Initializer);
             wrapper.ArgumentList.Should().BeEquivalentTo(objectCreation.ArgumentList);
+            wrapper.InitializerExpressions.Should().BeEquivalentTo(objectCreation.Initializer.Expressions);
             wrapper.TypeAsString(snippet.SemanticModel).Should().Be("A");
             wrapper.TypeSymbol(snippet.SemanticModel).Name.Should().Be("A");
+        }
+
+        [TestMethod]
+        public void ImplicitObjectCreationEmptyInitializerSyntax()
+        {
+            const string code = @"
+                public class A
+                {
+                    public int X;
+                    public A(int y) { }
+                }
+                public class B
+                {
+                    void Foo()
+                    {
+                        A bar = new (1);
+                    }
+                }";
+            var snippet = new SnippetCompiler(code);
+            var objectCreation = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<ImplicitObjectCreationExpressionSyntax>().First();
+            var wrapper = ObjectCreationFactory.Create(objectCreation);
+            wrapper.Initializer.Should().BeNull();
+            wrapper.InitializerExpressions.Should().BeNull();
         }
 
         [TestMethod]


### PR DESCRIPTION
First commit is a WIP from other rules to have `IObjectCreation.IsKnownType` and doesn't need a review.

Unrelated UTs are expected to fail before rebase.