### PR TITLE
UTs: Remove OldVerifier.VerifyNonConcurrentAnalyzer

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotDecreaseMemberVisibilityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotDecreaseMemberVisibilityTest.cs
@@ -28,17 +28,22 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class DoNotDecreaseMemberVisibilityTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<DoNotDecreaseMemberVisibility>().WithConcurrentAnalysis(false);
+
         [TestMethod]
         public void DoNotDecreaseMemberVisibility() =>
-            OldVerifier.VerifyNonConcurrentAnalyzer(new[] { @"TestCases\DoNotDecreaseMemberVisibility.cs", @"TestCases\DoNotDecreaseMemberVisibility2.cs", },
-                                    new DoNotDecreaseMemberVisibility(),
-                                    ParseOptionsHelper.FromCSharp8,
-                                    MetadataReferenceFacade.NETStandard21);
+            builder.AddPaths("DoNotDecreaseMemberVisibility.cs", "DoNotDecreaseMemberVisibility2.cs")
+                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .WithOptions(ParseOptionsHelper.FromCSharp8)
+                .Verify();
 
 #if NET
+
         [TestMethod]
         public void DoNotDecreaseMemberVisibility_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\DoNotDecreaseMemberVisibility.CSharp9.cs", new DoNotDecreaseMemberVisibility());
