### PR TITLE
Use SonarDiagnosticAnalyzer<TSyntaxKind> base type

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassNotInstantiatable.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassNotInstantiatable.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             var typeDeclarations = new CSharpRemovableDeclarationCollector(namedType, compilation).TypeDeclarations;
 
-            return typeDeclarations.Select(x => new ConstructorContext(x, Diagnostic.Create(rule, x.Node.Identifier.GetLocation(), x.Node.GetDeclarationTypeName(), messageArg)));
+            return typeDeclarations.Select(x => new ConstructorContext(x, Diagnostic.Create(Rule, x.Node.Identifier.GetLocation(), x.Node.GetDeclarationTypeName(), messageArg)));
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/BooleanLiteralUnnecessaryBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/BooleanLiteralUnnecessaryBase.cs
@@ -18,19 +18,17 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class BooleanLiteralUnnecessaryBase<TBinaryExpression, TSyntaxKind> : SonarDiagnosticAnalyzer
+    public abstract class BooleanLiteralUnnecessaryBase<TBinaryExpression, TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TBinaryExpression : SyntaxNode
         where TSyntaxKind : struct
     {
         internal const string DiagnosticId = "S1125";
-        private const string MessageFormat = "Remove the unnecessary Boolean literal(s).";
 
         protected enum ErrorLocation
         {
@@ -47,8 +45,6 @@ namespace SonarAnalyzer.Rules
 
         protected delegate bool IsBooleanLiteralKind(SyntaxNode node);
 
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
-
         protected abstract bool IsBooleanLiteral(SyntaxNode node);
         protected abstract SyntaxNode GetLeftNode(TBinaryExpression binaryExpression);
         protected abstract SyntaxNode GetRightNode(TBinaryExpression binaryExpression);
@@ -58,12 +54,9 @@ namespace SonarAnalyzer.Rules
         // For C# 7 syntax
         protected virtual bool IsInsideTernaryWithThrowExpression(TBinaryExpression syntaxNode) => false;
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        protected override string MessageFormat => "Remove the unnecessary Boolean literal(s).";
 
-        protected DiagnosticDescriptor Rule { get; }
-
-        protected BooleanLiteralUnnecessaryBase() =>
-            Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected BooleanLiteralUnnecessaryBase() : base(DiagnosticId) { }
 
         // LogicalAnd (C#) / AndAlso (VB)
         protected void CheckAndExpression(SyntaxNodeAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules
         TVariableSyntax,
         TLambdaSyntax,
         TMemberAccessSyntax
-        > : SonarDiagnosticAnalyzer
+        > : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
         where TArgumentSyntax : SyntaxNode
         where TExpressionSyntax : SyntaxNode
@@ -51,12 +51,8 @@ namespace SonarAnalyzer.Rules
         where TMemberAccessSyntax : SyntaxNode
     {
         protected const string DiagnosticId = "S4830";
-        private const string MessageFormat = "Enable server certificate validation on this SSL/TLS connection";
-        private readonly DiagnosticDescriptor rule;
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         internal /* for testing */ abstract MethodParameterLookupBase<TArgumentSyntax> CreateParameterLookup(SyntaxNode argumentListNode, IMethodSymbol method);
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract TSyntaxKind[] MethodDeclarationKinds { get; }
         protected abstract Location ExpressionLocation(SyntaxNode expression);
         protected abstract void SplitAssignment(TAssignmentExpressionSyntax assignment, out TIdentifierNameSyntax leftIdentifier, out TExpressionSyntax right);
@@ -70,10 +66,9 @@ namespace SonarAnalyzer.Rules
         protected abstract SyntaxNode SyntaxFromReference(SyntaxReference reference);
         private protected abstract KnownType GenericDelegateType();
 
-        protected CertificateValidationCheckBase()
-        {
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
-        }
+        protected override string MessageFormat => "Enable server certificate validation on this SSL/TLS connection";
+
+        protected CertificateValidationCheckBase() : base(DiagnosticId) { }
 
         protected void CheckAssignmentSyntax(SyntaxNodeAnalysisContext c)
         {
@@ -163,7 +158,7 @@ namespace SonarAnalyzer.Rules
             if (!locations.IsEmpty)
             {
                 // Report both, assignment as well as all implementation occurrences
-                c.Context.ReportIssue(Diagnostic.Create(rule, primaryLocation, locations));
+                c.Context.ReportIssue(Diagnostic.Create(Rule, primaryLocation, locations));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ClassNotInstantiatableBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ClassNotInstantiatableBase.cs
@@ -19,7 +19,6 @@
  */
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -28,23 +27,17 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class ClassNotInstantiatableBase<TBaseTypeSyntax, TSyntaxKind> : SonarDiagnosticAnalyzer
+    public abstract class ClassNotInstantiatableBase<TBaseTypeSyntax, TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TBaseTypeSyntax : SyntaxNode
         where TSyntaxKind : struct
     {
         protected const string DiagnosticId = "S3453";
-        private const string MessageFormat = "This {0} can't be instantiated; make {1} 'public'.";
-
-        protected readonly DiagnosticDescriptor rule;
-
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
 
         protected abstract IEnumerable<ConstructorContext> CollectRemovableDeclarations(INamedTypeSymbol namedType, Compilation compilation, string messageArg);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected override string MessageFormat => "This {0} can't be instantiated; make {1} 'public'.";
 
-        protected ClassNotInstantiatableBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected ClassNotInstantiatableBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSymbolAction(CheckClassWithOnlyUnusedPrivateConstructors, SymbolKind.NamedType);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DeclareTypesInNamespacesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DeclareTypesInNamespacesBase.cs
@@ -24,24 +24,19 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class DeclareTypesInNamespacesBase<TSyntaxKind> : SonarDiagnosticAnalyzer
+    public abstract class DeclareTypesInNamespacesBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
     {
         protected const string DiagnosticId = "S3903";
-        private const string MessageFormat = "Move '{0}' into a named namespace.";
 
-        private readonly DiagnosticDescriptor rule;
-
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract TSyntaxKind[] SyntaxKinds { get; }
 
         protected abstract bool IsInnerTypeOrWithinNamespace(SyntaxNode declaration, SemanticModel semanticModel);
         protected abstract SyntaxToken GetTypeIdentifier(SyntaxNode declaration);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected override string MessageFormat => "Move '{0}' into a named namespace.";
 
-        protected DeclareTypesInNamespacesBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected DeclareTypesInNamespacesBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context) =>
           context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer,
@@ -56,7 +51,7 @@ namespace SonarAnalyzer.Rules
                   }
 
                   var identifier = GetTypeIdentifier(declaration);
-                  c.ReportIssue(Diagnostic.Create(rule, identifier.GetLocation(), identifier.ValueText));
+                  c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.ValueText));
               },
               SyntaxKinds);
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCheckZeroSizeCollectionBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCheckZeroSizeCollectionBase.cs
@@ -20,7 +20,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -28,23 +27,19 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class DoNotCheckZeroSizeCollectionBase<TSyntaxKind> : SonarDiagnosticAnalyzer
+    public abstract class DoNotCheckZeroSizeCollectionBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
     {
         protected const string DiagnosticId = "S3981";
-        private const string MessageFormat = "The '{0}' of '{1}' always evaluates as '{2}' regardless the size.";
         private const string CountName = nameof(Enumerable.Count);
         private const string LengthName = nameof(Array.Length);
         private const string LongLengthName = nameof(Array.LongLength);
-        private readonly DiagnosticDescriptor rule;
 
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract string IEnumerableTString { get; }
 
-        protected DoNotCheckZeroSizeCollectionBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected override string MessageFormat => "The '{0}' of '{1}' always evaluates as '{2}' regardless the size.";
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected DoNotCheckZeroSizeCollectionBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer,
@@ -74,7 +69,7 @@ namespace SonarAnalyzer.Rules
                 && context.SemanticModel.GetSymbolInfo(expression).Symbol is ISymbol symbol
                 && CollecionSizeTypeName(symbol) is { } symbolType)
             {
-                context.ReportIssue(Diagnostic.Create(rule, issue.GetLocation(), symbol.Name, symbolType, result == CountComparisonResult.AlwaysTrue));
+                context.ReportIssue(Diagnostic.Create(Rule, issue.GetLocation(), symbol.Name, symbolType, result == CountComparisonResult.AlwaysTrue));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotOverwriteCollectionElementsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotOverwriteCollectionElementsBase.cs
@@ -20,7 +20,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -28,17 +27,11 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class DoNotOverwriteCollectionElementsBase<TSyntaxKind, TStatementSyntax> : SonarDiagnosticAnalyzer
+    public abstract class DoNotOverwriteCollectionElementsBase<TSyntaxKind, TStatementSyntax> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
         where TStatementSyntax : SyntaxNode
     {
         protected const string DiagnosticId = "S4143";
-        private const string MessageFormat = "Verify this is the index/key that was intended; " +
-            "a value has already been set for it.";
-
-        private readonly DiagnosticDescriptor rule;
-
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
 
         /// <summary>
         /// Returns the index or key from the provided InvocationExpression or SimpleAssignmentExpression.
@@ -59,10 +52,10 @@ namespace SonarAnalyzer.Rules
         /// </summary>
         protected abstract bool IsIdentifierOrLiteral(SyntaxNode syntaxNode);
 
-        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected override string MessageFormat => "Verify this is the index/key that was intended; " +
+            "a value has already been set for it.";
 
-        protected DoNotOverwriteCollectionElementsBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected DoNotOverwriteCollectionElementsBase() : base(DiagnosticId) { }
 
         protected void AnalysisAction(SyntaxNodeAnalysisContext context)
         {
@@ -84,7 +77,7 @@ namespace SonarAnalyzer.Rules
 
             if (previousSet != null)
             {
-                context.ReportIssue(Diagnostic.Create(rule, context.Node.GetLocation(), additionalLocations: new[] { previousSet.GetLocation() }));
+                context.ReportIssue(Diagnostic.Create(Rule, context.Node.GetLocation(), additionalLocations: new[] { previousSet.GetLocation() }));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/EmptyNestedBlockBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/EmptyNestedBlockBase.cs
@@ -19,29 +19,23 @@
  */
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class EmptyNestedBlockBase<TSyntaxKind> : SonarDiagnosticAnalyzer
+    public abstract class EmptyNestedBlockBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
     {
         protected const string DiagnosticId = "S108";
-        private const string MessageFormat = "Either remove or fill this block of code.";
 
-        private readonly DiagnosticDescriptor rule;
-
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract TSyntaxKind[] SyntaxKinds { get; }
 
         protected abstract IEnumerable<SyntaxNode> EmptyBlocks(SyntaxNode node);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected override string MessageFormat => "Either remove or fill this block of code.";
 
-        protected EmptyNestedBlockBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected EmptyNestedBlockBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(
@@ -50,7 +44,7 @@ namespace SonarAnalyzer.Rules
                 {
                     foreach (var node in EmptyBlocks(c.Node))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, node.GetLocation()));
+                        c.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
                     }
                 },
                 SyntaxKinds);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/EnumNameHasEnumSuffixBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/EnumNameHasEnumSuffixBase.cs
@@ -26,21 +26,15 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class EnumNameHasEnumSuffixBase<TSyntaxKind> : SonarDiagnosticAnalyzer
+    public abstract class EnumNameHasEnumSuffixBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
     {
         protected const string DiagnosticId = "S2344";
-        private const string MessageFormat = "Rename this enumeration to remove the '{0}' suffix.";
-
         private readonly IEnumerable<string> nameEndings = ImmutableArray.Create("enum", "flags");
 
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
+        protected override string MessageFormat => "Rename this enumeration to remove the '{0}' suffix.";
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
-        private readonly DiagnosticDescriptor rule;
-
-        protected EnumNameHasEnumSuffixBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected EnumNameHasEnumSuffixBase() : base(DiagnosticId) { }
 
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, c =>
@@ -48,7 +42,7 @@ namespace SonarAnalyzer.Rules
                     if (Language.Syntax.NodeIdentifier(c.Node) is { } identifier
                         && nameEndings.FirstOrDefault(ending => identifier.ValueText.EndsWith(ending, System.StringComparison.OrdinalIgnoreCase)) is { } nameEnding)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, identifier.GetLocation(), identifier.ValueText.Substring(identifier.ValueText.Length - nameEnding.Length)));
+                        c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.ValueText.Substring(identifier.ValueText.Length - nameEnding.Length)));
                     }
                 },
                 Language.SyntaxKind.EnumDeclaration);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FlagsEnumWithoutInitializerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FlagsEnumWithoutInitializerBase.cs
