### PR TITLE
Count ElseIf as executable line metric for VB.NET

### DIFF
--- a/analyzers/src/SonarAnalyzer.VisualBasic/Metrics/VisualBasicExecutableLinesMetric.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Metrics/VisualBasicExecutableLinesMetric.cs
@@ -97,6 +97,7 @@ namespace SonarAnalyzer.Metrics.VisualBasic
                     case SyntaxKind.WhileStatement:
 
                     case SyntaxKind.IfStatement:
+                    case SyntaxKind.ElseIfStatement:
                     case SyntaxKind.LabelStatement:
                     case SyntaxKind.SelectStatement:
                     case SyntaxKind.ConditionalAccessExpression:

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Metrics/CSharpExecutableLinesMetricTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Metrics/CSharpExecutableLinesMetricTest.cs
@@ -369,7 +369,7 @@ public class ComplicatedCode
     }}
 }}");
 
-         [TestMethod]
+        [TestMethod]
         public void ExcludeClassFromTestCoverage() =>
             AssertLinesOfCode(
 @"using System;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Metrics/VisualBasicExecutableLinesMetricTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Metrics/VisualBasicExecutableLinesMetricTest.cs
@@ -124,7 +124,7 @@ End Module", 3);
             Message = $""There are many items.""
         End If
     End Sub
-End Module", 4, 5, 7, 9);   // FIXME: 6 is missing
+End Module", 4, 5, 6, 7, 9);
 
         [TestMethod]
         public void SelectStatement() =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SnippetCompilerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SnippetCompilerTest.cs
@@ -121,8 +121,8 @@ public class Sample
 // Error CS1513 } expected
 {";
             using var log = new LogTester();
-            Action a = () => new SnippetCompiler(code);
-            a.Should().Throw<InvalidOperationException>();
+            Func<SnippetCompiler> f = () => new SnippetCompiler(code);
+            f.Should().Throw<InvalidOperationException>();
             log.AssertContain("CS1519 Line: 5: Invalid token '{' in class, record, struct, or interface member declaration");
             log.AssertContain("CS1513 Line: 5: } expected");
         }


### PR DESCRIPTION
Fixes #5109
