### PR TITLE
Use UniqueQueue in LVA

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/Helpers/UniqueQueue.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Helpers/UniqueQueue.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace SonarAnalyzer.CFG.Helpers
+{
+    public class UniqueQueue<T> : IEnumerable<T>
+    {
+        private readonly Queue<T> queue = new Queue<T>();
+        private readonly ISet<T> unique = new HashSet<T>();
+
+        public void Enqueue(T item)
+        {
+            if (!unique.Contains(item))
+            {
+                queue.Enqueue(item);
+                unique.Add(item);
+            }
+        }
+
+        public T Dequeue()
+        {
+            var ret = queue.Dequeue();
+            unique.Remove(ret);
+            return ret;
+        }
+
+        public IEnumerator<T> GetEnumerator() =>
+            queue.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() =>
+            GetEnumerator();
+    }
+}

--- a/analyzers/src/SonarAnalyzer.CFG/Helpers/UniqueQueue.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Helpers/UniqueQueue.cs
@@ -23,7 +23,7 @@ using System.Collections.Generic;
 
 namespace SonarAnalyzer.CFG.Helpers
 {
-    public class UniqueQueue<T> : IEnumerable<T>
+    internal class UniqueQueue<T> : IEnumerable<T>
     {
         private readonly Queue<T> queue = new Queue<T>();
         private readonly ISet<T> unique = new HashSet<T>();

--- a/analyzers/src/SonarAnalyzer.CFG/LiveVariableAnalysis/LiveVariableAnalysisBase.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/LiveVariableAnalysis/LiveVariableAnalysisBase.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.CFG.LiveVariableAnalysis
         protected void Analyze()
         {
             var states = new Dictionary<TBlock, State>();
-            var queue = new Queue<TBlock>();
+            var queue = new UniqueQueue<TBlock>();
             foreach (var block in ReversedBlocks())
             {
                 var state = ProcessBlock(block);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/UniqueQueueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/UniqueQueueTest.cs
@@ -1,0 +1,57 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.CFG.Helpers;
+
+namespace SonarAnalyzer.UnitTest.Helpers
+{
+    [TestClass]
+    public class UniqueQueueTest
+    {
+        [TestMethod]
+        public void Enqueue_UniqueItems()
+        {
+            var sut = new UniqueQueue<int>();
+            sut.Enqueue(42);
+            sut.Dequeue().Should().Be(42);
+            sut.Enqueue(42);
+            sut.Dequeue().Should().Be(42, "second enqueue of dequeued item should not prevent it from being enqueued again");
+        }
+
+        [TestMethod]
+        public void Dequeue_UniqueItems()
+        {
+            var sut = new UniqueQueue<int>();
+            sut.Enqueue(41);
+            sut.Enqueue(42);
+            sut.Enqueue(42);
+            sut.Enqueue(43);
+            sut.Enqueue(42);
+            sut.Dequeue().Should().Be(41);
+            sut.Enqueue(42);
+            sut.Dequeue().Should().Be(42);
+            sut.Dequeue().Should().Be(43);
+            sut.Invoking(x => x.Dequeue()).Should().Throw<InvalidOperationException>();
+        }
+    }
+}


### PR DESCRIPTION
Enqueuing predecessors after each LiveIn change tends to enqueue a single block multiple times when it is already in the queue. `Analyze()` then has to do some collection and HashSet manipulations to figure out that nothing has changed => no operation.

This PR should prevent that and improve the performance a little.