### PR TITLE
Improve SE performance for a long OR chain condition

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/AndSymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/AndSymbolicValue.cs
@@ -26,37 +26,26 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
 {
     public class AndSymbolicValue : BinarySymbolicValue
     {
-        public AndSymbolicValue(SymbolicValue leftOperand, SymbolicValue rightOperand)
-            : base(leftOperand, rightOperand)
-        {
-        }
+        public AndSymbolicValue(SymbolicValue leftOperand, SymbolicValue rightOperand) : base(leftOperand, rightOperand) { }
 
         public override IEnumerable<ProgramState> TrySetConstraint(SymbolicValueConstraint constraint, ProgramState programState)
         {
-            if (!(constraint is BoolConstraint boolConstraint))
+            if (constraint is BoolConstraint boolConstraint)
+            {
+                var ret = boolConstraint == BoolConstraint.True
+                    ? LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps))
+                    : LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))
+                        .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps)))
+                        .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps)));
+                return ThrowIfTooMany(ret);
+            }
+            else
             {
                 return new[] { programState };
             }
-
-            if (boolConstraint == BoolConstraint.True)
-            {
-                return ThrowIfTooMany(
-                    LeftOperand.TrySetConstraint(BoolConstraint.True, programState)
-                        .SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps)));
-            }
-
-            return ThrowIfTooMany(
-                LeftOperand.TrySetConstraint(BoolConstraint.True, programState)
-                    .SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))
-                .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState)
-                    .SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps)))
-                .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState)
-                    .SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))));
         }
 
-        public override string ToString()
-        {
-            return LeftOperand + " & " + RightOperand;
-        }
+        public override string ToString() =>
+            LeftOperand + " & " + RightOperand;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/AndSymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/AndSymbolicValue.cs
@@ -32,6 +32,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
         {
             if (constraint is BoolConstraint boolConstraint)
             {
+                ThrowIfTooNested();
                 var ret = boolConstraint == BoolConstraint.True
                     ? LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps))
                     : LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/AndSymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/AndSymbolicValue.cs
