### PR TITLE
S4507: relax `env.IsDevelopment()` validator check

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DeliveringDebugFeaturesInProduction.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DeliveringDebugFeaturesInProduction.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DeliveringDebugFeaturesInProductionBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DeliveringDebugFeaturesInProductionBase.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules
             new MemberDescriptor(KnownType.Microsoft_AspNetCore_Hosting_HostingEnvironmentExtensions, "IsDevelopment"),
             new MemberDescriptor(KnownType.Microsoft_Extensions_Hosting_HostEnvironmentEnvExtensions, "IsDevelopment"));
 
-        protected abstract bool IsInvokedConditionally(SyntaxNode node, SemanticModel semanticModel);
+        protected abstract bool IsDevelopmentCheckInvoked(SyntaxNode node, SemanticModel semanticModel);
 
         protected abstract bool IsInDevelopmentContext(SyntaxNode node);
 
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules
             t.Track(input,
                     t.MatchMethod(new MemberDescriptor(KnownType.Microsoft_AspNetCore_Builder_DeveloperExceptionPageExtensions, "UseDeveloperExceptionPage"),
                                   new MemberDescriptor(KnownType.Microsoft_AspNetCore_Builder_DatabaseErrorPageExtensions, "UseDatabaseErrorPage")),
-                    t.ExceptWhen(c => IsInvokedConditionally(c.Node, c.SemanticModel)),
+                    t.ExceptWhen(c => IsDevelopmentCheckInvoked(c.Node, c.SemanticModel)),
                     t.ExceptWhen(c => IsInDevelopmentContext(c.Node)));
         }
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DeliveringDebugFeaturesInProduction.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DeliveringDebugFeaturesInProduction.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         internal /*for testing*/ DeliveringDebugFeaturesInProduction(IAnalyzerConfiguration configuration) : base(configuration) { }
 
-        protected override bool IsInvokedConditionally(SyntaxNode node, SemanticModel semanticModel) =>
+        protected override bool IsDevelopmentCheckInvoked(SyntaxNode node, SemanticModel semanticModel) =>
             node.FirstAncestorOrSelf<StatementSyntax>() is var invocationStatement
             && invocationStatement.Ancestors().Any(x => IsDevelopmentCheck(x, semanticModel));
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DeliveringDebugFeaturesInProduction.NetCore2.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DeliveringDebugFeaturesInProduction.NetCore2.cs
@@ -14,42 +14,61 @@ namespace Tests.Diagnostics
                 app.UseDeveloperExceptionPage(); // Compliant
                 app.UseDatabaseErrorPage(); // Compliant
             }
+        }
 
+        public void Configure2(IApplicationBuilder app, IHostingEnvironment env)
+        {
             // Invoking as static methods
             if (HostingEnvironmentExtensions.IsDevelopment(env))
             {
                 DeveloperExceptionPageExtensions.UseDeveloperExceptionPage(app); // Compliant
                 DatabaseErrorPageExtensions.UseDatabaseErrorPage(app); // Compliant
             }
+        }
 
+        public void Configure3(IApplicationBuilder app, IHostingEnvironment env)
+        {
             // Not in development
             if (!env.IsDevelopment())
             {
-                DeveloperExceptionPageExtensions.UseDeveloperExceptionPage(app); // Noncompliant
-                DatabaseErrorPageExtensions.UseDatabaseErrorPage(app); // Noncompliant
+                DeveloperExceptionPageExtensions.UseDeveloperExceptionPage(app); // FN
+                DatabaseErrorPageExtensions.UseDatabaseErrorPage(app); // FN
             }
+        }
 
-            // Custom conditions are deliberately ignored
+        public void Configure4(IApplicationBuilder app, IHostingEnvironment env)
+        {
             var isDevelopment = env.IsDevelopment();
             if (isDevelopment)
             {
-                app.UseDeveloperExceptionPage(); // Noncompliant, False Positive
-                app.UseDatabaseErrorPage(); // Noncompliant, False Positive
+                app.UseDeveloperExceptionPage();
+                app.UseDatabaseErrorPage();
             }
+        }
 
