### PR TITLE
Return CaptureId from ShimLayer operations

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/CfgSerializer/CfgSerializer.RoslynCfgWalker.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/CfgSerializer/CfgSerializer.RoslynCfgWalker.cs
@@ -117,7 +117,13 @@ namespace SonarAnalyzer.CFG
                 .Concat(new IOperationWrapperSonar(operation).Children.SelectMany(x => SerializeOperation(level + 1, x)));
 
             private static string OperationSuffix(IOperation op) =>
-                IInvocationOperationWrapper.IsInstance(op) ? ": " + IInvocationOperationWrapper.FromOperation(op).TargetMethod.Name : null;
+                op switch
+                {
+                    var _ when IInvocationOperationWrapper.IsInstance(op) => ": " + IInvocationOperationWrapper.FromOperation(op).TargetMethod.Name,
+                    var _ when IFlowCaptureOperationWrapper.IsInstance(op) => ": #" + IFlowCaptureOperationWrapper.FromOperation(op).Id.GetHashCode(),
+                    var _ when IFlowCaptureReferenceOperationWrapper.IsInstance(op) => ": #" + IFlowCaptureReferenceOperationWrapper.FromOperation(op).Id.GetHashCode(),
+                    _ => null
+                };
 
             private void WriteEdges(BasicBlock block)
             {

--- a/analyzers/src/SonarAnalyzer.CFG/Roslyn/ControlFlowRegion.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Roslyn/ControlFlowRegion.cs
@@ -24,6 +24,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.CFG.Helpers;
+using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.CFG.Roslyn
 {

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/CaptureId.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/CaptureId.cs
@@ -20,7 +20,7 @@
 
 using System;
 
-namespace SonarAnalyzer.CFG.Roslyn
+namespace StyleCop.Analyzers.Lightup
 {
     public struct CaptureId : IEquatable<CaptureId>
     {

--- a/analyzers/src/SonarAnalyzer.ShimLayer.CodeGeneration/OperationLightupGenerator.cs
+++ b/analyzers/src/SonarAnalyzer.ShimLayer.CodeGeneration/OperationLightupGenerator.cs
@@ -1042,7 +1042,6 @@ namespace StyleCop.Analyzers.CodeGeneration
                     "ArgumentKind" => true,
                     "BinaryOperatorKind" => true,
                     "BranchKind" => true,
-                    "CaptureId" => true,
                     "CaseKind" => true,
                     "CommonConversion" => true,
                     "ForEachLoopOperationInfo" => true,

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/CaptureIdTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/CaptureIdTest.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.CFG.Roslyn;
+using StyleCop.Analyzers.Lightup;
 using IFlowCaptureReferenceOperation = Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureReferenceOperation;
 
 namespace SonarAnalyzer.UnitTest.CFG.Roslyn

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/RoslynCfgSerializerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/RoslynCfgSerializerTest.cs
@@ -125,9 +125,9 @@ class Sample
 @"digraph ""RoslynCfg"" {
 subgraph ""cluster_LocalLifetime region"" {
 label = ""LocalLifetime region""
-cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation / IdentifierNameSyntax: a|1# ParameterReferenceOperation / IdentifierNameSyntax: a|##########|## BranchValue ##|0# BinaryOperation / LiteralExpressionSyntax: 1|1# FlowCaptureReferenceOperation / IdentifierNameSyntax: a|1# LiteralOperation / LiteralExpressionSyntax: 1|##########}""]
+cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation: #0 / IdentifierNameSyntax: a|1# ParameterReferenceOperation / IdentifierNameSyntax: a|##########|## BranchValue ##|0# BinaryOperation / LiteralExpressionSyntax: 1|1# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: a|1# LiteralOperation / LiteralExpressionSyntax: 1|##########}""]
 cfg0_block2 [shape=record label=""{BLOCK #2|0# ExpressionStatementOperation / ExpressionStatementSyntax: c1();|1# InvocationOperation: c1 / InvocationExpressionSyntax: c1()|2# InstanceReferenceOperation / IdentifierNameSyntax: c1|##########}""]
-cfg0_block3 [shape=record label=""{BLOCK #3|## BranchValue ##|0# BinaryOperation / LiteralExpressionSyntax: 2|1# FlowCaptureReferenceOperation / IdentifierNameSyntax: a|1# LiteralOperation / LiteralExpressionSyntax: 2|##########}""]
+cfg0_block3 [shape=record label=""{BLOCK #3|## BranchValue ##|0# BinaryOperation / LiteralExpressionSyntax: 2|1# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: a|1# LiteralOperation / LiteralExpressionSyntax: 2|##########}""]
 cfg0_block4 [shape=record label=""{BLOCK #4|0# ExpressionStatementOperation / ExpressionStatementSyntax: c2();|1# InvocationOperation: c2 / InvocationExpressionSyntax: c2()|2# InstanceReferenceOperation / IdentifierNameSyntax: c2|##########}""]
 }
 cfg0_block0 [shape=record label=""{ENTRY #0}""]
@@ -201,18 +201,18 @@ subgraph ""cluster_Try region"" {
 label = ""Try region""
 subgraph ""cluster_LocalLifetime region"" {
 label = ""LocalLifetime region""
-cfg0_block3 [shape=record label=""{BLOCK #3|0# SimpleAssignmentOperation / IdentifierNameSyntax: var|1# LocalReferenceOperation / IdentifierNameSyntax: var|1# ConversionOperation / IdentifierNameSyntax: var|2# PropertyReferenceOperation / IdentifierNameSyntax: var|3# FlowCaptureReferenceOperation / IdentifierNameSyntax: items|##########|0# ExpressionStatementOperation / ExpressionStatementSyntax: Bar(i);|1# InvocationOperation: Bar / InvocationExpressionSyntax: Bar(i)|2# InstanceReferenceOperation / IdentifierNameSyntax: Bar|2# ArgumentOperation / ArgumentSyntax: i|3# LocalReferenceOperation / IdentifierNameSyntax: i|##########}""]
+cfg0_block3 [shape=record label=""{BLOCK #3|0# SimpleAssignmentOperation / IdentifierNameSyntax: var|1# LocalReferenceOperation / IdentifierNameSyntax: var|1# ConversionOperation / IdentifierNameSyntax: var|2# PropertyReferenceOperation / IdentifierNameSyntax: var|3# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: items|##########|0# ExpressionStatementOperation / ExpressionStatementSyntax: Bar(i);|1# InvocationOperation: Bar / InvocationExpressionSyntax: Bar(i)|2# InstanceReferenceOperation / IdentifierNameSyntax: Bar|2# ArgumentOperation / ArgumentSyntax: i|3# LocalReferenceOperation / IdentifierNameSyntax: i|##########}""]
 }
-cfg0_block2 [shape=record label=""{BLOCK #2|## BranchValue ##|0# InvocationOperation: MoveNext / IdentifierNameSyntax: items|1# FlowCaptureReferenceOperation / IdentifierNameSyntax: items|##########}""]
+cfg0_block2 [shape=record label=""{BLOCK #2|## BranchValue ##|0# InvocationOperation: MoveNext / IdentifierNameSyntax: items|1# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: items|##########}""]
 }
 subgraph ""cluster_Finally region"" {
 label = ""Finally region""
-cfg0_block4 [shape=record label=""{BLOCK #4|0# FlowCaptureOperation / IdentifierNameSyntax: items|1# ConversionOperation / IdentifierNameSyntax: items|2# FlowCaptureReferenceOperation / IdentifierNameSyntax: items|##########|## BranchValue ##|0# IsNullOperation / IdentifierNameSyntax: items|1# FlowCaptureReferenceOperation / IdentifierNameSyntax: items|##########}""]
-cfg0_block5 [shape=record label=""{BLOCK #5|0# InvocationOperation: Dispose / IdentifierNameSyntax: items|1# FlowCaptureReferenceOperation / IdentifierNameSyntax: items|##########}""]
+cfg0_block4 [shape=record label=""{BLOCK #4|0# FlowCaptureOperation: #1 / IdentifierNameSyntax: items|1# ConversionOperation / IdentifierNameSyntax: items|2# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: items|##########|## BranchValue ##|0# IsNullOperation / IdentifierNameSyntax: items|1# FlowCaptureReferenceOperation: #1 / IdentifierNameSyntax: items|##########}""]
+cfg0_block5 [shape=record label=""{BLOCK #5|0# InvocationOperation: Dispose / IdentifierNameSyntax: items|1# FlowCaptureReferenceOperation: #1 / IdentifierNameSyntax: items|##########}""]
 cfg0_block6 [shape=record label=""{BLOCK #6}""]
 }
 }
-cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation / IdentifierNameSyntax: items|1# InvocationOperation: GetEnumerator / IdentifierNameSyntax: items|2# ConversionOperation / IdentifierNameSyntax: items|3# ParameterReferenceOperation / IdentifierNameSyntax: items|##########}""]
+cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation: #0 / IdentifierNameSyntax: items|1# InvocationOperation: GetEnumerator / IdentifierNameSyntax: items|2# ConversionOperation / IdentifierNameSyntax: items|3# ParameterReferenceOperation / IdentifierNameSyntax: items|##########}""]
 }
 cfg0_block0 [shape=record label=""{ENTRY #0}""]
 cfg0_block7 [shape=record label=""{EXIT #7}""]
@@ -259,18 +259,18 @@ subgraph ""cluster_LocalLifetime region"" {
 label = ""LocalLifetime region""
 cfg0_block4 [shape=record label=""{BLOCK #4|0# SimpleAssignmentOperation / VariableDeclaratorSyntax: i = key|1# LocalReferenceOperation / VariableDeclaratorSyntax: i = key|1# LocalReferenceOperation / IdentifierNameSyntax: key|##########|0# SimpleAssignmentOperation / VariableDeclaratorSyntax: j = value|1# LocalReferenceOperation / VariableDeclaratorSyntax: j = value|1# LocalReferenceOperation / IdentifierNameSyntax: value|##########}""]
 }
-cfg0_block3 [shape=record label=""{BLOCK #3|0# DeconstructionAssignmentOperation / DeclarationExpressionSyntax: var (key, value)|1# DeclarationExpressionOperation / DeclarationExpressionSyntax: var (key, value)|2# TupleOperation / ParenthesizedVariableDesignationSyntax: (key, value)|3# LocalReferenceOperation / SingleVariableDesignationSyntax: key|3# LocalReferenceOperation / SingleVariableDesignationSyntax: value|1# ConversionOperation / DeclarationExpressionSyntax: var (key, value)|2# PropertyReferenceOperation / DeclarationExpressionSyntax: var (key, value)|3# FlowCaptureReferenceOperation / IdentifierNameSyntax: values|##########}""]
+cfg0_block3 [shape=record label=""{BLOCK #3|0# DeconstructionAssignmentOperation / DeclarationExpressionSyntax: var (key, value)|1# DeclarationExpressionOperation / DeclarationExpressionSyntax: var (key, value)|2# TupleOperation / ParenthesizedVariableDesignationSyntax: (key, value)|3# LocalReferenceOperation / SingleVariableDesignationSyntax: key|3# LocalReferenceOperation / SingleVariableDesignationSyntax: value|1# ConversionOperation / DeclarationExpressionSyntax: var (key, value)|2# PropertyReferenceOperation / DeclarationExpressionSyntax: var (key, value)|3# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: values|##########}""]
 }
-cfg0_block2 [shape=record label=""{BLOCK #2|## BranchValue ##|0# InvocationOperation: MoveNext / IdentifierNameSyntax: values|1# FlowCaptureReferenceOperation / IdentifierNameSyntax: values|##########}""]
+cfg0_block2 [shape=record label=""{BLOCK #2|## BranchValue ##|0# InvocationOperation: MoveNext / IdentifierNameSyntax: values|1# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: values|##########}""]
 }
 subgraph ""cluster_Finally region"" {
 label = ""Finally region""
-cfg0_block5 [shape=record label=""{BLOCK #5|0# FlowCaptureOperation / IdentifierNameSyntax: values|1# ConversionOperation / IdentifierNameSyntax: values|2# FlowCaptureReferenceOperation / IdentifierNameSyntax: values|##########|## BranchValue ##|0# IsNullOperation / IdentifierNameSyntax: values|1# FlowCaptureReferenceOperation / IdentifierNameSyntax: values|##########}""]
-cfg0_block6 [shape=record label=""{BLOCK #6|0# InvocationOperation: Dispose / IdentifierNameSyntax: values|1# FlowCaptureReferenceOperation / IdentifierNameSyntax: values|##########}""]
+cfg0_block5 [shape=record label=""{BLOCK #5|0# FlowCaptureOperation: #1 / IdentifierNameSyntax: values|1# ConversionOperation / IdentifierNameSyntax: values|2# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: values|##########|## BranchValue ##|0# IsNullOperation / IdentifierNameSyntax: values|1# FlowCaptureReferenceOperation: #1 / IdentifierNameSyntax: values|##########}""]
+cfg0_block6 [shape=record label=""{BLOCK #6|0# InvocationOperation: Dispose / IdentifierNameSyntax: values|1# FlowCaptureReferenceOperation: #1 / IdentifierNameSyntax: values|##########}""]
 cfg0_block7 [shape=record label=""{BLOCK #7}""]
 }
 }
-cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation / IdentifierNameSyntax: values|1# InvocationOperation: GetEnumerator / IdentifierNameSyntax: values|2# ConversionOperation / IdentifierNameSyntax: values|3# ParameterReferenceOperation / IdentifierNameSyntax: values|##########}""]
+cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation: #0 / IdentifierNameSyntax: values|1# InvocationOperation: GetEnumerator / IdentifierNameSyntax: values|2# ConversionOperation / IdentifierNameSyntax: values|3# ParameterReferenceOperation / IdentifierNameSyntax: values|##########}""]
 }
 cfg0_block0 [shape=record label=""{ENTRY #0}""]
 cfg0_block8 [shape=record label=""{EXIT #8}""]
@@ -398,16 +398,16 @@ subgraph ""cluster_TryAndFinally region"" {
 label = ""TryAndFinally region""
 subgraph ""cluster_Try region"" {
 label = ""Try region""
-cfg0_block2 [shape=record label=""{BLOCK #2|0# InvocationOperation: Enter / IdentifierNameSyntax: x|1# ArgumentOperation / IdentifierNameSyntax: x|2# FlowCaptureReferenceOperation / IdentifierNameSyntax: x|1# ArgumentOperation / IdentifierNameSyntax: x|2# LocalReferenceOperation / IdentifierNameSyntax: x|##########|0# ExpressionStatementOperation / ExpressionStatementSyntax: Bar();|1# InvocationOperation: Bar / InvocationExpressionSyntax: Bar()|2# InstanceReferenceOperation / IdentifierNameSyntax: Bar|##########}""]
+cfg0_block2 [shape=record label=""{BLOCK #2|0# InvocationOperation: Enter / IdentifierNameSyntax: x|1# ArgumentOperation / IdentifierNameSyntax: x|2# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: x|1# ArgumentOperation / IdentifierNameSyntax: x|2# LocalReferenceOperation / IdentifierNameSyntax: x|##########|0# ExpressionStatementOperation / ExpressionStatementSyntax: Bar();|1# InvocationOperation: Bar / InvocationExpressionSyntax: Bar()|2# InstanceReferenceOperation / IdentifierNameSyntax: Bar|##########}""]
 }
 subgraph ""cluster_Finally region"" {
 label = ""Finally region""
 cfg0_block3 [shape=record label=""{BLOCK #3|## BranchValue ##|0# LocalReferenceOperation / IdentifierNameSyntax: x|##########}""]
-cfg0_block4 [shape=record label=""{BLOCK #4|0# InvocationOperation: Exit / IdentifierNameSyntax: x|1# ArgumentOperation / IdentifierNameSyntax: x|2# FlowCaptureReferenceOperation / IdentifierNameSyntax: x|##########}""]
+cfg0_block4 [shape=record label=""{BLOCK #4|0# InvocationOperation: Exit / IdentifierNameSyntax: x|1# ArgumentOperation / IdentifierNameSyntax: x|2# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: x|##########}""]
 cfg0_block5 [shape=record label=""{BLOCK #5}""]
 }
 }
-cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation / IdentifierNameSyntax: x|1# FieldReferenceOperation / IdentifierNameSyntax: x|2# InstanceReferenceOperation / IdentifierNameSyntax: x|##########}""]
+cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation: #0 / IdentifierNameSyntax: x|1# FieldReferenceOperation / IdentifierNameSyntax: x|2# InstanceReferenceOperation / IdentifierNameSyntax: x|##########}""]
 }
 cfg0_block0 [shape=record label=""{ENTRY #0}""]
 cfg0_block6 [shape=record label=""{EXIT #6}""]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/RoslynCfgSerializerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/RoslynCfgSerializerTest.cs
@@ -604,5 +604,54 @@ cfg3_block1 -> cfg3_block2 [label=""Return""]
 }
 ");
         }
+
+        [TestMethod]
+        public void Serialize_CaptureId()
+        {
+            var code = @"
+class Sample
+{
+    void Method(bool arg)
+    {
+        int b = arg && false;
+        b = arg || true;
+    }
+}";
+            var dot = CfgSerializer.Serialize(TestHelper.CompileCfg(code));
+            dot.Should().BeIgnoringLineEndings(
+@"digraph ""RoslynCfg"" {
+subgraph ""cluster_LocalLifetime region"" {
+label = ""LocalLifetime region""
+subgraph ""cluster_LocalLifetime region"" {
+label = ""LocalLifetime region""
+cfg0_block1 [shape=record label=""{BLOCK #1|## BranchValue ##|0# ParameterReferenceOperation / IdentifierNameSyntax: arg|##########}""]
+cfg0_block2 [shape=record label=""{BLOCK #2|0# FlowCaptureOperation: #0 / LiteralExpressionSyntax: false|1# LiteralOperation / LiteralExpressionSyntax: false|##########}""]
+cfg0_block3 [shape=record label=""{BLOCK #3|0# FlowCaptureOperation: #0 / IdentifierNameSyntax: arg|1# LiteralOperation / IdentifierNameSyntax: arg|##########}""]
+cfg0_block4 [shape=record label=""{BLOCK #4|0# SimpleAssignmentOperation / VariableDeclaratorSyntax: b = arg && false|1# LocalReferenceOperation / VariableDeclaratorSyntax: b = arg && false|1# ConversionOperation / BinaryExpressionSyntax: arg && false|2# FlowCaptureReferenceOperation: #0 / BinaryExpressionSyntax: arg && false|##########}""]
+}
+subgraph ""cluster_LocalLifetime region"" {
+label = ""LocalLifetime region""
+cfg0_block5 [shape=record label=""{BLOCK #5|0# FlowCaptureOperation: #1 / IdentifierNameSyntax: b|1# LocalReferenceOperation / IdentifierNameSyntax: b|##########|## BranchValue ##|0# ParameterReferenceOperation / IdentifierNameSyntax: arg|##########}""]
+cfg0_block6 [shape=record label=""{BLOCK #6|0# FlowCaptureOperation: #2 / LiteralExpressionSyntax: true|1# LiteralOperation / LiteralExpressionSyntax: true|##########}""]
+cfg0_block7 [shape=record label=""{BLOCK #7|0# FlowCaptureOperation: #2 / IdentifierNameSyntax: arg|1# LiteralOperation / IdentifierNameSyntax: arg|##########}""]
+cfg0_block8 [shape=record label=""{BLOCK #8|0# ExpressionStatementOperation / ExpressionStatementSyntax: b = arg \|\| true;|1# SimpleAssignmentOperation / AssignmentExpressionSyntax: b = arg \|\| true|2# FlowCaptureReferenceOperation: #1 / IdentifierNameSyntax: b|2# ConversionOperation / BinaryExpressionSyntax: arg \|\| true|3# FlowCaptureReferenceOperation: #2 / BinaryExpressionSyntax: arg \|\| true|##########}""]
+}
+}
+cfg0_block0 [shape=record label=""{ENTRY #0}""]
+cfg0_block9 [shape=record label=""{EXIT #9}""]
+cfg0_block0 -> cfg0_block1
+cfg0_block1 -> cfg0_block2 [label=""Else""]
+cfg0_block1 -> cfg0_block3 [label=""WhenFalse""]
+cfg0_block2 -> cfg0_block4
+cfg0_block3 -> cfg0_block4
+cfg0_block4 -> cfg0_block5
+cfg0_block5 -> cfg0_block6 [label=""Else""]
+cfg0_block5 -> cfg0_block7 [label=""WhenTrue""]
+cfg0_block6 -> cfg0_block8
+cfg0_block7 -> cfg0_block8
+cfg0_block8 -> cfg0_block9
+}
+");
+        }
     }
 }


### PR DESCRIPTION
We need to return shimmed `CaptureId` instead of `InvalidOpertationException` when invoking `IFlowCaptureOperationWrapper.Id` and `IFlowCaptureReferenceOperationWrapper.Id`