### PR TITLE
Improve the detection time for project type (is test or main code)

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/ProjectTypeHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/ProjectTypeHelper.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -63,7 +62,7 @@ namespace SonarAnalyzer.Helpers
             public readonly bool Value;
 
             public IsTestWrapper(Compilation compilation) =>
-                Value = compilation.ReferencedAssemblyNames.Any(assembly => TestAssemblyNames.Contains(assembly.Name));
+                Value = compilation.ReferencedAssemblyNames.Any(x => TestAssemblyNames.Contains(x.Name));
         }
     }
 }


### PR DESCRIPTION
Fixes #4470

Measurements on a VM for `protoactor-dotnet`, using 
* an average from 6 runs 
* independent on other commits - I did code changes manually to isolate the change
* measured with `/p:ReportAnalyzer`
* collected with `ParseBuildOutput` tool
* commit b08def1e

Detection | Time | Compared to Optimum | Absolute Regression | Relative Improvement
--- | --- | --- | --- | ---
Precomputed from Scanner | 137s | - | - | -
Before regression | 167s | +22% | - | -
Original regression | 171s | +24.4% | +2% | -
ToUpper-free | 168s | +22.2% | +0.2% | -1.8%
This PR | 145s | +5.5% | -13.5% | -15.2%

Measurements on a VM for `efcore`, using
* same as before except commit f8a6198da (same as in #4642)

Detection | Time | Compared to Optimum | Absolute Regression | Relative Improvement
--- | --- | --- | --- | ---
Precomputed from Scanner | 1181s | - | - | -
Before regression | 1345s | +13.8% | - | -
Original regression | 3339s | +182.7% | +148% | -
ToUpper-free | 2131s | +80% | +58.5% | -36%
This PR | 1095s | -7.3% | -18.5% | -48.6%

There's around 10% inaccuracy in the numbers because this PR cannot be better than Scanner by-design.

Removing `ToUpper` brought 36% relative improvement.
This PR brings 48.6% relative improvement on `efcore`. Let's consider 38% to compensate for the inaccuracy.