### PR TITLE
Add Rule S4061: 'params' should be used instead of 'varargs'

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/analyzers/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -4774,7 +4774,7 @@
     <value>Critical Code Smell</value>
   </data>
   <data name="S2479_Description" xml:space="preserve">
-    <value>Non-encoded control characters and whitespace characters are often injected in the source code because of a bad manipulation. They are either invisible or difficult to recognize, which can result in bugs when the string is not what the developer expects. If you actually need to use a control character use their encoded version (ex: ASCII
+    <value>Non-encoded control characters and whitespace characters are often injected in the source code because of a bad manipulation. They are either invisible or difficult to recognize, which can result in bugs when the string is not what the developer expects. If you actually need to use a control character use their encoded version (ex: ASCII 
 ,	,…​ or Unicode U+000D, U+0009,…​).</value>
   </data>
   <data name="S2479_IsActivatedByDefault" xml:space="preserve">

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParamsInsteadOfVarargs.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParamsInsteadOfVarargs.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.CSharp
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Rule(DiagnosticId)]
+    public sealed class ParamsInsteadOfVarargs : SonarDiagnosticAnalyzer
+    {
+        private const string DiagnosticId = "S4061";
+        private const string MessageFormat = "VarArgs calling convention is not CLS compliant, use the 'params' keyword instead";
+
+        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        protected override void Initialize(SonarAnalysisContext context) =>
+            context.RegisterSyntaxNodeActionInNonGenerated(c =>
+                {
+                    var methodDeclaration = (MethodDeclarationSyntax)c.Node;
+                    var methodSymbol = c.SemanticModel.GetDeclaredSymbol(methodDeclaration);
+
+                    if (methodSymbol.IsVararg)
+                    {
+                        c.ReportDiagnosticWhenActive(Diagnostic.Create(Rule, methodDeclaration.GetLocation()));
+                    }
+                },
+                SyntaxKind.MethodDeclaration);
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ParamsInsteadOfVarargsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ParamsInsteadOfVarargsTest.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Rules.CSharp;
+using SonarAnalyzer.UnitTest.TestFramework;
+
+namespace SonarAnalyzer.UnitTest.Rules
+{
+    [TestClass]
+    public class ParamsInsteadOfVarargsTest
+    {
+        [TestMethod]
+        [TestCategory("Rule")]
+        public void ParamsInsteadOfVarargs_CS() =>
+            Verifier.VerifyAnalyzer(@"TestCases\ParamsInsteadOfVarargs.cs", new ParamsInsteadOfVarargs());
+
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParamsInsteadOfVarargs.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParamsInsteadOfVarargs.cs
@@ -1,0 +1,15 @@
+﻿namespace Tests.Diagnostics
+{
+    class Program
+    {
+        public static void TestFunc(__arglist) // Noncompliant {{VarArgs calling convention is not CLS compliant, use the 'params' keyword instead}}
+        {
+        }
+
+        public static void TestFunc(int firstVar, string secondVar, __arglist) // Noncompliant
+        {
+        }
+
+    }
+
+}


### PR DESCRIPTION
Fixes #4887 