+            builder.AddPaths("DoNotDecreaseMemberVisibility.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
+
 #endif
+
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/GenericTypeParameterEmptinessCheckingTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/GenericTypeParameterEmptinessCheckingTest.cs
@@ -28,28 +28,25 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class GenericTypeParameterEmptinessCheckingTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<GenericTypeParameterEmptinessChecking>().AddReferences(MetadataReferenceFacade.SystemCollections);
+
         [TestMethod]
         public void GenericTypeParameterEmptinessChecking() =>
-            OldVerifier.VerifyAnalyzer(
-                @"TestCases\GenericTypeParameterEmptinessChecking.cs",
-                new GenericTypeParameterEmptinessChecking(),
-                CompilationErrorBehavior.Ignore,
-                MetadataReferenceFacade.SystemCollections);
+            builder.AddPaths("GenericTypeParameterEmptinessChecking.cs").WithErrorBehavior(CompilationErrorBehavior.Ignore).Verify();
 
 #if NET
+
         [TestMethod]
         public void GenericTypeParameterEmptinessChecking_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Console(
-                @"TestCases\GenericTypeParameterEmptinessChecking.CSharp9.cs",
-                new GenericTypeParameterEmptinessChecking(),
-                MetadataReferenceFacade.SystemCollections);
+            builder.AddPaths("GenericTypeParameterEmptinessChecking.CSharp9.cs").WithTopLevelStatements().Verify();
+
 #endif
 
         [TestMethod]
         public void GenericTypeParameterEmptinessChecking_CodeFix() =>
-            OldVerifier.VerifyCodeFix<GenericTypeParameterEmptinessCheckingCodeFix>(
-                @"TestCases\GenericTypeParameterEmptinessChecking.cs",
-                @"TestCases\GenericTypeParameterEmptinessChecking.Fixed.cs",
-                new GenericTypeParameterEmptinessChecking());
+            builder.AddPaths("GenericTypeParameterEmptinessChecking.cs")
+                .WithCodeFix<GenericTypeParameterEmptinessCheckingCodeFix>()
+                .WithCodeFixedPath("GenericTypeParameterEmptinessChecking.Fixed.cs")
+                .VerifyCodeFix();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithAssemblyVersionAttributeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithAssemblyVersionAttributeTest.cs
@@ -57,24 +57,20 @@ namespace SonarAnalyzer.UnitTest.Rules
                 .Verify();
 
         [TestMethod]
-        public void MarkAssemblyWithAssemblyVersionAttributeNoncompliant_CS()
-        {
-            Action action = () => builderCS.AddPaths("MarkAssemblyWithAssemblyVersionAttributeNoncompliant.cs").WithConcurrentAnalysis(false).Verify();
-            action.Should().Throw<UnexpectedDiagnosticException>().WithMessage("*Provide an 'AssemblyVersion' attribute for assembly 'project0'.*");
-        }
+        public void MarkAssemblyWithAssemblyVersionAttributeNoncompliant_CS() =>
+            builderCS.AddPaths("MarkAssemblyWithAssemblyVersionAttributeNoncompliant.cs")
+                .WithConcurrentAnalysis(false)
+                .Invoking(x => x.Verify())
+                .Should().Throw<UnexpectedDiagnosticException>().WithMessage("*Provide an 'AssemblyVersion' attribute for assembly 'project0'.*");
 
         [TestMethod]
-        public void MarkAssemblyWithAssemblyVersionAttributeNoncompliant_NoTargets_ShouldNotRaise_CS()
-        {
-            Action action = () => builderCS
-                                  .AddPaths("MarkAssemblyWithAssemblyVersionAttributeNoncompliant.cs")
-                                  .WithConcurrentAnalysis(false)
-                                  .AddReferences(NuGetMetadataReference.MicrosoftBuildNoTargets())
-                                  .Verify();
-
-            // False positive. No assembly gets generated when Microsoft.Build.NoTargets is referenced.
-            action.Should().Throw<UnexpectedDiagnosticException>().WithMessage("*Provide an 'AssemblyVersion' attribute for assembly 'project0'.*");
-        }
+        public void MarkAssemblyWithAssemblyVersionAttributeNoncompliant_NoTargets_ShouldNotRaise_CS() =>
+            builderCS.AddPaths("MarkAssemblyWithAssemblyVersionAttributeNoncompliant.cs")
+                .AddReferences(NuGetMetadataReference.MicrosoftBuildNoTargets())
+                .WithConcurrentAnalysis(false)
+                .Invoking(x => x.Verify())
+                // False positive. No assembly gets generated when Microsoft.Build.NoTargets is referenced.
+                .Should().Throw<UnexpectedDiagnosticException>().WithMessage("*Provide an 'AssemblyVersion' attribute for assembly 'project0'.*");
 
         [TestMethod]
         public void MarkAssemblyWithAssemblyVersionAttribute_VB() =>
@@ -97,24 +93,20 @@ namespace SonarAnalyzer.UnitTest.Rules
                 .Verify();
 
         [TestMethod]
-        public void MarkAssemblyWithAssemblyVersionAttributeNoncompliant_VB()
-        {
-            Action action = () => builderVB.AddPaths("MarkAssemblyWithAssemblyVersionAttributeNoncompliant.vb").WithConcurrentAnalysis(false).Verify();
-            action.Should().Throw<UnexpectedDiagnosticException>().WithMessage("*Provide an 'AssemblyVersion' attribute for assembly 'project0'.*");
-        }
+        public void MarkAssemblyWithAssemblyVersionAttributeNoncompliant_VB() =>
+            builderVB.AddPaths("MarkAssemblyWithAssemblyVersionAttributeNoncompliant.vb")
+                .WithConcurrentAnalysis(false)
+                .Invoking(x => x.Verify())
+                .Should().Throw<UnexpectedDiagnosticException>().WithMessage("*Provide an 'AssemblyVersion' attribute for assembly 'project0'.*");
 
         [TestMethod]
-        public void MarkAssemblyWithAssemblyVersionAttributeNoncompliant_NoTargets_ShouldNotRaise_VB()
-        {
-            Action action = () => builderVB
-                                  .AddPaths("MarkAssemblyWithAssemblyVersionAttributeNoncompliant.vb")
-                                  .WithConcurrentAnalysis(false)
-                                  .AddReferences(GetAspNetCoreRazorReferences())
-                                  .Verify();
-
-            // False positive. No assembly gets generated when Microsoft.Build.NoTargets is referenced.
-            action.Should().Throw<UnexpectedDiagnosticException>().WithMessage("*Provide an 'AssemblyVersion' attribute for assembly 'project0'.*");
-        }
+        public void MarkAssemblyWithAssemblyVersionAttributeNoncompliant_NoTargets_ShouldNotRaise_VB() =>
+            builderVB.AddPaths("MarkAssemblyWithAssemblyVersionAttributeNoncompliant.vb")
+                .AddReferences(NuGetMetadataReference.MicrosoftBuildNoTargets())
+                .WithConcurrentAnalysis(false)
+                .Invoking(x => x.Verify())
+                // False positive. No assembly gets generated when Microsoft.Build.NoTargets is referenced.
+                .Should().Throw<UnexpectedDiagnosticException>().WithMessage("*Provide an 'AssemblyVersion' attribute for assembly 'project0'.*");
 
         private static IEnumerable<MetadataReference> GetAspNetCoreRazorReferences() =>
             NuGetMetadataReference.MicrosoftAspNetCoreMvcRazorRuntime(Constants.NuGetLatestVersion);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithNeutralResourcesLanguageAttributeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MarkAssemblyWithNeutralResourcesLanguageAttributeTest.cs
@@ -27,35 +27,22 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class MarkAssemblyWithNeutralResourcesLanguageAttributeTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<MarkAssemblyWithNeutralResourcesLanguageAttribute>().WithConcurrentAnalysis(false);
+
         [TestMethod]
         public void MarkAssemblyWithNeutralResourcesLanguageAttribute_HasResx_HasAttribute_Compliant() =>
-            new VerifierBuilder<MarkAssemblyWithNeutralResourcesLanguageAttribute>()
-                .AddPaths("MarkAssemblyWithNeutralResourcesLanguageAttribute.cs", @"Resources\SomeResources.Designer.cs", @"Resources\AnotherResources.Designer.cs")
-                .WithAutogenerateConcurrentFiles(false)
-                .Verify();
+            builder.AddPaths("MarkAssemblyWithNeutralResourcesLanguageAttribute.cs", @"Resources\SomeResources.Designer.cs", @"Resources\AnotherResources.Designer.cs").Verify();
 
         [TestMethod]
         public void MarkAssemblyWithNeutralResourcesLanguageAttribute_NoResx_HasAttribute_Compliant() =>
-            OldVerifier.VerifyNonConcurrentAnalyzer(
-                @"TestCases\MarkAssemblyWithNeutralResourcesLanguageAttribute.cs",
-                new MarkAssemblyWithNeutralResourcesLanguageAttribute());
+            builder.AddPaths("MarkAssemblyWithNeutralResourcesLanguageAttribute.cs").Verify();
 
         [TestMethod]
         public void MarkAssemblyWithNeutralResourcesLanguageAttribute_HasResx_HasInvalidAttribute_Noncompliant() =>
-            OldVerifier.VerifyNonConcurrentAnalyzer(
-                new[]
-                {
-                    @"TestCases\MarkAssemblyWithNeutralResourcesLanguageAttributeNonCompliant.Invalid.cs",
-                    @"TestCases\Resources\SomeResources.Designer.cs"
-                }, new MarkAssemblyWithNeutralResourcesLanguageAttribute());
+            builder.AddPaths("MarkAssemblyWithNeutralResourcesLanguageAttributeNonCompliant.Invalid.cs", @"Resources\SomeResources.Designer.cs").Verify();
 
         [TestMethod]
         public void MarkAssemblyWithNeutralResourcesLanguageAttribute_HasResx_NoAttribute_Noncompliant() =>
-            OldVerifier.VerifyNonConcurrentAnalyzer(
-                new[]
-                {
-                    @"TestCases\MarkAssemblyWithNeutralResourcesLanguageAttributeNonCompliant.cs",
-                    @"TestCases\Resources\SomeResources.Designer.cs"
-                }, new MarkAssemblyWithNeutralResourcesLanguageAttribute());
+            builder.AddPaths("MarkAssemblyWithNeutralResourcesLanguageAttributeNonCompliant.cs", @"Resources\SomeResources.Designer.cs").Verify();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/NativeMethodsShouldBeWrappedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/NativeMethodsShouldBeWrappedTest.cs
@@ -27,18 +27,23 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class NativeMethodsShouldBeWrappedTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<NativeMethodsShouldBeWrapped>();
+
         [TestMethod]
         public void NativeMethodsShouldBeWrapped() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\NativeMethodsShouldBeWrapped.cs", new NativeMethodsShouldBeWrapped(), CompilationErrorBehavior.Ignore);
+            builder.AddPaths("NativeMethodsShouldBeWrapped.cs").WithErrorBehavior(CompilationErrorBehavior.Ignore).Verify();
 
 #if NET
+
         [TestMethod]
         public void NativeMethodsShouldBeWrapped_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\NativeMethodsShouldBeWrapped.CSharp9.cs", new NativeMethodsShouldBeWrapped());
+            builder.AddPaths("NativeMethodsShouldBeWrapped.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
+
 #endif
 
         [TestMethod]
-        public void NativeMethodsShouldBeWrapped_InvalidCode() => OldVerifier.VerifyCSharpAnalyzer(@"
+        public void NativeMethodsShouldBeWrapped_InvalidCode() =>
+            builder.AddSnippet(@"
 public class InvalidSyntax
 {
     extern public void Extern1
@@ -56,6 +61,6 @@ public class InvalidSyntax
     {
         Extern3(x);
     }
-}", new NativeMethodsShouldBeWrapped(), CompilationErrorBehavior.Ignore);
+}").WithErrorBehavior(CompilationErrorBehavior.Ignore).Verify();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SerializationConstructorsShouldBeSecuredTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SerializationConstructorsShouldBeSecuredTest.cs
@@ -30,23 +30,23 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class SerializationConstructorsShouldBeSecuredTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<SerializationConstructorsShouldBeSecured>().AddReferences(MetadataReferenceFacade.SystemSecurityPermissions);
+
         [TestMethod]
         public void SerializationConstructorsShouldBeSecured() =>
-            OldVerifier.VerifyNonConcurrentAnalyzer(@"TestCases\SerializationConstructorsShouldBeSecured.cs",
-                                    new SerializationConstructorsShouldBeSecured(),
-                                    GetAdditionalReferences());
+            builder.AddPaths("SerializationConstructorsShouldBeSecured.cs").WithConcurrentAnalysis(false).Verify();
 
 #if NET
+
         [TestMethod]
         public void SerializationConstructorsShouldBeSecured_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\SerializationConstructorsShouldBeSecured.CSharp9.cs",
-                                    new SerializationConstructorsShouldBeSecured(),
-                                    GetAdditionalReferences());
+            builder.AddPaths("SerializationConstructorsShouldBeSecured.CSharp9.cs").WithConcurrentAnalysis(false).WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
+
 #endif
 
         [TestMethod]
         public void SerializationConstructorsShouldBeSecured_InvalidCode() =>
-            OldVerifier.VerifyCSharpAnalyzer(@"
+            builder.AddSnippet(@"
 [Serializable]
     public partial class InvalidCode : ISerializable
     {
@@ -57,26 +57,14 @@ namespace SonarAnalyzer.UnitTest.Rules
         protected (SerializationInfo info, StreamingContext context) { }
 
         public void GetObjectData(SerializationInfo info, StreamingContext context) { }
-    }", new SerializationConstructorsShouldBeSecured(), CompilationErrorBehavior.Ignore);
+    }").WithErrorBehavior(CompilationErrorBehavior.Ignore).Verify();
 
         [TestMethod]
         public void SerializationConstructorsShouldBeSecured_NoAssemblyAttribute() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\SerializationConstructorsShouldBeSecured_NoAssemblyAttribute.cs",
-                                    new SerializationConstructorsShouldBeSecured(),
-                                    GetAdditionalReferences());
+            builder.AddPaths("SerializationConstructorsShouldBeSecured_NoAssemblyAttribute.cs").Verify();
 
         [TestMethod]
         public void SerializationConstructorsShouldBeSecured_PartialClasses() =>
-            OldVerifier.VerifyNonConcurrentAnalyzer(
-                                    new[]
-                                    {
-                                        @"TestCases\SerializationConstructorsShouldBeSecured_Part1.cs",
-                                        @"TestCases\SerializationConstructorsShouldBeSecured_Part2.cs",
-                                    },
-                                    new SerializationConstructorsShouldBeSecured(),
-                                    GetAdditionalReferences());
-
-        private static IEnumerable<MetadataReference> GetAdditionalReferences() =>
-            MetadataReferenceFacade.SystemSecurityPermissions;
+            builder.AddPaths("SerializationConstructorsShouldBeSecured_Part1.cs", "SerializationConstructorsShouldBeSecured_Part2.cs").WithConcurrentAnalysis(false).Verify();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SerializationConstructorsShouldBeSecuredTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SerializationConstructorsShouldBeSecuredTest.cs
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
-using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.UnitTest.MetadataReferences;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ShouldImplementExportedInterfacesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ShouldImplementExportedInterfacesTest.cs
@@ -29,34 +29,27 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class ShouldImplementExportedInterfacesTest
     {
+        private readonly VerifierBuilder builderCS = new VerifierBuilder<CS.ShouldImplementExportedInterfaces>().AddReferences(MetadataReferenceFacade.SystemComponentModelComposition);
+        private readonly VerifierBuilder builderVB = new VerifierBuilder<VB.ShouldImplementExportedInterfaces>().AddReferences(MetadataReferenceFacade.SystemComponentModelComposition);
+
         [TestMethod]
         public void ShouldImplementExportedInterfaces_CS() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\ShouldImplementExportedInterfaces.cs",
-                                    new CS.ShouldImplementExportedInterfaces(),
-                                    MetadataReferenceFacade.SystemComponentModelComposition);
+            builderCS.AddPaths("ShouldImplementExportedInterfaces.cs").Verify();
 
 #if NET
+
         [TestMethod]
         public void ShouldImplementExportedInterfaces_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\ShouldImplementExportedInterfaces.CSharp9.cs",
-                                                      new CS.ShouldImplementExportedInterfaces(),
-                                                      MetadataReferenceFacade.SystemComponentModelComposition);
+            builderCS.AddPaths("ShouldImplementExportedInterfaces.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
+
 #endif
 
         [TestMethod]
         public void ShouldImplementExportedInterfaces_VB() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\ShouldImplementExportedInterfaces.vb",
-                                    new VB.ShouldImplementExportedInterfaces(),
-                                    MetadataReferenceFacade.SystemComponentModelComposition);
+            builderVB.AddPaths("ShouldImplementExportedInterfaces.vb").Verify();
 
         [TestMethod]
         public void ShouldImplementExportedInterfaces_Partial() =>
-            OldVerifier.VerifyAnalyzer(new[]
-                {
-                    @"TestCases\ShouldImplementExportedInterfaces_Part1.cs",
-                    @"TestCases\ShouldImplementExportedInterfaces_Part2.cs",
-                },
-                new CS.ShouldImplementExportedInterfaces(),
-                MetadataReferenceFacade.SystemComponentModelComposition);
+            builderCS.AddPaths("ShouldImplementExportedInterfaces_Part1.cs", "ShouldImplementExportedInterfaces_Part2.cs").Verify();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldNotBeIgnoredTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldNotBeIgnoredTest.cs
@@ -29,68 +29,57 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class TestMethodShouldNotBeIgnoredTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<TestMethodShouldNotBeIgnored>().AddReferences(NuGetMetadataReference.MSTestTestFrameworkV1);
+
         [TestMethod]
         public void TestMethodShouldNotBeIgnored_MsTest_Legacy() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\TestMethodShouldNotBeIgnored.MsTest.cs",
-                                    new TestMethodShouldNotBeIgnored(),
-                                    CompilationErrorBehavior.Ignore,    // IgnoreAttribute doesn't contain any reason param
-                                    NuGetMetadataReference.MSTestTestFramework("1.1.11"));
+            builder.AddPaths("TestMethodShouldNotBeIgnored.MsTest.cs")
+                .WithErrorBehavior(CompilationErrorBehavior.Ignore)    // IgnoreAttribute doesn't contain any reason param
+                .Verify();
 
         [DataTestMethod]
         [DataRow("1.2.0")]
         [DataRow(Constants.NuGetLatestVersion)]
         public void TestMethodShouldNotBeIgnored_MsTest(string testFwkVersion) =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\TestMethodShouldNotBeIgnored.MsTest.cs",
