### PR TITLE
S3442 suggests `private protected` instead of `protected` for internal ctors

### DIFF
--- a/analyzers/its/expected/akka.net/Akka--netstandard2.0-S3442.json
+++ b/analyzers/its/expected/akka.net/Akka--netstandard2.0-S3442.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S3442",
-"message":  "Change the visibility of this constructor to 'protected'.",
+"message":  "Change the visibility of this constructor to 'private protected'.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Pattern\BackoffSupervisorBase.cs",
 "region":  {

--- a/analyzers/rspec/cs/S3442_c#.html
+++ b/analyzers/rspec/cs/S3442_c#.html
@@ -1,11 +1,11 @@
 <p>Since <code>abstract</code> classes can’t be instantiated, there’s no point in their having <code>public</code> or <code>internal</code>
 constructors. If there is basic initialization logic that should run when an extending class instance is created, you can by all means put it in a
-constructor, but make that constructor <code>private</code> or <code>protected</code>.</p>
+constructor, but make that constructor <code>private</code>, <code>private protected</code> or <code>protected</code>.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
 abstract class Base
 {
-    public Base() // Noncompliant, should be private or protected
+    public Base() // Noncompliant, should be private, private protected or protected
     {
       //...
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/RspecStrings.resx
+++ b/analyzers/src/SonarAnalyzer.CSharp/RspecStrings.resx
@@ -7580,7 +7580,7 @@
     <value>Major Code Smell</value>
   </data>
   <data name="S3442_Description" xml:space="preserve">
-    <value>Since abstract classes can’t be instantiated, there’s no point in their having public or internal constructors. If there is basic initialization logic that should run when an extending class instance is created, you can by all means put it in a constructor, but make that constructor private or protected.</value>
+    <value>Since abstract classes can’t be instantiated, there’s no point in their having public or internal constructors. If there is basic initialization logic that should run when an extending class instance is created, you can by all means put it in a constructor, but make that constructor private, private protected or protected.</value>
   </data>
   <data name="S3442_IsActivatedByDefault" xml:space="preserve">
     <value>True</value>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AbstractTypesShouldNotHaveConstructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AbstractTypesShouldNotHaveConstructors.cs
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         var invalidAccessModifier = GetModifiers(c.Node).FirstOrDefault(IsPublicOrInternal);
                         if (invalidAccessModifier != default)
                         {
-                            c.ReportIssue(Diagnostic.Create(Rule, invalidAccessModifier.GetLocation(), SuggestedModifier(invalidAccessModifier)));
+                            c.ReportIssue(Diagnostic.Create(Rule, invalidAccessModifier.GetLocation(), SuggestModifier(invalidAccessModifier)));
                         }
                     }
                 },
@@ -69,7 +69,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool IsPublicOrInternal(SyntaxToken token) =>
             token.IsKind(SyntaxKind.PublicKeyword) || token.IsKind(SyntaxKind.InternalKeyword);
 
-        private static string SuggestedModifier(SyntaxToken token) =>
+        private static string SuggestModifier(SyntaxToken token) =>
             token.IsKind(SyntaxKind.InternalKeyword) ? "private protected" : "protected";
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AbstractTypesShouldNotHaveConstructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AbstractTypesShouldNotHaveConstructors.cs
@@ -37,10 +37,10 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3442";
         private const string MessageFormat = "Change the visibility of this constructor to 'protected'.";
 
-        private static readonly DiagnosticDescriptor rule =
+        private static readonly DiagnosticDescriptor Rule =
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         var invalidAccessModifier = GetModifiers(c.Node).FirstOrDefault(IsPublicOrInternal);
                         if (invalidAccessModifier != default)
                         {
-                            c.ReportIssue(Diagnostic.Create(rule, invalidAccessModifier.GetLocation()));
+                            c.ReportIssue(Diagnostic.Create(Rule, invalidAccessModifier.GetLocation()));
                         }
                     }
                 }, SyntaxKind.ConstructorDeclaration);
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 ClassDeclarationSyntax classDeclaration => classDeclaration.Modifiers,
                 ConstructorDeclarationSyntax ctorDeclaration => ctorDeclaration.Modifiers,
                 {} syntaxNode when RecordDeclarationSyntaxWrapper.IsInstance(syntaxNode) => ((RecordDeclarationSyntaxWrapper)syntaxNode).Modifiers,
-                _ => new SyntaxTokenList()
+                _ => default
             };
 
         private static bool IsPublicOrInternal(SyntaxToken token) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AbstractTypesShouldNotHaveConstructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AbstractTypesShouldNotHaveConstructors.cs
@@ -70,11 +70,6 @@ namespace SonarAnalyzer.Rules.CSharp
             token.IsKind(SyntaxKind.PublicKeyword) || token.IsKind(SyntaxKind.InternalKeyword);
 
         private static string SuggestedModifier(SyntaxToken token) =>