-            // Only simple IF checks are considered
+        public void Configure5(IApplicationBuilder app, IHostingEnvironment env)
+        {
             while (env.IsDevelopment())
             {
-                app.UseDeveloperExceptionPage(); // Noncompliant FP
-                app.UseDatabaseErrorPage(); // Noncompliant FP
+                app.UseDeveloperExceptionPage();
+                app.UseDatabaseErrorPage();
                 break;
             }
+        }
 
-            // These are called unconditionally
+        public void Configure6(IApplicationBuilder app, IHostingEnvironment env)
+        {
             app.UseDeveloperExceptionPage(); // Noncompliant
             app.UseDatabaseErrorPage(); // Noncompliant
             DeveloperExceptionPageExtensions.UseDeveloperExceptionPage(app); // Noncompliant
             DatabaseErrorPageExtensions.UseDatabaseErrorPage(app); // Noncompliant
+        }
+
+        public void Configure7(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            var x = env.IsDevelopment();
+            app.UseDeveloperExceptionPage(); // FN
+            app.UseDatabaseErrorPage(); // FN
         }
 
         public void ConfigureAsArrow(IApplicationBuilder app, IHostingEnvironment env) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DeliveringDebugFeaturesInProduction.NetCore2.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DeliveringDebugFeaturesInProduction.NetCore2.cs
@@ -6,6 +6,17 @@ namespace Tests.Diagnostics
 {
     public class Startup
     {
+        // for coverage
+        private IApplicationBuilder foo;
+        public IApplicationBuilder Foo
+        {
+            set
+            {
+                var x = value.UseDeveloperExceptionPage(); // Noncompliant
+                foo = value;
+            }
+        }
+
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             // Invoking as extension methods

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DeliveringDebugFeaturesInProduction.NetCore3.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DeliveringDebugFeaturesInProduction.NetCore3.cs
@@ -13,35 +13,54 @@ namespace NetCore3
             {
                 app.UseDeveloperExceptionPage(); // Compliant
             }
+        }
 
+        public void Configure2(IApplicationBuilder app, IWebHostEnvironment env)
+        {
             // Invoking as static methods
             if (HostEnvironmentEnvExtensions.IsDevelopment(env))
             {
                 DeveloperExceptionPageExtensions.UseDeveloperExceptionPage(app); // Compliant
             }
+        }
 
+        public void Configure3(IApplicationBuilder app, IWebHostEnvironment env)
+        {
             // Not in development
             if (!env.IsDevelopment())
             {
-                DeveloperExceptionPageExtensions.UseDeveloperExceptionPage(app); // Noncompliant
+                DeveloperExceptionPageExtensions.UseDeveloperExceptionPage(app); // FN
             }
+        }
 
-            // Custom conditions are deliberately ignored
+        public void Configure4(IApplicationBuilder app, IWebHostEnvironment env)
+        {
             var isDevelopment = env.IsDevelopment();
             if (isDevelopment)
             {
-                app.UseDeveloperExceptionPage(); // Noncompliant, False Positive
+                app.UseDeveloperExceptionPage();
             }
+        }
 
+        public void Configure5(IApplicationBuilder app, IWebHostEnvironment env)
+        {
             while (env.IsDevelopment())
             {
-                app.UseDeveloperExceptionPage(); // Noncompliant FP, we inspect only IF statements
+                app.UseDeveloperExceptionPage();
                 break;
             }
+        }
 
-            // These are called unconditionally
+        public void Configure6(IApplicationBuilder app, IWebHostEnvironment env)
+        {
             app.UseDeveloperExceptionPage(); // Noncompliant
             DeveloperExceptionPageExtensions.UseDeveloperExceptionPage(app); // Noncompliant
+        }
+
+        public void Configure7(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            var x = env.IsDevelopment();
+            app.UseDeveloperExceptionPage(); // FN
         }
 
         public void ConfigureAsArrow(IApplicationBuilder app, IWebHostEnvironment env) =>


### PR DESCRIPTION
S4507 

Fixes #5032 - only for C#

(opening draft to discuss first with AppSec if this really makes sense)