### PR TITLE
S4830 - add C#8 static local function test

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CertificateValidationCheck.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CertificateValidationCheck.CSharp8.cs
@@ -21,4 +21,17 @@ namespace TestCases
             //                                                                             ^^^^ Secondary
         }
     }
+
+    class StaticLocalFunctionCase
+    {
+        public void Foo()
+        {
+            InitAsArgument((sender, certificate, chain, SslPolicyErrors) => true);  // Secondary
+
+            static HttpWebRequest CreateRQ() => (HttpWebRequest)System.Net.HttpWebRequest.Create("http://localhost");
+
+            static void InitAsArgument(RemoteCertificateValidationCallback callback) =>
+                CreateRQ().ServerCertificateValidationCallback += callback; // Noncompliant
+        }
+    }
 }


### PR DESCRIPTION
(there is already support for C# 9 static lambdas, see [line 21](https://github.com/SonarSource/sonar-dotnet/blob/8.27.0.35380/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CertificateValidationCheck.CSharp9.cs#L21)