-                                    new TestMethodShouldNotBeIgnored(),
-                                    NuGetMetadataReference.MSTestTestFramework(testFwkVersion));
+            new VerifierBuilder<TestMethodShouldNotBeIgnored>()
+                .AddPaths("TestMethodShouldNotBeIgnored.MsTest.cs")
+                .AddReferences(NuGetMetadataReference.MSTestTestFramework(testFwkVersion)).Verify();
 
         [DataTestMethod]
         [DataRow("2.5.7.10213")]
         [DataRow("2.7.0")]
         public void TestMethodShouldNotBeIgnored_NUnit_V2(string testFwkVersion) =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\TestMethodShouldNotBeIgnored.NUnit.V2.cs",
-                                    new TestMethodShouldNotBeIgnored(),
-                                    NuGetMetadataReference.MSTestTestFrameworkV1
-                                        .Concat(NuGetMetadataReference.NUnit(testFwkVersion))
-                                        .ToArray());
+            builder.AddPaths("TestMethodShouldNotBeIgnored.NUnit.V2.cs")
+                .AddReferences(NuGetMetadataReference.NUnit(testFwkVersion))
+                .Verify();
 
         [DataTestMethod]
         [DataRow("3.0.0")] // Ignore without reason no longer exist
         [DataRow(Constants.NuGetLatestVersion)]
         public void TestMethodShouldNotBeIgnored_NUnit(string testFwkVersion) =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\TestMethodShouldNotBeIgnored.NUnit.cs",
