### PR TITLE
UTs: Unify VerifierBuilder.CodeFixPaths

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConditionalSimplificationTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConditionalSimplificationTest.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void ConditionalSimplification_CSharp8_CodeFix() =>
-            codeFix.AddPaths("ConditionalSimplification.CSharp8.cs").WithLanguageVersion(LanguageVersion.CSharp8).WithCodeFixedPath("ConditionalSimplification.CSharp8.Fixed.cs").VerifyCodeFix();
+            codeFix.AddPaths("ConditionalSimplification.CSharp8.cs").WithLanguageVersion(LanguageVersion.CSharp8).WithCodeFixedPaths("ConditionalSimplification.CSharp8.Fixed.cs").VerifyCodeFix();
 
         [TestMethod]
         public void ConditionalSimplification_FromCSharp8() =>
@@ -50,13 +50,13 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestMethod]
         public void ConditionalSimplification_BeforeCSharp8_CodeFix() =>
             codeFix.AddPaths("ConditionalSimplification.BeforeCSharp8.cs")
-                .WithCodeFixedPath("ConditionalSimplification.BeforeCSharp8.Fixed.cs")
+                .WithCodeFixedPaths("ConditionalSimplification.BeforeCSharp8.Fixed.cs")
                 .WithOptions(ParseOptionsHelper.BeforeCSharp8).VerifyCodeFix();
 
         [TestMethod]
         public void ConditionalSimplification_FromCSharp8_CodeFix() =>
             codeFix.AddPaths("ConditionalSimplification.FromCSharp8.cs")
-                .WithCodeFixedPath("ConditionalSimplification.FromCSharp8.Fixed.cs")
+                .WithCodeFixedPaths("ConditionalSimplification.FromCSharp8.Fixed.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .VerifyCodeFix();
 
@@ -73,14 +73,14 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestMethod]
         public void ConditionalSimplification_FromCSharp9_CodeFix() =>
             codeFix.AddPaths("ConditionalSimplification.FromCSharp9.cs")
-                .WithCodeFixedPath("ConditionalSimplification.FromCSharp9.Fixed.cs")
+                .WithCodeFixedPaths("ConditionalSimplification.FromCSharp9.Fixed.cs")
                 .WithTopLevelStatements()
                 .VerifyCodeFix();
 
         [TestMethod]
         public void ConditionalSimplification_FromCSharp10_CodeFix() =>
             codeFix.AddPaths("ConditionalSimplification.FromCSharp10.cs")
-                .WithCodeFixedPath("ConditionalSimplification.FromCSharp10.Fixed.cs")
+                .WithCodeFixedPaths("ConditionalSimplification.FromCSharp10.Fixed.cs")
                 .WithTopLevelStatements()
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .VerifyCodeFix();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/EmptyNamespaceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/EmptyNamespaceTest.cs
@@ -48,8 +48,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void EmptyNamespace_CodeFix() =>
             builder.AddPaths("EmptyNamespace.cs")
                 .WithCodeFix<EmptyNamespaceCodeFix>()
-                .WithCodeFixedPath("EmptyNamespace.Fixed.cs")
-                .WithCodeFixedPathBatch("EmptyNamespace.Fixed.Batch.cs")
+                .WithCodeFixedPaths("EmptyNamespace.Fixed.cs", "EmptyNamespace.Fixed.Batch.cs")
                 .VerifyCodeFix();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RedundantCastTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RedundantCastTest.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void RedundantCast_CodeFix() =>
-            builder.AddPaths("RedundantCast.cs").WithCodeFix<RedundantCastCodeFix>().WithCodeFixedPath("RedundantCast.Fixed.cs").VerifyCodeFix();
+            builder.AddPaths("RedundantCast.cs").WithCodeFix<RedundantCastCodeFix>().WithCodeFixedPaths("RedundantCast.Fixed.cs").VerifyCodeFix();
 
         [TestMethod]
         public void RedundantCast_DefaultLiteral() =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UnnecessaryUsingsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UnnecessaryUsingsTest.cs
@@ -68,8 +68,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void UnnecessaryUsings_CodeFix() =>
             builder.AddPaths("UnnecessaryUsings.cs")
                 .WithCodeFix<UnnecessaryUsingsCodeFix>()
-                .WithCodeFixedPath("UnnecessaryUsings.Fixed.cs")
-                .WithCodeFixedPathBatch("UnnecessaryUsings.Fixed.Batch.cs")
+                .WithCodeFixedPaths("UnnecessaryUsings.Fixed.cs", "UnnecessaryUsings.Fixed.Batch.cs")
                 .VerifyCodeFix();
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UnusedPrivateMemberTest.cs
@@ -202,8 +202,7 @@ namespace EntityFrameworkMigrations
         public void UnusedPrivateMember_CodeFix() =>
             builder.AddPaths("UnusedPrivateMember.cs")
                 .WithCodeFix<UnusedPrivateMemberCodeFix>()
