### PR TITLE
Rule S3604: add support for static constructors and module initializers

### DIFF
--- a/analyzers/its/expected/Net5/Net5--net5.0-S101.json
+++ b/analyzers/its/expected/Net5/Net5--net5.0-S101.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S101",
+"message":  "Rename record 'S3604_Record' to match pascal case naming rules, consider using 'S3604Record'.",
+"location":  {
+"uri":  "sources\Net5\Net5\S3604.cs",
+"region":  {
+"startLine":  22,
+"startColumn":  19,
+"endLine":  22,
+"endColumn":  31
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Net5/Net5--net5.0-S1118.json
+++ b/analyzers/its/expected/Net5/Net5--net5.0-S1118.json
@@ -4,6 +4,19 @@
 "id":  "S1118",
 "message":  "Add a 'protected' constructor or the 'static' keyword to the class declaration.",
 "location":  {
+"uri":  "sources\Net5\Net5\S3604.cs",
+"region":  {
+"startLine":  5,
+"startColumn":  18,
+"endLine":  5,
+"endColumn":  23
+}
+}
+},
+{
+"id":  "S1118",
+"message":  "Add a 'protected' constructor or the 'static' keyword to the class declaration.",
+"location":  {
 "uri":  "sources\Net5\Net5\S3877.cs",
 "region":  {
 "startLine":  6,

--- a/analyzers/its/expected/Net5/Net5--net5.0-S1451.json
+++ b/analyzers/its/expected/Net5/Net5--net5.0-S1451.json
@@ -602,6 +602,19 @@
 "id":  "S1451",
 "message":  "Add or update the header of this file.",
 "location":  {
+"uri":  "sources\Net5\Net5\S3604.cs",
+"region":  {
+"startLine":  1,
+"startColumn":  1,
+"endLine":  1,
+"endColumn":  1
+}
+}
+},
+{
+"id":  "S1451",
+"message":  "Add or update the header of this file.",
+"location":  {
 "uri":  "sources\Net5\Net5\S3626.cs",
 "region":  {
 "startLine":  1,

--- a/analyzers/its/expected/Net5/Net5--net5.0-S2933.json
+++ b/analyzers/its/expected/Net5/Net5--net5.0-S2933.json
@@ -106,6 +106,19 @@
 },
 {
 "id":  "S2933",
+"message":  "Make 'foo' 'readonly'.",
+"location":  {
+"uri":  "sources\Net5\Net5\S3604.cs",
+"region":  {
+"startLine":  24,
+"startColumn":  16,
+"endLine":  24,
+"endColumn":  19
+}
+}
+},
+{
+"id":  "S2933",
 "message":  "Make 'exception' 'readonly'.",
 "location":  {
 "uri":  "sources\Net5\Net5\S3928.cs",

--- a/analyzers/its/expected/Net5/Net5--net5.0-S3604.json
+++ b/analyzers/its/expected/Net5/Net5--net5.0-S3604.json
@@ -1,0 +1,30 @@
+{
+"issues":  [
+{
+"id":  "S3604",
+"message":  "Remove the static member initializer, a static constructor or module initializer sets an initial value for the member.",
+"location":  {
+"uri":  "sources\Net5\Net5\S3604.cs",
+"region":  {
+"startLine":  7,
+"startColumn":  24,
+"endLine":  7,
+"endColumn":  27
+}
+}
+},
+{
+"id":  "S3604",
+"message":  "Remove the static member initializer, a static constructor or module initializer sets an initial value for the member.",
+"location":  {
+"uri":  "sources\Net5\Net5\S3604.cs",
+"region":  {
+"startLine":  8,
+"startColumn":  24,
+"endLine":  8,
+"endColumn":  27
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Net5/Net5--net5.0-S3963.json
+++ b/analyzers/its/expected/Net5/Net5--net5.0-S3963.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S3963",
+"message":  "Initialize all 'static fields' inline and remove the 'static constructor'.",
+"location":  {
+"uri":  "sources\Net5\Net5\S3604.cs",
+"region":  {
+"startLine":  16,
+"startColumn":  9,
+"endLine":  19,
+"endColumn":  10
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Net5/Net5--net5.0-S4487.json
+++ b/analyzers/its/expected/Net5/Net5--net5.0-S4487.json
@@ -41,6 +41,45 @@
 },
 {
 "id":  "S4487",
+"message":  "Remove this unread private field 'foo' or refactor the code to use its value.",
+"location":  {
+"uri":  "sources\Net5\Net5\S3604.cs",
+"region":  {
+"startLine":  7,
+"startColumn":  20,
+"endLine":  7,
+"endColumn":  27
+}
+}
+},
+{
+"id":  "S4487",
+"message":  "Remove this unread private field 'bar' or refactor the code to use its value.",
+"location":  {
+"uri":  "sources\Net5\Net5\S3604.cs",
+"region":  {
+"startLine":  8,
+"startColumn":  20,
+"endLine":  8,
+"endColumn":  27
+}
+}
+},
+{
+"id":  "S4487",
+"message":  "Remove this unread private field 'foo' or refactor the code to use its value.",
+"location":  {
+"uri":  "sources\Net5\Net5\S3604.cs",
+"region":  {
+"startLine":  24,
+"startColumn":  16,
+"endLine":  24,
+"endColumn":  27
+}
+}
+},
+{
+"id":  "S4487",
 "message":  "Remove this unread private field 'field' or refactor the code to use its value.",
 "location":  {
 "uri":  "sources\Net5\Net5\S3776.cs",

--- a/analyzers/its/sources/Net5/Net5/S3604.cs
+++ b/analyzers/its/sources/Net5/Net5/S3604.cs
@@ -1,0 +1,30 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Net5
+{
+    public class S3604
+    {
+        static int foo = 1;
+        static int bar = 1;
+
+        [ModuleInitializer]
+        internal static void Initialize()
+        {
+            foo = 1;
+        }
+
+        static S3604()
+        {
+            bar = 1;
+        }
+    }
+
+    public record S3604_Record(string s)
+    {
+        string foo = "foo";
+        public S3604_Record() : this("x")
+        {
+            foo = "foo"; // handled by the C# compiler
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/IMethodSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/IMethodSymbolExtensions.cs
@@ -34,6 +34,9 @@ namespace SonarAnalyzer.Extensions
             symbol.ReturnsVoid &&
             symbol.DeclaredAccessibility == Accessibility.Public;
 
+        internal static bool IsModuleInitializer(this IMethodSymbol methodSymbol) =>
+            methodSymbol.AnyAttributeDerivesFrom(KnownType.System_Runtime_CompilerServices_ModuleInitializerAttribute);
+
         internal static bool IsGetTypeCall(this IMethodSymbol invokedMethod) =>
             invokedMethod.Name == nameof(Type.GetType)
             && !invokedMethod.IsStatic

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializerRedundant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializerRedundant.cs
@@ -95,7 +95,8 @@ namespace SonarAnalyzer.Rules.CSharp
                     }
                 },
                 SyntaxKind.ClassDeclaration,
-                SyntaxKind.StructDeclaration);
+                SyntaxKind.StructDeclaration,
+                SyntaxKindEx.RecordDeclaration);
 
         private static List<CtorDeclarationTuple> GetConstructorTuples(SyntaxNodeAnalysisContext context, List<IMethodSymbol> constructorSymbols) =>
             constructorSymbols

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MemberInitializerRedundantTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MemberInitializerRedundantTest.cs
@@ -42,7 +42,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                 new MemberInitializedToDefaultCodeFixProvider());
 
 #if NET
-
         [TestMethod]
         [TestCategory("Rule")]
         public void MemberInitializerRedundant_CSharp9() =>
@@ -57,8 +56,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                 new MemberInitializerRedundant(),
                 new MemberInitializedToDefaultCodeFixProvider(),
                 ParseOptionsHelper.FromCSharp9);
-
 #endif
-
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MemberInitializerRedundantTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MemberInitializerRedundantTest.cs
@@ -40,6 +40,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\MemberInitializerRedundant.CSharp9.cs", new MemberInitializerRedundant());
 
 #endif
+        // FIXME add codefix for C# 9
 
         [TestMethod]
         [TestCategory("CodeFix")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MemberInitializerRedundantTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MemberInitializerRedundantTest.cs
@@ -32,16 +32,6 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void MemberInitializerRedundant() =>
             Verifier.VerifyAnalyzer(@"TestCases\MemberInitializerRedundant.cs", new MemberInitializerRedundant(), ParseOptionsHelper.FromCSharp8);
 
-#if NET
-
-        [TestMethod]
-        [TestCategory("Rule")]
-        public void MemberInitializerRedundant_CSharp9() =>
-            Verifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\MemberInitializerRedundant.CSharp9.cs", new MemberInitializerRedundant());
-
-#endif
-        // FIXME add codefix for C# 9
-
         [TestMethod]
         [TestCategory("CodeFix")]
         public void MemberInitializerRedundant_CodeFix() =>
@@ -50,5 +40,25 @@ namespace SonarAnalyzer.UnitTest.Rules
                 @"TestCases\MemberInitializerRedundant.Fixed.cs",
                 new MemberInitializerRedundant(),
                 new MemberInitializedToDefaultCodeFixProvider());
+
+#if NET
+
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void MemberInitializerRedundant_CSharp9() =>
+            Verifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\MemberInitializerRedundant.CSharp9.cs", new MemberInitializerRedundant());
+
+        [TestMethod]
+        [TestCategory("CodeFix")]
+        public void MemberInitializerRedundant_CSharp9_CodeFix() =>
+            Verifier.VerifyCodeFix(
+                @"TestCases\MemberInitializerRedundant.CSharp9.cs",
+                @"TestCases\MemberInitializerRedundant.CSharp9.Fixed.cs",
+                new MemberInitializerRedundant(),
+                new MemberInitializedToDefaultCodeFixProvider(),
+                ParseOptionsHelper.FromCSharp9);
+
+#endif
+
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.Fixed.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 
 class Person
 {
+    const int forCoverage = 0;
     static int minAge = 0;
     static int Bar { get; set; } = 1;
     static event EventHandler Quix = (a, b) => { };
@@ -13,6 +14,8 @@ class Person
     static bool Nice; // Fixed
     static int Foo { get; set; } // Fixed
     static event EventHandler Taz; // Fixed
+
+    public Person() { } // for coverage
 
     [ModuleInitializer]
     internal static void Initialize()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.Fixed.cs
@@ -64,8 +64,8 @@ class Person
 record Foo
 {
     static int foo = 1; // FN
-    int bar = 42; // FN, reported by the C# compiler
-    int fred { get; init; } = 42; // FN, reported by the C# compiler
+    int bar = 42; // FN
+    int fred { get; init; } = 42; // FN
     int quix = 9; // ok, not initialized in all constructors
     const int barney = 1;
 
@@ -117,3 +117,26 @@ public record StaticRecord
 }
 
 record EmptyRecordForCoverage { }
+
+struct Struct1
+{
+    static int b; // Fixed
+    static int b2 = 2;
+
+    [ModuleInitializer]
+    internal static void Initialize() => b = 42;
+}
+
+interface SomeInterface
+{
+    static int Field; // Fixed
+    static int Field2 = 2;
+    static event EventHandler Taz; // Fixed
+
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        Field = 2;
+        Taz = (a, b) => { };
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.Fixed.cs
@@ -7,12 +7,12 @@ class Person
     static int Bar { get; set; } = 1;
     static event EventHandler Quix = (a, b) => { };
 
-    static int maxAge = 42; // Noncompliant {{Remove the static member initializer, a static constructor or module initializer sets an initial value for the member.}}
-    static string Name = "X"; // Noncompliant
-    static string Job = "1"; // Noncompliant
-    static bool Nice = true; // Noncompliant
-    static int Foo { get; set; } = 1; // Noncompliant
-    static event EventHandler Taz = (a, b) => { }; // Noncompliant
+    static int maxAge; // Fixed
+    static string Name; // Fixed
+    static string Job; // Fixed
+    static bool Nice; // Fixed
+    static int Foo { get; set; } // Fixed
+    static event EventHandler Taz; // Fixed
 
     [ModuleInitializer]
     internal static void Initialize()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.cs
@@ -64,8 +64,8 @@ class Person
 record Foo
 {
     static int foo = 1; // FN
-    int bar = 42; // FN, reported by the C# compiler
-    int fred { get; init; } = 42; // FN, reported by the C# compiler
+    int bar = 42; // FN
+    int fred { get; init; } = 42; // FN
     int quix = 9; // ok, not initialized in all constructors
     const int barney = 1;
 
@@ -117,3 +117,26 @@ public record StaticRecord
 }
 
 record EmptyRecordForCoverage { }
+
+struct Struct1
+{
+    static int b = 1; // Noncompliant
+    static int b2 = 2;
+
+    [ModuleInitializer]
+    internal static void Initialize() => b = 42;
+}
+
+interface SomeInterface
+{
+    static int Field = 1; // Noncompliant
+    static int Field2 = 2;
+    static event EventHandler Taz = (a, b) => { }; // Noncompliant
+
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        Field = 2;
+        Taz = (a, b) => { };
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.cs
@@ -1,13 +1,79 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 
 class Person
 {
     static int minAge = 0;
     static int maxAge = 42; // FN {{Remove the member initializer, module initializer sets an initial value for the member.}}
+    static string Name = "X"; // FN
+    static string Job = "1"; // FN
+    static bool Nice = true; // FN
 
     [ModuleInitializer]
     internal static void Initialize()
     {
         maxAge = 42;
     }
+
+    [Obsolete]
+    [ModuleInitializer]
+    internal static void SecondInitialize()
+    {
+        Name = "Foo";
+        Job = "2";
+        Nice = false;
+    }
+
+    [ModuleInitializer]
+    internal static void ThirdInitialize()
+    {
+        Job = "3";
+    }
+
+    [Obsolete]
+    internal static void Foo1()
+    {
+        minAge = 2;
+    }
+
+    [Obsolete("argument", false)]
+    internal static void Foo2()
+    {
+        minAge = 2;
+    }
+
+    internal static void Foo3()
+    {
+        minAge = 3;
+    }
 }
+
+record Foo
+{
+    static int foo = 1; // FN
+    int bar = 42; // FN
+    int fred { get; init; } = 42; // FN
+    int quix = 9; // ok, not initialized in all constructors
+
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        foo = 1;
+    }
+
+    public Foo()
+    {
+        bar = 30;
+        quix = 10;
+        fred = 10;
+    }
+
+    public Foo(int x)
+    {
+        bar = x;
+        fred = 10;
+    }
+
+    public Foo(int x, int y) : this(x) { }
+}
+

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.cs
@@ -4,10 +4,15 @@ using System.Runtime.CompilerServices;
 class Person
 {
     static int minAge = 0;
-    static int maxAge = 42; // FN {{Remove the member initializer, module initializer sets an initial value for the member.}}
-    static string Name = "X"; // FN
-    static string Job = "1"; // FN
-    static bool Nice = true; // FN
+    static int Bar { get; set; } = 1;
+    static event EventHandler Quix = (a, b) => { };
+
+    static int maxAge = 42; // Noncompliant {{Remove the static member initializer, a static constructor or module initializer sets an initial value for the member.}}
+    static string Name = "X"; // Noncompliant
+    static string Job = "1"; // Noncompliant
+    static bool Nice = true; // Noncompliant
+    static int Foo { get; set; } = 1; // Noncompliant
+    static event EventHandler Taz = (a, b) => { }; // Noncompliant
 
     [ModuleInitializer]
     internal static void Initialize()
@@ -22,6 +27,8 @@ class Person
         Name = "Foo";
         Job = "2";
         Nice = false;
+        Foo = 1;
+        Taz = (a, b) => { };
     }
 
     [ModuleInitializer]
@@ -45,12 +52,14 @@ class Person
     internal static void Foo3()
     {
         minAge = 3;
+        Bar = 2;
+        Quix = (a, b) => { };
     }
 }
 
 record Foo
 {
-    static int foo = 1; // FN
+    static int foo = 1; // Noncompliant
     int bar = 42; // Noncompliant
     int fred { get; init; } = 42; // Noncompliant
     int quix = 9; // ok, not initialized in all constructors

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 
 class Person
 {
+    const int forCoverage = 0;
     static int minAge = 0;
     static int Bar { get; set; } = 1;
     static event EventHandler Quix = (a, b) => { };
@@ -13,6 +14,8 @@ class Person
     static bool Nice = true; // Noncompliant
     static int Foo { get; set; } = 1; // Noncompliant
     static event EventHandler Taz = (a, b) => { }; // Noncompliant
+
+    public Person() { } // for coverage
 
     [ModuleInitializer]
     internal static void Initialize()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.CSharp9.cs
@@ -51,8 +51,8 @@ class Person
 record Foo
 {
     static int foo = 1; // FN
-    int bar = 42; // FN
-    int fred { get; init; } = 42; // FN
+    int bar = 42; // Noncompliant
+    int fred { get; init; } = 42; // Noncompliant
     int quix = 9; // ok, not initialized in all constructors
 
     [ModuleInitializer]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.Fixed.cs
@@ -185,6 +185,36 @@ namespace Tests.Diagnostics
         public Person11() => a = 42;
     }
 
+    class Person12
+    {
+        int age;
+        public Person12()
+        {
+            age = 0; // FN
+        }
+    }
+
+    class Person13
+    {
+        static int x = 42; // FN
+        static int y;
+        static Person13()
+        {
+            x = 41;
+            y = 41;
+        }
+    }
+
+    class Person14
+    {
+        static int x = 42; // Compliant
+        static Person14()
+        {
+            Console.WriteLine(x);
+            x = 41;
+        }
+    }
+
     class CSharp8_PersonA
     {
         int age = 42;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.Fixed.cs
@@ -261,4 +261,16 @@ namespace Tests.Diagnostics
             baz = 0;
         }
     }
+
+    struct Struct1
+    {
+        // structs cannot initialize instance fields/properties at declaration, only const
+        const int a = 42;
+        static int b; // Fixed
+        static int b2 = 2;
+
+        static Struct1() => b = 1;
+    }
+    class EmptyClassForCoverage { }
+    struct EmptyStructForCoverage { }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.Fixed.cs
@@ -65,6 +65,7 @@ namespace Tests.Diagnostics
     class Person3
     {
         int age; // Fixed
+        int id = 42; // only set in the second constructor
         public Person3(int age)
         {
             this.age = age;
@@ -73,6 +74,7 @@ namespace Tests.Diagnostics
         public Person3(int age, int other)
             : this(age)
         {
+            id = other;
         }
     }
 
@@ -196,12 +198,16 @@ namespace Tests.Diagnostics
 
     class Person13
     {
-        static int x = 42; // FN
+        static int x; // Fixed
         static int y;
+        static int z { get; } // Fixed
+        static event EventHandler w; // Fixed
         static Person13()
         {
             x = 41;
             y = 41;
+            z = 2;
+            w = (a, b) => { };
         }
     }
 
@@ -236,6 +242,23 @@ namespace Tests.Diagnostics
         public CSharp8_PersonB(int[] ids)
         {
             this.ids ??= ids;
+        }
+    }
+
+    class BaseClass
+    {
+        int foo; // Fixed
+        public BaseClass(int i)
+        {
+            foo = 42;
+        }
+    }
+    class NewClass : BaseClass
+    {
+        int baz = 0; // FN
+        public NewClass() : base(1)
+        {
+            baz = 0;
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.cs
@@ -263,4 +263,16 @@ namespace Tests.Diagnostics
             baz = 0;
         }
     }
+
+    struct Struct1
+    {
+        // structs cannot initialize instance fields/properties at declaration, only const
+        const int a = 42;
+        static int b = 1; // Noncompliant
+        static int b2 = 2;
+
+        static Struct1() => b = 1;
+    }
+    class EmptyClassForCoverage { }
+    struct EmptyStructForCoverage { }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.cs
@@ -67,6 +67,7 @@ namespace Tests.Diagnostics
     class Person3
     {
         int age = 42; // Noncompliant
+        int id = 42; // only set in the second constructor
         public Person3(int age)
         {
             this.age = age;
@@ -75,6 +76,7 @@ namespace Tests.Diagnostics
         public Person3(int age, int other)
             : this(age)
         {
+            id = other;
         }
     }
 
@@ -187,6 +189,36 @@ namespace Tests.Diagnostics
         public Person11() => a = 42;
     }
 
+    class Person12
+    {
+        int age;
+        public Person12()
+        {
+            age = 0; // FN
+        }
+    }
+
+    class Person13
+    {
+        static int x = 42; // FN
+        static int y;
+        static Person13()
+        {
+            x = 41;
+            y = 41;
+        }
+    }
+
+    class Person14
+    {
+        static int x = 42; // Compliant
+        static Person14()
+        {
+            Console.WriteLine(x);
+            x = 41;
+        }
+    }
+
     class CSharp8_PersonA
     {
         int age = 42;
@@ -208,6 +240,23 @@ namespace Tests.Diagnostics
         public CSharp8_PersonB(int[] ids)
         {
             this.ids ??= ids;
+        }
+    }
+
+    class BaseClass
+    {
+        int foo = 42; // Noncompliant
+        public BaseClass(int i)
+        {
+            foo = 42;
+        }
+    }
+    class NewClass : BaseClass
+    {
+        int baz = 0; // FN
+        public NewClass() : base(1)
+        {
+            baz = 0;
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MemberInitializerRedundant.cs
@@ -200,12 +200,16 @@ namespace Tests.Diagnostics
 
     class Person13
     {
-        static int x = 42; // FN
+        static int x = 42; // Noncompliant {{Remove the static member initializer, a static constructor or module initializer sets an initial value for the member.}}
         static int y;
+        static int z { get; } = 2; // Noncompliant
+        static event EventHandler w = (a, b) => { }; // Noncompliant
         static Person13()
         {
             x = 41;
             y = 41;
+            z = 2;
+            w = (a, b) => { };
         }
     }
 


### PR DESCRIPTION
related to the module initializers support in https://jira.sonarsource.com/browse/MMF-2227

RE: records = it seems that we missed this rule from the https://jira.sonarsource.com/browse/MMF-2223 , however the compiler is already handling this case for records. More exactly, for
```
public record Bar
{
    private string foo = "foo";    
    public Bar(string foo)
    {
        foo = "foo";
    }
}
```
The generated constructor (for which `IsImplicitlyDeclared` is `false` from a Roslyn API point of view...) is, according to sharplab.io 2 Aug 2021:
```
    [System.Runtime.CompilerServices.NullableContext(0)]
    public Bar(string foo)
    {
        this.foo = "foo";
        base..ctor();
        foo = "foo";
    }
```
In sharplab.io there is an issue being raised that the assignment to `foo` is not necessary (as tested in sharplab.io).

Even more, for 
```
public record Bar(string bar)
{
    public string foo = "foo";    
}
```
the generated code is
```
    public Bar(string bar)
    {
        <bar>k__BackingField = bar;
        foo = "foo";
        base..ctor();
    }
```

And even for static constructors...
```
public record Bar
{
    public static int FOO = 1;
    public static String BAR = "BAR";
    static Bar()
    {
        FOO = 2;
    }
}
```
it decompiles on
```
    static Bar()
    {
        FOO = 1;
        BAR = "BAR";
        FOO = 2;
    }
```
