### PR TITLE
Rename CSharpExplodedGraph to SonarExplodedGraph

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/Sonar/CSharpControlFlowGraphBuilder.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Sonar/CSharpControlFlowGraphBuilder.cs
@@ -1277,7 +1277,7 @@ namespace SonarAnalyzer.CFG.Sonar
             {
                 // Do nothing, this is just variable assignment and the Pattern itself contains
                 // only the new variable(s), which are not enough to evaluate the assignment.
-                // The handling should be done in CSharpExplodedGraph and UcfgInstructionFactory.
+                // The handling should be done in SonarExplodedGraph and UcfgInstructionFactory.
 
                 return currentBlock;
             }
@@ -1287,7 +1287,7 @@ namespace SonarAnalyzer.CFG.Sonar
             }
             else if (RecursivePatternSyntaxWrapper.IsInstance(patternSyntaxWrapper))
             {
-                // The recursive pattern will be handled in CSharpExplodedGraph and UcfgInstructionFactory.
+                // The recursive pattern will be handled in SonarExplodedGraph and UcfgInstructionFactory.
                 currentBlock.ReversedInstructions.Add(patternSyntaxWrapper);
                 return currentBlock;
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarAnalysisContextExtensions.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Extensions
 {
     internal static class SonarAnalysisContextExtensions
     {
-        public static void RegisterExplodedGraphBasedAnalysis(this SonarAnalysisContext context, Action<CSharpExplodedGraph, SyntaxNodeAnalysisContext> analyze)
+        public static void RegisterExplodedGraphBasedAnalysis(this SonarAnalysisContext context, Action<SonarExplodedGraph, SyntaxNodeAnalysisContext> analyze)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>
@@ -105,7 +105,7 @@ namespace SonarAnalyzer.Extensions
                 SyntaxKind.ParenthesizedLambdaExpression);
         }
 
-        private static void Analyze(CSharpSyntaxNode declarationBody, ISymbol symbol, Action<CSharpExplodedGraph, SyntaxNodeAnalysisContext> runAnalysis, SyntaxNodeAnalysisContext context)
+        private static void Analyze(CSharpSyntaxNode declarationBody, ISymbol symbol, Action<SonarExplodedGraph, SyntaxNodeAnalysisContext> runAnalysis, SyntaxNodeAnalysisContext context)
         {
             if (declarationBody == null
                 || declarationBody.ContainsDiagnostics
@@ -117,7 +117,7 @@ namespace SonarAnalyzer.Extensions
             var lva = new SonarCSharpLiveVariableAnalysis(cfg, symbol, context.SemanticModel);
             try
             {
-                var explodedGraph = new CSharpExplodedGraph(cfg, symbol, context.SemanticModel, lva);
+                var explodedGraph = new SonarExplodedGraph(cfg, symbol, context.SemanticModel, lva);
                 runAnalysis(explodedGraph, context);
             }
             catch (Exception e)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ConditionEvaluatesToConstant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ConditionEvaluatesToConstant.cs
@@ -103,12 +103,12 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(s2583, s2589);
 
-        public ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext AddChecks(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
             new AnalysisContext(explodedGraph, context);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext
         {
-            private readonly CSharpExplodedGraph explodedGraph;
+            private readonly SonarExplodedGraph explodedGraph;
             private readonly SyntaxNodeAnalysisContext context;
 
             private readonly HashSet<SyntaxNode> conditionTrue = new HashSet<SyntaxNode>();
@@ -119,7 +119,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             private bool hasYieldStatement;
 
-            public AnalysisContext(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
+            public AnalysisContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
             {
                 this.explodedGraph = explodedGraph;
                 this.context = context;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -89,7 +89,7 @@ namespace SonarAnalyzer.Rules.CSharp
             nameof(Dictionary<object, object>.TryGetValue),
         };
 
-        public ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext AddChecks(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext
@@ -97,7 +97,7 @@ namespace SonarAnalyzer.Rules.CSharp
             private readonly HashSet<SyntaxNode> emptyCollections = new HashSet<SyntaxNode>();
             private readonly HashSet<SyntaxNode> nonEmptyCollections = new HashSet<SyntaxNode>();
 
-            public AnalysisContext(CSharpExplodedGraph explodedGraph) =>
+            public AnalysisContext(SonarExplodedGraph explodedGraph) =>
                 explodedGraph.AddExplodedGraphCheck(new EmptyCollectionAccessedCheck(explodedGraph, this));
 
             public bool SupportsPartialResults => false;
@@ -118,7 +118,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             private readonly AnalysisContext context;
 
-            public EmptyCollectionAccessedCheck(CSharpExplodedGraph explodedGraph, AnalysisContext context) : base(explodedGraph) =>
+            public EmptyCollectionAccessedCheck(SonarExplodedGraph explodedGraph, AnalysisContext context) : base(explodedGraph) =>
                 this.context = context;
 
             public override ProgramState PreProcessInstruction(ProgramPoint programPoint, ProgramState programState)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyNullableValueAccess.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyNullableValueAccess.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-        public ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext AddChecks(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             public bool SupportsPartialResults => true;
 
-            public AnalysisContext(CSharpExplodedGraph explodedGraph)
+            public AnalysisContext(SonarExplodedGraph explodedGraph)
             {
                 nullableValueCheck = explodedGraph.NullableValueAccessedCheck;
                 nullableValueCheck.ValuePropertyAccessed += AddIdentifier;
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             public event EventHandler<MemberAccessedEventArgs> ValuePropertyAccessed;
 
-            public NullableValueAccessedCheck(CSharpExplodedGraph explodedGraph) : base(explodedGraph) { }
+            public NullableValueAccessedCheck(SonarExplodedGraph explodedGraph) : base(explodedGraph) { }
 
             private void OnValuePropertyAccessed(IdentifierNameSyntax identifier) =>
                 ValuePropertyAccessed?.Invoke(this, new MemberAccessedEventArgs(identifier));

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/HashesShouldHaveUnpredictableSalt.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/HashesShouldHaveUnpredictableSalt.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-        public ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext AddChecks(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
             new AnalysisContext(explodedGraph);
 
         internal sealed class LocationContext

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ISymbolicExecutionAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ISymbolicExecutionAnalyzer.cs
@@ -29,6 +29,6 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
     {
         IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; }
 
-        ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context);
+        ISymbolicExecutionAnalysisContext AddChecks(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InitializationVectorShouldBeRandom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InitializationVectorShouldBeRandom.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        public ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext AddChecks(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : DefaultAnalysisContext<Location>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InvalidCastToInterfaceSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InvalidCastToInterfaceSymbolicExecution.cs
@@ -38,19 +38,19 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics  { get; } = ImmutableArray.Create(InvalidCastToInterfaceRuleConstants.Rule);
 
-        public ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext AddChecks(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
             new AnalysisContext(explodedGraph, context);
 
         internal sealed class NullableCastCheck : ExplodedGraphCheck
         {
             private readonly SyntaxNodeAnalysisContext context;
 
-            public NullableCastCheck(CSharpExplodedGraph explodedGraph)
+            public NullableCastCheck(SonarExplodedGraph explodedGraph)
                 : base(explodedGraph)
             {
             }
 
-            public NullableCastCheck(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
+            public NullableCastCheck(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
                 : this(explodedGraph)
             {
                 this.context = context;
@@ -97,7 +97,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             public bool SupportsPartialResults => true;
 
-            public AnalysisContext(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+            public AnalysisContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
                 explodedGraph.AddExplodedGraphCheck(new NullableCastCheck(explodedGraph, context));
 
             public void Dispose()

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/NullPointerDereference.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/NullPointerDereference.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
-        public ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext AddChecks(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
             new AnalysisContext(explodedGraph, context);
 
         internal sealed class NullPointerCheck : ExplodedGraphCheck
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
             public event EventHandler<MemberAccessingEventArgs> MemberAccessing;
             public event EventHandler<MemberAccessedEventArgs> MemberAccessed;
 
-            public NullPointerCheck(CSharpExplodedGraph explodedGraph) : base(explodedGraph) { }
+            public NullPointerCheck(SonarExplodedGraph explodedGraph) : base(explodedGraph) { }
 
             private void OnMemberAccessing(IdentifierNameSyntax identifier, ISymbol symbol, ProgramState programState) =>
                 MemberAccessing?.Invoke(this, new MemberAccessingEventArgs(identifier, symbol, programState));
@@ -215,7 +215,7 @@ namespace SonarAnalyzer.Rules.CSharp
             private readonly HashSet<IdentifierNameSyntax> nullIdentifiers = new HashSet<IdentifierNameSyntax>();
             private readonly NullPointerCheck nullPointerCheck;
 
-            public AnalysisContext(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
+            public AnalysisContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
             {
                 this.context = context;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnce.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnce.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
-        public ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext AddChecks(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Rules.CSharp
             // the walked CFG paths could be different and FPs will appear.
             private readonly Dictionary<SyntaxNode, string> nodesToReport = new Dictionary<SyntaxNode, string>();
 
-            public AnalysisContext(CSharpExplodedGraph explodedGraph) =>
+            public AnalysisContext(SonarExplodedGraph explodedGraph) =>
                 explodedGraph.AddExplodedGraphCheck(new ObjectDisposedPointerCheck(explodedGraph, this));
 
             public bool SupportsPartialResults => true;
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             private readonly AnalysisContext context;
 
-            public ObjectDisposedPointerCheck(CSharpExplodedGraph explodedGraph, AnalysisContext context) : base(explodedGraph) =>
+            public ObjectDisposedPointerCheck(SonarExplodedGraph explodedGraph, AnalysisContext context) : base(explodedGraph) =>
                 this.context = context;
 
             public override ProgramState PreProcessUsingStatement(ProgramPoint programPoint, ProgramState programState)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        public ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext AddChecks(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
             new AnalysisContext(explodedGraph, context);
 
        private static void CollectMemberAccesses(MemberAccessingEventArgs args, ISet<IdentifierNameSyntax> identifiers, SemanticModel semanticModel)
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.Rules.CSharp
             private readonly NullPointerDereference.NullPointerCheck nullPointerCheck;
             private readonly SyntaxNodeAnalysisContext syntaxNodeAnalysisContext;
 
-            public AnalysisContext(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
+            public AnalysisContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
             {
                 if (!GetMethodSymbol(context).IsPubliclyAccessible())
                 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/RestrictDeserializedTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/RestrictDeserializedTypes.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
-        public ISymbolicExecutionAnalysisContext AddChecks(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext AddChecks(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterExplodedGraphBasedAnalysis(Analyze);
 
-        private void Analyze(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
+        private void Analyze(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
         {
             var analyzerContexts = InitializeAnalyzers(explodedGraph, context).ToList();
 
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
             }
         }
 
-        private IEnumerable<ISymbolicExecutionAnalysisContext> InitializeAnalyzers(CSharpExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        private IEnumerable<ISymbolicExecutionAnalysisContext> InitializeAnalyzers(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
             symbolicExecutionAnalyzerFactory
                 .GetEnabledAnalyzers(context)
                 .Select(analyzer => analyzer.AddChecks(explodedGraph, context));

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/SonarExplodedGraph.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/SonarExplodedGraph.cs
@@ -34,12 +34,12 @@ using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.SymbolicExecution.Sonar
 {
-    internal class CSharpExplodedGraph : AbstractExplodedGraph
+    internal class SonarExplodedGraph : AbstractExplodedGraph
     {
         private const string isNullOrEmpty = "IsNullOrEmpty";
         private const string isNullOrWhiteSpace = "IsNullOrWhiteSpace";
 
-        public CSharpExplodedGraph(IControlFlowGraph cfg, ISymbol declaration, SemanticModel semanticModel, SonarCSharpLiveVariableAnalysis lva)
+        public SonarExplodedGraph(IControlFlowGraph cfg, ISymbol declaration, SemanticModel semanticModel, SonarCSharpLiveVariableAnalysis lva)
             : base(cfg, declaration, semanticModel, lva)
         {
             NullPointerCheck = new NullPointerDereference.NullPointerCheck(this);
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar
         }
 
         /// <summary>
-        /// NullPointerCheck is added by default by the CSharpExplodedGraph to allow an early stop of the visit
+        /// NullPointerCheck is added by default by the SonarExplodedGraph to allow an early stop of the visit
         /// when a null pointer dereference is found.
         ///
         /// In order to be able to run all the rules within one single symbolic execution pass, we have to reuse,

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SonarExplodedGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SonarExplodedGraphTest.cs
@@ -40,7 +40,7 @@ using SonarAnalyzer.UnitTest.Helpers;
 namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar
 {
     [TestClass]
-    public class ExplodedGraphTest
+    public class SonarExplodedGraphTest
     {
         private const string TestInput = @"
 namespace NS
@@ -112,7 +112,7 @@ namespace NS
         public void ExplodedGraph_SequentialInput_Max()
         {
             var inputBuilder = new StringBuilder();
-            for (var i = 0; i < CSharpExplodedGraph.MaxStepCount / 2 + 1; i++)
+            for (var i = 0; i < SonarExplodedGraph.MaxStepCount / 2 + 1; i++)
             {
                 inputBuilder.AppendLine($"var x{i} = true;");
             }
@@ -1522,7 +1522,7 @@ namespace Namespace
             public readonly IMethodSymbol MainMethodSymbol;
             public readonly SonarCSharpLiveVariableAnalysis LiveVariableAnalysis;
             public readonly IControlFlowGraph ControlFlowGraph;
-            public readonly CSharpExplodedGraph ExplodedGraph;
+            public readonly SonarExplodedGraph ExplodedGraph;
 
             public bool ExplorationEnded;
             public bool MaxStepCountReached;
@@ -1545,7 +1545,7 @@ namespace Namespace
                 var methodBody = (CSharpSyntaxNode)MainMethod.Body ?? MainMethod.ExpressionBody;
                 ControlFlowGraph = CSharpControlFlowGraph.Create(methodBody, semanticModel);
                 LiveVariableAnalysis = new SonarCSharpLiveVariableAnalysis(ControlFlowGraph, MainMethodSymbol, semanticModel);
-                ExplodedGraph = new CSharpExplodedGraph(ControlFlowGraph, MainMethodSymbol, semanticModel, LiveVariableAnalysis);
+                ExplodedGraph = new SonarExplodedGraph(ControlFlowGraph, MainMethodSymbol, semanticModel, LiveVariableAnalysis);
                 ExplodedGraph.InstructionProcessed += (sender, args) => { NumberOfProcessedInstructions++; };
                 ExplodedGraph.ExplorationEnded += (sender, args) => { ExplorationEnded = true; };
                 ExplodedGraph.MaxStepCountReached += (sender, args) => { MaxStepCountReached = true; };


### PR DESCRIPTION
Only `Rename CSharpExplodedGraph to SonarExplodedGraph` commit needs a review.