-                .WithCodeFixedPath("UnusedPrivateMember.Fixed.cs")
-                .WithCodeFixedPathBatch("UnusedPrivateMember.Fixed.Batch.cs")
+                .WithCodeFixedPaths("UnusedPrivateMember.Fixed.cs", "UnusedPrivateMember.Fixed.Batch.cs")
                 .VerifyCodeFix();
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/OldVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/OldVerifier.cs
@@ -422,7 +422,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .WithOptions(options.IsDefault ? ImmutableArray<ParseOptions>.Empty : options)
                 .WithOutputKind(outputKind)
                 .WithCodeFix<TCodeFix>()
-                .WithCodeFixedPath(RemoveTestCasesPrefix(pathToExpected))
+                .WithCodeFixedPaths(RemoveTestCasesPrefix(pathToExpected))
                 .VerifyCodeFix();
 
         [Obsolete("Use VerifierBuilder instead.")]
@@ -439,8 +439,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .AddPaths(RemoveTestCasesPrefix(path))
                 .WithOptions(options.IsDefault ? ImmutableArray<ParseOptions>.Empty : options)
                 .WithCodeFix<TCodeFix>()
-                .WithCodeFixedPath(RemoveTestCasesPrefix(pathToExpected))
-                .WithCodeFixedPathBatch(RemoveTestCasesPrefix(pathToBatchExpected))
+                .WithCodeFixedPaths(RemoveTestCasesPrefix(pathToExpected), RemoveTestCasesPrefix(pathToBatchExpected))
                 .VerifyCodeFix();
 
         [Obsolete("Use VerifierBuilder instead.")]
@@ -458,7 +457,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .WithOptions(options.IsDefault ? ImmutableArray<ParseOptions>.Empty : options)
                 .WithCodeFix<TCodeFix>()
                 .WithCodeFixTitle(codeFixTitle)
-                .WithCodeFixedPath(RemoveTestCasesPrefix(pathToExpected))
+                .WithCodeFixedPaths(RemoveTestCasesPrefix(pathToExpected))
                 .VerifyCodeFix();
 
         private static string[] RemoveTestCasesPrefix(IEnumerable<string> paths) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierBuilderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierBuilderTest.cs
@@ -125,31 +125,20 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
         }
 
         [TestMethod]
-        public void WithCodeFixedPath_Overrides_IsImmutable()
+        public void WithCodeFixedPaths_Overrides_IsImmutable()
         {
-            var one = Empty.WithCodeFixedPath("First");
-            var two = one.WithCodeFixedPath("Second");
+            var one = Empty.WithCodeFixedPaths("First");
+            var two = one.WithCodeFixedPaths("Second");
+            var withBatch = one.WithCodeFixedPaths("Third", "Batch");
             Empty.CodeFixedPath.Should().BeNull();
             one.CodeFixedPath.Should().Be("First");
             two.CodeFixedPath.Should().Be("Second");
+            withBatch.CodeFixedPath.Should().Be("Third");
             // Batch version should not be modified:
             Empty.CodeFixedPathBatch.Should().BeNull();
             one.CodeFixedPathBatch.Should().BeNull();
             two.CodeFixedPathBatch.Should().BeNull();
-        }
-
-        [TestMethod]
-        public void WithCodeFixedPathBatch_Overrides_IsImmutable()
-        {
-            var one = Empty.WithCodeFixedPathBatch("First");
-            var two = one.WithCodeFixedPathBatch("Second");
-            Empty.CodeFixedPathBatch.Should().BeNull();
-            one.CodeFixedPathBatch.Should().Be("First");
-            two.CodeFixedPathBatch.Should().Be("Second");
-            // Non-Batch version should not be modified:
-            Empty.CodeFixedPath.Should().BeNull();
-            one.CodeFixedPath.Should().BeNull();
-            two.CodeFixedPath.Should().BeNull();
+            withBatch.CodeFixedPathBatch.Should().Be("Batch");
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierTest.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
         private static readonly VerifierBuilder DummyCodeFixCS = new VerifierBuilder<DummyAnalyzerCS>()
             .AddPaths("Path.cs")
             .WithCodeFix<DummyCodeFixCS>()
-            .WithCodeFixedPath("Expected.cs");
+            .WithCodeFixedPaths("Expected.cs");
 
         public TestContext TestContext { get; set; }
 
@@ -72,18 +72,18 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
 
         [TestMethod]
         public void Constructor_CodeFix_MissingCodeFixedPath_Throws() =>
-            DummyCodeFixCS.WithCodeFixedPath(null)
+            DummyCodeFixCS.WithCodeFixedPaths(null)
                 .Invoking(x => x.Build()).Should().Throw<ArgumentException>().WithMessage("CodeFixedPath was not set.");
 
         [TestMethod]
         public void Constructor_CodeFix_WrongCodeFixedPath_Throws() =>
-            DummyCodeFixCS.WithCodeFixedPath("File.vb")
+            DummyCodeFixCS.WithCodeFixedPaths("File.vb")
                 .Invoking(x => x.Build()).Should().Throw<ArgumentException>().WithMessage("Path 'File.vb' doesn't match C# file extension '.cs'.");
 
         [TestMethod]
         public void Constructor_CodeFix_WrongCodeFixedPathBatch_Throws() =>
-            DummyCodeFixCS.WithCodeFixedPathBatch("File.vb")
-                .Invoking(x => x.Build()).Should().Throw<ArgumentException>().WithMessage("Path 'File.vb' doesn't match C# file extension '.cs'.");
+            DummyCodeFixCS.WithCodeFixedPaths("File.cs", "Batch.vb")
+                .Invoking(x => x.Build()).Should().Throw<ArgumentException>().WithMessage("Path 'Batch.vb' doesn't match C# file extension '.cs'.");
 
         [TestMethod]
         public void Constructor_CodeFix_MultipleAnalyzers_Throws() =>
@@ -353,7 +353,7 @@ Line: 1, Type: primary, Id: 'second'
     private int b = default;     // Fixed
     private bool c = true;
 }");
