### PR TITLE
[AZP] provide `sonar.cs.vstest.reportsPaths` to SC begin step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,7 +174,7 @@ stages:
           projectVersion: '$(SONAR_PROJECT_VERSION)'
           extraProperties: |
             sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/**/coverage.**.xml"
-            sonar.cs.vstest.reportsPaths="$(Build.SourcesDirectory)/**/**.trx"
+            sonar.cs.vstest.reportsPaths="$(Build.SourcesDirectory)/**/tests/SonarAnalyzer.UnitTest/TestResults/*.trx"
             sonar.analysis.buildNumber=$(Build.BuildId)
             sonar.analysis.pipeline=$(Build.BuildId)
             sonar.analysis.sha1=$(System.PullRequest.SourceCommitId)
@@ -193,7 +193,7 @@ stages:
           projectVersion: '$(SONAR_PROJECT_VERSION)'
           extraProperties: |
             sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/**/coverage.**.xml"
-            sonar.cs.vstest.reportsPaths="$(Build.SourcesDirectory)/**/**.trx"
+            sonar.cs.vstest.reportsPaths="$(Build.SourcesDirectory)/**/tests/SonarAnalyzer.UnitTest/TestResults/*.trx"
             sonar.analysis.buildNumber=$(Build.BuildId)
             sonar.analysis.pipeline=$(Build.BuildId)
             sonar.analysis.sha1=$(Build.SourceVersion)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,6 +174,7 @@ stages:
           projectVersion: '$(SONAR_PROJECT_VERSION)'
           extraProperties: |
             sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/**/coverage.**.xml"
+            sonar.cs.vstest.reportsPaths="$(Build.SourcesDirectory)/**/**.trx"
             sonar.analysis.buildNumber=$(Build.BuildId)
             sonar.analysis.pipeline=$(Build.BuildId)
             sonar.analysis.sha1=$(System.PullRequest.SourceCommitId)
@@ -192,6 +193,7 @@ stages:
           projectVersion: '$(SONAR_PROJECT_VERSION)'
           extraProperties: |
             sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/**/coverage.**.xml"
+            sonar.cs.vstest.reportsPaths="$(Build.SourcesDirectory)/**/**.trx"
             sonar.analysis.buildNumber=$(Build.BuildId)
             sonar.analysis.pipeline=$(Build.BuildId)
             sonar.analysis.sha1=$(Build.SourceVersion)
@@ -216,7 +218,7 @@ stages:
 
           Foreach ($framework in $supportedFrameworks)
           {
-            & OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test $testProjFileName --no-build -c $(BuildConfiguration) -f $framework" -returntargetcode -filter:"+[SonarAnalyzer.CFG]* +[SonarAnalyzer]* +[SonarAnalyzer.CSharp]* +[SonarAnalyzer.Utilities]* +[SonarAnalyzer.VisualBasic]*" -output:tests\coverage.$framework.xml -oldStyle
+            & OpenCover.Console.exe -target:"dotnet.exe" -targetargs:"test $testProjFileName --no-build -c $(BuildConfiguration) -f $framework --logger trx" -returntargetcode -filter:"+[SonarAnalyzer.CFG]* +[SonarAnalyzer]* +[SonarAnalyzer.CSharp]* +[SonarAnalyzer.Utilities]* +[SonarAnalyzer.VisualBasic]*" -output:tests\coverage.$framework.xml -oldStyle
             Test-ExitCode "ERROR: Unit tests for $framework FAILED."
           }
 


### PR DESCRIPTION
This is necessary to dogfood our own analyzer as well as SonarCloud's metrics visualization. When we migrated the CI to AZP we missed to upload test results.

I tested this locally with SQ - the below screenshot is from the measures tab http://localhost:9000/component_measures?id=local-sonar-dotnet&metric=tests
![image](https://user-images.githubusercontent.com/38876598/125644191-efa8b2ee-7af6-48ae-9f97-39683d854640.png)

The number of tests is 4.9K because it's the sum of the `net48` and `net5.0` tests (however... they don't add up... it should be 4691 tests... - however data-driver UTs may be counted twice - to be investigated):
```
Passed!  - Failed:     0, Passed:  2230, Skipped:     0, Total:  2230, Duration: 2 m 33 s - SonarAnalyzer.UnitTest.dll (net48)
Passed!  - Failed:     0, Passed:  2461, Skipped:     0, Total:  2461, Duration: 44 s - SonarAnalyzer.UnitTest.dll (net5.0)
```