-            token.Kind() switch
-            {
-                SyntaxKind.PublicKeyword => "protected",
-                SyntaxKind.InternalKeyword => "private protected",
-                _ => string.Empty
-            };
+            token.IsKind(SyntaxKind.InternalKeyword) ? "private protected" : "protected";
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AbstractTypesShouldNotHaveConstructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AbstractTypesShouldNotHaveConstructors.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class AbstractTypesShouldNotHaveConstructors : SonarDiagnosticAnalyzer
     {
         private const string DiagnosticId = "S3442";
-        private const string MessageFormat = "Change the visibility of this constructor to {0}.";
+        private const string MessageFormat = "Change the visibility of this constructor to '{0}'.";
 
         private static readonly DiagnosticDescriptor Rule =
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
@@ -72,8 +72,8 @@ namespace SonarAnalyzer.Rules.CSharp
         private static string SuggestedModifier(SyntaxToken token) =>
             token.Kind() switch
             {
-                SyntaxKind.PublicKeyword => "'private', 'private protected' or 'protected'",
-                SyntaxKind.InternalKeyword => "'private' or 'private protected'",
+                SyntaxKind.PublicKeyword => "protected",
+                SyntaxKind.InternalKeyword => "private protected",
                 _ => string.Empty
             };
     }

--- a/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S3442.html
+++ b/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S3442.html
@@ -1,11 +1,11 @@
 <p>Since <code>abstract</code> classes can’t be instantiated, there’s no point in their having <code>public</code> or <code>internal</code>
 constructors. If there is basic initialization logic that should run when an extending class instance is created, you can by all means put it in a
-constructor, but make that constructor <code>private</code> or <code>protected</code>.</p>
+constructor, but make that constructor <code>private</code>, <code>private protected</code> or <code>protected</code>.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
 abstract class Base
 {
-    public Base() // Noncompliant, should be private or protected
+    public Base() // Noncompliant, should be private, private protected or protected
     {
       //...
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AbstractTypesShouldNotHaveConstructors.TopLevelStatements.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AbstractTypesShouldNotHaveConstructors.TopLevelStatements.cs
@@ -4,7 +4,7 @@ Console.WriteLine("Hello World!");
 
 abstract class Base
 {
-    public Base() { } // Noncompliant {{Change the visibility of this constructor to 'protected'.}}
+    public Base() { } // Noncompliant {{Change the visibility of this constructor to 'private', 'private protected' or 'protected'.}}
 
     private Base(int i) { } // Compliant
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AbstractTypesShouldNotHaveConstructors.TopLevelStatements.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AbstractTypesShouldNotHaveConstructors.TopLevelStatements.cs
@@ -4,7 +4,7 @@ Console.WriteLine("Hello World!");
 
 abstract class Base
 {
-    public Base() { } // Noncompliant {{Change the visibility of this constructor to 'private', 'private protected' or 'protected'.}}
+    public Base() { } // Noncompliant {{Change the visibility of this constructor to 'protected'.}}
 
     private Base(int i) { } // Compliant
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AbstractTypesShouldNotHaveConstructors.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AbstractTypesShouldNotHaveConstructors.cs
@@ -7,7 +7,7 @@ namespace Tests.Diagnostics
     {
         abstract class Base
         {
-            public Base() // Noncompliant {{Change the visibility of this constructor to 'protected'.}}
+            public Base() // Noncompliant {{Change the visibility of this constructor to 'private', 'private protected' or 'protected'.}}
 //          ^^^^^^
             {
                 //...
@@ -23,7 +23,7 @@ namespace Tests.Diagnostics
 
             }
 
-            internal Base(int i, int j, int k) // Noncompliant
+            internal Base(int i, int j, int k) // Noncompliant {{Change the visibility of this constructor to 'private' or 'private protected'.}}
             {
 
             }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AbstractTypesShouldNotHaveConstructors.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AbstractTypesShouldNotHaveConstructors.cs
@@ -7,7 +7,7 @@ namespace Tests.Diagnostics
     {
         abstract class Base
         {
-            public Base() // Noncompliant {{Change the visibility of this constructor to 'private', 'private protected' or 'protected'.}}
+            public Base() // Noncompliant {{Change the visibility of this constructor to 'protected'.}}
 //          ^^^^^^
             {
                 //...
@@ -23,7 +23,7 @@ namespace Tests.Diagnostics
 
             }
 
-            internal Base(int i, int j, int k) // Noncompliant {{Change the visibility of this constructor to 'private' or 'private protected'.}}
+            internal Base(int i, int j, int k) // Noncompliant {{Change the visibility of this constructor to 'private protected'.}}
             {
 
             }


### PR DESCRIPTION
Fixes #5006
