### PR TITLE
Refactor ProgramState to init-only setters

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/IsExternalInit.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/IsExternalInit.cs
@@ -22,7 +22,10 @@ using System.ComponentModel;
 
 namespace System.Runtime.CompilerServices
 {
-    // This empty class needs to exist when C# 9 init-only setters are used in project targeting net48.
+    // This empty class needs to exist when C# 9 init-only setters are used in project targeting .NET Framework.
+    // https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.isexternalinit?view=net-6.0
+    // It is used only by compiler to track metadata. It does not affect MSIL, CLR nor runtime.
+    // https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/init#metadata-encoding
     [EditorBrowsable(EditorBrowsableState.Never)]
     internal static class IsExternalInit { }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/IsExternalInit.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/IsExternalInit.cs
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#if NETFRAMEWORK
-
 using System.ComponentModel;
 
 namespace System.Runtime.CompilerServices
@@ -28,5 +26,3 @@ namespace System.Runtime.CompilerServices
     [EditorBrowsable(EditorBrowsableState.Never)]
     internal static class IsExternalInit { }
 }
-
-#endif

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -26,7 +26,7 @@ using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.SymbolicExecution.Roslyn
 {
-    public sealed class ProgramState
+    public sealed record ProgramState
     {
         public static readonly ProgramState Empty = new();
 
@@ -43,20 +43,14 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             SymbolValue = ImmutableDictionary<ISymbol, SymbolicValue>.Empty;
         }
 
-        private ProgramState(ProgramState original)
-        {
-            OperationValue = original.OperationValue;
-            SymbolValue = original.SymbolValue;
-        }
-
         public ProgramState SetOperationValue(IOperationWrapperSonar operation, SymbolicValue value) =>
             SetOperationValue(operation.Instance, value);
 
         public ProgramState SetOperationValue(IOperation operation, SymbolicValue value) =>
-            new(this) { OperationValue = OperationValue.SetItem(operation, value) };
+            this with { OperationValue = OperationValue.SetItem(operation, value) };
 
         public ProgramState SetSymbolValue(ISymbol symbol, SymbolicValue value) =>
-            new(this) { SymbolValue = SymbolValue.SetItem(symbol, value) };
+            this with { SymbolValue = SymbolValue.SetItem(symbol, value) };
 
         public IEnumerable<ISymbol> SymbolsWith(SymbolicConstraint constraint) =>
             SymbolValue.Where(x => x.Value != null && x.Value.HasConstraint(constraint)).Select(x => x.Key);


### PR DESCRIPTION
This approach will help to reduce duplications when more items are tracked.

It should prevent duplications like this:
https://github.com/SonarSource/sonar-dotnet/blob/c0d92c7faa43e0e0e112d3f667a78fc64e51bddd/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ProgramState.cs#L268-L341