### PR TITLE
Remove ITs/Expected from Solution Explorer

### DIFF
--- a/analyzers/SonarAnalyzer.sln
+++ b/analyzers/SonarAnalyzer.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29519.87
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common Solution Items", "Common Solution Items", "{0C3E0519-DB5C-47C0-ABB3-9D1FB23DFBAF}"
 	ProjectSection(SolutionItems) = preProject
@@ -64,8 +64,6 @@ EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Orchestration", "its\Orchestration.shproj", "{A64F1665-6EDB-4B69-B143-FEA6D0B24243}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Config", "its\config\Config.shproj", "{17E060C5-5D0B-443D-B716-F76C2EAC0B19}"
-EndProject
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Expected", "its\expected\Expected.shproj", "{19A2DC17-EFDA-4E15-A1B3-19A695B6F253}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Sources", "its\sources\Sources.shproj", "{28067DB4-C098-4A15-9846-2978711733F3}"
 EndProject
@@ -151,7 +149,6 @@ Global
 		{532AC70E-90CB-48AD-86F4-16767C22314D} = {0C3E0519-DB5C-47C0-ABB3-9D1FB23DFBAF}
 		{A64F1665-6EDB-4B69-B143-FEA6D0B24243} = {314A0C27-4768-4F15-B7FA-DC3C33C08180}
 		{17E060C5-5D0B-443D-B716-F76C2EAC0B19} = {314A0C27-4768-4F15-B7FA-DC3C33C08180}
-		{19A2DC17-EFDA-4E15-A1B3-19A695B6F253} = {314A0C27-4768-4F15-B7FA-DC3C33C08180}
 		{28067DB4-C098-4A15-9846-2978711733F3} = {314A0C27-4768-4F15-B7FA-DC3C33C08180}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/analyzers/its/expected/Expected.shproj
+++ b/analyzers/its/expected/Expected.shproj
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- This is a minimal Shared project to show the directory structure in Solution Explorer. This project should not be built nor referenced. -->
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
-  <ItemGroup>
-    <None Include="**\**" />
-  </ItemGroup>
-</Project>


### PR DESCRIPTION
It obstructs search results when searching for `reference`, `serial`, `engine`, ... in solution explorer file filter
