### PR TITLE
ReferenceEqualityCheckWhenEqualsExists cleanup

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -120,11 +120,6 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static IEnumerable<IMethodSymbol> GetEqualsOverrides(ITypeSymbol type)
         {
-            if (type == null)
-            {
-                return Enumerable.Empty<IMethodSymbol>();
-            }
-
             var candidateEqualsMethods = new HashSet<IMethodSymbol>();
 
             foreach (var currentType in type.GetSelfAndBaseTypes().TakeWhile(tp => !tp.Is(KnownType.System_Object)))
@@ -147,7 +142,6 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     return true;
                 }
-
                 currentMethod = currentMethod.OverriddenMethod;
             }
             return false;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -95,11 +95,10 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool MightOverrideEquals(ITypeSymbol type, ISet<INamedTypeSymbol> allInterfacesWithImplementationsOverriddenEquals) =>
             HasEqualsOverride(type)
             || allInterfacesWithImplementationsOverriddenEquals.Contains(type)
-            || HasTypeConstraintsWhichMightOverrideEquals(type, allInterfacesWithImplementationsOverriddenEquals);
+            || HasTypeConstraintsWhichMightOverrideEquals((ITypeParameterSymbol)type, allInterfacesWithImplementationsOverriddenEquals);
 
-        private static bool HasTypeConstraintsWhichMightOverrideEquals(ITypeSymbol type, ISet<INamedTypeSymbol> allInterfacesWithImplementationsOverriddenEquals) =>
-            type is ITypeParameterSymbol typeParameter
-            && typeParameter.ConstraintTypes.Any(x => MightOverrideEquals(x, allInterfacesWithImplementationsOverriddenEquals));
+        private static bool HasTypeConstraintsWhichMightOverrideEquals(ITypeParameterSymbol type, ISet<INamedTypeSymbol> allInterfacesWithImplementationsOverriddenEquals) =>
+            type.ConstraintTypes.Any(x => MightOverrideEquals(x, allInterfacesWithImplementationsOverriddenEquals));
 
         private static bool IsAllowedTypeOrNull(ITypeSymbol type) =>
             type is null || type.IsAny(AllowedTypes) || HasAllowedBaseType(type);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
         internal const string DiagnosticId = "S1698";
         private const string MessageFormat = "Consider using 'Equals' if value comparison was intended.";
-        private const string EqualsName = nameof(Equals);
+        private const string EqualsName = "Equals";
 
         private static readonly DiagnosticDescriptor Rule =
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
         internal const string DiagnosticId = "S1698";
         private const string MessageFormat = "Consider using 'Equals' if value comparison was intended.";
-        private const string EqualsName = "Equals";
+        private const string EqualsName = nameof(Equals);
 
         private static readonly DiagnosticDescriptor Rule =
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
@@ -95,10 +95,11 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool MightOverrideEquals(ITypeSymbol type, ISet<INamedTypeSymbol> allInterfacesWithImplementationsOverriddenEquals) =>
             HasEqualsOverride(type)
             || allInterfacesWithImplementationsOverriddenEquals.Contains(type)
-            || HasTypeConstraintsWhichMightOverrideEquals((ITypeParameterSymbol)type, allInterfacesWithImplementationsOverriddenEquals);
+            || HasTypeConstraintsWhichMightOverrideEquals(type, allInterfacesWithImplementationsOverriddenEquals);
 
-        private static bool HasTypeConstraintsWhichMightOverrideEquals(ITypeParameterSymbol type, ISet<INamedTypeSymbol> allInterfacesWithImplementationsOverriddenEquals) =>
-            type.ConstraintTypes.Any(x => MightOverrideEquals(x, allInterfacesWithImplementationsOverriddenEquals));
+        private static bool HasTypeConstraintsWhichMightOverrideEquals(ITypeSymbol type, ISet<INamedTypeSymbol> allInterfacesWithImplementationsOverriddenEquals) =>
+            type is ITypeParameterSymbol parameter
+            && parameter.ConstraintTypes.Any(x => MightOverrideEquals(x, allInterfacesWithImplementationsOverriddenEquals));
 
         private static bool IsAllowedTypeOrNull(ITypeSymbol type) =>
             type is null || type.IsAny(AllowedTypes) || HasAllowedBaseType(type);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -98,8 +98,8 @@ namespace SonarAnalyzer.Rules.CSharp
             || HasTypeConstraintsWhichMightOverrideEquals(type, allInterfacesWithImplementationsOverriddenEquals);
 
         private static bool HasTypeConstraintsWhichMightOverrideEquals(ITypeSymbol type, ISet<INamedTypeSymbol> allInterfacesWithImplementationsOverriddenEquals) =>
-            type is ITypeParameterSymbol parameter
-            && parameter.ConstraintTypes.Any(x => MightOverrideEquals(x, allInterfacesWithImplementationsOverriddenEquals));
+            type is ITypeParameterSymbol genericParameter
+            && genericParameter.ConstraintTypes.Any(x => MightOverrideEquals(x, allInterfacesWithImplementationsOverriddenEquals));
 
         private static bool IsAllowedTypeOrNull(ITypeSymbol type) =>
             type is null || type.IsAny(AllowedTypes) || HasAllowedBaseType(type);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -77,10 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                             var typeLeft = c.SemanticModel.GetTypeInfo(binary.Left).Type;
                             var typeRight = c.SemanticModel.GetTypeInfo(binary.Right).Type;
-                            if (typeLeft == null ||
-                                typeRight == null ||
-                                IsAllowedType(typeLeft) ||
-                                IsAllowedType(typeRight))
+                            if (IsAllowedTypeOrNull(typeLeft) || IsAllowedTypeOrNull(typeRight))
                             {
                                 return;
                             }
