### PR TITLE
Fix S3353 FP: Variable is used within an Expression

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
@@ -41,7 +41,13 @@ namespace SonarAnalyzer.Rules.CSharp
         private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-        private enum DeclarationType { CannotBeConst, Value, Reference, String };
+        private enum DeclarationType
+        {
+            CannotBeConst,
+            Value,
+            Reference,
+            String
+        }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(c =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
@@ -180,10 +180,10 @@ namespace SonarAnalyzer.Rules.CSharp
                     var lookup = new CSharpMethodParameterLookup(invocation, semanticModel);
                     return lookup.TryGetSymbol(argument, out var parameter) && parameter.IsType(KnownType.System_Linq_Expressions_Expression_T);
                 }
-                else if (lambda.Parent is AssignmentExpressionSyntax assignment // Lambda cannot be on the left side
-                    && semanticModel.GetSymbolInfo(assignment.Left).Symbol is { } assignmentTargetSymbol)
+                else if (lambda.Parent is AssignmentExpressionSyntax assignment)
                 {
-                    return assignmentTargetSymbol.GetSymbolType().Is(KnownType.System_Linq_Expressions_Expression_T);
+                    // Lambda cannot be on the left side, we don't need to check it
+                    return assignment.Left.IsKnownType(KnownType.System_Linq_Expressions_Expression_T, semanticModel);
                 }
             }
             return false;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
@@ -180,8 +180,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var lookup = new CSharpMethodParameterLookup(invocation, semanticModel);
                     return lookup.TryGetSymbol(argument, out var parameter) && parameter.IsType(KnownType.System_Linq_Expressions_Expression_T);
                 }
-                else if (lambda.Parent is AssignmentExpressionSyntax assignment
-                    && assignment.Right == lambda
+                else if (lambda.Parent is AssignmentExpressionSyntax assignment // Lambda cannot be on the left side
                     && semanticModel.GetSymbolInfo(assignment.Left).Symbol is { } assignmentTargetSymbol)
                 {
                     return assignmentTargetSymbol.GetSymbolType().Is(KnownType.System_Linq_Expressions_Expression_T);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.cs
@@ -352,6 +352,9 @@ namespace Tests.Diagnostics
 // https://github.com/SonarSource/sonar-dotnet/issues/4015
 public class Repro_4015
 {
+    Expression<Func<string>> fieldExpression;
+    Func<string> fieldFunc;
+
     public void Compliant_SimpleLambda()
     {
         string localVariable = null;    // Compliant, changing the Expression<Func<T>> below changes the behavior of the code
@@ -374,6 +377,48 @@ public class Repro_4015
     {
         string localVariable = null;    // Noncompliant, this can be const
         WithFuncArgument(() => localVariable);
+    }
+
+    public void Compliant_Assignment()
+    {
+        string a = null;
+        string b = null;
+        string c = null;
+        string d = null;
+        var repro = new Repro_4015();
+        Expression<Func<string>> variableExpression;
+
+        // Compliant cases, changing the Expression<Func<T>> below changes the behavior of the code
+        fieldExpression = () => a;
+        WithExpressionArgument(fieldExpression);
+
+        repro.fieldExpression = () => b;
+        WithExpressionArgument(repro.fieldExpression);
+
+        variableExpression = () => c;
+        WithExpressionArgument(variableExpression);
+
+        variableExpression = ((() => d));
+        WithExpressionArgument(variableExpression);
+    }
+
+    public void Noncompliant_Assignment()
+    {
+        string a = null;    // Noncompliant
+        string b = null;    // Noncompliant
+        string c = null;    // Noncompliant
+        var repro = new Repro_4015();
+        Func<string> variableFunc;
+
+        // Compliant cases, changing the Expression<Func<T>> below changes the behavior of the code
+        fieldFunc = () => a;
+        WithFuncArgument(fieldFunc);
+
+        repro.fieldFunc = () => b;
+        WithFuncArgument(repro.fieldFunc);
+
+        variableFunc = () => c;
+        WithFuncArgument(variableFunc);
     }
 
     private void WithExpressionArgument(Expression<Func<string>> expression)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.cs
@@ -410,7 +410,6 @@ public class Repro_4015
         var repro = new Repro_4015();
         Func<string> variableFunc;
 
-        // Compliant cases, changing the Expression<Func<T>> below changes the behavior of the code
         fieldFunc = () => a;
         WithFuncArgument(fieldFunc);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.cs
@@ -441,4 +441,27 @@ public class Repro_4015
     {
         expression();
     }
+
+    public void UndefinedInvocationSymbol()
+    {
+        string localVariable = null;        // Noncompliant
+        Undefined(() => localVariable);     // Error [CS0103]: The name 'Undefined' does not exist in the current context
+        undefined = () => localVariable;    // Error [CS0103]: The name 'undefined' does not exist in the current context
+    }
+
+    public void IndexerIndexedByLambda_CrazyCoverage()
+    {
+        string localVariable = null;        // Noncompliant
+        this[() => localVariable] = 42;     // Case with lambda on the left side of an assignment
+    }
+
+    public int this[Func<string> key]
+    {
+        get
+        {
+            var k = key();
+            return 42;
+        }
+        set { }
+    }
 }


### PR DESCRIPTION
Fixes #4015
