### PR TITLE
Rule S1862 and S2760: add support for C# 9 pattern matching

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpEquivalenceChecker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpEquivalenceChecker.cs
@@ -57,6 +57,11 @@ namespace SonarAnalyzer.Helpers
                 }
                 return NullCheckExpression(binary) is { } expression ? new NullCheck(expression, positive) : null;
             }
+            else if (node.IsKind(SyntaxKindEx.IsPatternExpression))
+            {
+                var isPattern = (IsPatternExpressionSyntaxWrapper)node;
+                return NullCheckPattern(isPattern.Expression, isPattern.Pattern.SyntaxNode, positive);
+            }
             else
             {
                 return null;
@@ -72,6 +77,18 @@ namespace SonarAnalyzer.Helpers
             else if (binary.Right.IsKind(SyntaxKind.NullLiteralExpression))
             {
                 return binary.Left;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private static NullCheck NullCheckPattern(SyntaxNode expression, SyntaxNode pattern, bool positive)
+        {
+            if (pattern.IsKind(SyntaxKindEx.ConstantPattern) && ((ConstantPatternSyntaxWrapper)pattern).Expression.IsKind(SyntaxKind.NullLiteralExpression))
+            {
+                return new NullCheck(expression, positive);
             }
             else
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpEquivalenceChecker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpEquivalenceChecker.cs
@@ -90,6 +90,10 @@ namespace SonarAnalyzer.Helpers
             {
                 return new NullCheck(expression, positive);
             }
+            else if (pattern.IsKind(SyntaxKindEx.NotPattern))
+            {
+                return NullCheckPattern(expression, ((UnaryPatternSyntaxWrapper)pattern).Pattern.SyntaxNode, !positive);
+            }
             else
             {
                 return null;

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpEquivalenceChecker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpEquivalenceChecker.cs
@@ -18,50 +18,36 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace SonarAnalyzer.Helpers
 {
     internal static class CSharpEquivalenceChecker
     {
-        public static bool AreEquivalent(SyntaxNode node1, SyntaxNode node2)
-        {
-            return Common.EquivalenceChecker.AreEquivalent(node1, node2,
-                (n1, n2) => SyntaxFactory.AreEquivalent(n1, n2));
-        }
+        public static bool AreEquivalent(SyntaxNode node1, SyntaxNode node2) =>
+            Common.EquivalenceChecker.AreEquivalent(node1, node2, (n1, n2) => SyntaxFactory.AreEquivalent(n1, n2));
 
-        public static bool AreEquivalent(SyntaxList<SyntaxNode> nodeList1, SyntaxList<SyntaxNode> nodeList2)
-        {
-            return Common.EquivalenceChecker.AreEquivalent(nodeList1, nodeList2,
-                (n1, n2) => SyntaxFactory.AreEquivalent(n1, n2));
-        }
+        public static bool AreEquivalent(SyntaxList<SyntaxNode> nodeList1, SyntaxList<SyntaxNode> nodeList2) =>
+            Common.EquivalenceChecker.AreEquivalent(nodeList1, nodeList2, (n1, n2) => SyntaxFactory.AreEquivalent(n1, n2));
     }
 
     internal class CSharpSyntaxNodeEqualityComparer<T> : IEqualityComparer<T>, IEqualityComparer<SyntaxList<T>>
         where T : SyntaxNode
     {
-        public bool Equals(T x, T y)
-        {
-            return CSharpEquivalenceChecker.AreEquivalent(x, y);
-        }
+        public bool Equals(T x, T y) =>
+            CSharpEquivalenceChecker.AreEquivalent(x, y);
 
-        public bool Equals(SyntaxList<T> x, SyntaxList<T> y)
-        {
-            return CSharpEquivalenceChecker.AreEquivalent(x, y);
-        }
+        public bool Equals(SyntaxList<T> x, SyntaxList<T> y) =>
+            CSharpEquivalenceChecker.AreEquivalent(x, y);
 
-        public int GetHashCode(T obj)
-        {
-            return obj.GetType().FullName.GetHashCode();
-        }
+        public int GetHashCode(T obj) =>
+            obj.GetType().FullName.GetHashCode();
 
-        public int GetHashCode(SyntaxList<T> obj)
-        {
-            return (obj.Count + string.Join(", ", obj.Select(x => x.GetType().FullName).Distinct())).GetHashCode();
-        }
+        public int GetHashCode(SyntaxList<T> obj) =>
+            (obj.Count + obj.Select(x => x.GetType().FullName).Distinct().JoinStr(", ")).GetHashCode();
     }
 
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpNavigationHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpNavigationHelper.cs
@@ -77,17 +77,7 @@ namespace SonarAnalyzer.Helpers
 
         #endregion Switch
 
-        #region Statement
-
-        public static StatementSyntax GetPrecedingStatement(this StatementSyntax currentStatement)
-        {
-            var statements = currentStatement.Parent.ChildNodes().OfType<StatementSyntax>().ToList();
-
-            var index = statements.IndexOf(currentStatement);
-
-            return index == 0 ? null : statements[index - 1];
-        }
-
-        #endregion Statement
+        public static StatementSyntax GetPrecedingStatement(this StatementSyntax currentStatement) =>
+            currentStatement.Parent.ChildNodes().OfType<StatementSyntax>().TakeWhile(x => x != currentStatement).LastOrDefault();
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 || statementDescendents.OfType<PrefixUnaryExpressionSyntax>().Any(x => HasCheckedSymbol(x.Operand));
 
             bool HasCheckedSymbol(SyntaxNode node) =>
-                checkedSymbolNames.Any(x => node.ToStringContains(x))
+                checkedSymbolNames.Any(node.ToStringContains)
                 && semanticModel.GetSymbolInfo(node).Symbol is { } symbol
                 && checkedSymbols.Contains(symbol);
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
@@ -70,13 +70,16 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool ContainsPossibleUpdate(StatementSyntax statement, ExpressionSyntax expression, SemanticModel semanticModel)
         {
             var checkedSymbols = expression.DescendantNodesAndSelf().Select(x => semanticModel.GetSymbolInfo(x).Symbol).WhereNotNull().ToHashSet();
+            var checkedSymbolNames = checkedSymbols.Select(x => x.Name).ToArray();
             var statementDescendents = statement.DescendantNodesAndSelf().ToArray();
             return statementDescendents.OfType<AssignmentExpressionSyntax>().Any(x => HasCheckedSymbol(x.Left))
                 || statementDescendents.OfType<PostfixUnaryExpressionSyntax>().Any(x => HasCheckedSymbol(x.Operand))
                 || statementDescendents.OfType<PrefixUnaryExpressionSyntax>().Any(x => HasCheckedSymbol(x.Operand));
 
             bool HasCheckedSymbol(SyntaxNode node) =>
-                semanticModel.GetSymbolInfo(node).Symbol is { } symbol && checkedSymbols.Contains(symbol);
+                checkedSymbolNames.Any(x => node.ToStringContains(x))
+                && semanticModel.GetSymbolInfo(node).Symbol is { } symbol
+                && checkedSymbols.Contains(symbol);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
@@ -69,7 +69,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static bool ContainsPossibleUpdate(StatementSyntax statement, ExpressionSyntax expression, SemanticModel semanticModel)
         {
-            var checkedSymbols = expression.DescendantNodesAndSelf().Select(x => semanticModel.GetSymbolInfo(x).Symbol).WhereNotNull().ToHashSet();
+            var checkedSymbols = expression.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>().Select(x => semanticModel.GetSymbolInfo(x).Symbol).WhereNotNull().ToHashSet();
             var checkedSymbolNames = checkedSymbols.Select(x => x.Name).ToArray();
             var statementDescendents = statement.DescendantNodesAndSelf().ToArray();
             return statementDescendents.OfType<AssignmentExpressionSyntax>().Any(x => HasCheckedSymbol(x.Left))

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/EquivalenceChecker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/EquivalenceChecker.cs
@@ -25,14 +25,10 @@ namespace SonarAnalyzer.Helpers.Common
 {
     internal static class EquivalenceChecker
     {
-        public static bool AreEquivalent(SyntaxNode node1, SyntaxNode node2, Func<SyntaxNode, SyntaxNode, bool> nodeComparator)
-        {
-            return node1.Language == node2.Language &&
-                nodeComparator(node1, node2);
-        }
+        public static bool AreEquivalent(SyntaxNode node1, SyntaxNode node2, Func<SyntaxNode, SyntaxNode, bool> nodeComparator) =>
+            node1.Language == node2.Language && nodeComparator(node1, node2);
 
-        public static bool AreEquivalent(SyntaxList<SyntaxNode> nodeList1, SyntaxList<SyntaxNode> nodeList2,
-            Func<SyntaxNode, SyntaxNode, bool> nodeComparator)
+        public static bool AreEquivalent(SyntaxList<SyntaxNode> nodeList1, SyntaxList<SyntaxNode> nodeList2, Func<SyntaxNode, SyntaxNode, bool> nodeComparator)
         {
             if (nodeList1.Count != nodeList2.Count)
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ConditionalStructureSameConditionBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ConditionalStructureSameConditionBase.cs
@@ -18,13 +18,24 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
     public abstract class ConditionalStructureSameConditionBase : SonarDiagnosticAnalyzer
     {
-        internal const string DiagnosticId = "S1862";
-        internal const string MessageFormat = "This branch duplicates the one on line {0}.";
+        protected const string DiagnosticId = "S1862";
+        protected const string MessageFormat = "This branch duplicates the one on line {0}.";
+
+        protected readonly DiagnosticDescriptor rule;
+
+        protected abstract ILanguageFacade Language { get; }
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+
+        protected ConditionalStructureSameConditionBase() =>
+            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/EquivalenceCheckerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/EquivalenceCheckerTest.cs
@@ -24,8 +24,8 @@ using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
-using CSharp = Microsoft.CodeAnalysis.CSharp.Syntax;
-using VisualBasic = Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using CS = Microsoft.CodeAnalysis.CSharp.Syntax;
+using VB = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
 namespace SonarAnalyzer.UnitTest.Helpers
 {
@@ -137,7 +137,7 @@ End Namespace";
         [TestMethod]
         public void EqualityComparer_Node_CS()
         {
-            var comparer = new CSharpSyntaxNodeEqualityComparer<CSharp.BlockSyntax>();
+            var comparer = new CSharpSyntaxNodeEqualityComparer<CS.BlockSyntax>();
 
             var result = comparer.Equals(csMethods.Method1, csMethods.Method2);
             result.Should().BeTrue();
@@ -145,7 +145,7 @@ End Namespace";
             result = comparer.Equals(csMethods.Method1, csMethods.Method3);
             result.Should().BeFalse();
 
-            var hashSet = new HashSet<CSharp.BlockSyntax>(new[] { csMethods.Method1, csMethods.Method2, csMethods.Method3 }, comparer);
+            var hashSet = new HashSet<CS.BlockSyntax>(new[] { csMethods.Method1, csMethods.Method2, csMethods.Method3 }, comparer);
             hashSet.Should().HaveCount(2);
             hashSet.Should().Contain(csMethods.Method1);
             hashSet.Should().NotContain(csMethods.Method4);
@@ -154,7 +154,7 @@ End Namespace";
         [TestMethod]
         public void EqualityComparer_List_CS()
         {
-            var comparer = new CSharpSyntaxNodeEqualityComparer<CSharp.StatementSyntax>();
+            var comparer = new CSharpSyntaxNodeEqualityComparer<CS.StatementSyntax>();
 
             var result = comparer.Equals(csMethods.Method1.Statements, csMethods.Method2.Statements);
             result.Should().BeTrue();
@@ -162,7 +162,7 @@ End Namespace";
             result = comparer.Equals(csMethods.Method1.Statements, csMethods.Method3.Statements);
             result.Should().BeFalse();
 
-            var hashSet = new HashSet<SyntaxList<CSharp.StatementSyntax>>(new[] { csMethods.Method1.Statements, csMethods.Method2.Statements, csMethods.Method3.Statements }, comparer);
+            var hashSet = new HashSet<SyntaxList<CS.StatementSyntax>>(new[] { csMethods.Method1.Statements, csMethods.Method2.Statements, csMethods.Method3.Statements }, comparer);
             hashSet.Should().HaveCount(2);
             hashSet.Should().Contain(csMethods.Method1.Statements);
             hashSet.Should().NotContain(csMethods.Method4.Statements);
@@ -191,7 +191,7 @@ End Namespace";
         [TestMethod]
         public void EqualityComparer_Node_VB()
         {
-            var comparer = new VisualBasicSyntaxNodeEqualityComparer<VisualBasic.StatementSyntax>();
+            var comparer = new VisualBasicSyntaxNodeEqualityComparer<VB.StatementSyntax>();
 
             var result = comparer.Equals(vbMethods.Method1.First(), vbMethods.Method2.First());
             result.Should().BeTrue();
@@ -199,7 +199,7 @@ End Namespace";
             result = comparer.Equals(vbMethods.Method1.First(), vbMethods.Method3.First());
             result.Should().BeFalse();
 
-            var hashSet = new HashSet<VisualBasic.StatementSyntax>(new[] { vbMethods.Method1.First(), vbMethods.Method2.First(), vbMethods.Method3.First() }, comparer);
+            var hashSet = new HashSet<VB.StatementSyntax>(new[] { vbMethods.Method1.First(), vbMethods.Method2.First(), vbMethods.Method3.First() }, comparer);
             hashSet.Should().HaveCount(2);
             hashSet.Should().Contain(vbMethods.Method1.First());
             hashSet.Should().NotContain(vbMethods.Method4.First());
@@ -208,7 +208,7 @@ End Namespace";
         [TestMethod]
         public void EqualityComparer_List_VB()
         {
-            var comparer = new VisualBasicSyntaxNodeEqualityComparer<VisualBasic.StatementSyntax>();
+            var comparer = new VisualBasicSyntaxNodeEqualityComparer<VB.StatementSyntax>();
 
             var result = comparer.Equals(vbMethods.Method1, vbMethods.Method2);
             result.Should().BeTrue();
@@ -216,7 +216,7 @@ End Namespace";
             result = comparer.Equals(vbMethods.Method1, vbMethods.Method3);
             result.Should().BeFalse();
 
-            var hashSet = new HashSet<SyntaxList<VisualBasic.StatementSyntax>>(new[] { vbMethods.Method1, vbMethods.Method2, vbMethods.Method3 }, comparer);
+            var hashSet = new HashSet<SyntaxList<VB.StatementSyntax>>(new[] { vbMethods.Method1, vbMethods.Method2, vbMethods.Method3 }, comparer);
             hashSet.Should().HaveCount(2);
             hashSet.Should().Contain(vbMethods.Method1);
             hashSet.Should().NotContain(vbMethods.Method4);
@@ -224,14 +224,14 @@ End Namespace";
 
         private class CSharpMethods
         {
-            public readonly CSharp.BlockSyntax Method1;
-            public readonly CSharp.BlockSyntax Method2;
-            public readonly CSharp.BlockSyntax Method3;
-            public readonly CSharp.BlockSyntax Method4;
+            public readonly CS.BlockSyntax Method1;
+            public readonly CS.BlockSyntax Method2;
+            public readonly CS.BlockSyntax Method3;
+            public readonly CS.BlockSyntax Method4;
 
             public CSharpMethods(string source)
             {
-                var methods = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(source).GetRoot().DescendantNodes().OfType<CSharp.MethodDeclarationSyntax>().ToArray();
+                var methods = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(source).GetRoot().DescendantNodes().OfType<CS.MethodDeclarationSyntax>().ToArray();
                 Method1 = methods.Single(m => m.Identifier.ValueText == "Method1").Body;
                 Method2 = methods.Single(m => m.Identifier.ValueText == "Method2").Body;
                 Method3 = methods.Single(m => m.Identifier.ValueText == "Method3").Body;
@@ -241,14 +241,14 @@ End Namespace";
 
         private class VisualBasicMethods
         {
-            public readonly SyntaxList<VisualBasic.StatementSyntax> Method1;
-            public readonly SyntaxList<VisualBasic.StatementSyntax> Method2;
-            public readonly SyntaxList<VisualBasic.StatementSyntax> Method3;
-            public readonly SyntaxList<VisualBasic.StatementSyntax> Method4;
+            public readonly SyntaxList<VB.StatementSyntax> Method1;
+            public readonly SyntaxList<VB.StatementSyntax> Method2;
+            public readonly SyntaxList<VB.StatementSyntax> Method3;
+            public readonly SyntaxList<VB.StatementSyntax> Method4;
 
             public VisualBasicMethods(string source)
             {
-                var methods = Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree.ParseText(source).GetRoot().DescendantNodes().OfType<VisualBasic.MethodBlockSyntax>().ToArray();
+                var methods = Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree.ParseText(source).GetRoot().DescendantNodes().OfType<VB.MethodBlockSyntax>().ToArray();
                 Method1 = methods.Single(m => m.GetIdentifierText() == "Method1").Statements;
                 Method2 = methods.Single(m => m.GetIdentifierText() == "Method2").Statements;
                 Method3 = methods.Single(m => m.GetIdentifierText() == "Method3").Statements;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/EquivalenceCheckerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/EquivalenceCheckerTest.cs
@@ -24,6 +24,7 @@ using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
+using SonarAnalyzer.Helpers.Common;
 using CS = Microsoft.CodeAnalysis.CSharp.Syntax;
 using VB = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
@@ -221,6 +222,10 @@ End Namespace";
             hashSet.Should().Contain(vbMethods.Method1);
             hashSet.Should().NotContain(vbMethods.Method4);
         }
+
+        [TestMethod]
+        public void EqualityComparer_Node_CrossLangauge() =>
+            EquivalenceChecker.AreEquivalent(vbMethods.Method1.First(), csMethods.Method1, null).Should().BeFalse();
 
         private class CSharpMethods
         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/EquivalenceCheckerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/EquivalenceCheckerTest.cs
@@ -224,7 +224,7 @@ End Namespace";
         }
 
         [TestMethod]
-        public void EqualityComparer_Node_CrossLangauge() =>
+        public void EqualityComparer_Node_CrossLanguage() =>
             EquivalenceChecker.AreEquivalent(vbMethods.Method1.First(), csMethods.Method1, null).Should().BeFalse();
 
         private class CSharpMethods

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalStructureSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalStructureSameCondition.CSharp9.cs
@@ -49,10 +49,10 @@ void Test(Apple a, Orange b, bool cond)
 void AnotherTest(object o)
 {
     if (o is not null) { }
-    else if (o != null) { } // FN, same as above
+    else if (o != null) { } // Noncompliant
 
     if (o is null) { }
-    else if (o == null) { } // FN, same as above
+    else if (o == null) { } // Noncompliant
 }
 
 abstract class Fruit { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalStructureSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalStructureSameCondition.CSharp9.cs
@@ -48,10 +48,10 @@ void Test(Apple a, Orange b, bool cond)
 
 void AnotherTest(object o)
 {
-    if (o is not null) { }
+    if (o is not null) { }  // Secondary
     else if (o != null) { } // Noncompliant
 
-    if (o is null) { }
+    if (o is null) { }      // Secondary
     else if (o == null) { } // Noncompliant
 }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
@@ -70,6 +70,7 @@
 
             if (!(f is null)) { }
             if (f != null) { }          // Noncompliant, same meaning
+            if (f is not not null) { }  // Compliant, equal to f == null
         }
 
         void doTheThing(object o) { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
@@ -60,6 +60,11 @@
             if (ch is >= 'a' and <= 'z') { } // Noncompliant
             if (ch is <= 'z' and >= 'a') { } // Compliant, even when the semantics is the same
 
+            if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '.' or '?') { }
+            if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '.' or '?') { } // Noncompliant
+            if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '?' or '.') { } // Compliant, even when the semantics is the same
+            if (ch is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or '?' or '.') { } // Compliant, even when the semantics is the same
+
             if (f is not null) { }
             if (f is not not not null) { }  // Noncompliant, same meaning
             if (f != null) { }              // Noncompliant, same meaning
@@ -71,12 +76,33 @@
             if (!(f is null)) { }
             if (f != null) { }          // Noncompliant, same meaning
             if (f is not not null) { }  // Compliant, equal to f == null
+
+            if (f is Apple) { }
+            if (f is Apple) { }   // Noncompliant
+
+            if (f is Apple or Orange) { }
+            if (f is Apple or Orange) { }   // Noncompliant
+            if (f is Orange or Apple) { }   // Compliant, even when the semantics is the same
+
+            if (f is not Apple) { }
+            if (f is not Apple) { } // Noncompliant
+
+            if (f is { Size: >= 5, Value: 0 }) { }
+            if (f is { Size: >= 5, Value: 0 }) { } // Noncompliant
+            if (f is { Value: 0, Size: >= 5 }) { } // Compliant, even when the semantics is the same
+
+            if (f is { Size: >= 5 }) { }
+            if (f is not { Size: < 5 }) { } // Compliant, even when the semantics is the same
         }
 
         void doTheThing(object o) { }
     }
 
-    abstract class Fruit { }
+    abstract class Fruit
+    {
+        public int Size { get; }
+        public int Value { get; }
+    }
     class Apple : Fruit { }
     class Orange : Fruit { }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
@@ -61,13 +61,15 @@
             if (ch is <= 'z' and >= 'a') { } // Compliant, even when the semantics is the same
 
             if (f is not null) { }
-            if (f != null) { } // Compliant, even when the semantics is the same
+            if (f is not not not null) { }  // Noncompliant, same meaning
+            if (f != null) { }              // Noncompliant, same meaning
 
             if (f is null) { }
-            if (f == null) { } // Noncompliant, same meaning
+            if (f == null) { }          // Noncompliant, same meaning
+            if (!(f is not null)) { }   // Noncompliant, same meaning
 
             if (!(f is null)) { }
-            if (f != null) { } // Noncompliant, same meaning
+            if (f != null) { }          // Noncompliant, same meaning
         }
 
         void doTheThing(object o) { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
@@ -62,10 +62,10 @@
 
 
             if (f is not null) { }
-            if (f != null) { } // FN, same as above
+            if (f != null) { } // Compliant, even when the semantics is the same
 
             if (f is null) { }
-            if (f == null) { } // FN, same as above
+            if (f == null) { } // Compliant, even when the semantics is the same
         }
 
         void doTheThing(object o) { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
@@ -64,7 +64,10 @@
             if (f != null) { } // Compliant, even when the semantics is the same
 
             if (f is null) { }
-            if (f == null) { } // Compliant, even when the semantics is the same
+            if (f == null) { } // Noncompliant, same meaning
+
+            if (!(f is null)) { }
+            if (f != null) { } // Noncompliant, same meaning
         }
 
         void doTheThing(object o) { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
@@ -58,12 +58,12 @@
             char ch = 'x';
             if (ch is >= 'a' and <= 'z') { }
             if (ch is >= 'a' and <= 'z') { } // Noncompliant
-            if (ch is <= 'z' and >= 'a') { } // Compliant, even when the semantics is the same
+            if (ch is <= 'z' and >= 'a') { } // FN, only syntax checks are currently supported
 
             if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '.' or '?') { }
             if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '.' or '?') { } // Noncompliant
-            if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '?' or '.') { } // Compliant, even when the semantics is the same
-            if (ch is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or '?' or '.') { } // Compliant, even when the semantics is the same
+            if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '?' or '.') { } // FN, only syntax checks are currently supported
+            if (ch is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or '?' or '.') { } // FN, only syntax checks are currently supported
 
             if (f is not null) { }
             if (f is not not not null) { }  // Noncompliant, same meaning
@@ -82,17 +82,17 @@
 
             if (f is Apple or Orange) { }
             if (f is Apple or Orange) { }   // Noncompliant
-            if (f is Orange or Apple) { }   // Compliant, even when the semantics is the same
+            if (f is Orange or Apple) { }   // FN, only syntax checks are currently supported
 
             if (f is not Apple) { }
             if (f is not Apple) { } // Noncompliant
 
             if (f is { Size: >= 5, Value: 0 }) { }
             if (f is { Size: >= 5, Value: 0 }) { } // Noncompliant
-            if (f is { Value: 0, Size: >= 5 }) { } // Compliant, even when the semantics is the same
+            if (f is { Value: 0, Size: >= 5 }) { } // FN, only syntax checks are currently supported
 
             if (f is { Size: >= 5 }) { }
-            if (f is not { Size: < 5 }) { } // Compliant, even when the semantics is the same
+            if (f is not { Size: < 5 }) { } // FN, only syntax checks are currently supported
         }
 
         void doTheThing(object o) { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
@@ -58,6 +58,8 @@
             char ch = 'x';
             if (ch is >= 'a' and <= 'z') { }
             if (ch is >= 'a' and <= 'z') { } // Noncompliant
+            if (ch is <= 'z' and >= 'a') { } // Compliant, even when the semantics is the same
+
 
             if (f is not null) { }
             if (f != null) { } // FN, same as above

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
@@ -1,108 +1,126 @@
-﻿namespace Tests.TestCases
+﻿class ConditionalsWithSameCondition
 {
-    class ConditionalsWithSameCondition
+    public void Foo()
     {
-        public void Foo()
+        string c = null;
+        if (c is null)
         {
-            string c = null;
-            if (c is null)
-            {
-                doTheThing(c);
-            }
-            if (c is null) // Noncompliant {{This condition was just checked on line 8.}}
-            {
-                doTheThing(c);
-            }
-            if (c is not null) // Compliant
-            {
-                doTheThing(c);
-            }
-
-            if (c is "banana") // Compliant, c might be updated in the previous if
-            {
-                c += "a";
-            }
-            if (c is "banana") // Compliant, c might be updated in the previous if
-            {
-                c = "";
-            }
-            if (c is "banana") // Compliant, c might be updated in the previous if
-            {
-                c = "";
-            }
-
-            int i = 0;
-            if (i is > 0 and < 100)
-            {
-                doTheThing(i);
-            }
-            if (i is > 0 and < 100) // Noncompliant {{This condition was just checked on line 35.}}
-            {
-                doTheThing(i);
-            }
-
-            Fruit f = null;
-            bool cond = false;
-            if (f is Apple)
-            {
-                f = cond ? new Apple() : new Orange();
-            }
-            if (f is Apple) // Compliant as f may change
-            {
-                f = cond ? new Apple() : new Orange();
-            }
-
-            if (f is null) { }
-            if (f is null) { }  // Noncompliant
-
-            char ch = 'x';
-            if (ch is >= 'a' and <= 'z') { }
-            if (ch is >= 'a' and <= 'z') { } // Noncompliant
-            if (ch is <= 'z' and >= 'a') { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
-
-            if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '.' or '?') { }
-            if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '.' or '?') { } // Noncompliant
-            if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '?' or '.') { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
-            if (ch is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or '?' or '.') { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
-
-            if (f is not null) { }
-            if (f is not not not null) { }  // Noncompliant, same meaning
-            if (f != null) { }              // Noncompliant, same meaning
-
-            if (f is null) { }
-            if (f == null) { }          // Noncompliant, same meaning
-            if (!(f is not null)) { }   // Noncompliant, same meaning
-
-            if (!(f is null)) { }
-            if (f != null) { }          // Noncompliant, same meaning
-            if (f is not not null) { }  // Compliant, equal to f == null
-
-            if (f is Apple) { }
-            if (f is Apple) { }   // Noncompliant
-
-            if (f is Apple or Orange) { }
-            if (f is Apple or Orange) { }   // Noncompliant
-            if (f is Orange or Apple) { }   // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
-
-            if (f is not Apple) { }
-            if (f is not Apple) { } // Noncompliant
-
-            if (f is { Size: >= 5, Value: 0 }) { }
-            if (f is { Size: >= 5, Value: 0 }) { } // Noncompliant
-            if (f is { Value: 0, Size: >= 5 }) { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
-
-            if (f is { Size: >= 5 }) { }
-            if (f is not { Size: < 5 }) { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
+            doTheThing(c);
+        }
+        if (c is null) // Noncompliant {{This condition was just checked on line 6.}}
+        {
+            doTheThing(c);
+        }
+        if (c is not null) // Compliant
+        {
+            doTheThing(c);
         }
 
-        void doTheThing(object o) { }
+        if (c is "banana") // Compliant, c might be updated in the previous if
+        {
+            c += "a";
+        }
+        if (c is "banana") // Compliant, c might be updated in the previous if
+        {
+            c = "";
+        }
+        if (c is "banana") // Compliant, c might be updated in the previous if
+        {
+            c = "";
+        }
+
+        int i = 0;
+        if (i is > 0 and < 100)
+        {
+            doTheThing(i);
+        }
+        if (i is > 0 and < 100) // Noncompliant {{This condition was just checked on line 33.}}
+        {
+            doTheThing(i);
+        }
+
+        Fruit f = null;
+        bool cond = false;
+        if (f is Apple)
+        {
+            f = cond ? new Apple() : new Orange();
+        }
+        if (f is Apple) // Compliant as f may change
+        {
+            f = cond ? new Apple() : new Orange();
+        }
+
+        if (f is null) { }
+        if (f is null) { }  // Noncompliant
+
+        char ch = 'x';
+        if (ch is >= 'a' and <= 'z') { }
+        if (ch is >= 'a' and <= 'z') { } // Noncompliant
+        if (ch is <= 'z' and >= 'a') { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
+
+        if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '.' or '?') { }
+        if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '.' or '?') { } // Noncompliant
+        if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '?' or '.') { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
+        if (ch is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or '?' or '.') { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
+
+        if (f is not null) { }
+        if (f is not not not null) { }  // Noncompliant, same meaning
+        if (f != null) { }              // Noncompliant, same meaning
+
+        if (f is null) { }
+        if (f == null) { }          // Noncompliant, same meaning
+        if (!(f is not null)) { }   // Noncompliant, same meaning
+
+        if (!(f is null)) { }
+        if (f != null) { }          // Noncompliant, same meaning
+        if (f is not not null) { }  // Compliant, equal to f == null
+
+        if (f is Apple) { }
+        if (f is Apple) { }   // Noncompliant
+
+        if (f is Apple or Orange) { }
+        if (f is Apple or Orange) { }   // Noncompliant
+        if (f is Orange or Apple) { }   // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
+
+        if (f is not Apple) { }
+        if (f is not Apple) { } // Noncompliant
+
+        if (f is { Size: >= 5, Value: 0 }) { }
+        if (f is { Size: >= 5, Value: 0 }) { } // Noncompliant
+        if (f is { Value: 0, Size: >= 5 }) { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
+
+        if (f is { Size: >= 5 }) { }
+        if (f is not { Size: < 5 }) { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
     }
 
-    abstract class Fruit
+    void doTheThing(object o) { }
+
+    public void PositionalPattern(Apple a)
     {
-        public int Size { get; }
-        public int Value { get; }
+        if (a is ("Sweet", "Red"))
+        {
+        }
+        if (a is ("Sweet", "Red")) // Noncompliant
+        {
+        }
+        if (a is { Taste: "Sweet", Color: "Red" }) // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
+        {
+        }
     }
-    class Apple : Fruit { }
-    class Orange : Fruit { }
 }
+
+abstract class Fruit
+{
+    public int Size { get; }
+    public int Value { get; }
+}
+
+class Apple : Fruit
+{
+    public string Taste;
+    public string Color;
+    public void Deconstruct(out string x, out string y) => (x, y) = (Taste, Color);
+}
+
+class Orange : Fruit { }
+

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
@@ -52,6 +52,13 @@
                 f = cond ? new Apple() : new Orange();
             }
 
+            if (f is null) { }
+            if (f is null) { }  // Noncompliant
+
+            char ch = 'x';
+            if (ch is >= 'a' and <= 'z') { }
+            if (ch is >= 'a' and <= 'z') { } // Noncompliant
+
             if (f is not null) { }
             if (f != null) { } // FN, same as above
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
@@ -58,12 +58,12 @@
             char ch = 'x';
             if (ch is >= 'a' and <= 'z') { }
             if (ch is >= 'a' and <= 'z') { } // Noncompliant
-            if (ch is <= 'z' and >= 'a') { } // FN, only syntax checks are currently supported
+            if (ch is <= 'z' and >= 'a') { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
 
             if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '.' or '?') { }
             if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '.' or '?') { } // Noncompliant
-            if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '?' or '.') { } // FN, only syntax checks are currently supported
-            if (ch is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or '?' or '.') { } // FN, only syntax checks are currently supported
+            if (ch is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or '?' or '.') { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
+            if (ch is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or '?' or '.') { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
 
             if (f is not null) { }
             if (f is not not not null) { }  // Noncompliant, same meaning
@@ -82,17 +82,17 @@
 
             if (f is Apple or Orange) { }
             if (f is Apple or Orange) { }   // Noncompliant
-            if (f is Orange or Apple) { }   // FN, only syntax checks are currently supported
+            if (f is Orange or Apple) { }   // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
 
             if (f is not Apple) { }
             if (f is not Apple) { } // Noncompliant
 
             if (f is { Size: >= 5, Value: 0 }) { }
             if (f is { Size: >= 5, Value: 0 }) { } // Noncompliant
-            if (f is { Value: 0, Size: >= 5 }) { } // FN, only syntax checks are currently supported
+            if (f is { Value: 0, Size: >= 5 }) { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
 
             if (f is { Size: >= 5 }) { }
-            if (f is not { Size: < 5 }) { } // FN, only syntax checks are currently supported
+            if (f is not { Size: < 5 }) { } // FN, rule is syntax based. Only null check equivalence is currenty supported in CSharpEquivalenceChecker
         }
 
         void doTheThing(object o) { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.CSharp9.cs
@@ -60,7 +60,6 @@
             if (ch is >= 'a' and <= 'z') { } // Noncompliant
             if (ch is <= 'z' and >= 'a') { } // Compliant, even when the semantics is the same
 
-
             if (f is not null) { }
             if (f != null) { } // Compliant, even when the semantics is the same
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.cs
@@ -52,6 +52,7 @@ namespace Tests.TestCases
             if (a == b && a == c) { } // Noncompliant
             if (a == c && a == b) { } // Compliant, even when the semantics is the same as the previous one. Properties or invocations can have side effects on the result.
         }
+
         public void TestSw()
         {
             switch (a)
@@ -59,11 +60,20 @@ namespace Tests.TestCases
                 case 1:
                     break;
             }
-            switch (a) // Noncompliant {{This condition was just checked on line 57.}}
+            switch (a) // Noncompliant {{This condition was just checked on line 58.}}
             {
                 case 2:
                     break;
             }
+        }
+
+        public void EquivalentChecksForNull(object o)
+        {
+            if (o == null) { }
+            if (null == o) { }      // Noncompliant, same meaning
+            if (!!(o == null)) { }  // Noncompliant, same meaning
+            if (!(o != null)) { }   // Noncompliant, same meaning
+            if (!(null != o)) { }   // Noncompliant, same meaning
         }
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.cs
@@ -66,4 +66,36 @@ namespace Tests.TestCases
             }
         }
     }
+
+    public class Coverage
+    {
+        private string name;
+
+        public void AssignedToFieldWithSameName(string name)
+        {
+            if (name == name)
+            {
+                this.name = null;
+            }
+            if (name == name) { } // Noncompliant
+        }
+
+        public void Undefined(string sameAsUndefinedField)
+        {
+            if (sameAsUndefinedField == sameAsUndefinedField)
+            {
+                this.sameAsUndefinedField = null; // Error [CS0103]: The name 'unresolvedSymbol' does not exist in the current context
+            }
+            if (sameAsUndefinedField == sameAsUndefinedField) { } // Noncompliant
+        }
+
+        public void NameMismatch(string otherName)
+        {
+            if (otherName == otherName)
+            {
+                this.name = null;
+            }
+            if (otherName == otherName) { } // Noncompliant
+        }
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ConditionalsWithSameCondition.cs
@@ -48,6 +48,9 @@ namespace Tests.TestCases
                 ++c;
             }
 
+            if (a == b && a == c) { }
+            if (a == b && a == c) { } // Noncompliant
+            if (a == c && a == b) { } // Compliant, even when the semantics is the same as the previous one. Properties or invocations can have side effects on the result.
         }
         public void TestSw()
         {
@@ -56,7 +59,7 @@ namespace Tests.TestCases
                 case 1:
                     break;
             }
-            switch (a) // Noncompliant {{This condition was just checked on line 54.}}
+            switch (a) // Noncompliant {{This condition was just checked on line 57.}}
             {
                 case 2:
                     break;


### PR DESCRIPTION
I don't want to fix this. PR contains only some cleanup and more UTs.

`CSharpEquivalenceChecker` can be updated to replace nodes in the tree to normalize null checks, but it's not worth the trouble and performance impact on all usages.

From syntax point of view, the check is not the same. Even when the semantic meaning is.