@@ -24,27 +24,16 @@ using SonarAnalyzer.SymbolicExecution.Constraints;
 
 namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
 {
-    public class AndSymbolicValue : BinarySymbolicValue
+    public class AndSymbolicValue : BoolBinarySymbolicValue
     {
         public AndSymbolicValue(SymbolicValue leftOperand, SymbolicValue rightOperand) : base(leftOperand, rightOperand) { }
 
-        public override IEnumerable<ProgramState> TrySetConstraint(SymbolicValueConstraint constraint, ProgramState programState)
-        {
-            if (constraint is BoolConstraint boolConstraint)
-            {
-                ThrowIfTooNested();
-                var ret = boolConstraint == BoolConstraint.True
-                    ? LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps))
-                    : LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))
-                        .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps)))
-                        .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps)));
-                return ThrowIfTooMany(ret);
-            }
-            else
-            {
-                return new[] { programState };
-            }
-        }
+        protected override IEnumerable<ProgramState> TrySetBoolConstraint(BoolConstraint constraint, ProgramState programState) =>
+            constraint == BoolConstraint.True
+                ? LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps))
+                : LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))
+                    .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps)))
+                    .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps)));
 
         public override string ToString() =>
             LeftOperand + " & " + RightOperand;

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/BinarySymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/BinarySymbolicValue.cs
@@ -22,6 +22,12 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
 {
     public class BinarySymbolicValue : SymbolicValue
     {
+        // NestedSize:  8, Created ProgramStates:   8, TrySetConstraint visits:    11, Time:  0.03s
+        // NestedSize: 16, Created ProgramStates: 128, TrySetConstraint visits:   247, Time:  0.2s
+        // NestedSize: 24, Created ProgramStates: 256, TrySetConstraint visits:  4083, Time:  3.0s
+        // NestedSize: 32, Created ProgramStates: 256, TrySetConstraint visits: 65519, Time: 46.2s
+        private const int NestedSizeLimit = 16;
+
         public SymbolicValue LeftOperand { get; }
         public SymbolicValue RightOperand { get; }
 
@@ -30,5 +36,17 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             LeftOperand = leftOperand;
             RightOperand = rightOperand;
         }
+
+        protected void ThrowIfTooNested()
+        {
+            if (NestedSize() > NestedSizeLimit)
+            {
+                throw new TooManyInternalStatesException();
+            }
+        }
+
+        private int NestedSize() =>
+            (LeftOperand is BinarySymbolicValue leftBinary ? leftBinary.NestedSize() : 1)
+            + (RightOperand is BinarySymbolicValue rightBinary ? rightBinary.NestedSize() : 1);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/BinarySymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/BinarySymbolicValue.cs
@@ -22,12 +22,6 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
 {
     public class BinarySymbolicValue : SymbolicValue
     {
-        // NestedSize:  8, Created ProgramStates:   8, TrySetConstraint visits:    11, Time:  0.03s
-        // NestedSize: 16, Created ProgramStates: 128, TrySetConstraint visits:   247, Time:  0.2s
-        // NestedSize: 24, Created ProgramStates: 256, TrySetConstraint visits:  4083, Time:  3.0s
-        // NestedSize: 32, Created ProgramStates: 256, TrySetConstraint visits: 65519, Time: 46.2s
-        private const int NestedSizeLimit = 16;
-
         public SymbolicValue LeftOperand { get; }
         public SymbolicValue RightOperand { get; }
 
@@ -36,17 +30,5 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             LeftOperand = leftOperand;
             RightOperand = rightOperand;
         }
-
-        protected void ThrowIfTooNested()
-        {
-            if (NestedSize() > NestedSizeLimit)
-            {
-                throw new TooManyInternalStatesException();
-            }
-        }
-
-        private int NestedSize() =>
-            (LeftOperand is BinarySymbolicValue leftBinary ? leftBinary.NestedSize() : 1)
-            + (RightOperand is BinarySymbolicValue rightBinary ? rightBinary.NestedSize() : 1);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/BoolBinarySymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/BoolBinarySymbolicValue.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using SonarAnalyzer.SymbolicExecution.Constraints;
+
+namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
+{
+    public abstract class BoolBinarySymbolicValue : BinarySymbolicValue
+    {
+        // NestedSize:  4, Created ProgramStates:   8, TrySetConstraint visits:    11, Time:  0.03s
+        // NestedSize:  8, Created ProgramStates: 128, TrySetConstraint visits:   247, Time:  0.2s
+        // NestedSize: 12, Created ProgramStates: 256, TrySetConstraint visits:  4083, Time:  3.0s
+        // NestedSize: 16, Created ProgramStates: 256, TrySetConstraint visits: 65519, Time: 46.2s
+        private const int NestedSizeLimit = 8;
+
+        protected abstract IEnumerable<ProgramState> TrySetBoolConstraint(BoolConstraint constraint, ProgramState programState);
+
+        protected BoolBinarySymbolicValue(SymbolicValue leftOperand, SymbolicValue rightOperand) : base(leftOperand, rightOperand) { }
+
+        public sealed override IEnumerable<ProgramState> TrySetConstraint(SymbolicValueConstraint constraint, ProgramState programState)
+        {
+            if (constraint is BoolConstraint boolConstraint)
+            {
+                return NestedSize() > NestedSizeLimit
+                    ? throw new TooManyInternalStatesException()
+                    : ThrowIfTooMany(TrySetBoolConstraint(boolConstraint, programState));
+            }
+            else
+            {
+                return new[] { programState };
+            }
+        }
+
+        private int NestedSize() =>
+            (LeftOperand is BoolBinarySymbolicValue left ? left.NestedSize() : 1)
+            + (RightOperand is BoolBinarySymbolicValue right ? right.NestedSize() : 1);
+    }
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/ComparisonSymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/ComparisonSymbolicValue.cs
@@ -25,48 +25,27 @@ using SonarAnalyzer.SymbolicExecution.Relationships;
 
 namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
 {
-    public class ComparisonSymbolicValue : BinarySymbolicValue
+    public class ComparisonSymbolicValue : BoolBinarySymbolicValue
     {
         private readonly ComparisonKind comparisonKind;
 
-        public ComparisonSymbolicValue(ComparisonKind comparisonKind, SymbolicValue leftOperand, SymbolicValue rightOperand)
-            : base(leftOperand, rightOperand)
-        {
+        public ComparisonSymbolicValue(ComparisonKind comparisonKind, SymbolicValue leftOperand, SymbolicValue rightOperand) : base(leftOperand, rightOperand) =>
             this.comparisonKind = comparisonKind;
-        }
 
-        public override IEnumerable<ProgramState> TrySetConstraint(SymbolicValueConstraint constraint, ProgramState programState)
-        {
-            if (!(constraint is BoolConstraint boolConstraint))
-            {
-                return new[] { programState };
-            }
-
-            var relationship = GetRelationship(boolConstraint);
-
-            var newProgramState = programState.TrySetRelationship(relationship);
-            if (newProgramState == null)
-            {
-                return Enumerable.Empty<ProgramState>();
-            }
-
-            return new[] { newProgramState };
-        }
+        protected override IEnumerable<ProgramState> TrySetBoolConstraint(BoolConstraint constraint, ProgramState programState) =>
+            programState.TrySetRelationship(GetRelationship(constraint)) is { } newProgramState
+            ? new[] { newProgramState }
+            : Enumerable.Empty<ProgramState>();
 
         private BinaryRelationship GetRelationship(BoolConstraint boolConstraint)
         {
-            var relationship = new ComparisonRelationship(this.comparisonKind, LeftOperand, RightOperand);
-
-            return boolConstraint == BoolConstraint.True
-                ? relationship
-                : relationship.Negate();
+            var relationship = new ComparisonRelationship(comparisonKind, LeftOperand, RightOperand);
+            return boolConstraint == BoolConstraint.True ? relationship : relationship.Negate();
         }
 
         public override string ToString()
         {
-            var op = this.comparisonKind == ComparisonKind.Less
-                ? "<"
-                : "<=";
+            var op = comparisonKind == ComparisonKind.Less ? "<" : "<=";
             return $"{op}({LeftOperand}, {RightOperand})";
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/OrSymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/OrSymbolicValue.cs
@@ -24,27 +24,16 @@ using SonarAnalyzer.SymbolicExecution.Constraints;
 
 namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
 {
-    public class OrSymbolicValue : BinarySymbolicValue
+    public class OrSymbolicValue : BoolBinarySymbolicValue
     {
         public OrSymbolicValue(SymbolicValue leftOperand, SymbolicValue rightOperand) : base(leftOperand, rightOperand) { }
 
-        public override IEnumerable<ProgramState> TrySetConstraint(SymbolicValueConstraint constraint, ProgramState programState)
-        {
-            if (constraint is BoolConstraint boolConstraint)
-            {
-                ThrowIfTooNested();
-                var ret = constraint == BoolConstraint.False
-                    ? LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))
-                    : LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))
-                        .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps)))
-                        .Union(LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps)));
-                return ThrowIfTooMany(ret);
-            }
-            else
-            {
-                return new[] { programState };
-            }
-        }
+        protected override IEnumerable<ProgramState> TrySetBoolConstraint(BoolConstraint constraint, ProgramState programState) =>
+            constraint == BoolConstraint.False
+                ? LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))
+                : LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))
+                    .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps)))
+                    .Union(LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps)));
 
         public override string ToString() =>
             LeftOperand + " | " + RightOperand;

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/OrSymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/OrSymbolicValue.cs
@@ -32,6 +32,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
         {
             if (constraint is BoolConstraint boolConstraint)
             {
+                ThrowIfTooNested();
                 var ret = constraint == BoolConstraint.False
                     ? LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))
                     : LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/RelationalSymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/RelationalSymbolicValue.cs
