### PR TITLE
Revert "Bump actions/github-script from 4.0.2 to 5 (#4923)"

### DIFF
--- a/.github/workflows/CreatePullRequest.yml
+++ b/.github/workflows/CreatePullRequest.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       # https://github.com/actions/github-script
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v4.0.2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/LabelIssue.yml
+++ b/.github/workflows/LabelIssue.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       # https://github.com/actions/github-script
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v4.0.2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/MilestoneIssue.yml
+++ b/.github/workflows/MilestoneIssue.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       # https://github.com/actions/github-script
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v4.0.2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       # https://github.com/actions/github-script
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v4.0.2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/StartProgress.yml
+++ b/.github/workflows/StartProgress.yml
@@ -13,7 +13,7 @@ jobs:
         && github.event.project_card.content_url != null
     steps:
       # https://github.com/actions/github-script
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v4.0.2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       # https://github.com/actions/github-script
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v4.0.2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
This reverts commit b7bf044e20ca8ee74a4b70de4b2d45c3c04f509e.

We're having some GitHub action failures since then.