### PR TITLE
UTs: Remove OldVerifier overloads for C# 9 and 10

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/BeginInvokePairedWithEndInvokeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/BeginInvokePairedWithEndInvokeTest.cs
@@ -28,26 +28,27 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class BeginInvokePairedWithEndInvokeTest
     {
+        private readonly VerifierBuilder builderCS = new VerifierBuilder<CS.BeginInvokePairedWithEndInvoke>();
+        private readonly VerifierBuilder builderVB = new VerifierBuilder<VB.BeginInvokePairedWithEndInvoke>();
+
         [TestMethod]
         public void BeginInvokePairedWithEndInvoke_CS() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\BeginInvokePairedWithEndInvoke.cs", new CS.BeginInvokePairedWithEndInvoke());
+            builderCS.AddPaths("BeginInvokePairedWithEndInvoke.cs").Verify();
 
 #if NET
+
         [TestMethod]
         public void BeginInvokePairedWithEndInvoke_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(
-                new[] { @"TestCases\BeginInvokePairedWithEndInvoke.CSharp9.Part1.cs", @"TestCases\BeginInvokePairedWithEndInvoke.CSharp9.Part2.cs" },
-                new CS.BeginInvokePairedWithEndInvoke());
+            builderCS.AddPaths("BeginInvokePairedWithEndInvoke.CSharp9.Part1.cs", "BeginInvokePairedWithEndInvoke.CSharp9.Part2.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void BeginInvokePairedWithEndInvoke_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(
-                new[] { @"TestCases\BeginInvokePairedWithEndInvoke.CSharp10.cs" },
-                new CS.BeginInvokePairedWithEndInvoke());
+            builderCS.AddPaths("BeginInvokePairedWithEndInvoke.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+
 #endif
 
         [TestMethod]
         public void BeginInvokePairedWithEndInvoke_VB() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\BeginInvokePairedWithEndInvoke.vb", new VB.BeginInvokePairedWithEndInvoke());
+            builderVB.AddPaths("BeginInvokePairedWithEndInvoke.vb").Verify();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CertificateValidationCheckTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CertificateValidationCheckTest.cs
@@ -19,10 +19,7 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
-using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.UnitTest.MetadataReferences;
 using SonarAnalyzer.UnitTest.TestFramework;
@@ -34,37 +31,38 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class CertificateValidationCheckTest
     {
+        private readonly VerifierBuilder builderCS = new VerifierBuilder<CS.CertificateValidationCheck>()
+            .AddReferences(MetadataReferenceFacade.SystemNetHttp)
+            .AddReferences(MetadataReferenceFacade.SystemSecurityCryptography)
+            .AddReferences(NetStandardMetadataReference.Netstandard);
+        private readonly VerifierBuilder builderVB = new VerifierBuilder<VB.CertificateValidationCheck>()
+            .AddReferences(MetadataReferenceFacade.SystemNetHttp)
+            .AddReferences(MetadataReferenceFacade.SystemSecurityCryptography)
+            .AddReferences(NetStandardMetadataReference.Netstandard);
+
         [TestMethod]
         public void CertificateValidationCheck_CS() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\CertificateValidationCheck.cs", new CS.CertificateValidationCheck(), GetAdditionalReferences());
+            builderCS.AddPaths("CertificateValidationCheck.cs").Verify();
 
 #if NET
+
         [TestMethod]
         public void CertificateValidationCheck_CSharp8() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\CertificateValidationCheck.CSharp8.cs",
-                                    new CS.CertificateValidationCheck(),
-                                    ParseOptionsHelper.FromCSharp8,
-                                    GetAdditionalReferences());
+            builderCS.AddPaths("CertificateValidationCheck.CSharp8.cs").WithOptions(ParseOptionsHelper.FromCSharp8).Verify();
 
         [TestMethod]
         public void CertificateValidationCheck_CS_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(
-                new[] { @"TestCases\CertificateValidationCheck.CSharp9.cs", @"TestCases\CertificateValidationCheck.CSharp9.Partial.cs" },
-                new CS.CertificateValidationCheck(),
-                GetAdditionalReferences());
+            builderCS.AddPaths("CertificateValidationCheck.CSharp9.cs", "CertificateValidationCheck.CSharp9.Partial.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void CertificateValidationCheck_CS_TopLevelStatements() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\CertificateValidationCheck.TopLevelStatements.cs",
-                                                      new CS.CertificateValidationCheck(),
-                                                      GetAdditionalReferences());
+            builderCS.AddPaths("CertificateValidationCheck.TopLevelStatements.cs").WithTopLevelStatements().Verify();
+
 #endif
 
         [TestMethod]
         public void CertificateValidationCheck_VB() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\CertificateValidationCheck.vb",
-                                    new VB.CertificateValidationCheck(),
-                                    GetAdditionalReferences());
+            builderVB.AddPaths("CertificateValidationCheck.vb").Verify();
 
         [TestMethod]
         public void CreateParameterLookup_CS_ThrowsException()
@@ -81,10 +79,5 @@ namespace SonarAnalyzer.UnitTest.Rules
             Action a = () => analyzer.CreateParameterLookup(null, null);
             a.Should().Throw<ArgumentException>();
         }
