### PR TITLE
Support C# 9 init-only setters in CSharpMethodDeclarationTracker

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Trackers/CSharpMethodDeclarationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Trackers/CSharpMethodDeclarationTracker.cs
@@ -69,23 +69,13 @@ namespace SonarAnalyzer.Helpers.Trackers
                 ConstructorDeclarationSyntax constructor => constructor.Identifier,
                 DestructorDeclarationSyntax destructor => destructor.Identifier,
                 OperatorDeclarationSyntax op => op.OperatorToken,
-                _ => AccessorIdentifier(methodDeclaration)
+                _ => methodDeclaration?.Parent.Parent switch // Accessors
+                {
+                    EventDeclarationSyntax e => e.Identifier,
+                    PropertyDeclarationSyntax p => p.Identifier,
+                    IndexerDeclarationSyntax i => i.ThisKeyword,
+                    _ => null
+                }
             };
-
-        private static SyntaxToken? AccessorIdentifier(SyntaxNode methodDeclaration)
-        {
-            switch (methodDeclaration?.Kind())
-            {
-                case SyntaxKind.AddAccessorDeclaration:
-                case SyntaxKind.RemoveAccessorDeclaration:
-                    return ((EventDeclarationSyntax)methodDeclaration.Parent.Parent).Identifier;
-                case SyntaxKind.GetAccessorDeclaration:
-                case SyntaxKind.SetAccessorDeclaration:
-                case SyntaxKindEx.InitAccessorDeclaration:
-                    return ((PropertyDeclarationSyntax)methodDeclaration.Parent.Parent).Identifier;
-                default:
-                    return null;
-            }
-        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Trackers/CSharpMethodDeclarationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Trackers/CSharpMethodDeclarationTracker.cs
@@ -62,16 +62,20 @@ namespace SonarAnalyzer.Helpers.Trackers
                         && parameterSymbol.Equals(semanticModel.GetSymbolInfo(node).Symbol));
             };
 
-        protected override SyntaxToken? GetMethodIdentifier(SyntaxNode methodDeclaration)
+        protected override SyntaxToken? GetMethodIdentifier(SyntaxNode methodDeclaration) =>
+            methodDeclaration switch
+            {
+                MethodDeclarationSyntax method => method.Identifier,
+                ConstructorDeclarationSyntax constructor => constructor.Identifier,
+                DestructorDeclarationSyntax destructor => destructor.Identifier,
+                OperatorDeclarationSyntax op => op.OperatorToken,
+                _ => AccessorIdentifier(methodDeclaration)
+            };
+
+        private static SyntaxToken? AccessorIdentifier(SyntaxNode methodDeclaration)
         {
             switch (methodDeclaration?.Kind())
             {
-                case SyntaxKind.MethodDeclaration:
-                    return ((MethodDeclarationSyntax)methodDeclaration).Identifier;
-                case SyntaxKind.ConstructorDeclaration:
-                    return ((ConstructorDeclarationSyntax)methodDeclaration).Identifier;
-                case SyntaxKind.DestructorDeclaration:
-                    return ((DestructorDeclarationSyntax)methodDeclaration).Identifier;
                 case SyntaxKind.AddAccessorDeclaration:
                 case SyntaxKind.RemoveAccessorDeclaration:
                     return ((EventDeclarationSyntax)methodDeclaration.Parent.Parent).Identifier;
@@ -79,8 +83,6 @@ namespace SonarAnalyzer.Helpers.Trackers
                 case SyntaxKind.SetAccessorDeclaration:
                 case SyntaxKindEx.InitAccessorDeclaration:
                     return ((PropertyDeclarationSyntax)methodDeclaration.Parent.Parent).Identifier;
-                case SyntaxKind.OperatorDeclaration:
-                    return ((OperatorDeclarationSyntax)methodDeclaration).OperatorToken;
                 default:
                     return null;
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Trackers/CSharpMethodDeclarationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Trackers/CSharpMethodDeclarationTracker.cs
@@ -77,6 +77,7 @@ namespace SonarAnalyzer.Helpers.Trackers
                     return ((EventDeclarationSyntax)methodDeclaration.Parent.Parent).Identifier;
                 case SyntaxKind.GetAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKindEx.InitAccessorDeclaration:
                     return ((PropertyDeclarationSyntax)methodDeclaration.Parent.Parent).Identifier;
                 case SyntaxKind.OperatorDeclaration:
                     return ((OperatorDeclarationSyntax)methodDeclaration).OperatorToken;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Trackers/VisualBasicMethodDeclarationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Trackers/VisualBasicMethodDeclarationTracker.cs
@@ -65,7 +65,12 @@ namespace SonarAnalyzer.Helpers.Trackers
                 SubNewStatementSyntax constructor => constructor.NewKeyword,
                 MethodStatementSyntax method => method.Identifier,
                 OperatorStatementSyntax op => op.OperatorToken,
-                _ => null
+                _ => methodDeclaration?.Parent.Parent switch
+                {
+                    EventBlockSyntax e => e.EventStatement.Identifier,
+                    PropertyBlockSyntax p => p.PropertyStatement.Identifier,
+                    _ => null
+                }
             };
 
         private static bool HasImplementation(MethodBlockSyntax methodBlock) =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Trackers/VisualBasicMethodDeclarationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Trackers/VisualBasicMethodDeclarationTracker.cs
@@ -59,27 +59,14 @@ namespace SonarAnalyzer.Helpers.Trackers
                         && parameterSymbol.Equals(semanticModel.GetSymbolInfo(node).Symbol));
             };
 