-            DummyCS.AddPaths(originalPath).WithCodeFix<DummyCodeFixCS>().WithCodeFixedPath(fixedPath).Invoking(x => x.VerifyCodeFix()).Should().NotThrow();
+            DummyCS.AddPaths(originalPath).WithCodeFix<DummyCodeFixCS>().WithCodeFixedPaths(fixedPath).Invoking(x => x.VerifyCodeFix()).Should().NotThrow();
         }
 
         [TestMethod]
@@ -371,7 +371,7 @@ End Class");
     Private B As Integer = Nothing   ' Fixed
     Private C As Boolean = True
 End Class");
-            DummyVB.AddPaths(originalPath).WithCodeFix<DummyCodeFixVB>().WithCodeFixedPath(fixedPath).Invoking(x => x.VerifyCodeFix()).Should().NotThrow();
+            DummyVB.AddPaths(originalPath).WithCodeFix<DummyCodeFixVB>().WithCodeFixedPaths(fixedPath).Invoking(x => x.VerifyCodeFix()).Should().NotThrow();
         }
 
         [TestMethod]
@@ -384,7 +384,7 @@ End Class");
     private int b = 0;     // Noncompliant
     private bool c = true;
 }");
-            DummyCS.AddPaths(originalPath).WithCodeFix<DummyCodeFixCS>().WithCodeFixedPath(originalPath).Invoking(x => x.VerifyCodeFix()).Should().Throw<AssertFailedException>().WithMessage(
+            DummyCS.AddPaths(originalPath).WithCodeFix<DummyCodeFixCS>().WithCodeFixedPaths(originalPath).Invoking(x => x.VerifyCodeFix()).Should().Throw<AssertFailedException>().WithMessage(
 @"Expected * to be*
 ""public class Sample
 {
@@ -409,7 +409,7 @@ End Class");
     Private B As Integer = 42   ' Noncompliant
     Private C As Boolean = True
 End Class");
-            DummyVB.AddPaths(originalPath).WithCodeFix<DummyCodeFixVB>().WithCodeFixedPath(originalPath).Invoking(x => x.VerifyCodeFix()).Should().Throw<AssertFailedException>().WithMessage(
+            DummyVB.AddPaths(originalPath).WithCodeFix<DummyCodeFixVB>().WithCodeFixedPaths(originalPath).Invoking(x => x.VerifyCodeFix()).Should().Throw<AssertFailedException>().WithMessage(
 @"Expected * to be*
 ""Public Class Sample
     Private A As Integer = 42   ' Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
@@ -90,14 +90,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public VerifierBuilder WithCodeFix<TCodeFix>() where TCodeFix : SonarCodeFix, new() =>
             this with { CodeFix = () => new TCodeFix() };
 
-        public VerifierBuilder WithCodeFixedPath(string codeFixedPath) =>
-            this with { CodeFixedPath = codeFixedPath };
-
-        /// <summary>
-        /// Optional alternative fixed file for cases when FixAllProvider produces different results than applying all code fixes on the same original document.
-        /// </summary>
-        public VerifierBuilder WithCodeFixedPathBatch(string codeFixedPathBatch) =>
-            this with { CodeFixedPathBatch = codeFixedPathBatch };
+        /// <param name="codeFixedPathBatch">Fixed file for cases when FixAllProvider produces different results than applying all code fixes on the same original document.</param>
+        public VerifierBuilder WithCodeFixedPaths(string codeFixedPath, string codeFixedPathBatch = null) =>
+            this with { CodeFixedPath = codeFixedPath, CodeFixedPathBatch = codeFixedPathBatch };
 
         public VerifierBuilder WithCodeFixTitle(string codeFixTitle) =>
             this with { CodeFixTitle = codeFixTitle };


### PR DESCRIPTION
Batch version is never used without a fixed version. So we can unify the methods.