-
-        private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.SystemNetHttp
-                                   .Concat(MetadataReferenceFacade.SystemSecurityCryptography)
-                                   .Concat(NetStandardMetadataReference.Netstandard);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CertificateValidationCheckTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CertificateValidationCheckTest.cs
@@ -31,14 +31,12 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class CertificateValidationCheckTest
     {
-        private readonly VerifierBuilder builderCS = new VerifierBuilder<CS.CertificateValidationCheck>()
+        private static readonly VerifierBuilder WithReferences = new VerifierBuilder()
             .AddReferences(MetadataReferenceFacade.SystemNetHttp)
             .AddReferences(MetadataReferenceFacade.SystemSecurityCryptography)
             .AddReferences(NetStandardMetadataReference.Netstandard);
-        private readonly VerifierBuilder builderVB = new VerifierBuilder<VB.CertificateValidationCheck>()
-            .AddReferences(MetadataReferenceFacade.SystemNetHttp)
-            .AddReferences(MetadataReferenceFacade.SystemSecurityCryptography)
-            .AddReferences(NetStandardMetadataReference.Netstandard);
+        private readonly VerifierBuilder builderCS = WithReferences.AddAnalyzer(() => new CS.CertificateValidationCheck());
+        private readonly VerifierBuilder builderVB = WithReferences.AddAnalyzer(() => new VB.CertificateValidationCheck());
 
         [TestMethod]
         public void CertificateValidationCheck_CS() =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ClassAndMethodNameTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ClassAndMethodNameTest.cs
@@ -33,81 +33,71 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class ClassAndMethodNameTest
     {
+        private readonly VerifierBuilder builderCS = new VerifierBuilder<CS.ClassAndMethodName>();
+
         [TestMethod]
         public void ClassName_CS() =>
-            OldVerifier.VerifyNonConcurrentAnalyzer(
-                new[]
-                {
-                    @"TestCases\ClassName.cs",
-                    @"TestCases\ClassName.Partial.cs",
-                },
-                new CS.ClassAndMethodName(),
-                ParseOptionsHelper.FromCSharp8,
-                MetadataReferenceFacade.NETStandard21);
+            builderCS.AddPaths("ClassName.cs", "ClassName.Partial.cs")
+                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .WithConcurrentAnalysis(false)
+                .WithOptions(ParseOptionsHelper.FromCSharp8)
+                .Verify();
 
         [TestMethod]
         public void ClassName_InTestProject_CS() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\ClassName.Tests.cs", new CS.ClassAndMethodName(), ParseOptionsHelper.FromCSharp8, NuGetMetadataReference.MSTestTestFrameworkV1);
+            builderCS.AddPaths("ClassName.Tests.cs").AddTestReference().WithOptions(ParseOptionsHelper.FromCSharp8).Verify();
 
 #if NET
+
         [TestMethod]
         public void ClassName_TopLevelStatement_CS() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\ClassName.TopLevelStatement.cs", new CS.ClassAndMethodName());
+            builderCS.AddPaths("ClassName.TopLevelStatement.cs").WithTopLevelStatements().Verify();
 
         [TestMethod]
         public void ClassName_TopLevelStatement_InTestProject_CS() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9ConsoleInTest(@"TestCases\ClassName.TopLevelStatement.Test.cs", new CS.ClassAndMethodName());
+            builderCS.AddPaths("ClassName.TopLevelStatement.Test.cs").AddTestReference().WithTopLevelStatements().Verify();
 
         [TestMethod]
         public void RecordName_CS() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\RecordName.cs", new CS.ClassAndMethodName());
+            builderCS.AddPaths("RecordName.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void RecordName_InTestProject_CS() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9LibraryInTest(@"TestCases\RecordName.cs", new CS.ClassAndMethodName());
+            builderCS.AddPaths("RecordName.cs").AddTestReference().WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void RecordStructName_CS() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(@"TestCases\RecordStructName.cs", new CS.ClassAndMethodName());
+            builderCS.AddPaths("RecordStructName.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
 
         [TestMethod]
         public void RecordStructName_InTestProject_CS() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10LibraryInTest(@"TestCases\RecordStructName.cs", new CS.ClassAndMethodName());
+            builderCS.AddPaths("RecordStructName.cs").AddTestReference().WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+
+        [TestMethod]
+        public void MethodName_CSharp9() =>
+            builderCS.AddPaths("MethodName.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
+
+        [TestMethod]
+        public void MethodName_InTestProject_CSharp9() =>
+            builderCS.AddPaths("MethodName.CSharp9.cs").AddTestReference().WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
+
+        [TestMethod]
+        public void MethodName_CSharpPreview() =>
+            builderCS.AddPaths("MethodName.CSharpPreview.cs").WithOptions(ParseOptionsHelper.CSharpPreview).Verify();
+
 #endif
 
         [DataTestMethod]
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void ClassName_VB(ProjectType projectType) =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\ClassName.vb", new VB.ClassName(), TestHelper.ProjectTypeReference(projectType));
+            new VerifierBuilder<VB.ClassName>().AddPaths("ClassName.vb").AddReferences(TestHelper.ProjectTypeReference(projectType)).Verify();
 
         [DataTestMethod]
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void MethodName(ProjectType projectType) =>
-            OldVerifier.VerifyAnalyzer(
-                new[]
-                {
-                    @"TestCases\MethodName.cs",
-                    @"TestCases\MethodName.Partial.cs",
-                },
-                new CS.ClassAndMethodName(),
-                ParseOptionsHelper.FromCSharp8,
-                TestHelper.ProjectTypeReference(projectType));
-
-#if NET
-        [TestMethod]
-        public void MethodName_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\MethodName.CSharp9.cs", new CS.ClassAndMethodName());
-
-        [TestMethod]
-        public void MethodName_InTestProject_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9LibraryInTest(@"TestCases\MethodName.CSharp9.cs", new CS.ClassAndMethodName());
-
-        [TestMethod]
-        public void MethodName_CSharpPreview() =>
-            OldVerifier.VerifyAnalyzerCSharpPreviewLibrary(@"TestCases\MethodName.CSharpPreview.cs", new CS.ClassAndMethodName());
-#endif
+            builderCS.AddPaths("MethodName.cs", "MethodName.Partial.cs").AddReferences(TestHelper.ProjectTypeReference(projectType)).WithOptions(ParseOptionsHelper.FromCSharp8).Verify();
 
         [TestMethod]
         public void TestSplitToParts() =>
@@ -120,7 +110,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 ("Ff9F", new[] { "Ff", "9", "F" }),
                 ("你好", new[] { "你", "好" }),
                 ("FFf", new[] { "F", "Ff" }),
-                ("",  Array.Empty<string>()),
+                (string.Empty,  Array.Empty<string>()),
                 ("FF9d", new[] { "FF", "9", "d" }),
                 ("y2x5__w7", new[] { "y", "2", "x", "5", "_", "_", "w", "7" }),
                 ("3%c#account", new[] { "3", "%", "c", "#", "account" }),

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CollectionsShouldImplementGenericInterfaceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CollectionsShouldImplementGenericInterfaceTest.cs
@@ -28,30 +28,25 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class CollectionsShouldImplementGenericInterfaceTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<CollectionsShouldImplementGenericInterface>()
+            .AddReferences(MetadataReferenceFacade.SystemCollections)
+            .WithErrorBehavior(CompilationErrorBehavior.Ignore);    // It would be too tedious to implement all those interfaces
+
         [TestMethod]
         public void CollectionsShouldImplementGenericInterface() =>
-            OldVerifier.VerifyAnalyzer(
-                @"TestCases\CollectionsShouldImplementGenericInterface.cs",
-                new CollectionsShouldImplementGenericInterface(),
-                CompilationErrorBehavior.Ignore,     // It would be too tedious to implement all those interfaces
-                MetadataReferenceFacade.SystemCollections);
+            builder.AddPaths("CollectionsShouldImplementGenericInterface.cs").Verify();
 
 #if NET
+
         [TestMethod]
         public void CollectionsShouldImplementGenericInterface_Csharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(
-                @"TestCases\CollectionsShouldImplementGenericInterface.CSharp9.cs",
-                new CollectionsShouldImplementGenericInterface(),
-                CompilationErrorBehavior.Ignore,     // It would be too tedious to implement all those interfaces
-                MetadataReferenceFacade.SystemCollections);
+            builder.AddPaths("CollectionsShouldImplementGenericInterface.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void CollectionsShouldImplementGenericInterface_Csharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(
-                @"TestCases\CollectionsShouldImplementGenericInterface.CSharp10.cs",
-                new CollectionsShouldImplementGenericInterface(),
-                CompilationErrorBehavior.Ignore,     // It would be too tedious to implement all those interfaces
-                MetadataReferenceFacade.SystemCollections);
+            builder.AddPaths("CollectionsShouldImplementGenericInterface.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+
 #endif
+
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DisposeNotImplementingDisposeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DisposeNotImplementingDisposeTest.cs
@@ -27,20 +27,23 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class DisposeNotImplementingDisposeTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<DisposeNotImplementingDispose>();
+
         [TestMethod]
         public void DisposeNotImplementingDispose() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\DisposeNotImplementingDispose.cs", new DisposeNotImplementingDispose(), ParseOptionsHelper.FromCSharp8);
+            builder.AddPaths("DisposeNotImplementingDispose.cs").WithOptions(ParseOptionsHelper.FromCSharp8).Verify();
 
 #if NET
+
         [TestMethod]
         public void DisposeNotImplementingDispose_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Console(
-                new[] { @"TestCases\DisposeNotImplementingDispose.CSharp9.Part1.cs", @"TestCases\DisposeNotImplementingDispose.CSharp9.Part2.cs", },
-                new DisposeNotImplementingDispose());
+            builder.AddPaths("DisposeNotImplementingDispose.CSharp9.Part1.cs", "DisposeNotImplementingDispose.CSharp9.Part2.cs").WithTopLevelStatements().Verify();
 
         [TestMethod]
         public void DisposeNotImplementingDispose_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(@"TestCases\DisposeNotImplementingDispose.CSharp10.cs", new DisposeNotImplementingDispose());
+            builder.AddPaths("DisposeNotImplementingDispose.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+
 #endif
+
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/EmptyNamespaceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/EmptyNamespaceTest.cs
@@ -27,24 +27,29 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class EmptyNamespaceTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<EmptyNamespace>();
+
         [TestMethod]
         public void EmptyNamespace() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\EmptyNamespace.cs", new EmptyNamespace());
+            builder.AddPaths("EmptyNamespace.cs").Verify();
 
 #if NET
+
         [TestMethod]
         public void EmptyNamespace_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(
-                new[] { @"TestCases\EmptyNamespace.CSharp10.Empty.cs", @"TestCases\EmptyNamespace.CSharp10.NotEmpty.cs" },
-                new EmptyNamespace());
+            builder.AddPaths("EmptyNamespace.CSharp10.Empty.cs", "EmptyNamespace.CSharp10.NotEmpty.cs")
+                .WithOptions(ParseOptionsHelper.FromCSharp10)
+                .WithConcurrentAnalysis(false)
+                .Verify();
+
 #endif
 
         [TestMethod]
         public void EmptyNamespace_CodeFix() =>
-            OldVerifier.VerifyCodeFix<EmptyNamespaceCodeFix>(
-                @"TestCases\EmptyNamespace.cs",
-                @"TestCases\EmptyNamespace.Fixed.cs",
-                @"TestCases\EmptyNamespace.Fixed.Batch.cs",
-                new EmptyNamespace());
+            builder.AddPaths("EmptyNamespace.cs")
+                .WithCodeFix<EmptyNamespaceCodeFix>()
+                .WithCodeFixedPath("EmptyNamespace.Fixed.cs")
+                .WithCodeFixedPathBatch("EmptyNamespace.Fixed.Batch.cs")
+                .VerifyCodeFix();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ImplementISerializableCorrectlyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ImplementISerializableCorrectlyTest.cs
@@ -27,22 +27,23 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class ImplementISerializableCorrectlyTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<ImplementISerializableCorrectly>();
+
         [TestMethod]
         public void ImplementISerializableCorrectly() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\ImplementISerializableCorrectly.cs", new ImplementISerializableCorrectly());
+            builder.AddPaths("ImplementISerializableCorrectly.cs").Verify();
 
 #if NET
+
         [TestMethod]
         public void ImplementISerializableCorrectly_FromCSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(
-                new string[] {@"TestCases\ImplementISerializableCorrectly.CSharp9.Part1.cs", @"TestCases\ImplementISerializableCorrectly.CSharp9.Part2.cs"},
-                new ImplementISerializableCorrectly());
+            builder.AddPaths("ImplementISerializableCorrectly.CSharp9.Part1.cs", "ImplementISerializableCorrectly.CSharp9.Part2.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void ImplementISerializableCorrectly_FromCSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(
-                @"TestCases\ImplementISerializableCorrectly.CSharp10.cs",
-                new ImplementISerializableCorrectly());
+            builder.AddPaths("ImplementISerializableCorrectly.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+
 #endif
+
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MutableFieldsShouldNotBePublicReadonlyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MutableFieldsShouldNotBePublicReadonlyTest.cs
@@ -28,27 +28,23 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class MutableFieldsShouldNotBePublicReadonlyTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<MutableFieldsShouldNotBePublicReadonly>().AddReferences(NuGetMetadataReference.SystemCollectionsImmutable("1.3.0"));
+
         [TestMethod]
         public void PublicMutableFieldsShouldNotBeReadonly() =>
-            OldVerifier.VerifyAnalyzer(
-                @"TestCases\MutableFieldsShouldNotBePublicReadonly.cs",
-                new MutableFieldsShouldNotBePublicReadonly(),
-                NuGetMetadataReference.SystemCollectionsImmutable("1.3.0"));
+            builder.AddPaths("MutableFieldsShouldNotBePublicReadonly.cs").Verify();
 
 #if NET
+
         [TestMethod]
         public void PublicMutableFieldsShouldNotBeReadonly_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(
-                @"TestCases\MutableFieldsShouldNotBePublicReadonly.CSharp9.cs",
-                new MutableFieldsShouldNotBePublicReadonly(),
-                NuGetMetadataReference.SystemCollectionsImmutable("1.3.0"));
+            builder.AddPaths("MutableFieldsShouldNotBePublicReadonly.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void PublicMutableFieldsShouldNotBeReadonly_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(
-                new[] { @"TestCases\MutableFieldsShouldNotBePublicReadonly.CSharp10.cs" },
-                new MutableFieldsShouldNotBePublicReadonly(),
-                NuGetMetadataReference.SystemCollectionsImmutable("1.3.0"));
+            builder.AddPaths("MutableFieldsShouldNotBePublicReadonly.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+
 #endif
+
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MutableFieldsShouldNotBePublicStaticTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MutableFieldsShouldNotBePublicStaticTest.cs
@@ -28,27 +28,23 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class MutableFieldsShouldNotBePublicStaticTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<MutableFieldsShouldNotBePublicStatic>().AddReferences(NuGetMetadataReference.SystemCollectionsImmutable("1.3.0"));
+
         [TestMethod]
         public void MutableFieldsShouldNotBePublicStatic() =>
-            OldVerifier.VerifyAnalyzer(
-                @"TestCases\MutableFieldsShouldNotBePublicStatic.cs",
-                new MutableFieldsShouldNotBePublicStatic(),
-                NuGetMetadataReference.SystemCollectionsImmutable("1.3.0"));
+            builder.AddPaths("MutableFieldsShouldNotBePublicStatic.cs").Verify();
 
 #if NET
+
         [TestMethod]
         public void MutableFieldsShouldNotBePublicStatic_Csharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(
-                @"TestCases\MutableFieldsShouldNotBePublicStatic.CSharp9.cs",
-                new MutableFieldsShouldNotBePublicStatic(),
-                NuGetMetadataReference.SystemCollectionsImmutable("1.3.0"));
+            builder.AddPaths("MutableFieldsShouldNotBePublicStatic.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void MutableFieldsShouldNotBePublicStatic_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(
-                new[] { @"TestCases\MutableFieldsShouldNotBePublicStatic.CSharp10.cs" },
-                new MutableFieldsShouldNotBePublicStatic(),
-                NuGetMetadataReference.SystemCollectionsImmutable("1.3.0"));
+            builder.AddPaths("MutableFieldsShouldNotBePublicStatic.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+
 #endif
+
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/PartialMethodNoImplementationTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/PartialMethodNoImplementationTest.cs
@@ -27,22 +27,23 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class PartialMethodNoImplementationTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<PartialMethodNoImplementation>();
+
         [TestMethod]
         public void PartialMethodNoImplementation() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\PartialMethodNoImplementation.cs", new PartialMethodNoImplementation());
+            builder.AddPaths("PartialMethodNoImplementation.cs").Verify();
 
 #if NET
+
         [TestMethod]
         public void PartialMethodNoImplementation_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(
-                new string[] { @"TestCases\PartialMethodNoImplementation.CSharp9.Part1.cs", @"TestCases\PartialMethodNoImplementation.CSharp9.Part2.cs"},
-                new PartialMethodNoImplementation());
+            builder.AddPaths("PartialMethodNoImplementation.CSharp9.Part1.cs", "PartialMethodNoImplementation.CSharp9.Part2.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void PartialMethodNoImplementation_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(
-                new string[] { @"TestCases\PartialMethodNoImplementation.CSharp10.Part1.cs", @"TestCases\PartialMethodNoImplementation.CSharp10.Part2.cs"},
-                new PartialMethodNoImplementation());
+            builder.AddPaths("PartialMethodNoImplementation.CSharp10.Part1.cs", "PartialMethodNoImplementation.CSharp10.Part2.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+
 #endif
+
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InvalidCastToInterfaceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InvalidCastToInterfaceTest.cs
@@ -18,9 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Linq;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.Rules.CSharp;
@@ -33,36 +30,32 @@ namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution
     [TestClass]
     public class InvalidCastToInterfaceTest
     {
-        private static readonly DiagnosticDescriptor[] OnlyDiagnostics = new[] { InvalidCastToInterfaceSymbolicExecution.S1944 };
+        private readonly VerifierBuilder builder = new VerifierBuilder<SymbolicExecutionRunner>()
+            .AddAnalyzer(() => new InvalidCastToInterface())
+            .WithBasePath(@"SymbolicExecution\Sonar")
+            .WithOnlyDiagnostics(InvalidCastToInterfaceSymbolicExecution.S1944);
 
         [DataTestMethod]
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void InvalidCastToInterface(ProjectType projectType) =>
-            OldVerifier.VerifyAnalyzer(
-                @"TestCases\SymbolicExecution\Sonar\InvalidCastToInterface.cs",
-                Analyzers(),
-                additionalReferences: TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NETStandard21),
-                options: ParseOptionsHelper.FromCSharp8,
-                onlyDiagnostics: OnlyDiagnostics);
+            builder.AddPaths("InvalidCastToInterface.cs")
+                .AddReferences(TestHelper.ProjectTypeReference(projectType))
+                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .WithOptions(ParseOptionsHelper.FromCSharp8)
+                .Verify();
 
 #if NET
+
         [TestMethod]
         public void InvalidCastToInterface_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Console(
-                @"TestCases\SymbolicExecution\Sonar\InvalidCastToInterface.CSharp9.cs",
-                Analyzers(),
-                onlyDiagnostics: OnlyDiagnostics);
+            builder.AddPaths("InvalidCastToInterface.CSharp9.cs").WithTopLevelStatements().Verify();
 
         [TestMethod]
         public void InvalidCastToInterface_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(
-                @"TestCases\SymbolicExecution\Sonar\InvalidCastToInterface.CSharp10.cs",
-                Analyzers(),
-                onlyDiagnostics: OnlyDiagnostics);
+            builder.AddPaths("InvalidCastToInterface.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+
 #endif
 
-        private static DiagnosticAnalyzer[] Analyzers() =>
-            new DiagnosticAnalyzer[] { new SymbolicExecutionRunner(), new InvalidCastToInterface() };
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/OldVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/OldVerifier.cs
@@ -108,87 +108,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .Verify();
 
         /// <summary>
-        /// Verify analyzer from C# 9 with top level statements in non-concurrent execution mode.
-        /// </summary>
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzerFromCSharp9Console(string[] paths, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(paths))
-                .WithOptions(ParseOptionsHelper.FromCSharp9)
-                .WithTopLevelStatements()
-                .Verify();
-
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzerFromCSharp10Console(string[] paths, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(paths))
-                .WithOptions(ParseOptionsHelper.FromCSharp10)
-                .WithTopLevelStatements()
-                .Verify();
-
-        /// <summary>
-        /// Verify analyzer from C# 9 with top level statements in non-concurrent execution mode.
-        /// </summary>
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzerFromCSharp9Console(string path,
-                                                            DiagnosticAnalyzer[] diagnosticAnalyzers,
-                                                            IEnumerable<MetadataReference> additionalReferences = null,
-                                                            DiagnosticDescriptor[] onlyDiagnostics = null) =>
-            diagnosticAnalyzers.Aggregate(new VerifierBuilder(), (builder, analyzer) => builder.AddAnalyzer(() => analyzer))
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(path))
-                .WithOptions(ParseOptionsHelper.FromCSharp9)
-                .WithTopLevelStatements()
-                .WithOnlyDiagnostics(onlyDiagnostics ?? Array.Empty<DiagnosticDescriptor>())
-                .Verify();
-
-        /// <summary>
-        /// Verify analyzer from C# 9 on a test library project in non-concurrent execution mode.
-        /// </summary>
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzerFromCSharp9LibraryInTest(string path, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddTestReference()
-                .AddPaths(RemoveTestCasesPrefix(path))
-                .WithConcurrentAnalysis(false)
-                .WithOptions(ParseOptionsHelper.FromCSharp9)
-                .Verify();
-
-        /// <summary>
-        /// Verify analyzer from C# 10 on a test library project in non-concurrent execution mode.
-        /// </summary>
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzerFromCSharp10LibraryInTest(string path, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddTestReference()
-                .AddPaths(RemoveTestCasesPrefix(path))
-                .WithConcurrentAnalysis(false)
-                .WithOptions(ParseOptionsHelper.FromCSharp10)
-                .Verify();
-
-        /// <summary>
-        /// Verify analyzer from C# 9 on a test console project in non-concurrent execution mode.
-        /// </summary>
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzerFromCSharp9ConsoleInTest(string path, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddTestReference()
-                .AddPaths(RemoveTestCasesPrefix(path))
-                .WithTopLevelStatements()
-                .WithOptions(ParseOptionsHelper.FromCSharp9)
-                .Verify();
-
-        /// <summary>
         /// Verify analyzer from C# 9 without top level statements in non-concurrent execution mode.
         /// </summary>
         [Obsolete("Use VerifierBuilder instead.")]
@@ -205,25 +124,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .WithOnlyDiagnostics(onlyDiagnostics ?? Array.Empty<DiagnosticDescriptor>())
                 .Verify();
 
-        /// <summary>
-        /// Verify analyzer from C# 9 without top level statements in non-concurrent execution mode.
-        /// </summary>
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzerFromCSharp9Library(string path,
-                                                            DiagnosticAnalyzer diagnosticAnalyzer,
-                                                            CompilationErrorBehavior behaviour,
-                                                            IEnumerable<MetadataReference> additionalReferences = null,
-                                                            DiagnosticDescriptor[] onlyDiagnostics = null) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(path))
-                .WithConcurrentAnalysis(false)
-                .WithOptions(ParseOptionsHelper.FromCSharp9)
-                .WithErrorBehavior(behaviour)
-                .WithOnlyDiagnostics(onlyDiagnostics ?? Array.Empty<DiagnosticDescriptor>())
-                .Verify();
-
         [Obsolete("Use VerifierBuilder instead.")]
         public static void VerifyAnalyzerFromCSharp10Library(string path,
                                                              DiagnosticAnalyzer diagnosticAnalyzer,
@@ -235,35 +135,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
-                .WithOnlyDiagnostics(onlyDiagnostics ?? Array.Empty<DiagnosticDescriptor>())
-                .Verify();
-
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzerFromCSharp10Library(string path,
-                                                             DiagnosticAnalyzer[] diagnosticAnalyzers,
-                                                             IEnumerable<MetadataReference> additionalReferences = null,
-                                                             DiagnosticDescriptor[] onlyDiagnostics = null) =>
-            diagnosticAnalyzers.Aggregate(new VerifierBuilder(), (builder, analyzer) => builder.AddAnalyzer(() => analyzer))
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(path))
-                .WithConcurrentAnalysis(false)
-                .WithOptions(ParseOptionsHelper.FromCSharp10)
-                .WithOnlyDiagnostics(onlyDiagnostics ?? Array.Empty<DiagnosticDescriptor>())
-                .Verify();
-
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzerFromCSharp10Library(string path,
-                                                             DiagnosticAnalyzer diagnosticAnalyzer,
-                                                             CompilationErrorBehavior behavior,
-                                                             IEnumerable<MetadataReference> additionalReferences = null,
-                                                             DiagnosticDescriptor[] onlyDiagnostics = null) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(path))
-                .WithConcurrentAnalysis(false)
-                .WithOptions(ParseOptionsHelper.FromCSharp10)
-                .WithErrorBehavior(behavior)
                 .WithOnlyDiagnostics(onlyDiagnostics ?? Array.Empty<DiagnosticDescriptor>())
                 .Verify();
 
@@ -275,29 +146,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.CSharpPreview)
-                .Verify();
-
-        /// <summary>
-        /// Verify analyzer from C# 9 without top level statements in non-concurrent execution mode.
-        /// </summary>
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzerFromCSharp9Library(string[] paths, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(paths))
-                .WithConcurrentAnalysis(false)
-                .WithOptions(ParseOptionsHelper.FromCSharp9)
-                .Verify();
-
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzerFromCSharp10Library(string[] paths, DiagnosticAnalyzer diagnosticAnalyzer, IEnumerable<MetadataReference> additionalReferences = null) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(paths))
-                .WithConcurrentAnalysis(false)
-                .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .Verify();
 
         [Obsolete("Use VerifierBuilder instead.")]


### PR DESCRIPTION
Squash commits doesn't need a review