@@ -18,36 +18,31 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.Common
 {
-    public abstract class FlagsEnumWithoutInitializerBase<TSyntaxKind, TEnumMemberDeclarationSyntax> : SonarDiagnosticAnalyzer
+    public abstract class FlagsEnumWithoutInitializerBase<TSyntaxKind, TEnumMemberDeclarationSyntax> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
         where TEnumMemberDeclarationSyntax : SyntaxNode
     {
         protected const string DiagnosticId = "S2345";
-        private const string MessageFormat = "Initialize all the members of this 'Flags' enumeration.";
         private const int AllowedEmptyMemberCount = 3;
 
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract bool IsInitialized(TEnumMemberDeclarationSyntax member);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
-        private readonly DiagnosticDescriptor rule;
+        protected override string MessageFormat => "Initialize all the members of this 'Flags' enumeration.";
 
-        protected FlagsEnumWithoutInitializerBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected FlagsEnumWithoutInitializerBase() : base(DiagnosticId) { }
 
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, c =>
                 {
                     if (c.Node.HasFlagsAttribute(c.SemanticModel) && !AreAllRequiredMembersInitialized(c.Node) && Language.Syntax.NodeIdentifier(c.Node) is { } identifier)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, identifier.GetLocation()));
+                        c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation()));
                     }
                 },
                 Language.SyntaxKind.EnumDeclaration);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FlagsEnumZeroMemberBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FlagsEnumZeroMemberBase.cs
