### PR TITLE
add repro for S4487 FP

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.CSharp10.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 
 namespace Tests.Diagnostics
 {
@@ -76,5 +77,17 @@ namespace Tests.Diagnostics
         public int B() => b;
 
         private record struct UnusedNested(string Name, int CategoryId) { } // FN
+    }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/2752
+    public class ReproIssue2752
+    {
+        private record struct PrivateRecordStruct
+        {
+            public uint part1; // Noncompliant FP. Type is communicated an external call.
+        }
+
+        [DllImport("user32.dll")]
+        private static extern bool ExternalMethod(ref PrivateRecordStruct reference);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.CSharp7.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.CSharp7.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
@@ -152,6 +153,26 @@ namespace Tests.Diagnostics
                 set => hasOnlyWrite = value;
             }
         }
+    }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/2752
+    public class ReproIssue2752
+    {
+        private struct PrivateStructRef
+        {
+            public uint part1; // Noncompliant FP. Type is communicated an external call.
+        }
+
+        private class PrivateClassRef
+        {
+            public uint part1; // Noncompliant FP. Type is communicated an external call.
+        }
+
+        [DllImport("user32.dll")]
+        private static extern bool ExternalMethodWithStruct(ref PrivateStructRef reference);
+
+        [DllImport("user32.dll")]
+        private static extern bool ExternalMethodWithClass(ref PrivateClassRef reference);
     }
 
     public class EmptyCtor

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.CSharp9.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 
 namespace Tests.Diagnostics
 {
@@ -103,5 +104,17 @@ namespace Tests.Diagnostics
 
     public partial class PartialMethods
     {
+    }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/2752
+    public class ReproIssue2752
+    {
+        private record PrivateRecordRef
+        {
+            public uint part1; // Noncompliant FP. Type is communicated an external call.
+        }
+
+        [DllImport("user32.dll")]
+        private static extern bool ExternalMethod(ref PrivateRecordRef reference);
     }
 }


### PR DESCRIPTION
add repro for #2752

I've motivated in https://github.com/SonarSource/sonar-dotnet/issues/2752#issuecomment-1005668009 why we should close as won't fix, but if after https://jira.sonarsource.com/browse/MMF-2417 the rule will be re-written, we could fix the FP if very easy and not impacting perf for such an edge case