### PR TITLE
Update gson to 2.8.9

### DIFF
--- a/sonar-dotnet-shared-library/pom.xml
+++ b/sonar-dotnet-shared-library/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.6</version>
+      <version>2.8.9</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -209,8 +209,8 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>4000000</maxsize>
-                  <minsize>3800000</minsize>
+                  <maxsize>4020000</maxsize>
+                  <minsize>4000000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>


### PR DESCRIPTION
WhiteSource flags this as vulnerable.