-        protected override SyntaxToken? GetMethodIdentifier(SyntaxNode methodDeclaration)
-        {
-            switch (methodDeclaration?.Kind())
+        protected override SyntaxToken? GetMethodIdentifier(SyntaxNode methodDeclaration) =>
+            methodDeclaration switch
             {
-                case SyntaxKind.SubStatement:
-                case SyntaxKind.FunctionStatement:
-                    return ((MethodStatementSyntax)methodDeclaration).Identifier;
-                case SyntaxKind.SubNewStatement:
-                    return ((SubNewStatementSyntax)methodDeclaration).NewKeyword;
-                case SyntaxKind.AddHandlerAccessorBlock:
-                case SyntaxKind.RemoveHandlerAccessorBlock:
-                    return ((EventBlockSyntax)methodDeclaration.Parent.Parent).EventStatement?.Identifier;
-                case SyntaxKind.GetAccessorBlock:
-                case SyntaxKind.SetAccessorBlock:
-                    return ((PropertyBlockSyntax)methodDeclaration.Parent.Parent).PropertyStatement?.Identifier;
-                case SyntaxKind.OperatorStatement:
-                    return ((OperatorStatementSyntax)methodDeclaration).OperatorToken;
-                default:
-                    return null;
-            }
-        }
+                SubNewStatementSyntax constructor => constructor.NewKeyword,
+                MethodStatementSyntax method => method.Identifier,
+                OperatorStatementSyntax op => op.OperatorToken,
+                _ => null
+            };
 
         private static bool HasImplementation(MethodBlockSyntax methodBlock) =>
             methodBlock.Statements.Count > 0;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/MethodDeclarationTrackerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/MethodDeclarationTrackerTest.cs
@@ -49,6 +49,8 @@ public class Sample
             tracker.MatchMethodName("Something")(context).Should().BeFalse();
         }
 
+#if NET
+
         [TestMethod]
         public void Track_VerifyMethodIdentifierLocations_CS()
         {
@@ -94,6 +96,8 @@ public class Sample
 }";
             Verifier.VerifyCSharpAnalyzer(code, new TestRule_CS(), ParseOptionsHelper.FromCSharp9);
         }
+
+#endif
 
         [TestMethod]
         public void Track_VerifyMethodIdentifierLocations_VB()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/MethodDeclarationTrackerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/MethodDeclarationTrackerTest.cs
@@ -118,21 +118,28 @@ Public Class Sample
         MyBase.Finalize()
     End Sub
 
-    Public Property Prop As Integer     'FIXME - doesn't work
+    Public Property Prop As Integer
+        '           ^^^^
+        '           ^^^^ @-1
         Get
         End Get
         Set(value As Integer)
         End Set
     End Property
 
-    Default Public Property Indexer(x As Integer, y As Integer) As Integer  'FIXME - doesn't work
+    Default Public Property Indexer(x As Integer, y As Integer) As Integer
+        '                   ^^^^^^^
+        '                   ^^^^^^^ @-1
         Get
         End Get
         Set(value As Integer)
         End Set
     End Property
 
-    Public Custom Event Changed As System.EventHandler      'FIXME - doesn't work
+    Public Custom Event Changed As System.EventHandler
+        '               ^^^^^^^
+        '               ^^^^^^^ @-1
+        '               ^^^^^^^ @-2
         AddHandler(value As System.EventHandler)
         End AddHandler
         RemoveHandler(value As System.EventHandler)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/MethodDeclarationTrackerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/MethodDeclarationTrackerTest.cs
@@ -74,6 +74,13 @@ public class Sample
         get => 42;
         init { }
     }
+    public int this[int index]
+//             ^^^^
+//             ^^^^ @-1
+    {
+        get => 42;
+        set { }
+    }
     public event System.EventHandler Event
 //                                   ^^^^^
 //                                   ^^^^^ @-1

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/MethodDeclarationTrackerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/MethodDeclarationTrackerTest.cs
@@ -55,12 +55,17 @@ public class Sample
         public void Track_VerifyMethodIdentifierLocations_CS()
         {
             const string code = @"
+abstract record AbstractRecordHasMethodSymbol(string Y); //For Coverage
+
 public class Sample
 {
     public Sample() {}
 //         ^^^^^^
-    public void Method() {}
+    public void Method()
 //              ^^^^^^
+    {
+        void LocalFunction() { } // Tracking of local functions is not supported
+    }
     ~Sample() {}
 //   ^^^^^^
     public int Property
@@ -155,6 +160,8 @@ Public Class Sample
     Public Shared Operator +(A As Sample, B As Sample) As Integer
         '                  ^
     End Operator
+
+    Declare Function ExternalMethod Lib ""foo.dll""(lpBuffer As String) As Integer
 
 End Class";
             Verifier.VerifyVisualBasicAnalyzer(code, new TestRule_VB());


### PR DESCRIPTION
There's no UT for this.
It could be reachable with `ControllingPermissions`, but it's obsolete and targets .NET Framework-only. 
It's too complicated to scaffold with artificial AnalyzerContext.