@@ -19,25 +19,18 @@
  */
 
 using System;
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.Common
 {
-    public abstract class FlagsEnumZeroMemberBase<TSyntaxKind> : SonarDiagnosticAnalyzer
+    public abstract class FlagsEnumZeroMemberBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
     {
         protected const string DiagnosticId = "S2346";
-        private const string MessageFormat = "Rename '{0}' to 'None'.";
+        protected override string MessageFormat => "Rename '{0}' to 'None'.";
 
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
-        private readonly DiagnosticDescriptor rule;
-
-        protected FlagsEnumZeroMemberBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected FlagsEnumZeroMemberBase() : base(DiagnosticId) { }
 
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, c =>
@@ -47,7 +40,7 @@ namespace SonarAnalyzer.Rules.Common
                         && Language.Syntax.NodeIdentifier(zeroMember) is { } identifier
                         && identifier.ValueText != "None")
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, zeroMember.GetLocation(), identifier.ValueText));
+                        c.ReportIssue(Diagnostic.Create(Rule, zeroMember.GetLocation(), identifier.ValueText));
                     }
                 },
                 Language.SyntaxKind.EnumDeclaration);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/GenericInheritanceShouldNotBeRecursiveBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/GenericInheritanceShouldNotBeRecursiveBase.cs
