### PR TITLE
Configure CS8032 as Error in ITs

### DIFF
--- a/analyzers/its/AllSonarAnalyzerRules.ruleset
+++ b/analyzers/its/AllSonarAnalyzerRules.ruleset
@@ -5,6 +5,11 @@
     <Rule Id="AD0001" Action="Error" />
   </Rules>
 
+  <!-- CS8032 An instance of analyzer ... cannot be created from ... -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+    <Rule Id="CS8032" Action="Error" />
+  </Rules>
+
   <!-- This list is just hardcoded for now with plausible existing & upcoming rule IDs -->
   <!-- It would be better to generate the actual list from the analyzer assemblies -->
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">

--- a/analyzers/its/SingleRule.ruleset.template
+++ b/analyzers/its/SingleRule.ruleset.template
@@ -5,6 +5,11 @@
     <Rule Id="AD0001" Action="Error" />
   </Rules>
 
+  <!-- CS8032 An instance of analyzer ... cannot be created from ... -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+    <Rule Id="CS8032" Action="Error" />
+  </Rules>
+
   <!-- This list is just hardcoded for now with plausible existing & upcoming rule IDs -->
   <!-- It would be better to generate the actual list from the analyzer assemblies -->
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">

--- a/analyzers/its/SonarAnalyzer.Testing.ImportBefore.targets
+++ b/analyzers/its/SonarAnalyzer.Testing.ImportBefore.targets
@@ -41,10 +41,10 @@
     <ItemGroup Condition="$(SonarAnalyzerRegressionTestRunning)">
       <!-- Remove all previously added analyzers -->
       <Analyzer Remove="@(Analyzer)" />
-
       <!-- Add the SonarAnalyzer analyzer DLLs -->
       <Analyzer Include="$(MSBuildStartupDirectory)\binaries\SonarAnalyzer*.dll" />
-	  <Analyzer Include="$(MSBuildStartupDirectory)\binaries\Newtonsoft.Json.dll" />
+	    <Analyzer Include="$(MSBuildStartupDirectory)\binaries\Google.Protobuf.dll" />
+	    <Analyzer Include="$(MSBuildStartupDirectory)\binaries\Newtonsoft.Json.dll" />
       <AdditionalFiles Include="$(MSBuildStartupDirectory)\output\$(PROJECT)\SonarLint.xml" />
       <AdditionalFiles Include="$(SonarProjectConfigFilePath)" />
     </ItemGroup>

--- a/its/src/test/java/com/sonar/it/shared/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/shared/TestUtils.java
@@ -152,7 +152,7 @@ public class TestUtils {
     Path msBuildPath = getMsBuildPath(orch);
 
     List<String> argumentList = new ArrayList<>(Arrays.asList(arguments));
-    argumentList.add("/warnaserror:AD0001");
+    argumentList.add("/warnaserror:AD0001;CS8032");
 
     Command command = Command.create(msBuildPath.toString())
       .addArguments(argumentList)


### PR DESCRIPTION
.NET ITs silently produced this

>Warning CS8032: An instance of analyzer SonarAnalyzer.Rules.CSharp.TokenTypeAnalyzer cannot be created from C:\Projects\sonar-dotnet\analyzers\its\binaries\SonarAnalyzer.CSharp.dll : Could not load file or assembly 'Google.Protobuf, Version=3.6.1.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604' or one of its dependencies. The system cannot find the file specified.

because `Google.Protobuf.dll` was not part of `Analyzers` property in targets file.