@@ -22,9 +22,6 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
 {
     public class RelationalSymbolicValue : BinarySymbolicValue
     {
-        protected RelationalSymbolicValue(SymbolicValue leftOperand, SymbolicValue rightOperand)
-            : base(leftOperand, rightOperand)
-        {
-        }
+        protected RelationalSymbolicValue(SymbolicValue leftOperand, SymbolicValue rightOperand) : base(leftOperand, rightOperand) { }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/XorSymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/Binary/XorSymbolicValue.cs
@@ -24,39 +24,18 @@ using SonarAnalyzer.SymbolicExecution.Constraints;
 
 namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
 {
-    public class XorSymbolicValue : BinarySymbolicValue
+    public class XorSymbolicValue : BoolBinarySymbolicValue
     {
-        public XorSymbolicValue(SymbolicValue leftOperand, SymbolicValue rightOperand)
-            : base(leftOperand, rightOperand)
-        {
-        }
+        public XorSymbolicValue(SymbolicValue leftOperand, SymbolicValue rightOperand) : base(leftOperand, rightOperand) { }
 
-        public override IEnumerable<ProgramState> TrySetConstraint(SymbolicValueConstraint constraint, ProgramState programState)
-        {
-            if (!(constraint is BoolConstraint boolConstraint))
-            {
-                return new[] { programState };
-            }
+        protected override IEnumerable<ProgramState> TrySetBoolConstraint(BoolConstraint constraint, ProgramState programState) =>
+            constraint == BoolConstraint.False
+                ? LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps))
+                    .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps)))
+                : LeftOperand.TrySetConstraint(BoolConstraint.True, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))
+                    .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState).SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps)));
 
-            if (constraint == BoolConstraint.False)
-            {
-                return ThrowIfTooMany(
-                    LeftOperand.TrySetConstraint(BoolConstraint.True, programState)
-                        .SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps))
-                        .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState)
-                            .SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))));
-            }
-
-            return ThrowIfTooMany(
-                LeftOperand.TrySetConstraint(BoolConstraint.True, programState)
-                    .SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.False, ps))
-                    .Union(LeftOperand.TrySetConstraint(BoolConstraint.False, programState)
-                        .SelectMany(ps => RightOperand.TrySetConstraint(BoolConstraint.True, ps))));
-        }
-
-        public override string ToString()
-        {
-            return LeftOperand + " ^ " + RightOperand;
-        }
+        public override string ToString() =>
+            LeftOperand + " ^ " + RightOperand;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/SymbolicValues/SymbolicValue_TrySetConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/SymbolicValues/SymbolicValue_TrySetConstraint.cs
@@ -30,49 +30,6 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
     [TestClass]
     public class SymbolicValue_TrySetConstraint
     {
-        [TestMethod]
-        [DynamicData(nameof(TrueConstraintData))]
-        [DynamicData(nameof(FalseConstraintData))]
-        [DynamicData(nameof(NullConstraintData))]
-        [DynamicData(nameof(NotNullConstraintData))]
-        [DynamicData(nameof(NoValueConstraintData))]
-        [DynamicData(nameof(HasValueConstraintData))]
-        [DynamicData(nameof(EmptyStringConstraintData))]
-        [DynamicData(nameof(FullStringConstraintData))]
-        [DynamicData(nameof(FullOrNullStringConstraintData))]
-        [DynamicData(nameof(WhiteSpaceStringConstraintData))]
-        [DynamicData(nameof(FullNotWhiteSpaceStringConstraintData))]
-        [DynamicData(nameof(NotWhiteSpaceStringConstraintData))]
-        [DynamicData(nameof(ByteArraySymbolicValueConstraintData))]
-        [DynamicData(nameof(CryptographyIVSymbolicValueConstraintData))]
-        [DynamicData(nameof(SaltSizeSymbolicValueConstraintData))]
-        public void TrySetConstraint(SymbolicValueConstraint constraint,
-                                     IList<SymbolicValueConstraint> existingConstraints,
-                                     IList<IList<SymbolicValueConstraint>> expectedConstraintsPerProgramState)
-        {
-            // Arrange
-            var sv = new SymbolicValue();
-            var ps = SetupProgramState(sv, existingConstraints);
-
-            // Act
-            var programStates = sv.TrySetConstraint(constraint, ps).ToList();
-
-            // Assert
-            programStates.Should().HaveCount(expectedConstraintsPerProgramState.Count);
-
-            for (var i = 0; i < programStates.Count; i++)
-            {
-                var programState = programStates[i];
-                var expectedConstraints = expectedConstraintsPerProgramState[i];
-
-                foreach (var expectedConstraint in expectedConstraints)
-                {
-                    programState.HasConstraint(sv, expectedConstraint).Should().BeTrue(
-                        $"{expectedConstraint} should be present in returned ProgramState.");
-                }
-            }
-        }
-
         public static IEnumerable<object[]> TrueConstraintData { get; } = new[]
         {
             new object[]
@@ -321,7 +278,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
                 ConstraintList(ObjectConstraint.NotNull), // existing
                 ProgramStateList(ConstraintList(ObjectConstraint.NotNull, StringConstraint.EmptyString)) // Expected
             },
-             new object[]
+            new object[]
             {
                 StringConstraint.EmptyString, // constraint to set
                 ConstraintList(StringConstraint.WhiteSpaceString), // existing
@@ -612,6 +569,49 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
                 ProgramStateList(ConstraintList(SaltSizeSymbolicValueConstraint.Short)) // Expected
             }
         };
