### PR TITLE
Add concurrency to VerifierBuilder

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CommentedOutCodeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CommentedOutCodeTest.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Rules.CSharp;
@@ -39,6 +41,6 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestMethod]
         public void CommentedOutCode_NoDocumentation() =>
             OldVerifier.VerifyNonConcurrentAnalyzer(@"TestCases\CommentedOutCode.cs", new CommentedOutCode(),
-                new[] { new CSharpParseOptions(documentationMode: Microsoft.CodeAnalysis.DocumentationMode.None) });
+                ImmutableArray.Create<ParseOptions>(new CSharpParseOptions(documentationMode: DocumentationMode.None)));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/UsingCommandLineArgumentsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/UsingCommandLineArgumentsTest.cs
@@ -42,27 +42,21 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestMethod]
         public void UsingCommandLineArguments_CS_Partial()
         {
-            var compilation = SolutionBuilder.Create()
-                .AddProject(AnalyzerLanguage.CSharp)
-                .AddSnippet(@"
+            const string code1 = @"
 partial class Program1
 {
     static partial void Main(params string[] args) // Noncompliant
     {
         System.Console.WriteLine(args);
     }
-}")
-                .AddSnippet(@"
+}";
+            const string code2 = @"
 partial class Program1
 {
     static partial void Main(params string[] args); // Compliant, we raise only on methods with implementation
-}")
-                .GetCompilation();
-
-            DiagnosticVerifier.Verify(
-                compilation,
-                new CS.UsingCommandLineArguments(AnalyzerConfiguration.AlwaysEnabled),
-                CompilationErrorBehavior.Default);
+}";
+            var compilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.CSharp).AddSnippets(code1, code2).GetCompilation();
+            DiagnosticVerifier.Verify(compilation, new CS.UsingCommandLineArguments(AnalyzerConfiguration.AlwaysEnabled), CompilationErrorBehavior.Default);
         }
 
         [TestMethod]
@@ -73,27 +67,19 @@ partial class Program1
         [TestMethod]
         public void UsingCommandLineArguments_VB_Partial()
         {
-            var compilation = SolutionBuilder.Create()
-                .AddProject(AnalyzerLanguage.VisualBasic)
-                .AddSnippet(@"
+            const string code1 = @"
 Partial Class Program1
     Private Shared Sub Main(ParamArray args As String()) ' Noncompliant
         System.Console.WriteLine(args)
     End Sub
-End Class
-")
-                .AddSnippet(@"
+End Class";
+            const string code2 = @"
 Partial Class Program1
     Private Shared Partial Sub Main(ParamArray args As String()) ' Compliant, we raise only on methods with implementation
     End Sub
-End Class
-")
-                .GetCompilation();
-
-            DiagnosticVerifier.Verify(
-                compilation,
-                new VB.UsingCommandLineArguments(AnalyzerConfiguration.AlwaysEnabled),
-                CompilationErrorBehavior.Default);
+End Class";
+            var compilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.VisualBasic).AddSnippets(code1, code2).GetCompilation();
+            DiagnosticVerifier.Verify(compilation, new VB.UsingCommandLineArguments(AnalyzerConfiguration.AlwaysEnabled), CompilationErrorBehavior.Default);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithAssemblyVersionAttributeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithAssemblyVersionAttributeTest.cs
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             Action action = () => OldVerifier.VerifyNonConcurrentAnalyzer(
                 @"TestCases\MarkAssemblyWithAssemblyVersionAttributeNoncompliant.vb",
-                new CS.MarkAssemblyWithAssemblyVersionAttribute(),
+                new VB.MarkAssemblyWithAssemblyVersionAttribute(),
                 NuGetMetadataReference.MicrosoftBuildNoTargets());
 
             // False positive. No assembly gets generated when Microsoft.Build.NoTargets is referenced.

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/NotAssignedPrivateMemberTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/NotAssignedPrivateMemberTest.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Rules.CSharp;
@@ -52,6 +54,6 @@ unsafe struct FixedArray
         a[0] = 42;
         b[0] = 42;
     }
-}", new NotAssignedPrivateMember(), new[] { new CSharpParseOptions(LanguageVersion.CSharp7_3) });   // ToDo: Use WithLanguageVersion instead
+}", new NotAssignedPrivateMember(), ImmutableArray.Create<ParseOptions>(new CSharpParseOptions(LanguageVersion.CSharp7_3)));   // ToDo: Use WithLanguageVersion instead
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RedundantCastTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RedundantCastTest.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Rules.CSharp;
@@ -73,6 +75,6 @@ public static class MyClass
 
      public static T RunFunc<T>(Func<T> func, T returnValue = default) => returnValue;
 }",
