### PR TITLE
ITs: Update SharpZipLib to 1.3.3 in Ember-MM

### DIFF
--- a/analyzers/its/sources/Ember-MM/Addons/generic.EmberCore.NMT/generic.EmberCore.NMT.vbproj
+++ b/analyzers/its/sources/Ember-MM/Addons/generic.EmberCore.NMT/generic.EmberCore.NMT.vbproj
@@ -58,8 +58,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.3.3.11, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpZipLib.1.3.3\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -170,6 +170,7 @@
       <LastGenOutput>Settings.Designer.vb</LastGenOutput>
     </None>
     <None Include="packages.config" />
+    <None Include="packages.lock.json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\EmberAPI\EmberAPI.vbproj">

--- a/analyzers/its/sources/Ember-MM/Addons/generic.EmberCore.NMT/packages.config
+++ b/analyzers/its/sources/Ember-MM/Addons/generic.EmberCore.NMT/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpZipLib" version="0.86.0" />
+  <package id="SharpZipLib" version="1.3.3" targetFramework="net452" />
   <package id="System.Data.SQLite" version="1.0.84.0" targetFramework="net35" requireReinstallation="true" />
 </packages>

--- a/analyzers/its/sources/Ember-MM/Addons/generic.EmberCore.NMT/packages.lock.json
+++ b/analyzers/its/sources/Ember-MM/Addons/generic.EmberCore.NMT/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETFramework,Version=v4.5.2": {
       "SharpZipLib": {
         "type": "Direct",
-        "requested": "[0.86.0, 0.86.0]",
-        "resolved": "0.86.0",
-        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+        "requested": "[1.3.3, 1.3.3]",
+        "resolved": "1.3.3",
+        "contentHash": "N8+hwhsKZm25tDJfWpBSW7EGhH/R7EMuiX+KJ4C4u+fCWVc1lJ5zg1u3S1RPPVYgTqhx/C3hxrqUpi6RwK5+Tg=="
       },
       "System.Data.SQLite": {
         "type": "Direct",

--- a/analyzers/its/sources/Ember-MM/Addons/scraper.EmberCore.XML/packages.config
+++ b/analyzers/its/sources/Ember-MM/Addons/scraper.EmberCore.XML/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpZipLib" version="0.86.0" />
+  <package id="SharpZipLib" version="1.3.3" targetFramework="net452" />
 </packages>

--- a/analyzers/its/sources/Ember-MM/Addons/scraper.EmberCore.XML/packages.lock.json
+++ b/analyzers/its/sources/Ember-MM/Addons/scraper.EmberCore.XML/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETFramework,Version=v4.5.2": {
       "SharpZipLib": {
         "type": "Direct",
-        "requested": "[0.86.0, 0.86.0]",
-        "resolved": "0.86.0",
-        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+        "requested": "[1.3.3, 1.3.3]",
+        "resolved": "1.3.3",
+        "contentHash": "N8+hwhsKZm25tDJfWpBSW7EGhH/R7EMuiX+KJ4C4u+fCWVc1lJ5zg1u3S1RPPVYgTqhx/C3hxrqUpi6RwK5+Tg=="
       }
     }
   }

--- a/analyzers/its/sources/Ember-MM/Addons/scraper.EmberCore.XML/scraper.EmberCore.XML.vbproj
+++ b/analyzers/its/sources/Ember-MM/Addons/scraper.EmberCore.XML/scraper.EmberCore.XML.vbproj
@@ -73,8 +73,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.3.3.11, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpZipLib.1.3.3\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
@@ -232,6 +232,7 @@
       <LastGenOutput>Settings.Designer.vb</LastGenOutput>
     </None>
     <None Include="packages.config" />
+    <None Include="packages.lock.json" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/analyzers/its/sources/Ember-MM/Addons/scraper.EmberCore/packages.config
+++ b/analyzers/its/sources/Ember-MM/Addons/scraper.EmberCore/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpZipLib" version="0.86.0" />
+  <package id="SharpZipLib" version="1.3.3" targetFramework="net452" />
   <package id="System.Data.SQLite" version="1.0.84.0" targetFramework="net35" requireReinstallation="true" />
 </packages>

--- a/analyzers/its/sources/Ember-MM/Addons/scraper.EmberCore/packages.lock.json
+++ b/analyzers/its/sources/Ember-MM/Addons/scraper.EmberCore/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETFramework,Version=v4.5.2": {
       "SharpZipLib": {
         "type": "Direct",
-        "requested": "[0.86.0, 0.86.0]",
-        "resolved": "0.86.0",
-        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+        "requested": "[1.3.3, 1.3.3]",
+        "resolved": "1.3.3",
+        "contentHash": "N8+hwhsKZm25tDJfWpBSW7EGhH/R7EMuiX+KJ4C4u+fCWVc1lJ5zg1u3S1RPPVYgTqhx/C3hxrqUpi6RwK5+Tg=="
       },
       "System.Data.SQLite": {
         "type": "Direct",

--- a/analyzers/its/sources/Ember-MM/Addons/scraper.EmberCore/scraper.EmberCore.vbproj
+++ b/analyzers/its/sources/Ember-MM/Addons/scraper.EmberCore/scraper.EmberCore.vbproj
@@ -73,8 +73,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.3.3.11, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpZipLib.1.3.3\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -276,6 +276,7 @@
       <LastGenOutput>Settings.Designer.vb</LastGenOutput>
     </None>
     <None Include="packages.config" />
+    <None Include="packages.lock.json" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/analyzers/its/sources/Ember-MM/Ember Media Manager/Ember Media Manager.vbproj
+++ b/analyzers/its/sources/Ember-MM/Ember Media Manager/Ember Media Manager.vbproj
@@ -66,8 +66,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.3.3.11, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.1.3.3\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -386,6 +386,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="packages.lock.json" />
     <None Include="Resources\actor_silhouette.jpg" />
   </ItemGroup>
   <ItemGroup>

--- a/analyzers/its/sources/Ember-MM/Ember Media Manager/packages.config
+++ b/analyzers/its/sources/Ember-MM/Ember Media Manager/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net35" />
+  <package id="SharpZipLib" version="1.3.3" targetFramework="net452" />
   <package id="System.Data.SQLite" version="1.0.84.0" targetFramework="net35" requireReinstallation="true" />
 </packages>

--- a/analyzers/its/sources/Ember-MM/Ember Media Manager/packages.lock.json
+++ b/analyzers/its/sources/Ember-MM/Ember Media Manager/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETFramework,Version=v4.5.2": {
       "SharpZipLib": {
         "type": "Direct",
-        "requested": "[0.86.0, 0.86.0]",
-        "resolved": "0.86.0",
-        "contentHash": "5DbS1SlKLMi+WG00Cm0ueYf2oyXJrowETQk8nx96rmdjTuHsA3laPykGV7Sxi0R5Xxfx0Kh/EfacAZ1f6M7y/g=="
+        "requested": "[1.3.3, 1.3.3]",
+        "resolved": "1.3.3",
+        "contentHash": "N8+hwhsKZm25tDJfWpBSW7EGhH/R7EMuiX+KJ4C4u+fCWVc1lJ5zg1u3S1RPPVYgTqhx/C3hxrqUpi6RwK5+Tg=="
       },
       "System.Data.SQLite": {
         "type": "Direct",


### PR DESCRIPTION
Updating dependency in ITs to avoid CVE warnings.

The CVE doesn't affect our analyzer.