+
+        [TestMethod]
+        [DynamicData(nameof(TrueConstraintData))]
+        [DynamicData(nameof(FalseConstraintData))]
+        [DynamicData(nameof(NullConstraintData))]
+        [DynamicData(nameof(NotNullConstraintData))]
+        [DynamicData(nameof(NoValueConstraintData))]
+        [DynamicData(nameof(HasValueConstraintData))]
+        [DynamicData(nameof(EmptyStringConstraintData))]
+        [DynamicData(nameof(FullStringConstraintData))]
+        [DynamicData(nameof(FullOrNullStringConstraintData))]
+        [DynamicData(nameof(WhiteSpaceStringConstraintData))]
+        [DynamicData(nameof(FullNotWhiteSpaceStringConstraintData))]
+        [DynamicData(nameof(NotWhiteSpaceStringConstraintData))]
+        [DynamicData(nameof(ByteArraySymbolicValueConstraintData))]
+        [DynamicData(nameof(CryptographyIVSymbolicValueConstraintData))]
+        [DynamicData(nameof(SaltSizeSymbolicValueConstraintData))]
+        public void TrySetConstraint(SymbolicValueConstraint constraint,
+                                     IList<SymbolicValueConstraint> existingConstraints,
+                                     IList<IList<SymbolicValueConstraint>> expectedConstraintsPerProgramState)
+        {
+            // Arrange
+            var sv = new SymbolicValue();
+            var ps = SetupProgramState(sv, existingConstraints);
+
+            // Act
+            var programStates = sv.TrySetConstraint(constraint, ps).ToList();
+
+            // Assert
+            programStates.Should().HaveCount(expectedConstraintsPerProgramState.Count);
+
+            for (var i = 0; i < programStates.Count; i++)
+            {
+                var programState = programStates[i];
+                var expectedConstraints = expectedConstraintsPerProgramState[i];
+
+                foreach (var expectedConstraint in expectedConstraints)
+                {
+                    programState.HasConstraint(sv, expectedConstraint).Should().BeTrue(
+                        $"{expectedConstraint} should be present in returned ProgramState.");
+                }
+            }
+        }
 
         private static IList<IList<SymbolicValueConstraint>> ProgramStateList(params IList<SymbolicValueConstraint>[] programStates) => programStates;
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/SymbolicValues/SymbolicValue_TrySetConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/SymbolicValues/SymbolicValue_TrySetConstraint.cs
@@ -613,6 +613,16 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             }
         }
 
+        [TestMethod]
+        public void WithNonBoolConstraint_ForBoolBinarySymbolicValue_ReturnsInputProgramState()
+        {
+            var sv = new AndSymbolicValue(SymbolicValue.True, SymbolicValue.False);
+            var inputProgramState = SetupProgramState(sv, new[] { BoolConstraint.True });
+            var newProgramStates = sv.TrySetConstraint(ObjectConstraint.NotNull, inputProgramState);
+
+            newProgramStates.Should().ContainSingle().And.BeEquivalentTo(inputProgramState);
+        }
+
         private static IList<IList<SymbolicValueConstraint>> ProgramStateList(params IList<SymbolicValueConstraint>[] programStates) => programStates;
 
         private static IList<SymbolicValueConstraint> ConstraintList(params SymbolicValueConstraint[] constraints) => constraints;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/SymbolicValues/SymbolicValue_TrySetConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/SymbolicValues/SymbolicValue_TrySetConstraint.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
     [TestClass]
     public class SymbolicValue_TrySetConstraint
     {
-        public static IEnumerable<object[]> TrueConstraintData { get; } = new[]
+        private static IEnumerable<object[]> TrueConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             },
         };
 