-                new RedundantCast(), new[] { new CSharpParseOptions(LanguageVersion.CSharp7_1) });  //ToDo: Use WithLanguageVersion instead
+                new RedundantCast(), ImmutableArray.Create<ParseOptions>(new CSharpParseOptions(LanguageVersion.CSharp7_1)));  //ToDo: Use WithLanguageVersion instead
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestFramework/Verifier.BasePath.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestFramework/Verifier.BasePath.cs
@@ -1,0 +1,4 @@
+﻿internal class VerifierBasePath
+{
+    private int dummy = 42; // Noncompliant {{Dummy message}}
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/OldVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/OldVerifier.cs
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                         IEnumerable<MetadataReference> additionalReferences = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddSnippet(snippet)
                 .WithConcurrentAnalysis(false)
                 .WithErrorBehavior(checkMode)
@@ -99,7 +99,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                 string sonarProjectConfigPath = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddSnippet(snippet)
                 .WithConcurrentAnalysis(false)
                 .WithOptions(options.IsDefault ? ImmutableArray<ParseOptions>.Empty : options)
@@ -119,7 +119,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                      IEnumerable<MetadataReference> additionalReferences = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddSnippet(snippet)
                 .WithConcurrentAnalysis(false)
                 .WithErrorBehavior(checkMode)
@@ -135,7 +135,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                             DiagnosticDescriptor[] onlyDiagnostics = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithOptions(ParseOptionsHelper.FromCSharp9)
                 .WithTopLevelStatements()
@@ -146,7 +146,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public static void VerifyAnalyzerFromCSharp10Console(string path, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .WithTopLevelStatements()
@@ -159,7 +159,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public static void VerifyAnalyzerFromCSharp9Console(string[] paths, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(paths))
                 .WithOptions(ParseOptionsHelper.FromCSharp9)
                 .WithTopLevelStatements()
@@ -169,7 +169,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public static void VerifyAnalyzerFromCSharp10Console(string[] paths, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(paths))
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .WithTopLevelStatements()
@@ -184,7 +184,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                             IEnumerable<MetadataReference> additionalReferences = null,
                                                             DiagnosticDescriptor[] onlyDiagnostics = null) =>
             diagnosticAnalyzers.Aggregate(new VerifierBuilder(), (builder, analyzer) => builder.AddAnalyzer(() => analyzer))
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithOptions(ParseOptionsHelper.FromCSharp9)
                 .WithTopLevelStatements()
@@ -198,7 +198,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public static void VerifyAnalyzerFromCSharp9LibraryInTest(string path, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddTestReference()
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
@@ -212,7 +212,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public static void VerifyAnalyzerFromCSharp10LibraryInTest(string path, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddTestReference()
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
@@ -226,7 +226,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public static void VerifyAnalyzerFromCSharp9ConsoleInTest(string path, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddTestReference()
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithTopLevelStatements()
@@ -243,7 +243,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                             DiagnosticDescriptor[] onlyDiagnostics = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.FromCSharp9)
@@ -261,7 +261,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                             DiagnosticDescriptor[] onlyDiagnostics = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.FromCSharp9)
@@ -276,7 +276,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                              DiagnosticDescriptor[] onlyDiagnostics = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
@@ -289,7 +289,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                              IEnumerable<MetadataReference> additionalReferences = null,
                                                              DiagnosticDescriptor[] onlyDiagnostics = null) =>
             diagnosticAnalyzers.Aggregate(new VerifierBuilder(), (builder, analyzer) => builder.AddAnalyzer(() => analyzer))
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
@@ -304,7 +304,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                              DiagnosticDescriptor[] onlyDiagnostics = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
@@ -316,7 +316,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public static void VerifyAnalyzerCSharpPreviewLibrary(string path, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.CSharpPreview)
@@ -329,7 +329,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public static void VerifyAnalyzerFromCSharp9Library(string[] paths, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(paths))
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.FromCSharp9)
@@ -339,7 +339,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public static void VerifyAnalyzerFromCSharp10Library(string[] paths, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(paths))
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
@@ -351,7 +351,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                        IEnumerable<MetadataReference> additionalReferences) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
                 .Verify();
@@ -366,7 +366,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                        DiagnosticDescriptor[] onlyDiagnostics = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
                 .WithOptions(options.IsDefault ? ImmutableArray<ParseOptions>.Empty : options)
