### PR TITLE
Revert "Fix main branch SC decoration (#4676)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,8 +198,6 @@ stages:
             sonar.analysis.pipeline=$(Build.BuildId)
             sonar.analysis.sha1=$(Build.SourceVersion)
             sonar.analysis.repository=$(Build.Repository.ID)
-            # needed for SonarCloud main branch decoration for unbound projects - see SC-3469
-            sonar.pullrequest.github.repository=$(Build.Repository.Name)
 
       - powershell: |
           . .\scripts\utils.ps1


### PR DESCRIPTION
This reverts commit 8268375f9fef627b412d0ac5516e55efccc98c20.

Related to #4676

This actually didn't work because the SC project needs to be bound to the Github repo. And this currently isn't possible via the SC UI - they plan it for Q3 [(details)](https://discuss.sonarsource.com/t/gh-integration-main-branch-commit-is-green-even-if-qg-failed/7941/12?u=andrei_epure).
