### PR TITLE
Filter rule scope in SymbolicExecutionFactory

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SymbolicExecutionAnalyzerFactoryTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SymbolicExecutionAnalyzerFactoryTest.cs
@@ -92,7 +92,7 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution.Sonar
         }
 
         [TestMethod]
-        public void GetEnabledAnalyzers_ReturnsEmptyList_OnTestProjectScannerRun()  // Old SE rules do not run on test code
+        public void GetEnabledAnalyzers_ReturnsEmptyList_OnTestProjectScannerRun()  // Old SE rules do not run on test code under scanner run
         {
             var sut = new SymbolicExecutionAnalyzerFactory();
             var diagnostics = symbolicExecutionRuleIds.ToImmutableDictionary(v => v, _ => ReportDiagnostic.Warn);


### PR DESCRIPTION
It does not change the behavior for now, because all rules run only on the main code. 

But having at least one rule running on Test&Main or Test causes `SymbolicExecutionRunner` to contain at least one diagnostic descriptor that should execute so all rules are executed, causing FPs in terms of their scope.