-        public static IEnumerable<object[]> FalseConstraintData { get; } = new[]
+        private static IEnumerable<object[]> FalseConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -98,7 +98,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             },
         };
 
-        public static IEnumerable<object[]> NullConstraintData { get; } = new[]
+        private static IEnumerable<object[]> NullConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -156,7 +156,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             },
         };
 
-        public static IEnumerable<object[]> NotNullConstraintData { get; } = new[]
+        private static IEnumerable<object[]> NotNullConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -214,7 +214,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             },
         };
 
-        public static IEnumerable<object[]> NoValueConstraintData { get; } = new[]
+        private static IEnumerable<object[]> NoValueConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -230,7 +230,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             },
         };
 
-        public static IEnumerable<object[]> HasValueConstraintData { get; } = new[]
+        private static IEnumerable<object[]> HasValueConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -246,7 +246,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             },
         };
 
-        public static IEnumerable<object[]> EmptyStringConstraintData { get; } = new[]
+        private static IEnumerable<object[]> EmptyStringConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -292,7 +292,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             },
         };
 
-        public static IEnumerable<object[]> FullStringConstraintData { get; } = new[]
+        private static IEnumerable<object[]> FullStringConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -338,7 +338,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             },
         };
 
-        public static IEnumerable<object[]> FullNotWhiteSpaceStringConstraintData { get; } = new[]
+        private static IEnumerable<object[]> FullNotWhiteSpaceStringConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -384,7 +384,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             },
         };
 
-        public static IEnumerable<object[]> WhiteSpaceStringConstraintData { get; } = new[]
+        private static IEnumerable<object[]> WhiteSpaceStringConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -430,7 +430,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             },
         };
 
-        public static IEnumerable<object[]> FullOrNullStringConstraintData { get; } = new[]
+        private static IEnumerable<object[]> FullOrNullStringConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -476,7 +476,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             },
         };
 
-        public static IEnumerable<object[]> NotWhiteSpaceStringConstraintData { get; } = new[]
+        private static IEnumerable<object[]> NotWhiteSpaceStringConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -522,7 +522,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             },
         };
 
-        public static IEnumerable<object[]> ByteArraySymbolicValueConstraintData { get; } = new[]
+        private static IEnumerable<object[]> ByteArraySymbolicValueConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -538,7 +538,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             }
         };
 
-        public static IEnumerable<object[]> CryptographyIVSymbolicValueConstraintData { get; } = new[]
+        private static IEnumerable<object[]> CryptographyIVSymbolicValueConstraintData { get; } = new[]
         {
             new object[]
             {
@@ -554,7 +554,7 @@ namespace SonarAnalyzer.SymbolicExecution.SymbolicValues
             }
         };
 