@@ -19,33 +19,27 @@
  */
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class GenericInheritanceShouldNotBeRecursiveBase<TSyntaxKind, TDeclaration> : SonarDiagnosticAnalyzer
+    public abstract class GenericInheritanceShouldNotBeRecursiveBase<TSyntaxKind, TDeclaration> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
         where TDeclaration : SyntaxNode
     {
         protected const string DiagnosticId = "S3464";
-        private const string MessageFormat = "Refactor this {0} so that the generic inheritance chain is not recursive.";
 
-        private readonly DiagnosticDescriptor rule;
-
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract TSyntaxKind[] SyntaxKinds { get; }
 
         protected abstract INamedTypeSymbol GetNamedTypeSymbol(TDeclaration declaration, SemanticModel semanticModel);
         protected abstract Location GetLocation(TDeclaration declaration);
         protected abstract SyntaxToken GetKeyword(TDeclaration declaration);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected override string MessageFormat => "Refactor this {0} so that the generic inheritance chain is not recursive.";
 
-        protected GenericInheritanceShouldNotBeRecursiveBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected GenericInheritanceShouldNotBeRecursiveBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer,
@@ -56,7 +50,7 @@ namespace SonarAnalyzer.Rules
                     if (c.ContainingSymbol.Kind == SymbolKind.NamedType
                         && IsRecursiveInheritance(GetNamedTypeSymbol(declaration, c.SemanticModel)))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, GetLocation(declaration), GetKeyword(declaration)));
