### PR TITLE
Remove comments related to Json feature branch

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Json/Parsing/SyntaxAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Json/Parsing/SyntaxAnalyzer.cs
@@ -67,7 +67,6 @@ namespace SonarAnalyzer.Json.Parsing
                     throw Unexpected("}");
                 }
             }
-            // FIXME: Verify that Roslyn needs to be one character behind the end, otherwise, we may use LastStart
             ret.UpdateEnd(new LinePosition(lexer.LastStart.Line, lexer.LastStart.Character + 1));
             return ret;
         }
@@ -105,7 +104,6 @@ namespace SonarAnalyzer.Json.Parsing
                     throw Unexpected("]");
                 }
             }
-            // FIXME: Verify that Roslyn needs to be one character behind the end, otherwise, we may use LastStart
             ret.UpdateEnd(new LinePosition(lexer.LastStart.Line, lexer.LastStart.Character + 1));
             return ret;
         }


### PR DESCRIPTION
`FIXME` comments should not be on `master`

These should have been removed in #5047 before the feature branch was merged to master as #5047 ensures the correct issue reporting.

This is a draft to prevent merging before release.