### PR TITLE
Improve S3984 performance

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [Rule(DiagnosticId)]
     public sealed class ExceptionsShouldBeUsed : SonarDiagnosticAnalyzer
     {
-        internal const string DiagnosticId = "S3984";
+        private const string DiagnosticId = "S3984";
         private const string MessageFormat = "Throw this exception or remove this useless statement.";
 
         private static readonly DiagnosticDescriptor Rule =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
@@ -45,13 +45,11 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 var objectCreation = (ObjectCreationExpressionSyntax)c.Node;
                 var parent = objectCreation.GetFirstNonParenthesizedParent();
-                if (parent.IsKind(SyntaxKind.ExpressionStatement))
+                if (parent.IsKind(SyntaxKind.ExpressionStatement)
+                    && c.SemanticModel.GetSymbolInfo(objectCreation.Type).Symbol is INamedTypeSymbol createdObjectType
+                    && createdObjectType.DerivesFrom(KnownType.System_Exception))
                 {
-                    var createdObjectType = c.SemanticModel.GetSymbolInfo(objectCreation.Type).Symbol as INamedTypeSymbol;
-                    if (createdObjectType.DerivesFrom(KnownType.System_Exception))
-                    {
-                        c.ReportDiagnosticWhenActive(Diagnostic.Create(Rule, objectCreation.GetLocation()));
-                    }
+                    c.ReportDiagnosticWhenActive(Diagnostic.Create(Rule, objectCreation.GetLocation()));
                 }
             },
             SyntaxKind.ObjectCreationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
@@ -45,17 +45,14 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
             {
                 var objectCreation = (ObjectCreationExpressionSyntax)c.Node;
-
-                var createdObjectType = c.SemanticModel.GetSymbolInfo(objectCreation.Type).Symbol as INamedTypeSymbol;
-                if (!createdObjectType.DerivesFrom(KnownType.System_Exception))
-                {
-                    return;
-                }
-
                 var parent = objectCreation.GetFirstNonParenthesizedParent();
                 if (parent.IsKind(SyntaxKind.ExpressionStatement))
                 {
-                    c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, objectCreation.GetLocation()));
+                    var createdObjectType = c.SemanticModel.GetSymbolInfo(objectCreation.Type).Symbol as INamedTypeSymbol;
+                    if (createdObjectType.DerivesFrom(KnownType.System_Exception))
+                    {
+                        c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, objectCreation.GetLocation()));
+                    }
                 }
             },
             SyntaxKind.ObjectCreationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
@@ -35,13 +35,12 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S3984";
         private const string MessageFormat = "Throw this exception or remove this useless statement.";
 
-        private static readonly DiagnosticDescriptor rule =
+        private static readonly DiagnosticDescriptor Rule =
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-        protected override void Initialize(SonarAnalysisContext context)
-        {
+        protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
             {
                 var objectCreation = (ObjectCreationExpressionSyntax)c.Node;
@@ -51,11 +50,10 @@ namespace SonarAnalyzer.Rules.CSharp
                     var createdObjectType = c.SemanticModel.GetSymbolInfo(objectCreation.Type).Symbol as INamedTypeSymbol;
                     if (createdObjectType.DerivesFrom(KnownType.System_Exception))
                     {
-                        c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, objectCreation.GetLocation()));
+                        c.ReportDiagnosticWhenActive(Diagnostic.Create(Rule, objectCreation.GetLocation()));
                     }
                 }
             },
             SyntaxKind.ObjectCreationExpression);
-        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExceptionsShouldBeUsed.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExceptionsShouldBeUsed.cs
@@ -4,11 +4,17 @@ using System.Collections.Generic;
 
 namespace Tests.Diagnostics
 {
+    public class CustomEx : Exception
+    {
+    }
+
     class ExceptionsShouldBeUsed
     {
         void NotCompliant()
         {
             new Exception(); // Noncompliant {{Throw this exception or remove this useless statement.}}
+            new CustomEx(); // Noncompliant
+            new ArgumentOutOfRangeException(); // Noncompliant
         }
 
         Exception Compliant()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExceptionsShouldBeUsed.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExceptionsShouldBeUsed.cs
@@ -27,6 +27,7 @@ namespace Tests.Diagnostics
             if (new Exception() != null) { }
             return new Exception();
             throw new Exception();
+            new ExceptionsShouldBeUsed(); // for coverage
         }
 
         void Foo(Exception ex) { }


### PR DESCRIPTION
In our [April perf evaluation](https://docs.google.com/spreadsheets/d/1uo7kSDPkbRFyoXtzBp7Piftcpda29i9mUoj-ZTluCtQ/edit#gid=1598900315) , on `nodatime`, S3984 behaved pretty badly:


<!--StartFragment--><google-sheets-html-origin><!--td {border: 1px solid #ccc;}br {mso-data-placement:same-cell;}-->
ExceptionsShouldBeUsed |  6324 ms (4%)
-- | -- |
<!--EndFragment-->
</google-sheets-html-origin>

Also, see [internal report.](https://discuss.sonarsource.com/t/performance-problem-reported-for-csharp-post-8-9-upgrade-rules-impacted-s1128-s3984-and-s1450/7867/3). 

It's pretty obvious it will behave bad because it's querying the symbol as the first operation in the rule.