+                        c.ReportIssue(Diagnostic.Create(Rule, GetLocation(declaration), GetKeyword(declaration)));
                     }
                 },
                 SyntaxKinds);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/IfChainWithoutElseBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/IfChainWithoutElseBase.cs
@@ -18,32 +18,27 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class IfChainWithoutElseBase<TSyntaxKind, TIfSyntax> : SonarDiagnosticAnalyzer
+    public abstract class IfChainWithoutElseBase<TSyntaxKind, TIfSyntax> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
         where TIfSyntax : SyntaxNode
     {
         protected const string DiagnosticId = "S126";
-        private const string MessageFormat = "Add the missing '{0}' clause with either the appropriate action or a suitable comment as to why no action is taken.";
-        private readonly DiagnosticDescriptor rule;
 
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract TSyntaxKind SyntaxKind { get; }
         protected abstract string ElseClause { get; }
 
         protected abstract bool IsElseIfWithoutElse(TIfSyntax ifSyntax);
         protected abstract Location IssueLocation(SyntaxNodeAnalysisContext context, TIfSyntax ifSyntax);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected override string MessageFormat => "Add the missing '{0}' clause with either the appropriate action or a suitable comment as to why no action is taken.";
 
-        protected IfChainWithoutElseBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected IfChainWithoutElseBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer,
@@ -55,7 +50,7 @@ namespace SonarAnalyzer.Rules
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(rule, IssueLocation(c, ifNode), ElseClause));
+                    c.ReportIssue(Diagnostic.Create(Rule, IssueLocation(c, ifNode), ElseClause));
                 },
                 SyntaxKind);
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/IndexOfCheckAgainstZeroBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/IndexOfCheckAgainstZeroBase.cs
@@ -25,12 +25,11 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class IndexOfCheckAgainstZeroBase<TSyntaxKind, TBinaryExpressionSyntax> : SonarDiagnosticAnalyzer
+    public abstract class IndexOfCheckAgainstZeroBase<TSyntaxKind, TBinaryExpressionSyntax> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
         where TBinaryExpressionSyntax : SyntaxNode
     {
         protected const string DiagnosticId = "S2692";
-        private const string MessageFormat = "0 is a valid index, but this check ignores it.";
 
         private static readonly string[] TrackedMethods =
             {
@@ -45,12 +44,8 @@ namespace SonarAnalyzer.Rules
                 KnownType.System_Array,
                 KnownType.System_Collections_Generic_IList_T,
                 KnownType.System_String,
-                KnownType.System_Collections_IList
-            );
+                KnownType.System_Collections_IList);
 