-                                    new TestMethodShouldNotBeIgnored(),
-                                    NuGetMetadataReference.MSTestTestFrameworkV1
-                                        .Concat(NuGetMetadataReference.NUnit(testFwkVersion))
-                                        .ToArray());
+            builder.AddPaths("TestMethodShouldNotBeIgnored.NUnit.cs").AddReferences(NuGetMetadataReference.NUnit(testFwkVersion)).Verify();
 
         [DataTestMethod]
         [DataRow("2.0.0")]
         [DataRow(Constants.NuGetLatestVersion)]
         public void TestMethodShouldNotBeIgnored_Xunit(string testFwkVersion) =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\TestMethodShouldNotBeIgnored.Xunit.cs",
-                                    new TestMethodShouldNotBeIgnored(),
-                                    NuGetMetadataReference.MSTestTestFrameworkV1
-                                        .Concat(NuGetMetadataReference.XunitFramework(testFwkVersion))
-                                        .ToArray());
+            builder.AddPaths("TestMethodShouldNotBeIgnored.Xunit.cs").AddReferences(NuGetMetadataReference.XunitFramework(testFwkVersion)).Verify();
 
         [TestMethod]
         public void TestMethodShouldNotBeIgnored_Xunit_v1() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\TestMethodShouldNotBeIgnored.Xunit.v1.cs",
