### PR TITLE
Bring back S109 RSPEC changes

### DIFF
--- a/analyzers/rspec/cs/S109_c#.html
+++ b/analyzers/rspec/cs/S109_c#.html
@@ -27,5 +27,12 @@ public static void DoSomething()
 }
 </pre>
 <h2>Exceptions</h2>
-<p>This rule doesn’t raise an issue when the magic number is used as part of the <code>GetHashCode</code> method or a variable/field declaration.</p>
+<p>This rule doesn’t raise an issue when the magic number is used as part of:</p>
+<ul>
+  <li> the <code>GetHashCode</code> method </li>
+  <li> a variable/field declaration </li>
+  <li> the single argument of an attribute </li>
+  <li> a named argument for a method or attribute </li>
+  <li> a constructor call </li>
+</ul>
 

--- a/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S109.html
+++ b/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S109.html
@@ -27,5 +27,12 @@ public static void DoSomething()
 }
 </pre>
 <h2>Exceptions</h2>
-<p>This rule doesn’t raise an issue when the magic number is used as part of the <code>GetHashCode</code> method or a variable/field declaration.</p>
+<p>This rule doesn’t raise an issue when the magic number is used as part of:</p>
+<ul>
+  <li> the <code>GetHashCode</code> method </li>
+  <li> a variable/field declaration </li>
+  <li> the single argument of an attribute </li>
+  <li> a named argument for a method or attribute </li>
+  <li> a constructor call </li>
+</ul>
 


### PR DESCRIPTION
S109 rule got updated in #5247 together with the RSPEC changes (I should have merged the rspec PR after #5247 got merged, my bad), which got reverted in #5273.

I did this via `git checkout  4b55e5119 ...` , not via the RSPEC script because the rspec PR is still not merged. I rebased and pushed https://github.com/SonarSource/rspec/pull/694 to rerun the SQ check and set it to merge, however there seems to be some test failures.
