### PR TITLE
Simplify DiagnosticVerifier

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/CBDE/CbdeHandlerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CBDE/CbdeHandlerTest.cs
@@ -131,7 +131,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                                              .AddReferences(additionalReferences)
                                              .AddDocument(path)
                                              .GetCompilation();
-            DiagnosticVerifier.GetDiagnostics(compilation, diagnosticAnalyzer, CompilationErrorBehavior.FailTest, verifyNoExceptionIsThrown: false);
+            DiagnosticVerifier.GetDiagnosticsIgnoreExceptions(compilation, diagnosticAnalyzer);
         }
 
         private static string CreateMockPath(string mockName)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/DisablingRequestValidationTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/DisablingRequestValidationTest.cs
@@ -103,7 +103,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
             try
             {
-                allDiagnostics = DiagnosticVerifier.GetDiagnostics(
+                allDiagnostics = DiagnosticVerifier.GetDiagnosticsNoExceptions(
                     compilation,
                     new CS.DisablingRequestValidation(AnalyzerConfiguration.AlwaysEnabled),
                     CompilationErrorBehavior.Default,

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/CodeFixVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/CodeFixVerifier.cs
@@ -171,7 +171,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
                 Compilation = project.GetCompilationAsync().Result;
                 Document = document;
-                Diagnostics = DiagnosticVerifier.GetDiagnostics(Compilation, diagnosticAnalyzer, CompilationErrorBehavior.Ignore).ToImmutableArray();
+                Diagnostics = DiagnosticVerifier.GetDiagnosticsNoExceptions(Compilation, diagnosticAnalyzer, CompilationErrorBehavior.Ignore).ToImmutableArray();
                 ActualCode = document.GetSyntaxRootAsync().Result.GetText().ToString();
             }
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
@@ -86,18 +86,16 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             }
         }
 
-        public static void VerifyNoIssueReported(
-                Compilation compilation,
-                DiagnosticAnalyzer diagnosticAnalyzer,
-                CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
-                string sonarProjectConfigPath = null) =>
+        public static void VerifyNoIssueReported(Compilation compilation,
+                                                 DiagnosticAnalyzer diagnosticAnalyzer,
+                                                 CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
+                                                 string sonarProjectConfigPath = null) =>
             GetDiagnosticsNoExceptions(compilation, diagnosticAnalyzer, checkMode, sonarProjectConfigPath: sonarProjectConfigPath).Should().BeEmpty();
 
-        public static IEnumerable<Diagnostic> GetDiagnosticsNoExceptions(
-            Compilation compilation,
-            DiagnosticAnalyzer diagnosticAnalyzer,
-            CompilationErrorBehavior checkMode,
-            string sonarProjectConfigPath = null)
+        public static IEnumerable<Diagnostic> GetDiagnosticsNoExceptions(Compilation compilation,
+                                                                         DiagnosticAnalyzer diagnosticAnalyzer,
+                                                                         CompilationErrorBehavior checkMode,
+                                                                         string sonarProjectConfigPath = null)
         {
             var ret = GetAnalyzerDiagnostics(compilation, new[] { diagnosticAnalyzer }, checkMode, sonarProjectConfigPath);
             VerifyNoExceptionThrown(ret);
@@ -107,11 +105,10 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public static IEnumerable<Diagnostic> GetDiagnosticsIgnoreExceptions(Compilation compilation, DiagnosticAnalyzer diagnosticAnalyzer) =>
             GetAnalyzerDiagnostics(compilation, new[] { diagnosticAnalyzer }, CompilationErrorBehavior.FailTest);
 
-        public static ImmutableArray<Diagnostic> GetAnalyzerDiagnostics(
-            Compilation compilation,
-            IEnumerable<DiagnosticAnalyzer> diagnosticAnalyzers,
-            CompilationErrorBehavior checkMode,
-            string sonarProjectConfigPath = null)
+        public static ImmutableArray<Diagnostic> GetAnalyzerDiagnostics(Compilation compilation,
+                                                                        IEnumerable<DiagnosticAnalyzer> diagnosticAnalyzers,
+                                                                        CompilationErrorBehavior checkMode,
+                                                                        string sonarProjectConfigPath = null)
         {
             var supportedDiagnostics = diagnosticAnalyzers
                     .SelectMany(analyzer => analyzer.SupportedDiagnostics)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
@@ -22,10 +22,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.CodeAnalysis;
@@ -88,6 +86,13 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             }
         }
 
