### PR TITLE
Change build tasks order

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,18 +95,6 @@ stages:
           configuration: '$(buildConfiguration)'
           msbuildArgs: '/p:DeployExtension=false /p:SignAssembly=true /p:AssemblyOriginatorKeyFile="$(snk.secureFilePath)" /p:Sha1=$(Build.SourceVersion) /p:BuildNumber=$(Build.BuildId) /p:WarningLevel=0'
 
-      - task: PublishPipelineArtifact@1
-        displayName: 'Publish analyzer binaries as pipeline artifact'
-        inputs:
-          path: analyzers/its/binaries/
-          artifact: Binaries
-
-      - task: PublishPipelineArtifact@1
-        displayName: 'Publish rule descriptor binaries as pipeline artifact'
-        inputs:
-          path: analyzers\src\SonarAnalyzer.RuleDescriptorGenerator\bin
-          artifact: RuleDescriptorBin
-
       - task: NuGetCommand@2
         displayName: "Build NuGet packages"
         inputs:
@@ -136,6 +124,18 @@ stages:
           artifactoryService: 'Repox artifactory'
           targetDeployRepo: '$(ARTIFACTORY_NUGET_REPO)'
           pathToNupkg: '$(Build.ArtifactStagingDirectory)/packages/SonarAnalyzer.CFG.CSharp.*.nupkg'
+
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish analyzer binaries as pipeline artifact'
+        inputs:
+          path: analyzers/its/binaries/
+          artifact: Binaries
+
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish rule descriptor binaries as pipeline artifact'
+        inputs:
+          path: analyzers\src\SonarAnalyzer.RuleDescriptorGenerator\bin
+          artifact: RuleDescriptorBin
 
 - template: stage-with-burgr-notifications.yml@pipelines-yaml-templates
   parameters:
@@ -249,7 +249,7 @@ stages:
 
       - task: PowerShell@2
         displayName: 'Run ITs'
-        env:          
+        env:
           SONAR_DOTNET_ENABLE_CONCURRENT_PROCESSING: true
         inputs:
           filePath: 'analyzers/its/regression-test.ps1'


### PR DESCRIPTION
Currently if the signing task fails it will let the build in an inconsistent state and any retry will lead to errors like: 
> ##[error]Artifact Binaries already exists for build 35465.

See: https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=35465&view=logs&jobId=f44a741f-9110-553a-520b-28a1a7416edf&j=f44a741f-9110-553a-520b-28a1a7416edf&t=af00f6af-222b-5187-006a-702a33759858

By pushing the artifacts after the signing occurs we avoid this.