### PR TITLE
S3433 - support C# 9 attributes on local functions

### DIFF
--- a/analyzers/its/expected/Net5/Net5Test--net5.0-S2187.json
+++ b/analyzers/its/expected/Net5/Net5Test--net5.0-S2187.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S2187",
+"message":  "Add some tests to this class.",
+"location":  {
+"uri":  "sources\Net5\Net5Test\S3433_Mstest.cs",
+"region":  {
+"startLine":  6,
+"startColumn":  18,
+"endLine":  6,
+"endColumn":  30
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Net5/Net5Test--net5.0-S2701.json
+++ b/analyzers/its/expected/Net5/Net5Test--net5.0-S2701.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S2701",
+"message":  "Remove or correct this assertion.",
+"location":  {
+"uri":  "sources\Net5\Net5Test\S3433_Mstest.cs",
+"region":  {
+"startLine":  13,
+"startColumn":  17,
+"endLine":  13,
+"endColumn":  36
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Net5/Net5Test--net5.0-S3433.json
+++ b/analyzers/its/expected/Net5/Net5Test--net5.0-S3433.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S3433",
+"message":  "Make this test method a public method instead of a local function.",
+"location":  {
+"uri":  "sources\Net5\Net5Test\S3433_Mstest.cs",
+"region":  {
+"startLine":  11,
+"startColumn":  18,
+"endLine":  11,
+"endColumn":  28
+}
+}
+}
+]
+}

--- a/analyzers/its/sources/Net5/Net5Test/Net5Test.csproj
+++ b/analyzers/its/sources/Net5/Net5Test/Net5Test.csproj
@@ -19,6 +19,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
   </ItemGroup>
 
 </Project>

--- a/analyzers/its/sources/Net5/Net5Test/S3433_Mstest.cs
+++ b/analyzers/its/sources/Net5/Net5Test/S3433_Mstest.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Net5Test
+{
+    [TestClass]
+    public class S3433_Mstest
+    {
+        public void Method()
+        {
+            [TestMethod]
+            void NestedTest()
+            {
+                Assert.IsTrue(true);
+            }
+        }
+    }
+}

--- a/analyzers/its/sources/Net5/Net5Test/S3433_Xunit.cs
+++ b/analyzers/its/sources/Net5/Net5Test/S3433_Xunit.cs
@@ -1,0 +1,16 @@
+﻿using Xunit;
+
+namespace Net5Test
+{
+    public class S3433_Xunit
+    {
+        public void Method()
+        {
+            [Fact]
+            void NestedFact()
+            {
+                Assert.True(true);
+            }
+        }
+    }
+}

--- a/analyzers/its/sources/Net5/Net5Test/packages.lock.json
+++ b/analyzers/its/sources/Net5/Net5Test/packages.lock.json
@@ -18,6 +18,26 @@
           "Microsoft.TestPlatform.TestHost": "16.9.4"
         }
       },
+      "MSTest.TestAdapter": {
+        "type": "Direct",
+        "requested": "[2.2.3, )",
+        "resolved": "2.2.3",
+        "contentHash": "Xxc6+JyELKOmM46CYrHxL9f2LMZGnx1Neh0dr52THZbmVTwlJM1tj0U5RQ50G+wxsfsU8ZfR1HAUugc+64b6TA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "System.Diagnostics.TextWriterTraceListener": "4.3.0"
+        }
+      },
+      "MSTest.TestFramework": {
+        "type": "Direct",
+        "requested": "[2.2.3, )",
+        "resolved": "2.2.3",
+        "contentHash": "wqrF2D/uqhTCFJ4bQjhf5vLPXnsjbRZMncr2/+wnhy922YAqLGO2VOjQ6grxGqOWyVWFeIDnQFpLKFRNnrAd7w==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "System.Diagnostics.TextWriterTraceListener": "4.3.0"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.4.1, )",
@@ -374,6 +394,19 @@
           "System.Threading": "4.3.0"
         }
       },
