### PR TITLE
Fix failing UTs

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CheckFileLicenseTest.cs
@@ -176,7 +176,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestMethod]
         public void CheckFileLicense_WhenProvidingAnInvalidRegex_ShouldThrowException_CS()
         {
-            var compilation = SolutionBuilder.CreateSolutionFromPaths(new[] { @"TestCases\CheckFileLicense_NoLicenseStartWithUsing.cs" }).Compile(ParseOptionsHelper.OnlyCSharp7.ToArray()).Single();
+            var compilation = SolutionBuilder.CreateSolutionFromPaths(new[] { @"TestCases\CheckFileLicense_NoLicenseStartWithUsing.cs" }).Compile(ParseOptionsHelper.CSharpLatest.ToArray()).Single();
             var diagnostics = DiagnosticVerifier.GetDiagnosticsIgnoreExceptions(compilation, new CS.CheckFileLicense { HeaderFormat = FailingSingleLineRegexHeader, IsRegularExpression = true });
             diagnostics.Should().ContainSingle(x => x.Id == "AD0001").Which.GetMessage().Should()
                 .StartWith("Analyzer 'SonarAnalyzer.Rules.CSharp.CheckFileLicense' threw an exception of type 'System.InvalidOperationException' with message 'Invalid regular expression:");

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldNotHaveTooManyLinesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldNotHaveTooManyLinesTest.cs
@@ -101,7 +101,7 @@ public class Foo
         public void MethodsShouldNotHaveTooManyLines_InvalidMaxThreshold_CS(int max)
         {
             var compilation = SolutionBuilder.CreateSolutionFromPaths(new[] { @"TestCases\MethodsShouldNotHaveTooManyLines_CustomValues.cs" })
-                .Compile(ParseOptionsHelper.OnlyCSharp7.ToArray()).Single();
+                .Compile(ParseOptionsHelper.CSharpLatest.ToArray()).Single();
             var diagnostics = DiagnosticVerifier.GetDiagnosticsIgnoreExceptions(compilation, new CS.MethodsShouldNotHaveTooManyLines { Max = max });
             diagnostics.Should().OnlyContain(x => x.Id == "AD0001" && x.GetMessage(null).Contains("Invalid rule parameter: maximum number of lines = ")).And.HaveCount(12);
         }


### PR DESCRIPTION
`OnlyCSharp7` actually contains `CSharp7`, `CSharp7_1`, `CSharp7_2` and `CSharp7_3` on `master` build.