### PR TITLE
Skip S3949 when running ITs

### DIFF
--- a/analyzers/its/AllSonarAnalyzerRules.ruleset
+++ b/analyzers/its/AllSonarAnalyzerRules.ruleset
@@ -3956,7 +3956,7 @@
     <Rule Id="S3946" Action="Warning" />
     <Rule Id="S3947" Action="Warning" />
     <Rule Id="S3948" Action="Warning" />
-    <Rule Id="S3949" Action="Warning" />
+    <Rule Id="S3949" Action="None" />
     <Rule Id="S3950" Action="Warning" />
     <Rule Id="S3951" Action="Warning" />
     <Rule Id="S3952" Action="Warning" />
@@ -13958,7 +13958,7 @@
     <Rule Id="S3946" Action="Warning" />
     <Rule Id="S3947" Action="Warning" />
     <Rule Id="S3948" Action="Warning" />
-    <Rule Id="S3949" Action="Warning" />
+    <Rule Id="S3949" Action="None" />
     <Rule Id="S3950" Action="Warning" />
     <Rule Id="S3951" Action="Warning" />
     <Rule Id="S3952" Action="Warning" />

--- a/analyzers/its/AllSonarAnalyzerRules.ruleset
+++ b/analyzers/its/AllSonarAnalyzerRules.ruleset
@@ -3956,7 +3956,7 @@
     <Rule Id="S3946" Action="Warning" />
     <Rule Id="S3947" Action="Warning" />
     <Rule Id="S3948" Action="Warning" />
-    <Rule Id="S3949" Action="None" />
+    <Rule Id="S3949" Action="None" /> <!-- Enable this rule once https://github.com/SonarSource/sonar-dotnet/issues/4631 is done. -->
     <Rule Id="S3950" Action="Warning" />
     <Rule Id="S3951" Action="Warning" />
     <Rule Id="S3952" Action="Warning" />
@@ -13958,7 +13958,7 @@
     <Rule Id="S3946" Action="Warning" />
     <Rule Id="S3947" Action="Warning" />
     <Rule Id="S3948" Action="Warning" />
-    <Rule Id="S3949" Action="None" />
+    <Rule Id="S3949" Action="None" /> <!-- Enable this rule once https://github.com/SonarSource/sonar-dotnet/issues/4631 is done. -->
     <Rule Id="S3950" Action="Warning" />
     <Rule Id="S3951" Action="Warning" />
     <Rule Id="S3952" Action="Warning" />

--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/IntentionalFindings/S3949.cs
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/IntentionalFindings/S3949.cs
@@ -10,16 +10,16 @@ namespace IntentionalFindings
 {
     public class S3949
     {
-        public void PositiveOverflow()
+        public void PositiveOverflow() // Noncompliant (S2325)
         {
             int i = 2147483600;
-            i += 100; // Noncompliant (S3949) {{There is a path on which this operation always overflows}}
+            i += 100; // Disabled rule (S3949) {{There is a path on which this operation always overflows}}
         }
 
-        public void NegativeOverflow()
+        public void NegativeOverflow() // Noncompliant
         {
             int i = -2147483600;
-            i -= 100; // Noncompliant (S3949) {{There is a path on which this operation always overflows}}
+            i -= 100; // Disabled rule (S3949) {{There is a path on which this operation always overflows}}
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CbdeHandlerRule.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CbdeHandlerRule.cs
@@ -30,7 +30,9 @@ namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     [Rule(S3949DiagnosticId)]
-    // Note: For now, this rule actually runs only under windows and outside of SonarLint
+    // Note (1): For now, this rule actually runs only under windows and outside of SonarLint
+    // Note (2): This rule is disabled for integration tests due to inconsistent behavior.
+    // After removing the CBDE and rewriting the rule please don't forget to enable it in `AllSonarAnalyzerRules.ruleset`
     public sealed class CbdeHandlerRule : SonarDiagnosticAnalyzer
     {
         private const string S3949DiagnosticId = "S3949";


### PR DESCRIPTION
Currently this rule is disabled by default and we plan to rewrite it.

Fixes #4619 