@@ -381,7 +381,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                        IEnumerable<MetadataReference> additionalReferences) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(paths))
                 .WithConcurrentAnalysis(false)
                 .Verify();
@@ -393,7 +393,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                                        IEnumerable<MetadataReference> additionalReferences = null) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(paths))
                 .WithConcurrentAnalysis(false)
                 .WithOptions(options.IsDefault ? ImmutableArray<ParseOptions>.Empty : options)
@@ -405,7 +405,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                                           IEnumerable<MetadataReference> additionalReferences) =>
             new VerifierBuilder()
                 .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences)
+                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(paths))
                 .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/ProjectBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/ProjectBuilder.cs
@@ -103,15 +103,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 : AddDocument(Project, fileInfo.Name, File.ReadAllText(fileInfo.FullName, Encoding.UTF8), removeAnalysisComments);
         }
 
-        public ProjectBuilder AddSnippets(params string[] snippets)
-        {
-            var ret = this;
-            foreach (var snippet in snippets)
-            {
-                ret = ret.AddSnippet(snippet);
-            }
-            return ret;
-        }
+        public ProjectBuilder AddSnippets(params string[] snippets) =>
+            snippets.Aggregate(this, (current, snippet) => current.AddSnippet(snippet));
 
         public ProjectBuilder AddSnippet(string code, string fileName = null, bool removeAnalysisComments = false)
         {
@@ -126,7 +119,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         }
 
         public static ProjectBuilder FromProject(Project project) =>
-            new ProjectBuilder(project);
+            new(project);
 
         private static ProjectBuilder AddDocument(Project project, string fileName, string fileContent, bool removeAnalysisComments)
         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/ProjectBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/ProjectBuilder.cs
@@ -103,6 +103,16 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 : AddDocument(Project, fileInfo.Name, File.ReadAllText(fileInfo.FullName, Encoding.UTF8), removeAnalysisComments);
         }
 
