### PR TITLE
Remove duplicate property and reduce the scope for the warning suppression

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
+++ b/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.1.37">
       <!-- Downgrade System.Collections.Immutable to support VS2015 Update 3 -->
-      <NoWarn>NU1701</NoWarn>
+      <NoWarn>NU1605, NU1701</NoWarn>
     </PackageReference>
   </ItemGroup>
 
@@ -29,15 +29,6 @@
       <SonarQubeExclude>true</SonarQubeExclude>
     </Compile>
   </ItemGroup>
-  <!--
-    This PropertyGroup is used as a hack to prevent the NU1605 issue to be reported as an error. The rule is detecting
-    the downgrade of System.Collections.Immutable from 1.2.0 to 1.1.37 (VS 2015 Update 3 only embeds 1.1.37).
-    Do not use NoWarn in order to avoid hiding other issues.
-  -->
-  <PropertyGroup>
-    <WarningsAsErrors />
-    <NoWarn>NU1605</NoWarn>
-  </PropertyGroup>
 
   <PropertyGroup>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
+++ b/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <AssemblyName>SonarAnalyzer.CFG</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
-    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <ProjectGuid>{F766F556-CB91-408A-9149-EB963DE1B817}</ProjectGuid>
     <LangVersion>8</LangVersion>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>

--- a/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -19,7 +19,7 @@
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.1.37">
       <!-- Downgrade System.Collections.Immutable to support VS2015 Update 3 -->
-      <NoWarn>NU1701</NoWarn>
+      <NoWarn>NU1605, NU1701</NoWarn>
     </PackageReference>
   </ItemGroup>
 
@@ -46,15 +46,6 @@
     </Content>
   </ItemGroup>
 
-  <!--
-    This PropertyGroup is used as a hack to prevent the NU1605 issue to be reported as an error. The rule is detecting
-    the downgrade of System.Collections.Immutable from 1.2.0 to 1.1.37 (VS 2015 Update 3 only embeds 1.1.37).
-    Do not use NoWarn in order to avoid hiding other issues.
-  -->
-  <PropertyGroup>
-    <WarningsAsErrors />
-    <NoWarn>NU1605</NoWarn>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineConstants>TRACE;CS</DefineConstants>
   </PropertyGroup>

--- a/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -4,7 +4,6 @@
     <LangVersion>8.0</LangVersion>
     <AssemblyName>SonarAnalyzer.CSharp</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
-    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <ProjectGuid>{ca8eec07-8775-42e3-91eb-e51f4db72a48}</ProjectGuid>
   </PropertyGroup>

--- a/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="1.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.1.37">
       <!-- Downgrade System.Collections.Immutable to support VS2015 Update 3 -->
-      <NoWarn>NU1701</NoWarn>
+      <NoWarn>NU1605, NU1701</NoWarn>
     </PackageReference>
   </ItemGroup>
 
@@ -49,15 +49,5 @@
     <Exec Command="$(ProtocCompiler) -I=./Protobuf --csharp_out=./Protobuf ./Protobuf/AnalyzerReport.proto" />
     <Message Importance="high" Text="Protobuf classes generated." />
   </Target>
-
-  <!--
-    This PropertyGroup is used as a hack to prevent the NU1605 issue to be reported as an error. The rule is detecting
-    the downgrade of System.Collections.Immutable from 1.2.0 to 1.1.37 (VS 2015 Update 3 only embeds 1.1.37).
-    Do not use NoWarn in order to avoid hiding other issues.
-  -->
-  <PropertyGroup>
-    <WarningsAsErrors />
-    <NoWarn>NU1605</NoWarn>
-  </PropertyGroup>
 
 </Project>

--- a/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -4,7 +4,6 @@
     <LangVersion>8.0</LangVersion>
     <AssemblyName>SonarAnalyzer</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
-    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <ProjectGuid>{8a8a663e-1318-4361-bc97-2e63666feadb}</ProjectGuid>
   </PropertyGroup>

--- a/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/SonarAnalyzer.RuleDescriptorGenerator.csproj
+++ b/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/SonarAnalyzer.RuleDescriptorGenerator.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>SonarAnalyzer.RuleDescriptorGenerator</AssemblyName>
     <RootNamespace>SonarAnalyzer.RuleDescriptorGenerator</RootNamespace>
     <OutputType>Exe</OutputType>
-    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <TargetFrameworks>net46;netcoreapp3.1</TargetFrameworks>
     <ProjectGuid>{07e31f39-7419-4b4e-998e-c2bf1a6bb91c}</ProjectGuid>
   </PropertyGroup>

--- a/analyzers/src/SonarAnalyzer.Utilities/SonarAnalyzer.Utilities.csproj
+++ b/analyzers/src/SonarAnalyzer.Utilities/SonarAnalyzer.Utilities.csproj
@@ -4,7 +4,6 @@
     <LangVersion>8.0</LangVersion>
     <AssemblyName>SonarAnalyzer.Utilities</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
-    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <ProjectGuid>{664e86bd-0863-49d5-b343-141ceaf47f4a}</ProjectGuid>
   </PropertyGroup>

--- a/analyzers/src/SonarAnalyzer.Utilities/SonarAnalyzer.Utilities.csproj
+++ b/analyzers/src/SonarAnalyzer.Utilities/SonarAnalyzer.Utilities.csproj
@@ -25,14 +25,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <!--
-    This PropertyGroup is used as a hack to prevent the NU1605 issue to be reported as an error. The rule is detecting
-    the downgrade of System.Collections.Immutable from 1.2.0 to 1.1.37 (VS 2015 Update 3 only embeds 1.1.37).
-    Do not use NoWarn in order to avoid hiding other issues.
-  -->
-  <PropertyGroup>
-    <WarningsAsErrors />
-    <NoWarn>NU1605</NoWarn>
-  </PropertyGroup>
-
 </Project>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.1.37">
       <!-- Downgrade System.Collections.Immutable to support VS2015 Update 3 -->
-      <NoWarn>NU1701</NoWarn>
+      <NoWarn>NU1605, NU1701</NoWarn>
     </PackageReference>
   </ItemGroup>
 
@@ -24,18 +24,10 @@
     <Compile Include="..\AssemblyInfo.Shared.cs" Link="Properties\AssemblyInfo.Shared.cs" />
   </ItemGroup>
 
-  <!--
-    This PropertyGroup is used as a hack to prevent the NU1605 issue to be reported as an error. The rule is detecting
-    the downgrade of System.Collections.Immutable from 1.2.0 to 1.1.37 (VS 2015 Update 3 only embeds 1.1.37).
-    Do not use NoWarn in order to avoid hiding other issues.
-  -->
-  <PropertyGroup>
-    <WarningsAsErrors />
-    <NoWarn>NU1605</NoWarn>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineConstants>TRACE;VB</DefineConstants>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>TRACE;VB</DefineConstants>
   </PropertyGroup>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
@@ -4,7 +4,6 @@
     <LangVersion>8.0</LangVersion>
     <AssemblyName>SonarAnalyzer.VisualBasic</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
-    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <ProjectGuid>{7cfa8fa5-8842-4e89-bb90-39d5c0f20ba8}</ProjectGuid>
   </PropertyGroup>


### PR DESCRIPTION
`DisableImplicitNuGetFallbackFolder` it is already defined in Directory.Build.props