-                                    new TestMethodShouldNotBeIgnored(),
-                                    NuGetMetadataReference.MSTestTestFrameworkV1
-                                        .Concat(NuGetMetadataReference.XunitFrameworkV1)
-                                        .ToArray());
+            builder.AddPaths("TestMethodShouldNotBeIgnored.Xunit.v1.cs").AddReferences(NuGetMetadataReference.XunitFrameworkV1).Verify();
 
 #if NET
+
         [TestMethod]
         public void TestMethodShouldNotBeIgnored_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\TestMethodShouldNotBeIgnored.CSharp9.cs",
-                                                new TestMethodShouldNotBeIgnored(),
-                                                NuGetMetadataReference.MSTestTestFrameworkV1
-                                                    .Concat(NuGetMetadataReference.XunitFrameworkV1)
-                                                    .Concat(NuGetMetadataReference.NUnit(Constants.NuGetLatestVersion))
-                                                    .ToArray());
+            builder.AddPaths("TestMethodShouldNotBeIgnored.CSharp9.cs")
+                .AddReferences(NuGetMetadataReference.XunitFrameworkV1)
+                .AddReferences(NuGetMetadataReference.NUnit(Constants.NuGetLatestVersion))
+                .WithOptions(ParseOptionsHelper.FromCSharp9)
+                .Verify();
+
 #endif