+        public ProjectBuilder AddSnippets(params string[] snippets)
+        {
+            var ret = this;
+            foreach (var snippet in snippets)
+            {
+                ret = ret.AddSnippet(snippet);
+            }
+            return ret;
+        }
+
         public ProjectBuilder AddSnippet(string code, string fileName = null, bool removeAnalysisComments = false)
         {
             if (code == null)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/ProjectBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/ProjectBuilder.cs
@@ -70,11 +70,16 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
         public ProjectBuilder AddReferences(IEnumerable<MetadataReference> references)
         {
-            var existingReferences = Project.MetadataReferences;
-            var deduplicated = references == null
-                ? Enumerable.Empty<MetadataReference>()
-                : references.Where(mr => !existingReferences.Contains(mr)).Distinct().ToHashSet();
-            return FromProject(Project.AddMetadataReferences(deduplicated));
+            if (references == null || !references.Any())
+            {
+                return this;
+            }
+            if (references.Any(x => x.Display.Contains("\\netstandard")))
+            {
+                references = references.Concat(NetStandardMetadataReference.Netstandard);
+            }
+            var existingReferences = Project.MetadataReferences.ToHashSet();
+            return FromProject(Project.AddMetadataReferences(references.Distinct().Where(x => !existingReferences.Contains(x))));
         }
 
         public ProjectBuilder AddProjectReference(Func<SolutionBuilder, ProjectId> getProjectId) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SolutionBuilder.cs
@@ -78,12 +78,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .AddDocuments(paths)
                 .AddReferences(additionalReferences);
 
-            if (additionalReferences != null
-                && additionalReferences.Any(r => r.Display.Contains("\\netstandard")))
-            {
-                project = project.AddReferences(NetStandardMetadataReference.Netstandard);
-            }
-
             return project.GetSolution();
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/IssueLocationCollectorTest.GetPreciseIssueLocations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/IssueLocationCollectorTest.GetPreciseIssueLocations.cs
@@ -27,6 +27,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
 {
     public partial class IssueLocationCollectorTest
     {
+        [TestMethod]
         public void GetPreciseIssueLocations_NoMessage_NoIds()
         {
             var line = GetLine(3, @"if (a > b)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/IssueLocationCollectorTest.GetPreciseIssueLocations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/IssueLocationCollectorTest.GetPreciseIssueLocations.cs
@@ -27,7 +27,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
 {
     public partial class IssueLocationCollectorTest
     {
-        [TestMethod]
         public void GetPreciseIssueLocations_NoMessage_NoIds()
         {
             var line = GetLine(3, @"if (a > b)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierBuilderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierBuilderTest.cs
@@ -75,6 +75,46 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
         }
 
         [TestMethod]
+        public void AddSnippet_Appends_IsImmutable()
+        {
+            var one = Empty.AddSnippet("First");
+            var two = one.AddSnippet("Second");
+            Empty.Snippets.Should().BeEmpty();
+            one.Snippets.Should().BeEquivalentTo("First");
+            two.Snippets.Should().BeEquivalentTo("First", "Second");
+        }
+
+        [TestMethod]
+        public void AddTestReference_Concatenates_IsImmutable()
+        {
+            var one = Empty.AddReferences(MetadataReferenceFacade.MsCorLib);
+            var two = one.AddTestReference();
+            Empty.References.Should().BeEmpty();
+            one.References.Should().BeEquivalentTo(MetadataReferenceFacade.MsCorLib).And.HaveCount(1);
+            two.References.Should().BeEquivalentTo(MetadataReferenceFacade.MsCorLib.Concat(NuGetMetadataReference.MSTestTestFrameworkV1));
+        }
+
+        [TestMethod]
+        public void WithBasePath()
+        {
+            var one = Empty.WithBasePath("Hotspots");
+            var two = Empty.WithBasePath("SymbolicExecution");
+            Empty.BasePath.Should().BeNull();
+            one.BasePath.Should().Be("Hotspots");
+            two.BasePath.Should().Be("SymbolicExecution");
+        }
+
+        [TestMethod]
+        public void WithConcurrentAnalysis_Overrides_IsImmutable()
+        {
+            var one = Empty.WithConcurrentAnalysis(false);
+            var two = Empty.WithConcurrentAnalysis(true);
+            Empty.ConcurrentAnalysis.Should().BeTrue();
+            one.ConcurrentAnalysis.Should().BeFalse();
+            two.ConcurrentAnalysis.Should().BeTrue();
+        }
+
+        [TestMethod]
         public void WithErrorBehavior_Overrides_IsImmutable()
         {
             var one = Empty.WithErrorBehavior(CompilationErrorBehavior.FailTest);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierBuilderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierBuilderTest.cs
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
         }
 
         [TestMethod]
-        public void WithBasePath()
+        public void WithBasePath_Overrides_IsImmutable()
         {
             var one = Empty.WithBasePath("Hotspots");
             var two = Empty.WithBasePath("SymbolicExecution");

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
@@ -77,11 +77,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             var project = SolutionBuilder.Create()
                 .AddProject(language, true, builder.OutputKind)
                 .AddDocuments(pathsWithConcurrencyTests)
+                .AddSnippets(builder.Snippets.ToArray())
                 .AddReferences(builder.References);
-            foreach (var snippet in builder.Snippets)
-            {
-                project = project.AddSnippet(snippet);
-            }
             foreach (var compilation in project.GetSolution().Compile(builder.ParseOptions.ToArray()))
             {
                 DiagnosticVerifier.Verify(compilation, analyzers, builder.ErrorBehavior, builder.SonarProjectConfigPath, builder.OnlyDiagnostics.Select(x => x.Id).ToArray());

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
@@ -57,9 +57,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 throw new ArgumentException($"All {nameof(builder.Analyzers)} must declare the same language in their DiagnosticAnalyzerAttribute.");
             }
             language = AnalyzerLanguage.FromName(allLanguages.Single());
-            if (!builder.Paths.Any())
+            if (!builder.Paths.Any() && !builder.Snippets.Any())
             {
-                throw new ArgumentException($"{nameof(builder.Paths)} cannot be empty. Add at least one path using {nameof(builder)}.{nameof(builder.AddPaths)}().");
+                throw new ArgumentException($"{nameof(builder.Paths)} cannot be empty. Add at least one file using {nameof(builder)}.{nameof(builder.AddPaths)}() or {nameof(builder.AddSnippet)}().");
             }
             if (builder.Paths.FirstOrDefault(x => !Path.GetExtension(x).Equals(language.FileExtension, StringComparison.OrdinalIgnoreCase)) is { } unexpectedPath)
             {
@@ -69,11 +69,20 @@ namespace SonarAnalyzer.UnitTest.TestFramework
 
         public void Verify()    // This should never has any arguments
         {
-            using var scope = new EnvironmentVariableScope { EnableConcurrentAnalysis = true };         // ToDo: Implement properly
-            var paths = builder.Paths.Select(x => Path.GetFullPath(Path.Combine("TestCases", x)));
-            var pathsWithConcurrencyTests = paths.Count() == 1 ? CreateConcurrencyTest(paths) : paths;  // ToDo: Redesign when implementing concurrency
-            var solution = SolutionBuilder.CreateSolutionFromPaths(pathsWithConcurrencyTests, builder.OutputKind, builder.References);
-            foreach (var compilation in solution.Compile(builder.ParseOptions.ToArray()))
+            const string TestCases = "TestCases";
+            using var scope = new EnvironmentVariableScope { EnableConcurrentAnalysis = builder.ConcurrentAnalysis};
+            var basePath = Path.GetFullPath(builder.BasePath == null ? TestCases : Path.Combine(TestCases, builder.BasePath));
+            var paths = builder.Paths.Select(x => Path.Combine(basePath, x));
+            var pathsWithConcurrencyTests = paths.Count() == 1 && builder.ConcurrentAnalysis ? CreateConcurrencyTest(paths) : paths;  // ToDo: Redesign when implementing concurrency
+            var project = SolutionBuilder.Create()
+                .AddProject(language, true, builder.OutputKind)
+                .AddDocuments(pathsWithConcurrencyTests)
+                .AddReferences(builder.References);
+            foreach (var snippet in builder.Snippets)
+            {
+                project = project.AddSnippet(snippet);
+            }
+            foreach (var compilation in project.GetSolution().Compile(builder.ParseOptions.ToArray()))
             {
                 DiagnosticVerifier.Verify(compilation, analyzers, builder.ErrorBehavior, builder.SonarProjectConfigPath, builder.OnlyDiagnostics.Select(x => x.Id).ToArray());
             }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
@@ -89,7 +89,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         /// <summary>
         /// Path infix relative to TestCases directory.
         /// </summary>
-        /// <remarks>If we ever need to change the root outside TestCases directory, add WithRootPath(..)</remarks>
+        /// <remarks>If we ever need to change the root outside the .\TestCases directory, add WithRootPath(..) while WithBasePath(..) would still append another part after the root path.</remarks>
         public VerifierBuilder WithBasePath(string basePath) =>
             new(this) { BasePath = basePath };
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
@@ -87,7 +87,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             AddReferences(NuGetMetadataReference.MSTestTestFrameworkV1);
 
         /// <summary>
-        /// Path infix relative to TestCases directory
+        /// Path infix relative to TestCases directory.
         /// </summary>
         /// <remarks>If we ever need to change the root outside TestCases directory, add WithRootPath(..)</remarks>
         public VerifierBuilder WithBasePath(string basePath) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/ConstantValueFinderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/ConstantValueFinderTest.cs
@@ -48,10 +48,7 @@ public partial class Sample
         return Field;
     }
 }";
-            var compilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.CSharp, createExtraEmptyFile: false)
-                .AddSnippet(code1)
-                .AddSnippet(code2)
-                .GetCompilation();
+            var compilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.CSharp, createExtraEmptyFile: false).AddSnippets(code1, code2).GetCompilation();
             var tree = compilation.SyntaxTrees.Single(x => x.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Any());
             var returnExpression = tree.GetRoot().DescendantNodes().OfType<ReturnStatementSyntax>().Single().Expression;
             var finder = new CSharpConstantValueFinder(compilation.GetSemanticModel(tree));
@@ -76,12 +73,8 @@ public class Bar
         return Field;
     }
 }";
-            var firstCompilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.CSharp, createExtraEmptyFile: false)
-                .AddSnippet(firstSnippet)
-                .GetCompilation();
-            var secondCompilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.CSharp, createExtraEmptyFile: false)
-                .AddSnippet(secondSnippet)
-                .GetCompilation();
+            var firstCompilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.CSharp, createExtraEmptyFile: false).AddSnippet(firstSnippet).GetCompilation();
+            var secondCompilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.CSharp, createExtraEmptyFile: false).AddSnippet(secondSnippet).GetCompilation();
             var secondCompilationReturnExpression = secondCompilation.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<ReturnStatementSyntax>().Single().Expression;
             var firstCompilationFinder = new CSharpConstantValueFinder(firstCompilation.GetSemanticModel(firstCompilation.SyntaxTrees.Single()));
             firstCompilationFinder.FindConstant(secondCompilationReturnExpression).Should().BeNull();


### PR DESCRIPTION
Contributes to #5186

Add more options:
* `.AddSnippet`
* `.AddTestReference`
* `.WithBasePath`
* `.WithConcurrentAnalysis`

This is a draft, rebase will be needed after #5231 is merged. The squash commits doesn't need a review for the same reason.