-        private readonly DiagnosticDescriptor rule;
-
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract TSyntaxKind LessThanExpression { get; }
         protected abstract TSyntaxKind GreaterThanExpression { get; }
 
@@ -58,10 +53,9 @@ namespace SonarAnalyzer.Rules
         protected abstract SyntaxNode Right(TBinaryExpressionSyntax binaryExpression);
         protected abstract SyntaxToken OperatorToken(TBinaryExpressionSyntax binaryExpression);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected override string MessageFormat => "0 is a valid index, but this check ignores it.";
 
-        protected IndexOfCheckAgainstZeroBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected IndexOfCheckAgainstZeroBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context)
         {
@@ -72,7 +66,7 @@ namespace SonarAnalyzer.Rules
                     var lessThan = (TBinaryExpressionSyntax)c.Node;
                     if (IsInvalidComparison(Left(lessThan), Right(lessThan), c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, Left(lessThan).CreateLocation(OperatorToken(lessThan))));
+                        c.ReportIssue(Diagnostic.Create(Rule, Left(lessThan).CreateLocation(OperatorToken(lessThan))));
                     }
                 },
                 LessThanExpression);
@@ -84,7 +78,7 @@ namespace SonarAnalyzer.Rules
                     var greaterThan = (TBinaryExpressionSyntax)c.Node;
                     if (IsInvalidComparison(Right(greaterThan), Left(greaterThan), c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, OperatorToken(greaterThan).CreateLocation(Right(greaterThan))));
+                        c.ReportIssue(Diagnostic.Create(Rule, OperatorToken(greaterThan).CreateLocation(Right(greaterThan))));
                     }
                 },
                 GreaterThanExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MarkWindowsFormsMainWithStaThreadBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MarkWindowsFormsMainWithStaThreadBase.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -26,26 +25,21 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class MarkWindowsFormsMainWithStaThreadBase<TSyntaxKind, TMethodSyntax> : SonarDiagnosticAnalyzer
+    public abstract class MarkWindowsFormsMainWithStaThreadBase<TSyntaxKind, TMethodSyntax> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
         where TMethodSyntax : SyntaxNode
     {
         protected const string DiagnosticId = "S4210";
-        private const string MessageFormat = "{0}";
         private const string AddStaThreadMessage = "Add the 'STAThread' attribute to this entry point.";
         private const string ChangeMtaThreadToStaThreadMessage = "Change the 'MTAThread' attribute of this entry point to 'STAThread'.";
 
-        private readonly DiagnosticDescriptor rule;
-
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract TSyntaxKind[] SyntaxKinds { get; }
 
         protected abstract Location GetLocation(TMethodSyntax method);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected override string MessageFormat => "{0}";
 
-        protected MarkWindowsFormsMainWithStaThreadBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected MarkWindowsFormsMainWithStaThreadBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, Action, SyntaxKinds);
@@ -65,7 +59,7 @@ namespace SonarAnalyzer.Rules
                     ? ChangeMtaThreadToStaThreadMessage
                     : AddStaThreadMessage;
 