+      "System.Diagnostics.TextWriterTraceListener": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "F11kHWeiwYjFWto+kr8tt9ULMH0k8MsT1XmdCGPTLYHhWgN+2g7JsIZiXDrxlFGccSNkbjfwQy4xIS38gzUiZA==",
+        "dependencies": {
+          "System.Diagnostics.TraceSource": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
       "System.Diagnostics.Tools": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -382,6 +415,22 @@
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.TraceSource": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "VnYp1NxGx8Ww731y2LJ1vpfb/DKVNKEZ8Jsh5SgQTZREL/YpWRArgh9pI8CDLmgHspZmLL697CaLvH85qQpRiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0"
         }
       },
       "System.Diagnostics.Tracing": {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
@@ -33,16 +33,12 @@ namespace SonarAnalyzer.Rules.CSharp
     [Rule(DiagnosticId)]
     public sealed class TestMethodShouldHaveCorrectSignature : SonarDiagnosticAnalyzer
     {
-        internal const string DiagnosticId = "S3433";
+        private const string DiagnosticId = "S3433";
         private const string MessageFormat = "Make this test method {0}.";
         private const string MakePublicMessage = "'public'";
         private const string MakeNonAsyncOrTaskMessage = "non-'async' or return 'Task'";
         private const string MakeNotGenericMessage = "non-generic";
         private const string MakeMethodNotLocalFunction = "a public method instead of a local function.";
-
-        private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         /// <summary>
         /// Validation method. Checks the supplied method and returns the error message,
@@ -57,7 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
         // Rather than writing lots of conditional code, we're using a simple table-driven approach.
         // Currently we use the same validation method for all method types, but we could have a
         // different validation method for each type in future if necessary.
-        private static readonly Dictionary<KnownType, SignatureValidator> attributeToConstraintsMap = new Dictionary<KnownType, SignatureValidator>
+        private static readonly Dictionary<KnownType, SignatureValidator> AttributeToConstraintsMap = new Dictionary<KnownType, SignatureValidator>
         {
             // MSTest
             {
@@ -102,6 +98,11 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         };
 
+        private static readonly DiagnosticDescriptor Rule =
+            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(AnalyzeMethod, SyntaxKind.MethodDeclaration);
 
@@ -116,7 +117,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var message = validator(methodSymbol);
             if (message != null)
             {
-                c.ReportDiagnosticWhenActive(Diagnostic.Create(rule, methodSymbol.Locations.First(), message));
+                c.ReportDiagnosticWhenActive(Diagnostic.Create(Rule, methodSymbol.Locations.First(), message));
             }
         }
 
@@ -129,7 +130,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 return NullValidator;
             }
 
-            return attributeToConstraintsMap.GetValueOrDefault(attributeKnownType);
+            return AttributeToConstraintsMap.GetValueOrDefault(attributeKnownType);
         }
 
         private static string GetFaultMessage(IMethodSymbol methodSymbol, bool publicOnly, bool allowGenerics) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
@@ -23,6 +23,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
@@ -108,16 +109,16 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private void AnalyzeMethod(SyntaxNodeAnalysisContext c)
         {
-            if (!(c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol methodSymbol))
+            if (c.Node is MethodDeclarationSyntax methodDeclaration
+                && methodDeclaration.AttributeLists.Count > 0
+                && c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol methodSymbol)
             {
-                return;
-            }
-
-            var validator = GetValidator(methodSymbol);
-            var message = validator(methodSymbol);
-            if (message != null)
-            {
-                c.ReportDiagnosticWhenActive(Diagnostic.Create(Rule, methodSymbol.Locations.First(), message));
+                var validator = GetValidator(methodSymbol);
+                var message = validator(methodSymbol);
+                if (message != null)
+                {
+                    c.ReportDiagnosticWhenActive(Diagnostic.Create(Rule, methodSymbol.Locations.First(), message));
+                }
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
@@ -46,9 +46,9 @@ namespace SonarAnalyzer.Rules.CSharp
         /// Validation method. Checks the supplied method and returns the error message,
         /// or null if there is no issue.
         /// </summary>
-        private delegate string SignatureValidator(SyntaxNode node, IMethodSymbol method);
+        private delegate string SignatureValidator(SyntaxNode methodNode, IMethodSymbol methodSymbol);
 
-        private static readonly SignatureValidator NullValidator = (n, m) => null;
+        private static readonly SignatureValidator NullValidator = (node, symbol) => null;
 
         // We currently support three test framework, each of which supports multiple test method attribute markers, and each of which
         // has differing constraints (public/private, generic/non-generic).
@@ -60,43 +60,43 @@ namespace SonarAnalyzer.Rules.CSharp
             // MSTest
             {
                 KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_TestMethodAttribute,
-                (n, m) => GetFaultMessage(n, m, publicOnly: true, allowGenerics: false)
+                (node, symbol) => GetFaultMessage(node, symbol, publicOnly: true, allowGenerics: false)
             },
             {
                 KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_DataTestMethodAttribute,
-                (n, m) => GetFaultMessage(n, m, publicOnly: true, allowGenerics: false)
+                (node, symbol) => GetFaultMessage(node, symbol, publicOnly: true, allowGenerics: false)
             },
 
             // NUnit
             {
                 KnownType.NUnit_Framework_TestAttribute,
-                (n, m) => GetFaultMessage(n, m, publicOnly: true, allowGenerics: false)
+                (node, symbol) => GetFaultMessage(node, symbol, publicOnly: true, allowGenerics: false)
             },
             {
                 KnownType.NUnit_Framework_TestCaseAttribute,
-                (n, m) => GetFaultMessage(n, m, publicOnly: true, allowGenerics: true)
+                (node, symbol) => GetFaultMessage(node, symbol, publicOnly: true, allowGenerics: true)
             },
             {
                 KnownType.NUnit_Framework_TestCaseSourceAttribute,
-                (n, m) => GetFaultMessage(n, m, publicOnly: true, allowGenerics: true)
+                (node, symbol) => GetFaultMessage(node, symbol, publicOnly: true, allowGenerics: true)
             },
             {
                 KnownType.NUnit_Framework_TheoryAttribute,
-                (n, m) => GetFaultMessage(n, m, publicOnly: true, allowGenerics: false)
+                (node, symbol) => GetFaultMessage(node, symbol, publicOnly: true, allowGenerics: false)
             },
 
             // XUnit - note that local functions can be test methods, thus we skip checking the syntax node
             {
                 KnownType.Xunit_FactAttribute,
-                (_, m) => GetFaultMessage(m, publicOnly: false, allowGenerics: false)
+                (_, symbol) => GetFaultMessage(symbol, publicOnly: false, allowGenerics: false)
             },
             {
                 KnownType.Xunit_TheoryAttribute,
-                (_, m) => GetFaultMessage(m, publicOnly: false, allowGenerics: true)
+                (_, symbol) => GetFaultMessage(symbol, publicOnly: false, allowGenerics: true)
             },
             {
                 KnownType.LegacyXunit_TheoryAttribute,
-                (_, m) => GetFaultMessage(m, publicOnly: false, allowGenerics: true)
+                (_, symbol) => GetFaultMessage(symbol, publicOnly: false, allowGenerics: true)
             }
         };
 
@@ -138,8 +138,8 @@ namespace SonarAnalyzer.Rules.CSharp
             return AttributeToConstraintsMap.GetValueOrDefault(attributeKnownType);
         }
 
