### PR TITLE
GitHub workflow: await removeAssignees

### DIFF
--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -76,7 +76,7 @@ jobs:
             //
             async function processIssue(issue) {
                 if(issue.state == "open") {
-                  removeAssignees(issue);
+                  await removeAssignees(issue);
                   addAssignee(issue, context.payload.requested_reviewer.login);
                   const card = await findCard(issue.url);
                   if (card) {

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -78,7 +78,7 @@ jobs:
             }
             //
             async function processIssue(issue) {
-                removeAssignees(issue);
+                await removeAssignees(issue);
                 addAssignee(issue, context.payload.pull_request.user.login);
                 if (issue.state == "open") {
                     const card = await findCard(issue.url);


### PR DESCRIPTION
Old state: When card was already assigned to the desired user, `removeAssignees` and `addAssignee` happend asynchronously. So user was often added and them all users were removed.

New state: Wait for removal before adding the desired user.