+
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldNotBeIgnoredTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldNotBeIgnoredTest.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.UnitTest.MetadataReferences;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/XmlExternalEntityShouldNotBeParsedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/XmlExternalEntityShouldNotBeParsedTest.cs
@@ -18,11 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarAnalyzer.Helpers;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/OldVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/OldVerifier.cs
@@ -147,7 +147,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.CSharpPreview)
                 .Verify();
-
+        //FIXME: Remove after rebase
         [Obsolete("Use VerifierBuilder instead.")]
         public static void VerifyNonConcurrentAnalyzer(string path,
                                                        DiagnosticAnalyzer diagnosticAnalyzer,
@@ -172,57 +172,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithConcurrentAnalysis(false)
-                .WithOptions(options.IsDefault ? ImmutableArray<ParseOptions>.Empty : options)
-                .WithErrorBehavior(checkMode)
-                .WithOutputKind(outputKind)
-                .WithOnlyDiagnostics(onlyDiagnostics ?? Array.Empty<DiagnosticDescriptor>())
-                .Verify();
-
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyNonConcurrentAnalyzer(IEnumerable<string> paths,
-                                                       DiagnosticAnalyzer diagnosticAnalyzer,
-                                                       IEnumerable<MetadataReference> additionalReferences) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(paths))
-                .WithConcurrentAnalysis(false)
-                .Verify();
-
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyNonConcurrentAnalyzer(IEnumerable<string> paths,
-                                                       DiagnosticAnalyzer diagnosticAnalyzer,
-                                                       ImmutableArray<ParseOptions> options = default,
-                                                       IEnumerable<MetadataReference> additionalReferences = null) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(paths))
-                .WithConcurrentAnalysis(false)
-                .WithOptions(options.IsDefault ? ImmutableArray<ParseOptions>.Empty : options)
-                .Verify();
-
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzer(IEnumerable<string> paths,
-                                          DiagnosticAnalyzer diagnosticAnalyzer,
-                                          IEnumerable<MetadataReference> additionalReferences) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(paths))
-                .Verify();
-
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzer(string path,
-                                          DiagnosticAnalyzer[] diagnosticAnalyzers,
-                                          ImmutableArray<ParseOptions> options = default,
-                                          CompilationErrorBehavior checkMode = CompilationErrorBehavior.Default,
-                                          OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary,
-                                          IEnumerable<MetadataReference> additionalReferences = null,
-                                          DiagnosticDescriptor[] onlyDiagnostics = null) =>
-            diagnosticAnalyzers.Aggregate(new VerifierBuilder(), (builder, analyzer) => builder.AddAnalyzer(() => analyzer))
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(path))
                 .WithOptions(options.IsDefault ? ImmutableArray<ParseOptions>.Empty : options)
                 .WithErrorBehavior(checkMode)
                 .WithOutputKind(outputKind)