-        private static string GetFaultMessage(SyntaxNode node, IMethodSymbol methodSymbol, bool publicOnly, bool allowGenerics) =>
-            LocalFunctionStatementSyntaxWrapper.IsInstance(node)
+        private static string GetFaultMessage(SyntaxNode methodNode, IMethodSymbol methodSymbol, bool publicOnly, bool allowGenerics) =>
+            LocalFunctionStatementSyntaxWrapper.IsInstance(methodNode)
             ? MakeMethodNotLocalFunction
             : GetFaultMessage(methodSymbol, publicOnly, allowGenerics);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
@@ -38,6 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MakePublicMessage = "'public'";
         private const string MakeNonAsyncOrTaskMessage = "non-'async' or return 'Task'";
         private const string MakeNotGenericMessage = "non-generic";
+        private const string MakeMethodNotLocalFunction = "a public method instead of a local function.";
 
         private static readonly DiagnosticDescriptor rule =
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldHaveCorrectSignature.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldHaveCorrectSignature.CSharp9.cs
@@ -8,10 +8,10 @@
         public void Method()
         {
             [TestMethod]
-            void NestedTest() { } // Compliant - FN, test is not run by the test runner
+            void NestedTest() { } // Noncompliant {{Make this test method a public method instead of a local function.}}
 
             [DataTestMethod]
-            void NestedDataTest() { } // Compliant - FN, test is not run by the test runner
+            void NestedDataTest() { } // Noncompliant
         }
     }
 }
@@ -26,10 +26,10 @@ namespace NUnitTests
         public void Method()
         {
             [Test]
-            void NestedTest() { } // Compliant - FN, test is not run by the test runner
+            void NestedTest() { } // Noncompliant
 
             [TestCase(42)]
-            void NestedTestCase() { } // Compliant - FN, test is not run by the test runner
+            void NestedTestCase() { } // Noncompliant
         }
     }
 }
@@ -43,10 +43,10 @@ namespace XUnitTests
         public void Method()
         {
             [Fact]
-            void NestedFact() { } // Compliant - FN, test is not run by the test runner
+            void NestedFact() { } // Noncompliant
 
             [Theory]
-            void NestedTheory() { } // Compliant - FN, test is not run by the test runner
+            void NestedTheory() { } // Noncompliant
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldHaveCorrectSignature.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldHaveCorrectSignature.CSharp9.cs
@@ -42,11 +42,13 @@ namespace XUnitTests
     {
         public void Method()
         {
+            // Compliant - xUnit allows local functions to be executed as test methods
+
             [Fact]
-            void NestedFact() { } // Noncompliant
+            void NestedFact() { }
 
             [Theory]
-            void NestedTheory() { } // Noncompliant
+            void NestedTheory() { }
         }
     }
 }


### PR DESCRIPTION
If a local function has a test method attribute, it should be flagged for NUnit and VSTest, but not for xUnit (which allows this behavior).

For adding ITs, I need to rebase on master after #4834 gets merged (it's adding a new test project to the Net5 solution; avoid polluting this PR until rebase).
