### PR TITLE
Fix ignored namespace in OperationLightupGenerator

### DIFF
--- a/analyzers/src/SonarAnalyzer.ShimLayer.CodeGeneration/OperationLightupGenerator.cs
+++ b/analyzers/src/SonarAnalyzer.ShimLayer.CodeGeneration/OperationLightupGenerator.cs
@@ -69,7 +69,7 @@ namespace StyleCop.Analyzers.CodeGeneration
                     variables: SyntaxFactory.SingletonSeparatedList(SyntaxFactory.VariableDeclarator(
                         identifier: SyntaxFactory.Identifier("WrappedTypeName"),
                         argumentList: null,
-                        initializer: SyntaxFactory.EqualsValueClause(SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal("Microsoft.CodeAnalysis.Operations." + node.InterfaceName))))))));
+                        initializer: SyntaxFactory.EqualsValueClause(SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal($"Microsoft.CodeAnalysis.{node.Namespace}.{node.InterfaceName}"))))))));
 
             // private static readonly Type WrappedType;
             members = members.Add(SyntaxFactory.FieldDeclaration(
@@ -988,6 +988,7 @@ namespace StyleCop.Analyzers.CodeGeneration
 
                 this.OperationKinds = operationKinds;
                 this.InterfaceName = node.Attribute("Name").Value;
+                this.Namespace = node.Attribute("Namespace")?.Value ?? "Operations";
                 this.Name = this.InterfaceName.Substring("I".Length, this.InterfaceName.Length - "I".Length - "Operation".Length);
                 this.WrapperName = this.InterfaceName + "Wrapper";
                 this.BaseInterfaceName = node.Attribute("Base").Value;
@@ -998,6 +999,8 @@ namespace StyleCop.Analyzers.CodeGeneration
             public ImmutableArray<(string name, int value, string? extraDescription)> OperationKinds { get; }
 
             public string InterfaceName { get; }
+
+            public string Namespace { get; }
 
             public string Name { get; }
 


### PR DESCRIPTION
Most of the wrapped `IOperation`s are in `Microsoft.CodeAnalysis.Operations` namespace and there are 6 more of them in `FlowAnalysis` namespace:
```
Microsoft.CodeAnalysis.FlowAnalysis.ICaughtExceptionOperation
Microsoft.CodeAnalysis.FlowAnalysis.IFlowAnonymousFunctionOperation
Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureOperation
Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureReferenceOperation
Microsoft.CodeAnalysis.FlowAnalysis.IIsNullOperation
Microsoft.CodeAnalysis.FlowAnalysis.IStaticLocalInitializationSemaphoreOperation
```
This change is configured in `analyzers\src\SonarAnalyzer.CFG\ShimLayer\OperationInterfaces.xml` file, but the `Namespace` attribute was ignored in the code.