### PR TITLE
Update Vsix NuGet references

### DIFF
--- a/analyzers/src/SonarAnalyzer.Vsix/SonarAnalyzer.Vsix.csproj
+++ b/analyzers/src/SonarAnalyzer.Vsix/SonarAnalyzer.Vsix.csproj
@@ -58,7 +58,6 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.lock.json" />
     <None Include="SonarAnalyzer.CSharp.nuspec">
       <SubType>Designer</SubType>
     </None>

--- a/analyzers/src/SonarAnalyzer.Vsix/SonarAnalyzer.Vsix.csproj
+++ b/analyzers/src/SonarAnalyzer.Vsix/SonarAnalyzer.Vsix.csproj
@@ -58,6 +58,7 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.lock.json" />
     <None Include="SonarAnalyzer.CSharp.nuspec">
       <SubType>Designer</SubType>
     </None>
@@ -121,13 +122,17 @@
       <Version>3.6.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers">
-      <Version>15.8.36</Version>
+      <Version>16.10.10</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
-      <Version>15.8.192</Version>
+      <Version>17.0.64</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>15.9.3032</Version>
+      <Version>17.0.5232</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/analyzers/src/SonarAnalyzer.Vsix/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.Vsix/packages.lock.json
@@ -10,24 +10,21 @@
       },
       "Microsoft.VisualStudio.SDK.Analyzers": {
         "type": "Direct",
-        "requested": "[15.8.36, )",
-        "resolved": "15.8.36",
-        "contentHash": "bsPf9+WP1/eqxGRR7pfgOJWrHU4DUEy0hg8sTPH2npH74D5b5R2WmzT4TgZCOzMIFrr0lKY7QLhBGJp5tEQNfA==",
-        "dependencies": {
-          "Microsoft.VisualStudio.Threading.Analyzers": "15.8.168"
-        }
+        "requested": "[16.10.10, )",
+        "resolved": "16.10.10",
+        "contentHash": "LuhBHy7MJJ5SjpS7J2GuHqPyL1VeqXUwYc+mTagaUCzXbNwJmLcSUAioCyQyAzPIn6qtnzuM5Lz6ULOQS3ifUA=="
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
-        "requested": "[15.8.192, )",
-        "resolved": "15.8.192",
-        "contentHash": "hok2oGcyCvgwUYhE3CisLYxtFSm2E9iJAs9vrqSQqBE0IbYRDDwq5S251VmXDIc8w0o2TJuXPwN7nLREDcOShQ=="
+        "requested": "[17.0.64, )",
+        "resolved": "17.0.64",
+        "contentHash": "+xz3lAqA3h2/5q6H7Udmz9TsxDQ99O+PjoQ4k4BTO3SfAfyJX7ejh7I1D1N/M/GzGUci9YOUpr6KBO4vXLg+zQ=="
       },
       "Microsoft.VSSDK.BuildTools": {
         "type": "Direct",
-        "requested": "[15.9.3032, )",
-        "resolved": "15.9.3032",
-        "contentHash": "Gn+amfA2mKIvVRr8Zo4Nu6mNYIwdFBTzs8DhFftsgeyAoKdIu1dV4gq06h/lRSbuWWoz6m/eS+fQyJ0O8C8Wng==",
+        "requested": "[17.0.5232, )",
+        "resolved": "17.0.5232",
+        "contentHash": "k2+OBg4wxpOofGrEdsm9+vQXgghOusae4f2Vo7XLbEFWv6S9zWqQ5KQ6wy1Ygu845I82CbthEiubmxtVye1fsA==",
         "dependencies": {
           "Microsoft.VisualStudio.SDK.Analyzers": "15.8.33"
         }


### PR DESCRIPTION
The old version of `Microsoft.VSSDK.BuildTools` could not be used in VS 2022 to compile the project.

>The target "CreateClientEnabledPkgFiles" does not exist