-                c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], GetLocation(methodDeclaration), message));
+                c.ReportIssue(Diagnostic.Create(Rule, GetLocation(methodDeclaration), message));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/NameOfShouldBeUsedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/NameOfShouldBeUsedBase.cs
@@ -28,21 +28,16 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class NameOfShouldBeUsedBase<TMethodSyntax, TSyntaxKind, TThrowSyntax> : SonarDiagnosticAnalyzer
+    public abstract class NameOfShouldBeUsedBase<TMethodSyntax, TSyntaxKind, TThrowSyntax> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TMethodSyntax : SyntaxNode
         where TSyntaxKind : struct
         where TThrowSyntax : SyntaxNode
     {
         internal const string DiagnosticId = "S2302";
-        private const string MessageFormat = "Replace the string '{0}' with 'nameof({0})'.";
         // when the parameter name is inside a bigger string, we want to avoid common English words like
         // "a", "then", "he", "of", "have" etc, to avoid false positives
         private const int MinStringLength = 5;
         private readonly char[] separators = { ' ', '.', ',', ';', '!', '?' };
-
-        private readonly DiagnosticDescriptor rule;
-
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
 
         // Is string literal or interpolated string
         protected abstract bool IsStringLiteral(SyntaxToken t);
@@ -54,10 +49,9 @@ namespace SonarAnalyzer.Rules
 
         protected abstract bool IsArgumentExceptionCallingNameOf(SyntaxNode node, IEnumerable<string> arguments);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected override string MessageFormat => "Replace the string '{0}' with 'nameof({0})'.";
 
-        protected NameOfShouldBeUsedBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected NameOfShouldBeUsedBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context)
         {
@@ -107,7 +101,7 @@ namespace SonarAnalyzer.Rules
             foreach (var stringTokenAndParam in stringTokenAndParameterPairs)
             {
                 context.ReportIssue(Diagnostic.Create(
-                    descriptor: rule,
+                    descriptor: Rule,
                     location: stringTokenAndParam.Key.GetLocation(),
                     messageArgs: stringTokenAndParam.Value));
             }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertyWriteOnlyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertyWriteOnlyBase.cs
@@ -18,29 +18,24 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.Common
 {
-    public abstract class PropertyWriteOnlyBase<TSyntaxKind, TPropertyDeclaration> : SonarDiagnosticAnalyzer
+    public abstract class PropertyWriteOnlyBase<TSyntaxKind, TPropertyDeclaration> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
         where TPropertyDeclaration : SyntaxNode
     {
         protected const string DiagnosticId = "S2376";
-        private const string MessageFormat = "Provide a getter for '{0}' or replace the property with a 'Set{0}' method.";
-        private readonly DiagnosticDescriptor rule;
 
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract TSyntaxKind SyntaxKind { get; }
 
         protected abstract bool IsWriteOnlyProperty(TPropertyDeclaration prop);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected override string MessageFormat => "Provide a getter for '{0}' or replace the property with a 'Set{0}' method.";
 
-        protected PropertyWriteOnlyBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected PropertyWriteOnlyBase() : base(DiagnosticId) { }
 
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PureAttributeOnVoidMethodBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PureAttributeOnVoidMethodBase.cs
@@ -18,27 +18,20 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class PureAttributeOnVoidMethodBase<TSyntaxKind> : SonarDiagnosticAnalyzer
+    public abstract class PureAttributeOnVoidMethodBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
     {
         protected const string DiagnosticId = "S3603";
-        private const string MessageFormat = "Remove the 'Pure' attribute or change the method to return a value.";
 
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
+        protected override string MessageFormat => "Remove the 'Pure' attribute or change the method to return a value.";
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
-
-        protected DiagnosticDescriptor Rule { get; }
-
-        protected PureAttributeOnVoidMethodBase() =>
-            Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected PureAttributeOnVoidMethodBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSymbolAction(

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SecurityPInvokeMethodShouldNotBeCalledBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SecurityPInvokeMethodShouldNotBeCalledBase.cs
@@ -20,7 +20,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -28,22 +27,17 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class SecurityPInvokeMethodShouldNotBeCalledBase<TSyntaxKind, TInvocationExpressionSyntax> : SonarDiagnosticAnalyzer
+    public abstract class SecurityPInvokeMethodShouldNotBeCalledBase<TSyntaxKind, TInvocationExpressionSyntax> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
         where TInvocationExpressionSyntax : SyntaxNode
     {
         protected const string DiagnosticId = "S3884";
-        protected const string MessageFormat = "Refactor the code to remove this use of '{0}'.";
         protected const string InteropName = "ole32";
         protected const string InteropDllName = InteropName + ".dll";
 
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
-
         protected abstract IMethodSymbol MethodSymbolForInvalidInvocation(SyntaxNode syntaxNode, SemanticModel semanticModel);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
-
-        protected DiagnosticDescriptor Rule { get; }
+        protected override string MessageFormat => "Refactor the code to remove this use of '{0}'.";
 
         protected ISet<string> InvalidMethods { get; } = new HashSet<string>
         {
@@ -51,8 +45,7 @@ namespace SonarAnalyzer.Rules
             "CoInitializeSecurity"
         };
 
-        protected SecurityPInvokeMethodShouldNotBeCalledBase() =>
-            Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected SecurityPInvokeMethodShouldNotBeCalledBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, CheckForIssue, Language.SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ShouldImplementExportedInterfacesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ShouldImplementExportedInterfacesBase.cs
@@ -26,13 +26,12 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.Common
 {
-    public abstract class ShouldImplementExportedInterfacesBase<TArgumentSyntax, TAttributeSyntax, TSyntaxKind> : SonarDiagnosticAnalyzer
+    public abstract class ShouldImplementExportedInterfacesBase<TArgumentSyntax, TAttributeSyntax, TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TArgumentSyntax : SyntaxNode
         where TAttributeSyntax : SyntaxNode
         where TSyntaxKind : struct
     {
         internal const string DiagnosticId = "S4159";
-        private const string MessageFormat = "{0} '{1}' on '{2}' or remove this export attribute.";
         private const string ActionForInterface = "Implement";
         private const string ActionForClass = "Derive from";
 
@@ -44,15 +43,13 @@ namespace SonarAnalyzer.Rules.Common
 
         protected abstract SeparatedSyntaxList<TArgumentSyntax>? GetAttributeArguments(TAttributeSyntax attributeSyntax);
         protected abstract SyntaxNode GetAttributeName(TAttributeSyntax attributeSyntax);
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract bool IsClassOrRecordSyntax(SyntaxNode syntaxNode);
         // Retrieve the expression inside of the typeof()/GetType() (e.g. typeof(Foo) => Foo)
         protected abstract SyntaxNode GetTypeOfOrGetTypeExpression(SyntaxNode expressionSyntax);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected override string MessageFormat => "{0} '{1}' on '{2}' or remove this export attribute.";
 
-        protected ShouldImplementExportedInterfacesBase() =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
+        protected ShouldImplementExportedInterfacesBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ShouldImplementExportedInterfacesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ShouldImplementExportedInterfacesBase.cs
@@ -35,7 +35,6 @@ namespace SonarAnalyzer.Rules.Common
         private const string ActionForInterface = "Implement";
         private const string ActionForClass = "Derive from";
 
-        private readonly DiagnosticDescriptor rule;
         private readonly ImmutableArray<KnownType> exportAttributes =
             ImmutableArray.Create(
                 KnownType.System_ComponentModel_Composition_ExportAttribute,
@@ -72,7 +71,7 @@ namespace SonarAnalyzer.Rules.Common
                             ? ActionForInterface
                             : ActionForClass;
 
-                        c.ReportIssue(Diagnostic.Create(rule, attributeSyntax.GetLocation(), action,
+                        c.ReportIssue(Diagnostic.Create(Rule, attributeSyntax.GetLocation(), action,
                             exportedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
                             attributeTargetType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
                     }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ClassNotInstantiatable.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ClassNotInstantiatable.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         {
             var typeDeclarations = new VisualBasicRemovableDeclarationCollector(namedType, compilation).TypeDeclarations;
 
-            return typeDeclarations.Select(x => new ConstructorContext(x, Diagnostic.Create(rule, x.Node.BlockStatement.Identifier.GetLocation(), "class", messageArg)));
+            return typeDeclarations.Select(x => new ConstructorContext(x, Diagnostic.Create(Rule, x.Node.BlockStatement.Identifier.GetLocation(), "class", messageArg)));
         }
     }
 }


### PR DESCRIPTION
Refactored all SonarDiagnosticAnalyzer base classes contained

``` C#
protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
```

To inhertit from `SonarDiagnosticAnalyzer <TSyntaxKind>` instead (introduced in PR #5106 )
