### PR TITLE
Fix AD0001 with Symbolic Execution engine

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyNullableValueAccess.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyNullableValueAccess.cs
@@ -140,16 +140,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
 
                 var nullabilityConstraint = boolConstraint == BoolConstraint.True ? ObjectConstraint.NotNull : ObjectConstraint.Null;
-                if (programState.Constraints.TryGetValue(MemberExpression, out var oldConstraints) && oldConstraints.GetConstraintOrDefault<NullableValueConstraint>() is { } oldNullableConstraint)
-                {
-                    return oldNullableConstraint == NullableValueConstraint.HasValue ^ nullabilityConstraint == ObjectConstraint.NotNull
-                        ? Enumerable.Empty<ProgramState>()  // Unreachable state, cannot be HasValue && Null nor NoValue && NotNull at the same time => don't explore this branch
-                        : new[] { programState };           // Just keep what we had, because situation didn't change
-                }
-                else
-                {
-                    return MemberExpression.TrySetConstraint(nullabilityConstraint, programState);
-                }
+                return MemberExpression.TrySetConstraint(nullabilityConstraint, programState);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Common/SymbolicValues/SymbolicValue.cs
@@ -143,7 +143,7 @@ namespace SonarAnalyzer.SymbolicExecution
                 // It was null, and now it should be true or false
                 return new[] { programState };
             }
-            else if (oldConstraints.GetConstraintOrDefault<BoolConstraint>() is { }  oldBoolConstraint && oldBoolConstraint != constraint)
+            else if (oldConstraints.GetConstraintOrDefault<BoolConstraint>() is { } oldBoolConstraint && oldBoolConstraint != constraint)
             {
                 return Enumerable.Empty<ProgramState>();
             }
@@ -171,6 +171,12 @@ namespace SonarAnalyzer.SymbolicExecution
             else if (oldConstraints.GetConstraintOrDefault<ObjectConstraint>() is { } oldObjectConstraint)
             {
                 return oldObjectConstraint != constraint ? Enumerable.Empty<ProgramState>() : new[] { programState.SetConstraint(this, constraint) };
+            }
+            else if (oldConstraints.GetConstraintOrDefault<NullableValueConstraint>() is { } oldNullableConstraint)
+            {
+                return oldNullableConstraint == NullableValueConstraint.HasValue ^ constraint == ObjectConstraint.NotNull
+                    ? Enumerable.Empty<ProgramState>()  // Unreachable state, cannot be HasValue && Null nor NoValue && NotNull at the same time => don't explore this branch
+                    : new[] { programState.SetConstraint(this, constraint) };
             }
             else
             {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ConditionEvaluatesToConstantTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ConditionEvaluatesToConstantTest.cs
@@ -69,44 +69,6 @@ namespace SonarAnalyzer.UnitTest.Rules
             Verifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\ConditionEvaluatesToConstant.CSharp9.TopLevelStatements.cs", GetAnalyzer());
 #endif
 
-        [TestMethod]
-        public void ConditionEvaluatesToConstant_UncaughtException()
-        {
-            Action action = () => Verifier.VerifyCSharpAnalyzer(@"
-using System;
-public class Reproducer
-{
-    private DateTime? foo;
-
-    public virtual DateTime? Foo
-    {
-        get { return foo; }
-
-        set
-        {
-            if (value.HasValue)
-            {
-                value = DateTime.SpecifyKind(value.Value, DateTimeKind.Unspecified);
-            }
-
-            if (foo != value || (foo.HasValue && value.HasValue && foo.Value.Kind != value.Value.Kind))
-            {
-                foo = value;
-                Bar(""x"");
-            }
-        }
-    }
-    public void Bar(string x) { }
-}", GetAnalyzer(), CompilationErrorBehavior.Ignore);
-
-            // https://github.com/SonarSource/sonar-dotnet/issues/4573
-            action.Should().Throw<AssertFailedException>().Where(e =>
-                e.Message.Contains("Expected diagnostics {error AD0001: Analyzer 'SonarAnalyzer.Rules.SymbolicExecution.SymbolicExecutionRunner' threw an exception of type " +
-                "'SonarAnalyzer.SymbolicExecution.SymbolicExecutionException' with message 'Error processing method: set_Foo ## Method file: snippet1.cs " +
-                "## Method line: 11,8 ## Inner exception: System.NotSupportedException: Unexpected constraint type: ObjectConstraint.Old constraints: NoValue " +
-                "##    at SonarAnalyzer.SymbolicExecution.SymbolicValue.TrySetObjectConstraint(ObjectConstraint constraint, SymbolicValueConstraints oldConstraints, ProgramState programState)"));
-        }
-
         private static SonarDiagnosticAnalyzer GetAnalyzer() =>
             new SymbolicExecutionRunner(new ConditionEvaluatesToConstant());
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
@@ -208,16 +208,12 @@ public class Repro_4573
         {
             if (value.HasValue)
             {
-                value = DateTime.SpecifyKind(value.Value, DateTimeKind.Unspecified);
+                //HasValue and NoValue constraints are set here
             }
-
-            if (foo != value || (foo.HasValue && value.HasValue && foo.Value.Kind != value.Value.Kind))
+            if (foo != value || foo.HasValue)
             {
                 foo = value;
-                Bar("x");
             }
         }
     }
-
-    public void Bar(string x) { }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
@@ -243,7 +243,35 @@ public class Repro_4573
         }
     }
 
