### PR TITLE
Update Ember-MM log4net dependency

### DIFF
--- a/analyzers/its/sources/Ember-MM/Ember.Plugins/Ember.Plugins.csproj
+++ b/analyzers/its/sources/Ember-MM/Ember.Plugins/Ember.Plugins.csproj
@@ -42,12 +42,13 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net">
-      <HintPath>..\packages\log4net.2.0.0\lib\net35-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.14.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.14\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -87,6 +88,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />
+    <None Include="packages.lock.json" />
     <None Include="Properties\Settings.settings">
       <Generator>PublicSettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/analyzers/its/sources/Ember-MM/Ember.Plugins/packages.config
+++ b/analyzers/its/sources/Ember-MM/Ember.Plugins/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.0" targetFramework="net35" />
+  <package id="log4net" version="2.0.14" targetFramework="net452" />
 </packages>

--- a/analyzers/its/sources/Ember-MM/Ember.Plugins/packages.lock.json
+++ b/analyzers/its/sources/Ember-MM/Ember.Plugins/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETFramework,Version=v4.5.2": {
       "log4net": {
         "type": "Direct",
-        "requested": "[2.0.0, 2.0.0]",
-        "resolved": "2.0.0",
-        "contentHash": "KPajjkU1rbF6uY2rnakbh36LB9z9FVcYlciyOi6C5SJ3AMNywxjCGxBTN/Hl5nQEinRLuWvHWPF8W7YHh9sONw=="
+        "requested": "[2.0.14, 2.0.14]",
+        "resolved": "2.0.14",
+        "contentHash": "KevyXUuhOyhx7l1jWwq6ZGVlRC2Aetg0qDp6rJpfSZGcDPKQDwfOE6yEuVkVf0kEP08NQqBDn/TQ/TJv4wgyhw=="
       }
     }
   }


### PR DESCRIPTION
Update Integration Test dependency to avoid CVE-2018-1285 being raised. 
Our analyzer is not at risk.