### PR TITLE
S2699: add tests with Shouldly

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldContainAssertion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldContainAssertion.cs
@@ -50,6 +50,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {"InOrder", KnownType.NSubstitute_Received }
         };
 
+        /// The assertions in the Shouldly library are supported by <see cref="UnitTestHelper.KnownAssertionMethodParts"/> (they all contain "Should")
         private static readonly ImmutableArray<KnownType> KnownAssertionTypes = ImmutableArray.Create(
                 KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_Assert,
                 KnownType.NFluent_Check,

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
@@ -202,11 +202,13 @@ public class Foo
         public static IEnumerable<MetadataReference> AdditionalTestReferences(IEnumerable<MetadataReference> testFrameworkReference,
                                                                               string fluentVersion = Constants.NuGetLatestVersion,
                                                                               string nSubstituteVersion = Constants.NuGetLatestVersion,
-                                                                              string nFluentVersion = Constants.NuGetLatestVersion) =>
+                                                                              string nFluentVersion = Constants.NuGetLatestVersion,
+                                                                              string shouldlyVersion = Constants.NuGetLatestVersion) =>
             testFrameworkReference
                 .Concat(NuGetMetadataReference.FluentAssertions(fluentVersion))
                 .Concat(NuGetMetadataReference.NSubstitute(nSubstituteVersion))
                 .Concat(NuGetMetadataReference.NFluent(nFluentVersion))
+                .Concat(NuGetMetadataReference.Shouldly(shouldlyVersion))
                 .Concat(MetadataReferenceFacade.SystemData)
                 .Concat(MetadataReferenceFacade.SystemXml)
                 .Concat(MetadataReferenceFacade.SystemXmlLinq)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.MsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.MsTest.cs
@@ -6,6 +6,7 @@
     using NFluent;
     using NSubstitute;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Shouldly;
 
     using static Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
@@ -339,14 +340,21 @@
     }
 
     /// <summary>
-    /// The NSubstitute assertions are extensively verified in the NUnit test files.
+    /// The NSubstitute and Shoudly assertions are extensively verified in the NUnit test files.
     /// Here we just do a simple test to confirm that the errors are not raised in conjunction with MsTest.
     /// </summary>
     [TestClass]
-    public class NSubstituteTests
+    public class NSubstituteAndShouldlyTests
     {
         [TestMethod]
         public void Received() => Substitute.For<IDisposable>().Received().Dispose();
+
+        [TestMethod]
+        public void Shouldly()
+        {
+            int[] array = { 1, 2, 3 };
+            array.ShouldAllBe(x => x > 0);
+        }
     }
 
     [TestClass]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
@@ -2,11 +2,13 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using FluentAssertions;
     using NFluent;
     using NSubstitute;
     using NUnit.Framework;
+    using Shouldly;
 
     using static NUnit.Framework.Assert;
 
@@ -526,6 +528,53 @@
                 calculator.Add(1, 2);
             });
         }
+    }
+
+    // All assert methods start with "Should*". We do not test all APIs, just some.
+    public class ShouldlyTests
+    {
+        int i = 1;
+        public dynamic Foo() => null;
+        public void Bar() { }
+
+        [TestCase]
+        public void NoAssert() // Noncompliant
+        {
+        }
+
+        [TestCase]
+        public void W()
+        {
+            int[] empty = { };
+            empty.ShouldBeEmpty();
+
+            var dict = new Dictionary<string, string> { { "x", "x" } };
+            dict.ShouldContainKey("y");
+
+            Should.Throw<IndexOutOfRangeException>(() => Bar());
+        }
+
+        [TestCase]
+        public void X() => "Foo".ShouldMatchApproved();
+
+        [TestCase]
+        public void Y() => i.ShouldBeInRange(30000, 40000);
+
+        [TestCase]
+        public void Z() => Should.NotThrow(() => Bar());
+
+        [TestCase]
+        public void Dynamic()
+        {
+            dynamic theFuture = Foo();
+            DynamicShould.HaveProperty(theFuture, "X");
+        }
+
+        [TestCase]
+        public void CompleteIn() =>
+            Should.CompleteIn(action: () => { Thread.Sleep(TimeSpan.FromSeconds(2)); },
+                              timeout: TimeSpan.FromSeconds(1),
+                              customMessage: "Some additional context");
     }
 
     internal interface ICalculator

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
@@ -538,11 +538,6 @@
         public void Bar() { }
 
         [TestCase]
-        public void NoAssert() // Noncompliant
-        {
-        }
-
-        [TestCase]
         public void W()
         {
             int[] empty = { };

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.Xunit.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.Xunit.cs
@@ -4,6 +4,7 @@
     using FluentAssertions;
     using NFluent;
     using NSubstitute;
+    using Shouldly;
     using Xunit;
 
     using static Xunit.Assert;
@@ -225,12 +226,15 @@
     }
 
     /// <summary>
-    /// The NSubstitute assertions are extensively verified in the NUnit test files.
+    /// The NSubstitute and Shoudly assertions are extensively verified in the NUnit test files.
     /// Here we just do a simple test to confirm that the errors are not raised in conjunction with XUnit.
     /// </summary>
-    public class NSubstituteTests
+    public class NSubstituteAndShouldlyTests
     {
         [Fact]
         public void Received() => Substitute.For<IDisposable>().Received().Dispose();
+
+        [Fact]
+        public void Shouldly() => "".ShouldBe("foo");
     }
 }


### PR DESCRIPTION
Shouldly is already supported by the UnitTestHelper KnownAssertionMethodParts - https://github.com/SonarSource/sonar-dotnet/blob/8.27.0.35380/analyzers/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs#L60 - all methods contain "Should" .

I don't want to add explicit support because it would be additional logic with no functional gain.

Related to #1353

Might have conflicts with #4862 (rebase will be needed)