@@ -104,8 +101,8 @@ namespace SonarAnalyzer.Rules.CSharp
             type is ITypeParameterSymbol typeParameter
             && typeParameter.ConstraintTypes.Any(x => MightOverrideEquals(x, allInterfacesWithImplementationsOverriddenEquals));
 
-        private static bool IsAllowedType(ITypeSymbol type) =>
-            type.IsAny(AllowedTypes) || HasAllowedBaseType(type);
+        private static bool IsAllowedTypeOrNull(ITypeSymbol type) =>
+            type is null || type.IsAny(AllowedTypes) || HasAllowedBaseType(type);
 
         private static bool HasAllowedBaseType(ITypeSymbol type) =>
             type.GetSelfAndBaseTypes().Any(t => t.IsAny(AllowedTypesWithAllDerived));

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -103,9 +103,10 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool HasTypeConstraintsWhichMightOverrideEquals(ITypeSymbol type, ISet<INamedTypeSymbol> allInterfacesWithImplementationsOverriddenEquals) =>
             type.TypeKind == TypeKind.TypeParameter
             && type is ITypeParameterSymbol typeParameter
-            && typeParameter.ConstraintTypes.Any(t => MightOverrideEquals(t, allInterfacesWithImplementationsOverriddenEquals));
+            && typeParameter.ConstraintTypes.Any(x => MightOverrideEquals(x, allInterfacesWithImplementationsOverriddenEquals));
 
-        private static bool IsAllowedType(ITypeSymbol type) => type.IsAny(AllowedTypes) || HasAllowedBaseType(type);
+        private static bool IsAllowedType(ITypeSymbol type) => 
+            type.IsAny(AllowedTypes) || HasAllowedBaseType(type);
 
         private static bool HasAllowedBaseType(ITypeSymbol type) =>
             type.GetSelfAndBaseTypes().Any(t => t.IsAny(AllowedTypesWithAllDerived));
@@ -116,7 +117,7 @@ namespace SonarAnalyzer.Rules.CSharp
             && !IsInEqualsOverride(semanticModel.GetEnclosingSymbol(binary.SpanStart) as IMethodSymbol);
 
         private static bool HasEqualsOverride(ITypeSymbol type) =>
-            GetEqualsOverrides(type).Any(m => m.OverriddenMethod.IsInType(KnownType.System_Object));
+            GetEqualsOverrides(type).Any(x => x.OverriddenMethod.IsInType(KnownType.System_Object));
 
         private static IEnumerable<IMethodSymbol> GetEqualsOverrides(ITypeSymbol type)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -105,7 +105,7 @@ namespace SonarAnalyzer.Rules.CSharp
             && type is ITypeParameterSymbol typeParameter
             && typeParameter.ConstraintTypes.Any(x => MightOverrideEquals(x, allInterfacesWithImplementationsOverriddenEquals));
 
-        private static bool IsAllowedType(ITypeSymbol type) => 
+        private static bool IsAllowedType(ITypeSymbol type) =>
             type.IsAny(AllowedTypes) || HasAllowedBaseType(type);
 
         private static bool HasAllowedBaseType(ITypeSymbol type) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -101,8 +101,7 @@ namespace SonarAnalyzer.Rules.CSharp
             || HasTypeConstraintsWhichMightOverrideEquals(type, allInterfacesWithImplementationsOverriddenEquals);
 
         private static bool HasTypeConstraintsWhichMightOverrideEquals(ITypeSymbol type, ISet<INamedTypeSymbol> allInterfacesWithImplementationsOverriddenEquals) =>
-            type.TypeKind == TypeKind.TypeParameter
-            && type is ITypeParameterSymbol typeParameter
+            type is ITypeParameterSymbol typeParameter
             && typeParameter.ConstraintTypes.Any(x => MightOverrideEquals(x, allInterfacesWithImplementationsOverriddenEquals));
 
         private static bool IsAllowedType(ITypeSymbol type) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -124,7 +124,8 @@ namespace SonarAnalyzer.Rules.CSharp
 
             foreach (var currentType in type.GetSelfAndBaseTypes().TakeWhile(tp => !tp.Is(KnownType.System_Object)))
             {
-                candidateEqualsMethods.UnionWith(currentType.GetMembers(EqualsName)
+                candidateEqualsMethods.UnionWith(currentType
+                    .GetMembers(EqualsName)
                     .OfType<IMethodSymbol>()
                     .Where(method => method.IsOverride && method.OverriddenMethod != null));
             }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -92,3 +92,18 @@ namespace Tests.Diagnostics
         }
     }
 }
+namespace MissingGeneric
+    {
+    interface IWithGeneric
+    {
+        void Something<T>();
+    }
+
+    class UsingInterfaces
+    {
+        public void Compare(IWithGeneric a, IWithGeneric b)
+        {
+            if (a == b) { }
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -93,7 +93,7 @@ namespace Tests.Diagnostics
     }
 }
 namespace MissingGeneric
-    {
+{
     interface IWithGeneric
     {
         void Something<T>();


### PR DESCRIPTION
When updating to  version `8.26.0.34506` I got the following error:

`AD0001: Analyzer 'SonarAnalyzer.Rules.CSharp.ReferenceEqualityCheckWhenEqualsExists' threw an exception of type 'System.NullReferenceException' with message 'Object reference not set to an instance of an object.'.`

I got this twice (as, I got for two different projects in my solution). Unfortunately, after reloading the solution, I could not longer reproduce it.

Nevertheless, I checked the code, and made some small adjustments that should fix potential null de-references. 