-    public void Nested(DateTime? value)
+    public void NestedIsolated1(DateTime? value)
+    {
+        if (foo == value)   // Relationship is added here
+        {
+            if (value.HasValue)
+            {
+                if (!foo.HasValue)
+                {
+                    Console.WriteLine(foo.Value.ToString());    // Compliant
+                }
+            }
+        }
+    }
+
+    public void NestedIsolated2(DateTime? value)
+    {
+        if (foo == value)   // Relationship is added here
+        {
+            if (!value.HasValue)
+            {
+                if (foo == null)
+                {
+                    Console.WriteLine(foo.Value.ToString());    // Noncompliant
+                }
+            }
+        }
+    }
+
+    public void NestedCombined(DateTime? value)
     {
         if (foo == value)   // Relationship is added here
         {
@@ -255,7 +283,7 @@ public class Repro_4573
                 }
                 if (!foo.HasValue)
                 {
-                    Console.WriteLine(foo.Value.ToString());    // Noncompliant FP, unreachable
+                    Console.WriteLine(foo.Value.ToString());    // Noncompliant FP, unreachable. It works as expected when isolated, see NestedIsolated1() above
                 }
                 if (foo == null)
                 {
@@ -278,7 +306,7 @@ public class Repro_4573
                 }
                 if (foo == null)
                 {
-                    Console.WriteLine(foo.Value.ToString());    // FN
+                    Console.WriteLine(foo.Value.ToString());    // FN. It works as expected when isolated, see NestedIsolated2() above
                 }
                 if (foo != null)
                 {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
@@ -202,8 +202,7 @@ public class Repro_4573
 
     public virtual DateTime? Foo
     {
-        get { return foo; }
-
+        get => foo;
         set
         {
             if (value.HasValue)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
@@ -131,7 +131,7 @@ namespace Tests.Diagnostics
 
         public int CSharp8_SwitchExpressions3(int? value)
         {
-            return value.HasValue switch { true => value.Value, false => 0};
+            return value.HasValue switch { true => value.Value, false => 0 };
         }
 
         public int CSharp8_SwitchExpressions4(int? value)
@@ -212,6 +212,78 @@ public class Repro_4573
             if (foo != value || foo.HasValue)
             {
                 foo = value;
+            }
+        }
+    }
+
+    public void Sequence(DateTime? value)
+    {
+        if (value.HasValue)
+        {
+            //HasValue and NoValue constraints are set here
+        }
+        if (foo == value)   // Relationship is added here
+        {
+            if (foo.HasValue)
+            {
+                Console.WriteLine(foo.Value.ToString());
+            }
+            if (!foo.HasValue)
+            {
+                Console.WriteLine(foo.Value.ToString());    // Noncompliant
+            }
+            if (foo == null)
+            {
+                Console.WriteLine(foo.Value.ToString());    // Noncompliant
+            }
+            if (foo != null)
+            {
+                Console.WriteLine(foo.Value.ToString());
+            }
+        }
+    }
+
+    public void Nested(DateTime? value)
+    {
+        if (foo == value)   // Relationship is added here
+        {
+            if (value.HasValue)
+            {
+                if (foo.HasValue)
+                {
+                    Console.WriteLine(foo.Value.ToString());
+                }
+                if (!foo.HasValue)
+                {
+                    Console.WriteLine(foo.Value.ToString());    // Noncompliant FP, unreachable
+                }
+                if (foo == null)
+                {
+                    Console.WriteLine(foo.Value.ToString());    // Compliant, unreachable
+                }
+                if (foo != null)
+                {
+                    Console.WriteLine(foo.Value.ToString());
+                }
+            }
+            else
+            {
+                if (foo.HasValue)
+                {
+                    Console.WriteLine(foo.Value.ToString());    // Compliant, unreachable
+                }
+                if (!foo.HasValue)
+                {
+                    Console.WriteLine(foo.Value.ToString());    // FN
+                }
+                if (foo == null)
+                {
+                    Console.WriteLine(foo.Value.ToString());    // Noncompliant
+                }
+                if (foo != null)
+                {
+                    Console.WriteLine(foo.Value.ToString());    // Compliant, unreachable
+                }
             }
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
@@ -193,5 +193,31 @@ namespace Tests.Diagnostics
             return i.Value; //Noncompliant
         }
     }
+}
 
+// https://github.com/SonarSource/sonar-dotnet/issues/4573
+public class Repro_4573
+{
+    private DateTime? foo;
+
+    public virtual DateTime? Foo
+    {
+        get { return foo; }
+
+        set
+        {
+            if (value.HasValue)
+            {
+                value = DateTime.SpecifyKind(value.Value, DateTimeKind.Unspecified);
+            }
+
+            if (foo != value || (foo.HasValue && value.HasValue && foo.Value.Kind != value.Value.Kind))
+            {
+                foo = value;
+                Bar("x");
+            }
+        }
+    }
+
+    public void Bar(string x) { }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EmptyNullableValueAccess.cs
@@ -234,7 +234,7 @@ public class Repro_4573
             }
             if (foo == null)
             {
-                Console.WriteLine(foo.Value.ToString());    // Noncompliant
+                Console.WriteLine(foo.Value.ToString());    // FN
             }
             if (foo != null)
             {
@@ -274,11 +274,11 @@ public class Repro_4573
                 }
                 if (!foo.HasValue)
                 {
-                    Console.WriteLine(foo.Value.ToString());    // FN
+                    Console.WriteLine(foo.Value.ToString());    // Noncompliant
                 }
                 if (foo == null)
                 {
-                    Console.WriteLine(foo.Value.ToString());    // Noncompliant
+                    Console.WriteLine(foo.Value.ToString());    // FN
                 }
                 if (foo != null)
                 {


### PR DESCRIPTION
Fixes #4573

The `NestedCombined` demonstrates, that there's something wrong with general condition processing in the engine itself. Relationships are probably not taken into considerations properly for consequent `if` statements - that's just documented for now.