### PR TITLE
AZP: Rename pipelines-yaml-templates from commonTemplates to pipelines-yaml-templates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,13 +18,13 @@ variables:
 
 resources:
   repositories:
-    - repository: commonTemplates
+    - repository: pipelines-yaml-templates
       type: git
       name: pipelines-yaml-templates
       ref:  refs/tags/v1.0.13
 
 stages:
-- template: stage-with-burgr-notifications.yml@commonTemplates
+- template: stage-with-burgr-notifications.yml@pipelines-yaml-templates
   parameters:
     burgrName: 'build'
     burgrType: 'build'
@@ -49,7 +49,7 @@ stages:
         artifact: Azp-Variables
         displayName: "Publish AZP Variables as pipeline artifact"
 
-      - template: set-azp-variables-steps.yml@commonTemplates
+      - template: set-azp-variables-steps.yml@pipelines-yaml-templates
 
       - powershell: |
           cd analyzers
@@ -137,7 +137,7 @@ stages:
           targetDeployRepo: '$(ARTIFACTORY_NUGET_REPO)'
           pathToNupkg: '$(Build.ArtifactStagingDirectory)/packages/SonarAnalyzer.CFG.CSharp.*.nupkg'
 
-- template: stage-with-burgr-notifications.yml@commonTemplates
+- template: stage-with-burgr-notifications.yml@pipelines-yaml-templates
   parameters:
     burgrName: 'qa'
     burgrType: 'qa'
@@ -154,7 +154,7 @@ stages:
       - task: NuGetToolInstaller@1
         displayName: "Install NuGet"
 
-      - template: set-azp-variables-steps.yml@commonTemplates
+      - template: set-azp-variables-steps.yml@pipelines-yaml-templates
 
       - task: VSBuild@1
         displayName: 'Set BranchName, Sha1 and BuildNumber properties from Azure pipeline variables'
@@ -268,7 +268,7 @@ stages:
           artifact: RuleDescriptorBin
           targetPath: analyzers\src\SonarAnalyzer.RuleDescriptorGenerator\bin
 
-      - template: set-azp-variables-steps.yml@commonTemplates
+      - template: set-azp-variables-steps.yml@pipelines-yaml-templates
 
       - task: DownloadSecureFile@1
         displayName: 'Download Maven settings'
@@ -316,7 +316,7 @@ stages:
         inputs:
           secureFile: 'maven-settings.xml'
 
-      - template: set-azp-variables-steps.yml@commonTemplates
+      - template: set-azp-variables-steps.yml@pipelines-yaml-templates
 
       - template: update-maven-version-steps.yml
         parameters:
@@ -388,7 +388,7 @@ stages:
           artifact: RuleDescriptorBin
           targetPath: 'analyzers\src\SonarAnalyzer.RuleDescriptorGenerator\bin'
 
-      - template: set-azp-variables-steps.yml@commonTemplates
+      - template: set-azp-variables-steps.yml@pipelines-yaml-templates
 
       - task: Maven@3
         displayName: 'Maven install'
@@ -430,7 +430,7 @@ stages:
     - job: promoteRepox
       displayName: 'SonarAnalyzer.CFG.CSharp'
       steps:
-        - template: set-azp-variables-steps.yml@commonTemplates
+        - template: set-azp-variables-steps.yml@pipelines-yaml-templates
 
         - task: UsePythonVersion@0
           inputs:
@@ -482,7 +482,7 @@ stages:
       pool: server
       condition: failed()
       steps:
-      - template: notify-burgr-steps.yml@commonTemplates
+      - template: notify-burgr-steps.yml@pipelines-yaml-templates
         parameters:
           name: 'artifacts'
           type: 'promotion'
@@ -494,14 +494,14 @@ stages:
       pool: server
       condition: canceled()
       steps:
-      - template: notify-burgr-steps.yml@commonTemplates
+      - template: notify-burgr-steps.yml@pipelines-yaml-templates
         parameters:
           name: 'artifacts'
           type: 'promotion'
           status: 'canceled'
           fixedBranch: $(fixedBranch)
 
-- template: promote-stage.yml@commonTemplates
+- template: promote-stage.yml@pipelines-yaml-templates
   parameters:
     stageName: 'Artifacts:'
     stageDependencies:


### PR DESCRIPTION
This confuses me every time I read the YML file.
