### PR TITLE
Update the task versions from the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           RELEASE_SSH_KEY: ${{ secrets.RELEASE_SSH_KEY }}
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN }}
         # Put your action repo here
-        uses: SonarSource/gh-action_release/main@v4
+        uses: SonarSource/gh-action_release/main@4.0.1
 
       - name: Check outputs
         if: always()
@@ -59,14 +59,14 @@ jobs:
         id: local_repo
         run: echo ::set-output name=dir::"$(mktemp -d repo.XXXXXXXX)"
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@v4
+        uses: SonarSource/gh-action_release/download-build@4.0.1
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@v4
+        uses: SonarSource/gh-action_release/maven-central-sync@4.0.1
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
         env:
@@ -74,7 +74,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
       - name: Notify on failure
         if: ${{ failure() || steps.maven-central-sync.outcome == 'failure' }}
-        uses: 8398a7/action-slack@v4
+        uses: 8398a7/action-slack@v3.13.0
         with:
           status: failure
           fields: repo,author,eventName


### PR DESCRIPTION
I've used tags in the task reference.

All the versions can be found here:

- https://github.com/SonarSource/gh-action_release/releases
- https://github.com/jfrog/setup-jfrog-cli/releases
- https://github.com/8398a7/action-slack/releases