### PR TITLE
Introduce IOperation wrapper

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/IOperationWrapperSonar.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/IOperationWrapperSonar.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using SonarAnalyzer.CFG.Helpers;
+
+namespace SonarAnalyzer.CFG.Roslyn
+{
+    // This is a temporary substitute for IOperationWrapper in case StyleCop will accept PR https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3381
+    public class IOperationWrapperSonar
+    {
+        private static readonly PropertyInfo ParentProperty;
+        private static readonly PropertyInfo ChildrenProperty;
+        private static readonly PropertyInfo LanguageProperty;
+        private static readonly PropertyInfo IsImplicitProperty;
+        private static readonly PropertyInfo SemanticModelProperty;
+
+        private readonly Lazy<IOperation> parent;
+        private readonly Lazy<IEnumerable<IOperation>> children;
+        private readonly Lazy<string> language;
+        private readonly Lazy<bool> isImplicit;
+        private readonly Lazy<SemanticModel> semanticModel;
+
+        public IOperation Instance { get; }
+        public IOperation Parent => parent.Value;
+        public IEnumerable<IOperation> Children => children.Value;
+        public string Language => language.Value;
+        public bool IsImplicit => isImplicit.Value;
+        public SemanticModel SemanticModel => semanticModel.Value;
+
+        static IOperationWrapperSonar()
+        {
+            var type = typeof(IOperation);
+            ParentProperty = type.GetProperty(nameof(Parent));
+            ChildrenProperty = type.GetProperty(nameof(Children));
+            LanguageProperty = type.GetProperty(nameof(Language));
+            IsImplicitProperty = type.GetProperty(nameof(IsImplicit));
+            SemanticModelProperty = type.GetProperty(nameof(SemanticModel));
+        }
+
+        public IOperationWrapperSonar(IOperation instance)
+        {
+            Instance = instance ?? throw new ArgumentNullException(nameof(instance));
+            parent = ParentProperty.ReadValue<IOperation>(instance);
+            children = ChildrenProperty.ReadValue<IEnumerable<IOperation>>(instance);
+            language = LanguageProperty.ReadValue<string>(instance);
+            isImplicit = IsImplicitProperty.ReadValue<bool>(instance);
+            semanticModel = SemanticModelProperty.ReadValue<SemanticModel>(instance);
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/IOperationWrapperSonar.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/IOperationWrapperSonar.cs
@@ -24,7 +24,7 @@ using System.Reflection;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.CFG.Helpers;
 
-namespace SonarAnalyzer.CFG.Roslyn
+namespace StyleCop.Analyzers.Lightup
 {
     // This is a temporary substitute for IOperationWrapper in case StyleCop will accept PR https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3381
     public class IOperationWrapperSonar

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/BasicBlockTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/BasicBlockTest.cs
@@ -20,7 +20,6 @@
 
 using System.Linq;
 using FluentAssertions;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.CFG.Roslyn;
@@ -48,7 +47,7 @@ public class Sample
             field = 42;
     }
 }";
-            var cfg = Compile(code);
+            var cfg = TestHelper.CompileCfg(code);
             /*
              *           Entry 0
              *             |
@@ -119,13 +118,6 @@ public class Sample
             branch.Predecessors.Should().HaveCount(1);
             assign.Predecessors.Should().HaveCount(1);
             exit.Predecessors.Should().HaveCount(2);
-        }
-
-        private static ControlFlowGraph Compile(string snippet)
-        {
-            var (tree, semanticModel) = TestHelper.Compile(snippet);
-            var method = tree.GetRoot().DescendantNodes().First(x => x.RawKind == (int)SyntaxKind.MethodDeclaration);
-            return ControlFlowGraph.Create(method, semanticModel);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/CaptureIdTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/CaptureIdTest.cs
@@ -21,7 +21,6 @@
 using System;
 using System.Linq;
 using FluentAssertions;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.CFG.Roslyn;
 using IFlowCaptureReferenceOperation = Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureReferenceOperation;
@@ -55,7 +54,7 @@ public class Sample
     public string Method(object a, object b) =>
         a?.ToString() + b?.ToString();
 }";
-            var cfg = Compile(code);
+            var cfg = TestHelper.CompileCfg(code);
             var outerLocalLifetimeRegion = cfg.Root.NestedRegions.Single();
             outerLocalLifetimeRegion.Kind.Should().Be(ControlFlowRegionKind.LocalLifetime);
             outerLocalLifetimeRegion.NestedRegions.Should().HaveCount(2).And.OnlyContain(x => x.Kind == ControlFlowRegionKind.LocalLifetime);
@@ -76,13 +75,6 @@ public class Sample
                 flowCapture.Syntax.ToString().Should().Be(expectedName);
                 return new CaptureId(flowCapture.Id);
             }
-        }
-
-        private static ControlFlowGraph Compile(string snippet)
-        {
-            var (tree, semanticModel) = TestHelper.Compile(snippet);
-            var method = tree.GetRoot().DescendantNodes().First(x => x.RawKind == (int)SyntaxKind.MethodDeclaration);
-            return ControlFlowGraph.Create(method, semanticModel);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/ControlFlowBranchTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/ControlFlowBranchTest.cs
@@ -20,7 +20,6 @@
 
 using System.Linq;
 using FluentAssertions;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.CFG.Roslyn;
 
@@ -37,7 +36,7 @@ public class Sample
 {
     public void Method(bool condition) { } // Empty, just Entry and Exit block
 }";
-            var cfg = Compile(code);
+            var cfg = TestHelper.CompileCfg(code);
             var entry = cfg.Blocks[0];
             var exit = cfg.Blocks[1];
             entry.Kind.Should().Be(BasicBlockKind.Entry);
@@ -72,7 +71,7 @@ public class Sample
         }
     }
 }";
-            var cfg = Compile(code);
+            var cfg = TestHelper.CompileCfg(code);
             /*
              *          Entry 0
              *            |
@@ -128,13 +127,6 @@ public class Sample
             entering.EnteringRegions.Should().HaveCount(2).And.ContainInOrder(tryAndFinallyRegion, tryRegion); // Weird, but Roslyn does it this way.
             entering.LeavingRegions.Should().BeEmpty();
             entering.FinallyRegions.Should().BeEmpty();
-        }
-
-        private static ControlFlowGraph Compile(string snippet)
-        {
-            var (tree, semanticModel) = TestHelper.Compile(snippet);
-            var method = tree.GetRoot().DescendantNodes().First(x => x.RawKind == (int)SyntaxKind.MethodDeclaration);
-            return ControlFlowGraph.Create(method, semanticModel);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/ControlFlowRegionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/ControlFlowRegionTest.cs
@@ -20,7 +20,6 @@
 
 using System.Linq;
 using FluentAssertions;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.CFG.Roslyn;
 
@@ -53,7 +52,7 @@ public class Sample
         int LocalMethod() => 42;
     }
 }";
-            var root = Compile(code).Root;
+            var root = TestHelper.CompileCfg(code).Root;
 
             root.Should().NotBeNull();
             root.Kind.Should().Be(ControlFlowRegionKind.Root);
@@ -90,13 +89,6 @@ public class Sample
             catchRegion.Kind.Should().Be(ControlFlowRegionKind.Catch);
             catchRegion.ExceptionType.Should().NotBeNull();
             catchRegion.ExceptionType.Name.Should().Be("InvalidOperationException");
-        }
-
-        private static ControlFlowGraph Compile(string snippet)
-        {
-            var (tree, semanticModel) = TestHelper.Compile(snippet);
-            var method = tree.GetRoot().DescendantNodes().First(x => x.RawKind == (int)SyntaxKind.MethodDeclaration);
-            return ControlFlowGraph.Create(method, semanticModel);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/RoslynControlFlowGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/RoslynControlFlowGraphTest.cs
@@ -24,9 +24,7 @@ using Microsoft.CodeAnalysis.Operations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.CFG.Roslyn;
 using StyleCop.Analyzers.Lightup;
-using CS = Microsoft.CodeAnalysis.CSharp;
 using FlowAnalysis = Microsoft.CodeAnalysis.FlowAnalysis;
-using VB = Microsoft.CodeAnalysis.VisualBasic;
 
 namespace SonarAnalyzer.UnitTest.CFG.Roslyn
 {
@@ -48,7 +46,7 @@ public class Sample
         return 42;
     }
 }";
-            Compile(code).Should().NotBeNull();
+            TestHelper.CompileCfg(code).Should().NotBeNull();
         }
 
         [TestMethod]
@@ -60,7 +58,7 @@ Public Class Sample
         Return 42
     End Function
 End Class";
-            Compile(code, false).Should().NotBeNull();
+            TestHelper.CompileCfg(code, false).Should().NotBeNull();
         }
 
         [TestMethod]
@@ -77,7 +75,7 @@ public class Sample
         int LocalMethod() => 42;
     }
 }";
-            var cfg = Compile(code);
+            var cfg = TestHelper.CompileCfg(code);
             cfg.Should().NotBeNull();
             cfg.Root.Should().NotBeNull();
             cfg.Blocks.Should().NotBeNull().And.HaveCount(3); // Enter, Instructions, Exit
@@ -86,13 +84,6 @@ public class Sample
             cfg.GetLocalFunctionControlFlowGraph(cfg.LocalFunctions.Single()).Should().NotBeNull();
             var anonymousFunction = cfg.Blocks.SelectMany(x => x.Operations).SelectMany(x => x.DescendantsAndSelf()).OfType<FlowAnalysis.IFlowAnonymousFunctionOperation>().Single();
             cfg.GetAnonymousFunctionControlFlowGraph(IFlowAnonymousFunctionOperationWrapper.FromOperation(anonymousFunction)).Should().NotBeNull();
-        }
-
-        private static ControlFlowGraph Compile(string snippet, bool isCSharp = true)
-        {
-            var (tree, semanticModel) = TestHelper.Compile(snippet, isCSharp);
-            var method = tree.GetRoot().DescendantNodes().First(x => x.RawKind == (isCSharp ? (int)CS.SyntaxKind.MethodDeclaration : (int)VB.SyntaxKind.FunctionBlock));
-            return ControlFlowGraph.Create(method, semanticModel);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/IOperationWrapperSonarTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/IOperationWrapperSonarTest.cs
@@ -24,9 +24,9 @@ using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarAnalyzer.CFG.Roslyn;
+using StyleCop.Analyzers.Lightup;
 
-namespace SonarAnalyzer.UnitTest.CFG.Roslyn
+namespace SonarAnalyzer.UnitTest.Wrappers
 {
     [TestClass]
     public class IOperationWrapperSonarTest

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/IOperationWrapperSonarTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/IOperationWrapperSonarTest.cs
@@ -1,0 +1,66 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.CFG.Roslyn;
+
+namespace SonarAnalyzer.UnitTest.CFG.Roslyn
+{
+    [TestClass]
+    public class IOperationWrapperSonarTest
+    {
+        [TestMethod]
+        public void Null_Throws()
+        {
+            Action a = () => new IOperationWrapperSonar(null).ToString();
+            a.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void ValidateReflection()
+        {
+            const string code = @"
+public class Sample
+{
+    public void Method()
+    {
+        var value = 42;
+    }
+}";
+            var (tree, semanticModel) = TestHelper.Compile(code);
+            var declaration = tree.GetRoot().DescendantNodes().OfType<EqualsValueClauseSyntax>().Single();
+            var sut = new IOperationWrapperSonar(semanticModel.GetOperation(declaration));
+            sut.Parent.Should().NotBeNull();
+            sut.Parent.Kind.Should().Be(OperationKind.VariableDeclarator);
+            sut.Instance.Should().NotBeNull();
+            sut.Instance.Kind.Should().Be(OperationKind.VariableInitializer);
+            sut.Children.Should().HaveCount(1);
+            sut.Children.Single().Kind.Should().Be(OperationKind.Literal);
+            sut.Language.Should().Be("C#");
+            sut.IsImplicit.Should().Be(false);
+            sut.SemanticModel.Should().Be(semanticModel);
+        }
+    }
+}


### PR DESCRIPTION
There already exist `IOperationWrapper` interface in the ShimLayer as a base type for all wrapped interfaces.

This class has the same prefix to be easily found.