-        public static IEnumerable<object[]> SaltSizeSymbolicValueConstraintData { get; } = new[]
+        private static IEnumerable<object[]> SaltSizeSymbolicValueConstraintData { get; } = new[]
         {
             new object[]
             {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/SymbolicValues/SymbolicValuesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/SymbolicValues/SymbolicValuesTest.cs
@@ -21,6 +21,7 @@
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.SymbolicExecution;
+using SonarAnalyzer.SymbolicExecution.SymbolicValues;
 
 namespace SonarAnalyzer.UnitTest.SymbolicExecution.SymbolicValues
 {
@@ -28,7 +29,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.SymbolicValues
     public class SymbolicValuesTest
     {
         [TestMethod]
-        public void Test_Prebuilt_StringRepresentation()
+        public void Prebuilt_StringRepresentation()
         {
             SymbolicValue.This.ToString().Should().Be("SV_THIS");
             SymbolicValue.Base.ToString().Should().Be("SV_BASE");
@@ -36,10 +37,30 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.SymbolicValues
         }
 
         [TestMethod]
-        public void Test_Custom_StringRepresentation()
+        public void Custom_StringRepresentation()
         {
             var sv = new SymbolicValue();
             sv.ToString().Should().StartWith("SV_");
         }
+
+        [TestMethod]
+        public void AndConstraint_ToString() =>
+            new AndSymbolicValue(SymbolicValue.True, SymbolicValue.False).ToString().Should().Be("SV_True & SV_False");
+
+        [TestMethod]
+        public void OrConstraint_ToString() =>
+            new OrSymbolicValue(SymbolicValue.True, SymbolicValue.False).ToString().Should().Be("SV_True | SV_False");
+
+        [TestMethod]
+        public void XorConstraint_ToString() =>
+            new XorSymbolicValue(SymbolicValue.True, SymbolicValue.False).ToString().Should().Be("SV_True ^ SV_False");
+
+        [TestMethod]
+        public void ComparisonConstraint_ToString_Less() =>
+            new ComparisonSymbolicValue(ComparisonKind.Less, SymbolicValue.True, SymbolicValue.False).ToString().Should().Be("<(SV_True, SV_False)");
+
+        [TestMethod]
+        public void ComparisonConstraint_ToString_LessOrEqual() =>
+            new ComparisonSymbolicValue(ComparisonKind.LessOrEqual, SymbolicValue.True, SymbolicValue.False).ToString().Should().Be("<=(SV_True, SV_False)");
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/SymbolicValues/SymbolicValuesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/SymbolicValues/SymbolicValuesTest.cs
@@ -48,12 +48,24 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.SymbolicValues
             new AndSymbolicValue(SymbolicValue.True, SymbolicValue.False).ToString().Should().Be("SV_True & SV_False");
 
         [TestMethod]
+        public void AndConstraint_ForNull_ToString() =>
+            new AndSymbolicValue(null, null).ToString().Should().Be(" & ");
+
+        [TestMethod]
         public void OrConstraint_ToString() =>
             new OrSymbolicValue(SymbolicValue.True, SymbolicValue.False).ToString().Should().Be("SV_True | SV_False");
 
         [TestMethod]
+        public void OrConstraint_ForNull_ToString() =>
+            new OrSymbolicValue(null, null).ToString().Should().Be(" | ");
+
+        [TestMethod]
         public void XorConstraint_ToString() =>
             new XorSymbolicValue(SymbolicValue.True, SymbolicValue.False).ToString().Should().Be("SV_True ^ SV_False");
+
+        [TestMethod]
+        public void XorConstraint_ForNull_ToString() =>
+            new XorSymbolicValue(null, null).ToString().Should().Be(" ^ ");
 
         [TestMethod]
         public void ComparisonConstraint_ToString_Less() =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
@@ -889,13 +889,29 @@ namespace Repro_3395
         {
             var helper = Helper.A;
             object o = null;
-            if (helper == Helper.A & helper == Helper.B & helper == Helper.C ^ helper == Helper.D
-                | helper == Helper.E & helper == Helper.F & helper == Helper.G & helper == Helper.H
-                | helper == Helper.I & helper == Helper.A & helper == Helper.B & helper == Helper.C
-                | helper == Helper.D & helper == Helper.E & helper == Helper.F & helper == Helper.G
-                | helper == Helper.H & helper == Helper.I & helper == Helper.A & helper == Helper.B
-                | helper == Helper.C & helper == Helper.D & helper == Helper.E & helper == Helper.F
-                | helper == Helper.G & helper == Helper.H & helper == Helper.I & helper == Helper.J)
+            if (helper == Helper.A ^ helper == Helper.B ^ helper == Helper.C ^ helper == Helper.D
+                ^ helper == Helper.E ^ helper == Helper.F ^ helper == Helper.G ^ helper == Helper.H
+                ^ helper == Helper.I ^ helper == Helper.A ^ helper == Helper.B ^ helper == Helper.C
+                ^ helper == Helper.D ^ helper == Helper.E ^ helper == Helper.F ^ helper == Helper.G
+                ^ helper == Helper.H ^ helper == Helper.I ^ helper == Helper.A ^ helper == Helper.B
+                ^ helper == Helper.C ^ helper == Helper.D ^ helper == Helper.E ^ helper == Helper.F
+                ^ helper == Helper.G ^ helper == Helper.H ^ helper == Helper.I ^ helper == Helper.J)
+            {
+                o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
+            }
+        }
+
+        public static void ComparisonConstraint()
+        {
+            var helper = Helper.A;
+            object o = null;
+            if (helper > Helper.A | helper > Helper.B | helper > Helper.C | helper > Helper.D
+                | helper >= Helper.E | helper >= Helper.F | helper >= Helper.G | helper >= Helper.H
+                | helper == Helper.I | helper == Helper.A | helper == Helper.B | helper == Helper.C
+                | helper < Helper.D | helper < Helper.E | helper < Helper.F | helper < Helper.G
+                | helper >= Helper.H | helper >= Helper.I | helper >= Helper.A | helper >= Helper.B
+                | helper != Helper.C | helper != Helper.D | helper != Helper.E | helper != Helper.F
+                | helper == Helper.G | helper == Helper.H | helper == Helper.I | helper == Helper.J)
             {
                 o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
             }
@@ -905,13 +921,13 @@ namespace Repro_3395
         {
             var helper = Helper.A;
             object o = null;
-            if (helper == Helper.A & helper == Helper.B | helper == Helper.C & helper == Helper.D
-                | helper == Helper.E & helper == Helper.F | helper == Helper.G & helper == Helper.H
-                | helper == Helper.I & helper == Helper.A | helper == Helper.B & helper == Helper.C
-                | helper == Helper.D & helper == Helper.E | helper == Helper.F & helper == Helper.G
-                | helper == Helper.H & helper == Helper.I | helper == Helper.A & helper == Helper.B
-                | helper == Helper.C & helper == Helper.D | helper == Helper.E & helper == Helper.F
-                | helper == Helper.G & helper == Helper.H | helper == Helper.I & helper == Helper.J)
+            if (helper == Helper.A & helper == Helper.B ^ helper == Helper.C & helper == Helper.D
+                | helper == Helper.E & helper == Helper.F ^ helper == Helper.G & helper == Helper.H
+                | helper == Helper.I & helper == Helper.A ^ helper == Helper.B & helper == Helper.C
+                | helper == Helper.D & helper == Helper.E ^ helper == Helper.F & helper == Helper.G
+                | helper == Helper.H & helper == Helper.I ^ helper == Helper.A & helper == Helper.B
+                | helper == Helper.C & helper == Helper.D ^ helper == Helper.E & helper == Helper.F
+                | helper == Helper.G & helper == Helper.H ^ helper == Helper.I & helper == Helper.J)
             {
                 o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
             }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
@@ -830,48 +830,90 @@ namespace Repro_3395
     }
     public static class Test
     {
+        public static void SupportedSize()
+        {
+            var helper = Helper.A;
+            object o = null;
+            if (helper == Helper.A | helper == Helper.B | helper == Helper.C | helper == Helper.D
+                | helper == Helper.E | helper == Helper.F | helper == Helper.G | helper == Helper.H)
+            {
+                o.ToString(); // Noncompliant, this condition size is within the limit
+            }
+        }
+
+        public static void UnsupportedSize()
+        {
+            var helper = Helper.A;
+            object o = null;
+            if (helper == Helper.A | helper == Helper.B | helper == Helper.C | helper == Helper.D
+                | helper == Helper.E | helper == Helper.F | helper == Helper.G | helper == Helper.H
+                | helper == Helper.I)
+            {
+                o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
+            }
+        }
+
         public static void OrConstraint()
         {
             var helper = Helper.A;
-            if (helper == Helper.A | helper == Helper.B | helper == Helper.C | helper == Helper.D |
-               helper == Helper.E | helper == Helper.F | helper == Helper.G | helper == Helper.H |
-               helper == Helper.I | helper == Helper.A | helper == Helper.B | helper == Helper.C |
-               helper == Helper.D | helper == Helper.E | helper == Helper.F | helper == Helper.G |
-               helper == Helper.H | helper == Helper.I | helper == Helper.A | helper == Helper.B |
-               helper == Helper.C | helper == Helper.D | helper == Helper.E | helper == Helper.F |
-               helper == Helper.G | helper == Helper.H | helper == Helper.I)
+            object o = null;
+            if (helper == Helper.A | helper == Helper.B | helper == Helper.C | helper == Helper.D
+                | helper == Helper.E | helper == Helper.F | helper == Helper.G | helper == Helper.H
+                | helper == Helper.I | helper == Helper.A | helper == Helper.B | helper == Helper.C
+                | helper == Helper.D | helper == Helper.E | helper == Helper.F | helper == Helper.G
+                | helper == Helper.H | helper == Helper.I | helper == Helper.A | helper == Helper.B
+                | helper == Helper.C | helper == Helper.D | helper == Helper.E | helper == Helper.F
+                | helper == Helper.G | helper == Helper.H | helper == Helper.I | helper == Helper.J)
             {
-                System.Console.WriteLine("");
+                o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
             }
         }
 
         public static void AndConstraint()
         {
             var helper = Helper.A;
-            if (helper == Helper.A & helper == Helper.B & helper == Helper.C & helper == Helper.D |
-               helper == Helper.E & helper == Helper.F & helper == Helper.G & helper == Helper.H |
-               helper == Helper.I & helper == Helper.A & helper == Helper.B & helper == Helper.C |
-               helper == Helper.D & helper == Helper.E & helper == Helper.F & helper == Helper.G |
-               helper == Helper.H & helper == Helper.I & helper == Helper.A & helper == Helper.B |
-               helper == Helper.C & helper == Helper.D & helper == Helper.E & helper == Helper.F |
-               helper == Helper.G & helper == Helper.H & helper == Helper.I)
+            object o = null;
+            if (helper == Helper.A & helper == Helper.B & helper == Helper.C & helper == Helper.D
+                & helper == Helper.E & helper == Helper.F & helper == Helper.G & helper == Helper.H
+                & helper == Helper.I & helper == Helper.A & helper == Helper.B & helper == Helper.C
+                & helper == Helper.D & helper == Helper.E & helper == Helper.F & helper == Helper.G
+                & helper == Helper.H & helper == Helper.I & helper == Helper.A & helper == Helper.B
+                & helper == Helper.C & helper == Helper.D & helper == Helper.E & helper == Helper.F
+                & helper == Helper.G & helper == Helper.H & helper == Helper.I & helper == Helper.J)
             {
-                System.Console.WriteLine("");
+                o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
+            }
+        }
+
+        public static void XorConstraint()
+        {
+            var helper = Helper.A;
+            object o = null;
+            if (helper == Helper.A & helper == Helper.B & helper == Helper.C ^ helper == Helper.D
+                | helper == Helper.E & helper == Helper.F & helper == Helper.G & helper == Helper.H
+                | helper == Helper.I & helper == Helper.A & helper == Helper.B & helper == Helper.C
+                | helper == Helper.D & helper == Helper.E & helper == Helper.F & helper == Helper.G
+                | helper == Helper.H & helper == Helper.I & helper == Helper.A & helper == Helper.B
+                | helper == Helper.C & helper == Helper.D & helper == Helper.E & helper == Helper.F
+                | helper == Helper.G & helper == Helper.H & helper == Helper.I & helper == Helper.J)
+            {
+                o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
             }
         }
 
         public static void MixedConstraints()
         {
             var helper = Helper.A;
-            if (helper == Helper.A & helper == Helper.B | helper == Helper.C & helper == Helper.D |
-               helper == Helper.E & helper == Helper.F | helper == Helper.G & helper == Helper.H |
-               helper == Helper.I & helper == Helper.A | helper == Helper.B & helper == Helper.C |
-               helper == Helper.D & helper == Helper.E | helper == Helper.F & helper == Helper.G |
-               helper == Helper.H & helper == Helper.I | helper == Helper.A & helper == Helper.B |
-               helper == Helper.C & helper == Helper.D | helper == Helper.E & helper == Helper.F |
-               helper == Helper.G & helper == Helper.H | helper == Helper.I)
+            object o = null;
+            if (helper == Helper.A & helper == Helper.B | helper == Helper.C & helper == Helper.D
+                | helper == Helper.E & helper == Helper.F | helper == Helper.G & helper == Helper.H
+                | helper == Helper.I & helper == Helper.A | helper == Helper.B & helper == Helper.C
+                | helper == Helper.D & helper == Helper.E | helper == Helper.F & helper == Helper.G
+                | helper == Helper.H & helper == Helper.I | helper == Helper.A & helper == Helper.B
+                | helper == Helper.C & helper == Helper.D | helper == Helper.E & helper == Helper.F
+                | helper == Helper.G & helper == Helper.H | helper == Helper.I & helper == Helper.J)
             {
-                System.Console.WriteLine("");
+                o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
             }
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
@@ -821,3 +821,58 @@ namespace Tests.Diagnostics
     }
 }
 
+// https://github.com/SonarSource/sonar-dotnet/issues/3395s
+namespace Repro_3395
+{
+    public enum Helper
+    {
+        A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P
+    }
+    public static class Test
+    {
+        public static void OrConstraint()
+        {
+            var helper = Helper.A;
+            if (helper == Helper.A | helper == Helper.B | helper == Helper.C | helper == Helper.D |
+               helper == Helper.E | helper == Helper.F | helper == Helper.G | helper == Helper.H |
+               helper == Helper.I | helper == Helper.A | helper == Helper.B | helper == Helper.C |
+               helper == Helper.D | helper == Helper.E | helper == Helper.F | helper == Helper.G |
+               helper == Helper.H | helper == Helper.I | helper == Helper.A | helper == Helper.B |
+               helper == Helper.C | helper == Helper.D | helper == Helper.E | helper == Helper.F |
+               helper == Helper.G | helper == Helper.H | helper == Helper.I)
+            {
+                System.Console.WriteLine("");
+            }
+        }
+
+        public static void AndConstraint()
+        {
+            var helper = Helper.A;
+            if (helper == Helper.A & helper == Helper.B & helper == Helper.C & helper == Helper.D |
+               helper == Helper.E & helper == Helper.F & helper == Helper.G & helper == Helper.H |
+               helper == Helper.I & helper == Helper.A & helper == Helper.B & helper == Helper.C |
+               helper == Helper.D & helper == Helper.E & helper == Helper.F & helper == Helper.G |
+               helper == Helper.H & helper == Helper.I & helper == Helper.A & helper == Helper.B |
+               helper == Helper.C & helper == Helper.D & helper == Helper.E & helper == Helper.F |
+               helper == Helper.G & helper == Helper.H & helper == Helper.I)
+            {
+                System.Console.WriteLine("");
+            }
+        }
+
+        public static void MixedConstraints()
+        {
+            var helper = Helper.A;
+            if (helper == Helper.A & helper == Helper.B | helper == Helper.C & helper == Helper.D |
+               helper == Helper.E & helper == Helper.F | helper == Helper.G & helper == Helper.H |
+               helper == Helper.I & helper == Helper.A | helper == Helper.B & helper == Helper.C |
+               helper == Helper.D & helper == Helper.E | helper == Helper.F & helper == Helper.G |
+               helper == Helper.H & helper == Helper.I | helper == Helper.A & helper == Helper.B |
+               helper == Helper.C & helper == Helper.D | helper == Helper.E & helper == Helper.F |
+               helper == Helper.G & helper == Helper.H | helper == Helper.I)
+            {
+                System.Console.WriteLine("");
+            }
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NullPointerDereference.cs
@@ -821,7 +821,7 @@ namespace Tests.Diagnostics
     }
 }
 
-// https://github.com/SonarSource/sonar-dotnet/issues/3395s
+// https://github.com/SonarSource/sonar-dotnet/issues/3395
 namespace Repro_3395
 {
     public enum Helper


### PR DESCRIPTION
Fixes #3395

`OrSymbolicValue.TrySetConstraint` triggered too deep exponential tree evaluation. Same happens for other binary constraints as well.

Changes:
* Introduced `BoolBinarySymbolicValue` to extract common logic for all `BinarySymbolicValue` types that work with `BoolContraint`
* Measure nested size of operands
* Limit size of explored operands based on measurements

SE flow:
* All instructions are processed
* `VisitBinaryBranch` is called at the end of the block
* Constraint is set in `TrySetConstraint` here https://github.com/SonarSource/sonar-dotnet/blob/954aaee95a640e6de52480e5bdacdf67e7b0a687/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/CSharp/CSharpExplodedGraph.cs#L870