@@ -297,18 +246,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
                 .AddPaths(RemoveTestCasesPrefix(paths))
                 .WithOptions(options.IsDefault ? ImmutableArray<ParseOptions>.Empty : options)
-                .Verify();
-
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyAnalyzer(string path,
-                                          DiagnosticAnalyzer diagnosticAnalyzer,
-                                          CompilationErrorBehavior checkMode,
-                                          IEnumerable<MetadataReference> additionalReferences = null) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(path))
-                .WithErrorBehavior(checkMode)
                 .Verify();
 
         public static void VerifyNonConcurrentUtilityAnalyzer<TMessage>(IEnumerable<string> paths,

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/OldVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/OldVerifier.cs
@@ -147,17 +147,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.CSharpPreview)
                 .Verify();
-        //FIXME: Remove after rebase
-        [Obsolete("Use VerifierBuilder instead.")]
-        public static void VerifyNonConcurrentAnalyzer(string path,
-                                                       DiagnosticAnalyzer diagnosticAnalyzer,
-                                                       IEnumerable<MetadataReference> additionalReferences) =>
-            new VerifierBuilder()
-                .AddAnalyzer(() => diagnosticAnalyzer)
-                .AddReferences(additionalReferences ?? Enumerable.Empty<MetadataReference>())
-                .AddPaths(RemoveTestCasesPrefix(path))
-                .WithConcurrentAnalysis(false)
-                .Verify();
 
         [Obsolete("Use VerifierBuilder instead.")]
         public static void VerifyNonConcurrentAnalyzer(string path,


### PR DESCRIPTION
This is draft for now. Rebase will be needed after the merge of #5294 (current target branch of this PR) and #5293 (see comment below)