+        public static void VerifyNoIssueReported(
+                Compilation compilation,
+                DiagnosticAnalyzer diagnosticAnalyzer,
+                CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
+                string sonarProjectConfigPath = null) =>
+            GetDiagnosticsNoExceptions(compilation, diagnosticAnalyzer, checkMode, sonarProjectConfigPath: sonarProjectConfigPath).Should().BeEmpty();
+
         public static IEnumerable<Diagnostic> GetDiagnosticsNoExceptions(
             Compilation compilation,
             DiagnosticAnalyzer diagnosticAnalyzer,
@@ -101,13 +106,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
         public static IEnumerable<Diagnostic> GetDiagnosticsIgnoreExceptions(Compilation compilation, DiagnosticAnalyzer diagnosticAnalyzer) =>
             GetAnalyzerDiagnostics(compilation, new[] { diagnosticAnalyzer }, CompilationErrorBehavior.FailTest);
-
-        public static void VerifyNoIssueReported(
-            Compilation compilation,
-            DiagnosticAnalyzer diagnosticAnalyzer,
-            CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
-            string sonarProjectConfigPath = null) =>
-            GetDiagnosticsNoExceptions(compilation, diagnosticAnalyzer, checkMode, sonarProjectConfigPath: sonarProjectConfigPath).Should().BeEmpty();
 
         public static ImmutableArray<Diagnostic> GetAnalyzerDiagnostics(
             Compilation compilation,

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
@@ -71,6 +71,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             {
                 var diagnostics = GetDiagnostics(compilation, diagnosticAnalyzers, checkMode, sonarProjectConfigPath: sonarProjectConfigPath);
                 var expectedIssues = sources.Select(x => x.ToExpectedIssueLocations()).ToArray();
+                VerifyNoExceptionThrown(diagnostics);
                 CompareActualToExpected(compilation.LanguageVersionString(), diagnostics, expectedIssues, false);
 
                 // When there are no diagnostics reported from the test (for example the FileLines analyzer
@@ -87,22 +88,31 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             }
         }
 
-        public static IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation,
-            DiagnosticAnalyzer diagnosticAnalyzer, CompilationErrorBehavior checkMode,
-            bool verifyNoExceptionIsThrown = true,
+        public static IEnumerable<Diagnostic> GetDiagnosticsNoExceptions(
+            Compilation compilation,
+            DiagnosticAnalyzer diagnosticAnalyzer,
+            CompilationErrorBehavior checkMode,
+            string sonarProjectConfigPath = null)
+        {
+            var ret = GetDiagnostics(compilation, new[] { diagnosticAnalyzer }, checkMode, sonarProjectConfigPath);
+            VerifyNoExceptionThrown(ret);
+            return ret;
+        }
+
+        public static IEnumerable<Diagnostic> GetDiagnosticsIgnoreExceptions(Compilation compilation, DiagnosticAnalyzer diagnosticAnalyzer) =>
+            GetDiagnostics(compilation, new[] { diagnosticAnalyzer }, CompilationErrorBehavior.FailTest);
+
+        public static void VerifyNoIssueReported(
+            Compilation compilation,
+            DiagnosticAnalyzer diagnosticAnalyzer,
+            CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
             string sonarProjectConfigPath = null) =>
-            GetDiagnostics(compilation, new[] { diagnosticAnalyzer }, checkMode, verifyNoExceptionIsThrown, sonarProjectConfigPath);
+            GetDiagnosticsNoExceptions(compilation, diagnosticAnalyzer, checkMode, sonarProjectConfigPath: sonarProjectConfigPath).Should().BeEmpty();
 
-        public static void VerifyNoIssueReported(Compilation compilation,
-                                                 DiagnosticAnalyzer diagnosticAnalyzer,
-                                                 CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
-                                                 string sonarProjectConfigPath = null) =>
-            GetDiagnostics(compilation, diagnosticAnalyzer, checkMode, sonarProjectConfigPath: sonarProjectConfigPath).Should().BeEmpty();
-
-        public static ImmutableArray<Diagnostic> GetAllDiagnostics(Compilation compilation,
-            IEnumerable<DiagnosticAnalyzer> diagnosticAnalyzers, CompilationErrorBehavior checkMode,
-            bool verifyNoException = true,
-            CancellationToken? cancellationToken = null,
+        public static ImmutableArray<Diagnostic> GetAllDiagnostics(
+            Compilation compilation,
+            IEnumerable<DiagnosticAnalyzer> diagnosticAnalyzers,
+            CompilationErrorBehavior checkMode,
             string sonarProjectConfigPath = null)
         {
             var supportedDiagnostics = diagnosticAnalyzers
@@ -111,46 +121,32 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                     .Concat(new[] { new KeyValuePair<string, ReportDiagnostic>(AnalyzerFailedDiagnosticId, ReportDiagnostic.Error) });
 
             var compilationOptions = compilation.Options.WithSpecificDiagnosticOptions(supportedDiagnostics);
-            var actualToken = cancellationToken ?? CancellationToken.None;
             var analyzerOptions = string.IsNullOrWhiteSpace(sonarProjectConfigPath) ? null : TestHelper.CreateOptions(sonarProjectConfigPath);
-
             var diagnostics = compilation
                 .WithOptions(compilationOptions)
                 .WithAnalyzers(diagnosticAnalyzers.ToImmutableArray(), analyzerOptions)
-                .GetAllDiagnosticsAsync(actualToken)
+                .GetAllDiagnosticsAsync(default)
                 .Result;
 
-            if (!actualToken.IsCancellationRequested)
+            if (checkMode == CompilationErrorBehavior.FailTest)
             {
-                if (verifyNoException)
-                {
-                    VerifyNoExceptionThrown(diagnostics);
-                }
-                if (checkMode == CompilationErrorBehavior.FailTest)
-                {
-                    VerifyBuildErrors(diagnostics, compilation);
-                }
+                VerifyBuildErrors(diagnostics, compilation);
             }
-
             return diagnostics;
         }
 
-        internal static IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation,
-            DiagnosticAnalyzer[] diagnosticAnalyzers, CompilationErrorBehavior checkMode,
-            bool verifyNoExceptionIsThrown = true,
+        private static IEnumerable<Diagnostic> GetDiagnostics(
+            Compilation compilation,
+            DiagnosticAnalyzer[] diagnosticAnalyzers,
+            CompilationErrorBehavior checkMode,
             string sonarProjectConfigPath = null)
         {
-            var ids = diagnosticAnalyzers
-                .SelectMany(analyzer => analyzer.SupportedDiagnostics)
-                .Select(diagnostic => diagnostic.Id)
-                .Distinct()
-                .ToHashSet();
-
-            return GetAllDiagnostics(compilation, diagnosticAnalyzers, checkMode, verifyNoExceptionIsThrown, sonarProjectConfigPath: sonarProjectConfigPath)
-                .Where(d => ids.Contains(d.Id));
+            var ids = diagnosticAnalyzers.SelectMany(x => x.SupportedDiagnostics).Select(x => x.Id).ToHashSet();
+            return GetAllDiagnostics(compilation, diagnosticAnalyzers, checkMode, sonarProjectConfigPath: sonarProjectConfigPath)
+                .Where(x => ids.Contains(x.Id));
         }
 
-        internal static void CompareActualToExpected(string languageVersion, IEnumerable<Diagnostic> diagnostics, FileIssueLocations[] expectedIssuesPerFile, bool compareIdToMessage)
+        public static void CompareActualToExpected(string languageVersion, IEnumerable<Diagnostic> diagnostics, FileIssueLocations[] expectedIssuesPerFile, bool compareIdToMessage)
         {
             DumpActualDiagnostics(languageVersion, diagnostics);
 
@@ -227,7 +223,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 && (d.Id.StartsWith("CS") || d.Id.StartsWith("BC"))
                 && !BuildErrorsToIgnore.Contains(d.Id));
 
-        private static void VerifyNoExceptionThrown(IEnumerable<Diagnostic> diagnostics) =>
+        public static void VerifyNoExceptionThrown(IEnumerable<Diagnostic> diagnostics) =>
             diagnostics.Should().NotContain(d => d.Id == AnalyzerFailedDiagnosticId);
 
         private static string VerifyPrimaryIssue(string languageVersion, IList<IIssueLocation> expectedIssues, Func<IIssueLocation, bool> issueFilter,
@@ -305,7 +301,7 @@ Actual  : '{message}'");
             }
 
             public FileIssueLocations ToExpectedIssueLocations() =>
-                new (fileName, IssueLocationCollector.GetExpectedIssueLocations(content.Lines));
+                new(fileName, IssueLocationCollector.GetExpectedIssueLocations(content.Lines));
         }
 
         internal class FileIssueLocations

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
@@ -54,7 +54,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .AddDocument(path)
                 .GetCompilation();
 
-            DiagnosticVerifier.GetAllDiagnostics(compilation, diagnosticAnalyzers, checkMode);
+            var diagnostics = DiagnosticVerifier.GetAllDiagnostics(compilation, diagnosticAnalyzers, checkMode);
+            DiagnosticVerifier.VerifyNoExceptionThrown(diagnostics);
         }
 
         /// <summary>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .AddDocument(path)
                 .GetCompilation();
 
-            var diagnostics = DiagnosticVerifier.GetAllDiagnostics(compilation, diagnosticAnalyzers, checkMode);
+            var diagnostics = DiagnosticVerifier.GetAnalyzerDiagnostics(compilation, diagnosticAnalyzers, checkMode);
             DiagnosticVerifier.VerifyNoExceptionThrown(diagnostics);
         }
 


### PR DESCRIPTION
This is a prerequisite for #5159

`DiagnosticVerifier.GetAllDiagnostics` does also some verification that should not be its responsibility. Making the API hard to user (and long to write)
