### PR TITLE
GitHub workflow: Don't run CreatePullRequest for bots

### DIFF
--- a/.github/workflows/CreatePullRequest.yml
+++ b/.github/workflows/CreatePullRequest.yml
@@ -8,8 +8,12 @@ jobs:
   assign_and_create_card:
     name: Assign issue to sender and create Kanban card
     runs-on: ubuntu-latest
+    # Single quotes must be used here https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#literals
     # PRs from forks don't have required token authorization
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Dependabot works directly under our repository, but doesn't have enough priviledges to create project card
+    if: |
+        github.event.pull_request.head.repo.full_name == github.repository
+        && github.event.sender.type != 'Bot'
 
     steps:
       # https://github.com/actions/github-script


### PR DESCRIPTION
Dependabot is creating PRs directly from our repository, so it passes the original `if` condition.
It doesn't have enough permissions and creates errors like this https://github.com/SonarSource/sonar-dotnet/pull/4543/checks?check_run_id=2817846021

We don't need a card for bot PRs. It will be created later, when needed by other actions (request (self) review, approve review)