### PR TITLE
Fix test-framework test cases for Preview

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/LogAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/LogAnalyzerTest.cs
@@ -128,7 +128,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             var versionMessage = messages.SingleOrDefault(x => x.Text.Contains("Language version"));
             versionMessage.Should().NotBeNull();
             versionMessage.Severity.Should().Be(LogSeverity.Info);
-            versionMessage.Text.Should().MatchRegex(@"^Language version: (CSharp|VisualBasic)\d");
+            versionMessage.Text.Should().MatchRegex(@"^Language version: (Preview|(CSharp|VisualBasic)\d+)");
         }
 
         private static void VerifyConcurrentExecution(IEnumerable<LogInfo> messages, string expectedConcurrencyMessage)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/ParseOptionsHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/ParseOptionsHelperTest.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                     CS.LanguageVersion.CSharp7_3,
                     CS.LanguageVersion.CSharp8,
                     CS.LanguageVersion.CSharp9,
-                    CS.LanguageVersion.CSharp10);
+                    CS.LanguageVersion.Preview);
 
                 vbVersions.Should().BeEquivalentTo(
                     VB.LanguageVersion.VisualBasic12,


### PR DESCRIPTION
fix main build (RE: #4981), where we run all language versions (as opposed to PR and local where we only run the latest)

To test locally what happens on master we need to modify the `TestContextHelper` methods:
- `IsAzureDevOpsContext` to return `true`
- `IsPullRequestBuild` to return `false`