### PR TITLE
Fix S1172 FP: Parameter captured in a referenced generic local function

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/LiveVariableAnalysis/CSharp/CSharpLiveVariableAnalysis.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/LiveVariableAnalysis/CSharp/CSharpLiveVariableAnalysis.cs
@@ -79,6 +79,10 @@ namespace SonarAnalyzer.LiveVariableAnalysis.CSharp
                         ProcessIdentifier((IdentifierNameSyntax)instruction, state);
                         break;
 
+                    case SyntaxKind.GenericName:
+                        ProcessGenericName(instruction, state);
+                        break;
+
                     case SyntaxKind.SimpleAssignmentExpression:
                         ProcessSimpleAssignment((AssignmentExpressionSyntax)instruction, state);
                         break;
@@ -175,6 +179,16 @@ namespace SonarAnalyzer.LiveVariableAnalysis.CSharp
                 {
                     ProcessLocalFunction(symbol, state);
                 }
+            }
+        }
+
+        private void ProcessGenericName(SyntaxNode genericName, State state)
+        {
+            if (genericName.Parent.IsKind(SyntaxKind.InvocationExpression)
+                && semanticModel.GetSymbolInfo(genericName).Symbol is IMethodSymbol method
+                && method.MethodKind == MethodKindEx.LocalFunction)
+            {
+                ProcessLocalFunction(method, state);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/LiveVariableAnalysis/CSharp/CSharpLiveVariableAnalysis.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/LiveVariableAnalysis/CSharp/CSharpLiveVariableAnalysis.cs
@@ -80,7 +80,7 @@ namespace SonarAnalyzer.LiveVariableAnalysis.CSharp
                         break;
 
                     case SyntaxKind.GenericName:
-                        ProcessGenericName(instruction, state);
+                        ProcessGenericName((GenericNameSyntax)instruction, state);
                         break;
 
                     case SyntaxKind.SimpleAssignmentExpression:
@@ -175,18 +175,17 @@ namespace SonarAnalyzer.LiveVariableAnalysis.CSharp
                     }
                 }
 
-                if (symbol is IMethodSymbol method && method.MethodKind == MethodKindEx.LocalFunction)
+                if (symbol is IMethodSymbol { MethodKind: MethodKindEx.LocalFunction } method)
                 {
                     ProcessLocalFunction(symbol, state);
                 }
             }
         }
 
-        private void ProcessGenericName(SyntaxNode genericName, State state)
+        private void ProcessGenericName(GenericNameSyntax genericName, State state)
         {
-            if (genericName.Parent.IsKind(SyntaxKind.InvocationExpression)
-                && semanticModel.GetSymbolInfo(genericName).Symbol is IMethodSymbol method
-                && method.MethodKind == MethodKindEx.LocalFunction)
+            if (!genericName.GetSelfOrTopParenthesizedExpression().IsInNameOfArgument(semanticModel)
+                && semanticModel.GetSymbolInfo(genericName).Symbol is IMethodSymbol {MethodKind: MethodKindEx.LocalFunction } method)
             {
                 ProcessLocalFunction(method, state);
             }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodParameterUnused.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodParameterUnused.CSharp8.cs
@@ -144,5 +144,48 @@ namespace Tests.TestCases
                 Console.WriteLine(someString.Length);
             }
         }
+
+        private static void UsedByReferenceWithStruct(this int someNumber, string someString)
+        {
+            Action x = PrintSomeSum<int>;
+
+            x();
+
+            void PrintSomeSum<TOptions>() where TOptions : struct
+            {
+                Console.WriteLine(someNumber + someString.Length);
+            }
+        }
+
+        private static void UsedByReferenceAsArgument(int[] list, string arg)
+        {
+            list.Where(LocalFunction<int>);
+
+            bool LocalFunction<TOptions>(TOptions x) where TOptions : struct
+            {
+                Console.WriteLine(arg);
+                return true;
+            }
+        }
+
+        private static void InsideNameOf_Valid(string arg)   // Noncompliant
+        {
+            var name = nameof(LocalFunction);
+
+            void LocalFunction<TOptions>() where TOptions : struct
+            {
+                Console.WriteLine(arg);
+            }
+        }
+
+        private static void InsideNameOf_Invalid(string arg)   // Noncompliant
+        {
+            var name = nameof(LocalFunction<int>);      // Error [CS8084] Type parameters are not allowed on a method group as an argument to 'nameof'
+
+            void LocalFunction<TOptions>() where TOptions : struct
+            {
+                Console.WriteLine(arg);
+            }
+        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodParameterUnused.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodParameterUnused.CSharp8.cs
@@ -124,13 +124,24 @@ namespace Tests.TestCases
     // https://github.com/SonarSource/sonar-dotnet/issues/4704
     public static  class Repro_4704
     {
-        private static void ConfigureAndValidateSettings(this int someNumber, string someString) // Noncompliant FP
+        private static void ConfigureAndValidateSettings(this int someNumber, string someString)    // Compliant, captured in generic local method
         {
             PrintSomeSum<int>();
 
             void PrintSomeSum<TOptions>() where TOptions : struct
             {
                 Console.WriteLine(someNumber + someString.Length);
+            }
+        }
+
+        private static void NotInvoked(string someString)    // Noncompliant
+        {
+            var somethingWithGenericName = new System.Lazy<object>(() => null);
+            Undefined<int>(); // Error [CS0103] The name 'Undefined' does not exist in the current context
+
+            void PrintSomeSum<TOptions>() where TOptions : struct
+            {
+                Console.WriteLine(someString.Length);
             }
         }
     }


### PR DESCRIPTION
Fixes #4704

The key idea is to handle `GenericNameSyntax` (that has `.Identifier`) the same way as `ProcessIdentifier` was updated in #3818