### PR TITLE
Introduce a rule that detects unicode vulnerabilities

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PreventUnicodeVulnerabilities.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PreventUnicodeVulnerabilities.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.CSharp
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [Rule(DiagnosticId)]
+    public sealed class PreventUnicodeVulnerabilities : PreventUnicodeVulnerabilitiesBase
+    {
+        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager, false);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
+            CSharpGeneratedCodeRecognizer.Instance;
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PreventUnicodeVulnerabilitiesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PreventUnicodeVulnerabilitiesBase.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules
+{
+    public abstract class PreventUnicodeVulnerabilitiesBase : SonarDiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "S1940";
+        internal const string MessageFormat = "Vulnerable character U+{0:x} detected";
+
+        protected abstract GeneratedCodeRecognizer GeneratedCodeRecognizer { get; }
+
+        protected override void Initialize(SonarAnalysisContext context)
+        {
+            context.RegisterSyntaxTreeActionInNonGenerated(
+                GeneratedCodeRecognizer,
+                c =>
+                {
+                    foreach (var point in c.Tree.GetText().Lines
+                        .SelectMany(line => CodePoint.Parse(line.ToString(), line.Start))
+                        .Where(point => IsVulnerability(point.Utf32)))
+                    {
+                        c.ReportIssue(
+                            Diagnostic.Create(
+                                SupportedDiagnostics[0],
+                                c.Tree.GetLocation(point.TextSpan),
+                                point.Utf32));
+                    }
+                });
+        }
+
+        internal static bool IsVulnerability(char ch)
+            => IsSuspiciousCategory(char.GetUnicodeCategory(ch))
+            && !InAllowedRange(ch);
+
+        internal static bool IsVulnerability(int utf32)
+            => IsSuspiciousCategory(utf32)
+            && !InAllowedRange(utf32);
+
+        private static bool IsSuspiciousCategory(int utf32)
+        {
+            var str = char.ConvertFromUtf32(utf32);
+            return str.Any(ch => IsSuspiciousCategory(char.GetUnicodeCategory(ch)));
+        }
+
+        private static bool IsSuspiciousCategory(UnicodeCategory cat)
+            => cat == UnicodeCategory.Control
+            || cat == UnicodeCategory.Format
+            || cat == UnicodeCategory.Surrogate
+            || cat == UnicodeCategory.OtherNotAssigned;
+
+        private static bool InAllowedRange(int utf32)
+            => Arabic.Contains(utf32)
+            || ArabicExtendedA.Contains(utf32)
+            || ArabicExtendedB.Contains(utf32)
+            || ArabicPresentationFormsA.Contains(utf32)
+            || ArabicPresentationFormsB.Contains(utf32)
+            || RumiNumeralSymbols.Contains(utf32)
+            || IndicSiyaqNumbers.Contains(utf32)
+            || OttomanSiyaqNumbers.Contains(utf32)
+            || ArabicMathematicalAlphabeticSymbols.Contains(utf32)
+            || CJKUnifiedIdeographs.Contains(utf32)
+            || CJKUnifiedIdeographsExtensionA.Contains(utf32)
+            || CJKUnifiedIdeographsExtensionB.Contains(utf32)
+            || CJKUnifiedIdeographsExtensionC.Contains(utf32)
+            || CJKUnifiedIdeographsExtensionD.Contains(utf32)
+            || CJKUnifiedIdeographsExtensionE.Contains(utf32)
+            || CJKUnifiedIdeographsExtensionF.Contains(utf32)
+            || CyrillicExtendedC.Contains(utf32);
+
+        private static readonly Range Arabic = new Range(0x00600, 0x006FF);
+        private static readonly Range ArabicSupplement = new Range(0x00750, 0x0077F);
+        private static readonly Range ArabicExtendedA = new Range(0x008A0, 0x008FF);
+        private static readonly Range ArabicExtendedB = new Range(0x00870, 0x0089F);
+        private static readonly Range ArabicPresentationFormsA = new Range(0x0FB50, 0x0FDFF);
+        private static readonly Range ArabicPresentationFormsB = new Range(0x0FE70, 0x0FEFF);
+        private static readonly Range RumiNumeralSymbols = new Range(0x10E60, 0x10E7F);
+        private static readonly Range IndicSiyaqNumbers = new Range(0x1EC70, 0x1ECBF);
+        private static readonly Range OttomanSiyaqNumbers = new Range(0x1ED00, 0x1ED4F);
+        private static readonly Range ArabicMathematicalAlphabeticSymbols = new Range(0x1EE00, 0x1EEFF);
+        private static readonly Range CJKUnifiedIdeographs = new Range(0x04E00, 0X09FEF);
+        private static readonly Range CJKUnifiedIdeographsExtensionA = new Range(0x03400, 0X04DBF);
+        private static readonly Range CJKUnifiedIdeographsExtensionB = new Range(0x20000, 0X2A6DF);
+        private static readonly Range CJKUnifiedIdeographsExtensionC = new Range(0x2A700, 0X2B73F);
+        private static readonly Range CJKUnifiedIdeographsExtensionD = new Range(0x2B740, 0X2B81F);
+        private static readonly Range CJKUnifiedIdeographsExtensionE = new Range(0x2B820, 0X2CEAF);
+        private static readonly Range CJKUnifiedIdeographsExtensionF = new Range(0x2CEB0, 0X2EBEF);
+        private static readonly Range CyrillicExtendedC = new Range(0x01C80, 0x01C8F);
+
+        private readonly struct Range
+        {
+            public Range(int start, int end)
+            {
+                Start = start;
+                End = end;
+            }
+            public int Start { get; }
+            public int End { get; }
+            public bool Contains(int utf32) => utf32 >= Start && utf32 <= End;
+        }
+
+        private readonly struct CodePoint
+        {
+            public CodePoint(int utf32, int index)
+            {
+                Utf32 = utf32;
+                Index = index;
+            }
+            public int Utf32 { get; }
+            public int Index { get; }
+            public TextSpan TextSpan => TextSpan.FromBounds(Index, Index + 1);
+
+            public static IEnumerable<CodePoint> Parse(string str, int offset)
+            {
+                var codePoints = new List<CodePoint>(str.Length + 8);
+                var index = 0;
+                while (index < str.Length)
+                {
+                    var utf32 = char.ConvertToUtf32(str, index);
+                    var size = char.IsHighSurrogate(str[index]) ? 2 : 1;
+                    codePoints.Add(new CodePoint(utf32, index + offset));
+                    offset -= size - 1;
+                    index += size;
+                }
+                return codePoints;
+            }
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PreventUnicodeVulnerabilities.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PreventUnicodeVulnerabilities.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2021 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.VisualBasic
+{
+    [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+    [Rule(DiagnosticId)]
+    public sealed class PreventUnicodeVulnerabilities : PreventUnicodeVulnerabilitiesBase
+    {
+        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager, false);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
+            VisualBasicGeneratedCodeRecognizer.Instance;
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/PreventUnicodeVulnerabilitiesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/PreventUnicodeVulnerabilitiesTest.cs
@@ -1,0 +1,59 @@
+﻿using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.Rules;
+using SonarAnalyzer.UnitTest.TestFramework;
+using CS = SonarAnalyzer.Rules.CSharp;
+using VB = SonarAnalyzer.Rules.VisualBasic;
+
+namespace SonarAnalyzer.UnitTest.Rules
+{
+    [TestClass]
+    public class PreventUnicodeVulnerabilitiesTest
+    {
+        [TestMethod]
+        public void PreventUnicodeVulnerabilities_CS()
+            => Verifier.VerifyAnalyzer(
+                @"TestCases\PreventUnicodeVulnerabilities.cs",
+                new CS.PreventUnicodeVulnerabilities());
+
+        [TestMethod]
+        public void PreventUnicodeVulnerabilities_VB()
+            => Verifier.VerifyAnalyzer(
+                @"TestCases\PreventUnicodeVulnerabilities.cs",
+                new VB.PreventUnicodeVulnerabilities());
+
+        [DataTestMethod]
+        [DataRow(0x00600, 0x006FF, "Arabic")]
+        [DataRow(0x00750, 0x0077F, "Arabic Supplement")]
+        [DataRow(0x00870, 0x0089F, "Arabic Extended-B")]
+        [DataRow(0x008A0, 0x008FF, "Arabic Extended-A")]
+        [DataRow(0x0FB50, 0x0FDFF, "Arabic Presentation Forms-A")]
+        [DataRow(0x0FE70, 0x0FEFF, "Arabic Presentation Forms-B")]
+        [DataRow(0x10E60, 0x10E7F, "Rumi Numeral Symbols")]
+        [DataRow(0x1EC70, 0x1ECBF, "Indic Siyaq Numbers")]
+        [DataRow(0x1ED00, 0x1ED4F, "Ottoman Siyaq Numbers")]
+        [DataRow(0x1EE00, 0x1EEFF, "Arabic Mathematical Alphabetic Symbols")]
+        [DataRow(0x04E00, 0X09FEF, "CJK Unified Ideographs")]
+        [DataRow(0x03400, 0X04DBF, "CJK Unified Ideographs Extension A")]
+        [DataRow(0x20000, 0X2A6DF, "CJK Unified Ideographs Extension B")]
+        [DataRow(0x2A700, 0X2B73F, "CJK Unified Ideographs Extension C")]
+        [DataRow(0x2B740, 0X2B81F, "CJK Unified Ideographs Extension D")]
+        [DataRow(0x2B820, 0X2CEAF, "CJK Unified Ideographs Extension E")]
+        [DataRow(0x2CEB0, 0X2EBEF, "CJK Unified Ideographs Extension F")]
+        [DataRow(0x03007, 0X03007, "block CJK Symbols and Punctuation")]
+        [DataRow(0x00400, 0x004FF, "Cyrillic")]
+        [DataRow(0x00500, 0x0052F, "Cyrillic Supplement")]
+        [DataRow(0x02DE0, 0x02DFF, "Cyrillic Extended-A")]
+        [DataRow(0x0A640, 0x0A69F, "Cyrillic Extended-B")]
+        [DataRow(0x01C80, 0x01C8F, "Cyrillic Extended-C")]
+        [DataRow(0x01D2B, 0x01D78, "Phonetic Extensions")]
+        [DataRow(0x0FE2E, 0x0FE2F, "Combining Half Marks")]
+        public void NoVulnerability(int start, int end, string range)
+        {
+            var utf32s = Enumerable.Range(start, 1 + end - start);
+            var vulnerabilities = utf32s.Where(utf32 => PreventUnicodeVulnerabilitiesBase.IsVulnerability(utf32));
+            vulnerabilities.Should().BeEmpty(because: "U+{0:X}-U+{1:X} represents {2}.", start, end, range);
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PreventUnicodeVulnerabilities.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PreventUnicodeVulnerabilities.cs
@@ -1,0 +1,13 @@
+﻿class Controller
+{
+    bool Access()
+    {
+        string access_level = "user";
+        if (access_level != "⁣user") // Noncompliant {{Vulnerable character U+2063 detected}}
+        //                   ^
+        {
+            return true;
+        }
+        return false;
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PreventUnicodeVulnerabilities.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PreventUnicodeVulnerabilities.vb
@@ -1,0 +1,11 @@
+﻿Class Controller
+    Function Access() As Boolean
+
+        String access_level = "user";
+        If (access_level! = "⁣user") Then ' Noncompliant {{Vulnerable character U+2063 detected}}
+            '                ^
+            Return True
+        End If
+        Return False
+    End Function
+End Class


### PR DESCRIPTION
See: https://community.sonarsource.com/t/warn-on-suspicious-unicode-characters/52992
I gave it a try, and think it works just as it should. Obviously, some (a lot) of administration has to be done.