### PR TITLE
Make SymbolicValue constraints immutable

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/LocksReleasedAllPathsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/LocksReleasedAllPathsBase.cs
@@ -110,29 +110,14 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
 
         private ProgramState AddLock(SymbolicContext context, ISymbol symbol)
         {
-            var state = context.State;
-            if (state[symbol] == null)
-            {
-                state = state.SetSymbolValue(symbol, context.CreateSymbolicValue());
-            }
-
-            state[symbol].SetConstraint(LockConstraint.Held);
             lastSymbolLock[symbol] = context.Operation;
-            return state;
+            return context.SetSymbolConstraint(symbol, LockConstraint.Held);
         }
 
         private ProgramState RemoveLock(SymbolicContext context, ISymbol symbol)
         {
-            var state = context.State;
-            if (state[symbol] == null)
-            {
-                // In this case the mutex has been released without being held.
-                state = state.SetSymbolValue(symbol, context.CreateSymbolicValue());
-            }
-
-            state[symbol].SetConstraint(LockConstraint.Released);
             releasedSymbols.Add(symbol);
-            return state;
+            return context.SetSymbolConstraint(symbol, LockConstraint.Released);
         }
 
         private static ISymbol FirstArgumentSymbol(IInvocationOperationWrapper invocation) =>

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicContext.cs
@@ -19,6 +19,7 @@
  */
 
 using System;
+using Microsoft.CodeAnalysis;
 using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.SymbolicExecution.Roslyn
@@ -40,19 +41,10 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         public SymbolicValue CreateSymbolicValue() =>
             new(symbolicValueCounter);
 
-        public ProgramState SetOperationConstraint(SymbolicConstraint constraint)
-        {
-            if (State[Operation] is { } value)
-            {
-                value.SetConstraint(constraint);
-                return State;
-            }
-            else
-            {
-                value = CreateSymbolicValue();
-                value.SetConstraint(constraint);
-                return State.SetOperationValue(Operation, value);
-            }
-        }
+        public ProgramState SetOperationConstraint(SymbolicConstraint constraint) =>
+            State.SetOperationValue(Operation, (State[Operation] ?? CreateSymbolicValue()).WithConstraint(constraint));
+
+        public ProgramState SetSymbolConstraint(ISymbol symbol, SymbolicConstraint constraint) =>
+            State.SetSymbolValue(symbol, (State[symbol] ?? CreateSymbolicValue()).WithConstraint(constraint));
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -26,7 +26,7 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.SymbolicExecution.Roslyn
 {
-    public record SymbolicValue : IEquatable<SymbolicValue>
+    public sealed record SymbolicValue
     {
         private readonly SymbolicValueCounter counter;
         private readonly int identifier;    // This is debug information that is intentionally excluded from GetHashCode and Equals
@@ -46,16 +46,8 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             Constraints = original.Constraints;
         }
 
-        public override string ToString()
-        {
-            var ret = new StringBuilder();
-            ret.Append("SV_").Append(identifier);
-            if (Constraints.Any())
-            {
-                ret.Append(": ").Append(Constraints.Values.Select(x => x.ToString()).OrderBy(x => x).JoinStr(", "));
-            }
-            return ret.ToString();
-        }
+        public override string ToString() =>
+            $"SV_{identifier}{SerializeConstraints()}";
 
         public SymbolicValue WithConstraint(SymbolicConstraint constraint) =>
             this with { Constraints = Constraints.SetItem(constraint.GetType(), constraint) };
@@ -74,7 +66,12 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         public override int GetHashCode() =>
             HashCode.DictionaryContentHash(Constraints);
 
-        public virtual bool Equals(SymbolicValue other) =>
+        public bool Equals(SymbolicValue other) =>
             other is not null && other.Constraints.DictionaryEquals(Constraints);
+
+        private string SerializeConstraints() =>
+            Constraints.Any()
+                ? ": " + Constraints.Values.Select(x => x.ToString()).OrderBy(x => x).JoinStr(", ")
+                : null;
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -19,57 +19,61 @@
  */
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.SymbolicExecution.Roslyn
 {
-    public class SymbolicValue : IEquatable<SymbolicValue>
+    public record SymbolicValue : IEquatable<SymbolicValue>
     {
+        private readonly SymbolicValueCounter counter;
         private readonly int identifier;    // This is debug information that is intentionally excluded from GetHashCode and Equals
-        private readonly Lazy<Dictionary<Type, SymbolicConstraint>> constraints = new(() => new());  // SymbolicValue can have only one constraint instance of specific type at a time
+        // SymbolicValue can have only one constraint instance of specific type at a time
+        private ImmutableDictionary<Type, SymbolicConstraint> Constraints { get; init; } = ImmutableDictionary<Type, SymbolicConstraint>.Empty;
 
-        public SymbolicValue(SymbolicValueCounter counter) =>
+        public SymbolicValue(SymbolicValueCounter counter)
+        {
+            this.counter = counter;
             identifier = counter.NextIdentifier();
+        }
+
+        protected SymbolicValue(SymbolicValue original) // Custom record copying constructor
+        {
+            counter = original.counter;
+            identifier = counter.NextIdentifier();
+            Constraints = original.Constraints;
+        }
 
         public override string ToString()
         {
             var ret = new StringBuilder();
             ret.Append("SV_").Append(identifier);
-            if (constraints.Value.Any())
+            if (Constraints.Any())
             {
-                ret.Append(": ").Append(constraints.Value.Values.JoinStr(", ", x => x.ToString()));
+                ret.Append(": ").Append(Constraints.Values.JoinStr(", ", x => x.ToString()));
             }
             return ret.ToString();
         }
 
-        public void SetConstraint(SymbolicConstraint constraint) =>
-            constraints.Value[constraint.GetType()] = constraint;
+        public SymbolicValue WithConstraint(SymbolicConstraint constraint) =>
+            this with { Constraints = Constraints.SetItem(constraint.GetType(), constraint) };
 
-        public void RemoveConstraint(SymbolicConstraint constraint)
-        {
-            if (HasConstraint(constraint))
-            {
-                constraints.Value.Remove(constraint.GetType());
-            }
-        }
+        public SymbolicValue WithoutConstraint(SymbolicConstraint constraint) =>
+            HasConstraint(constraint)
+                ? this with { Constraints = Constraints.Remove(constraint.GetType()) }
+                : this;
 
         public bool HasConstraint<T>() where T : SymbolicConstraint =>
-            constraints.Value.ContainsKey(typeof(T));
+            Constraints.ContainsKey(typeof(T));
 
         public bool HasConstraint(SymbolicConstraint constraint) =>
-            constraints.Value.TryGetValue(constraint.GetType(), out var current) && constraint == current;
+            Constraints.TryGetValue(constraint.GetType(), out var current) && constraint == current;
 
         public override int GetHashCode() => 0; // We can't calculate stable hash code. This class is not supposed to be used as a key in sets and dictionaries.
 
-        public override bool Equals(object obj) =>
-            Equals(obj as SymbolicValue);
-
         public virtual bool Equals(SymbolicValue other) =>
-            other is not null
-            && other.constraints.IsValueCreated == constraints.IsValueCreated
-            && (!constraints.IsValueCreated || other.constraints.Value.DictionaryEquals(constraints.Value));
+            other is not null && other.Constraints.DictionaryEquals(Constraints);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             ret.Append("SV_").Append(identifier);
             if (Constraints.Any())
             {
-                ret.Append(": ").Append(Constraints.Values.JoinStr(", ", x => x.ToString()));
+                ret.Append(": ").Append(Constraints.Values.Select(x => x.ToString()).OrderBy(x => x).JoinStr(", "));
             }
             return ret.ToString();
         }
@@ -71,7 +71,8 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         public bool HasConstraint(SymbolicConstraint constraint) =>
             Constraints.TryGetValue(constraint.GetType(), out var current) && constraint == current;
 
-        public override int GetHashCode() => 0; // We can't calculate stable hash code. This class is not supposed to be used as a key in sets and dictionaries.
+        public override int GetHashCode() =>
+            HashCode.DictionaryContentHash(Constraints);
 
         public virtual bool Equals(SymbolicValue other) =>
             other is not null && other.Constraints.DictionaryEquals(Constraints);

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -21,7 +21,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.SymbolicExecution.Roslyn

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.SymbolicExecution.Constraints;
@@ -268,6 +269,35 @@ Tag(""End"", value);";
             var validator = SETestContext.CreateCS(code, new BoolTestCheck(), postProcess).Validator;
             validator.ValidateExitReachCount(2);
             captured.Should().OnlyContain(x => x.Value.HasConstraint(BoolConstraint.True) == x.ExpectedHasTrueConstraint);
+        }
+
+        [TestMethod]
+        public void Branching_VisitedSymbolicValue_IsImmutable()
+        {
+            const string code = @"
+var value = true;
+if (boolParameter)
+{
+    value.ToString();
+    Tag(""ToString"", value);
+}
+else
+{
+    value.GetHashCode();    // Another invocation to have same instruction count in both branches
+    Tag(""GetHashCode"", value);
+}";
+            var postProcess = new PostProcessTestCheck(x =>
+            {
+                if (x.Operation.Instance is IInvocationOperation invocation && invocation.TargetMethod.Name == "ToString")
+                {
+                    x.State[invocation.Instance.TrackedSymbol()].SetConstraint(TestConstraint.First);
+                }
+                return x.State;
+            });
+            var validator = SETestContext.CreateCS(code, new BoolTestCheck(), postProcess).Validator;
+            validator.ValidateTag("ToString", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
+            validator.ValidateTag("GetHashCode", x => x.HasConstraint<TestConstraint>().Should().BeTrue()); // FIXME: Should be False, nobody set the constraint on that path
+            validator.ValidateExitReachCount(1);    // FIXME: Should be 2. // Once for each state
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -292,8 +292,8 @@ else
                     : x.State);
             var validator = SETestContext.CreateCS(code, new BoolTestCheck(), postProcess).Validator;
             validator.ValidateTag("ToString", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
-            validator.ValidateTag("GetHashCode", x => x.HasConstraint<TestConstraint>().Should().BeTrue()); // FIXME: Should be False, nobody set the constraint on that path
-            validator.ValidateExitReachCount(1);    // FIXME: Should be 2. // Once for each state
+            validator.ValidateTag("GetHashCode", x => x.HasConstraint<TestConstraint>().Should().BeFalse()); // Nobody set the constraint on that path
+            validator.ValidateExitReachCount(2);    // Once for each state
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -287,13 +287,9 @@ else
     Tag(""GetHashCode"", value);
 }";
             var postProcess = new PostProcessTestCheck(x =>
-            {
-                if (x.Operation.Instance is IInvocationOperation invocation && invocation.TargetMethod.Name == "ToString")
-                {
-                    x.State[invocation.Instance.TrackedSymbol()].SetConstraint(TestConstraint.First);
-                }
-                return x.State;
-            });
+                x.Operation.Instance is IInvocationOperation invocation && invocation.TargetMethod.Name == "ToString"
+                    ? x.SetSymbolConstraint(invocation.Instance.TrackedSymbol(), TestConstraint.First)
+                    : x.State);
             var validator = SETestContext.CreateCS(code, new BoolTestCheck(), postProcess).Validator;
             validator.ValidateTag("ToString", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
             validator.ValidateTag("GetHashCode", x => x.HasConstraint<TestConstraint>().Should().BeTrue()); // FIXME: Should be False, nobody set the constraint on that path

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -287,12 +287,12 @@ else
     Tag(""GetHashCode"", value);
 }";
             var postProcess = new PostProcessTestCheck(x =>
-                x.Operation.Instance is IInvocationOperation invocation && invocation.TargetMethod.Name == "ToString"
+                x.Operation.Instance is IInvocationOperation { TargetMethod: { Name: "ToString" } } invocation
                     ? x.SetSymbolConstraint(invocation.Instance.TrackedSymbol(), TestConstraint.First)
                     : x.State);
-            var validator = SETestContext.CreateCS(code, new BoolTestCheck(), postProcess).Validator;
+            var validator = SETestContext.CreateCS(code, postProcess).Validator;
             validator.ValidateTag("ToString", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
-            validator.ValidateTag("GetHashCode", x => x.HasConstraint<TestConstraint>().Should().BeFalse()); // Nobody set the constraint on that path
+            validator.ValidateTag("GetHashCode", x => x.Should().BeNull()); // Nobody set the constraint on that path
             validator.ValidateExitReachCount(2);    // Once for each state
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicContextTest.cs
@@ -19,6 +19,7 @@
  */
 
 using System;
+using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.SymbolicExecution.Roslyn;
@@ -68,7 +69,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
-        public void SetOperationConstraint_WithExistingValue_ReusesProgramState()
+        public void SetOperationConstraint_WithExistingValue()
         {
             var counter = new SymbolicValueCounter();
             var operation = CreateOperation();
@@ -76,12 +77,12 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
 
             var sut = new SymbolicContext(counter, operation, state);
             var result = sut.SetOperationConstraint(DummyConstraint.Dummy);
-            result.Should().Be(state);
+            result.Should().NotBe(state, "new ProgramState instance should be created");
             result[operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue();
         }
 
         [TestMethod]
-        public void SetOperationConstraint_WithNewValue_CreatesNewProgramState()
+        public void SetOperationConstraint_WithNewValue()
         {
             var counter = new SymbolicValueCounter();
             var operation = CreateOperation();
@@ -91,6 +92,34 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             var result = sut.SetOperationConstraint(DummyConstraint.Dummy);
             result.Should().NotBe(state, "new ProgramState instance should be created");
             result[operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void SetSymbolConstraint_WithExistringValue()
+        {
+            var counter = new SymbolicValueCounter();
+            var operation = CreateOperation();
+            var symbol = operation.Children.First().TrackedSymbol();
+            var state = ProgramState.Empty.SetSymbolValue(symbol, new SymbolicValue(counter));
+
+            var sut = new SymbolicContext(counter, operation, state);
+            var result = sut.SetSymbolConstraint(symbol, DummyConstraint.Dummy);
+            result.Should().NotBe(state, "new ProgramState instance should be created");
+            result[symbol].HasConstraint(DummyConstraint.Dummy).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void SetSymbolConstraint_WithNewValue()
+        {
+            var counter = new SymbolicValueCounter();
+            var operation = CreateOperation();
+            var symbol = operation.Children.First().TrackedSymbol();
+            var state = ProgramState.Empty;
+
+            var sut = new SymbolicContext(counter, operation, state);
+            var result = sut.SetSymbolConstraint(symbol, DummyConstraint.Dummy);
+            result.Should().NotBe(state, "new ProgramState instance should be created");
+            result[symbol].HasConstraint(DummyConstraint.Dummy).Should().BeTrue();
         }
 
         private static IOperationWrapperSonar CreateOperation() =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicContextTest.cs
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
-        public void SetSymbolConstraint_WithExistringValue()
+        public void SetSymbolConstraint_WithExistingValue()
         {
             var counter = new SymbolicValueCounter();
             var operation = CreateOperation();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -55,60 +55,59 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void ToString_WithConstraints()
         {
-            var sut = new SymbolicValue(new SymbolicValueCounter());
+            var sut = new SymbolicValue(new());
             sut.ToString().Should().Be("SV_1");
 
-            sut.SetConstraint(LockConstraint.Held);
-            sut.ToString().Should().Be("SV_1: Held");
+            sut = sut.WithConstraint(LockConstraint.Held);
+            sut.ToString().Should().Be("SV_2: Held");
 
-            sut.SetConstraint(TestConstraint.First);
-            sut.ToString().Should().Be("SV_1: Held, First");
+            sut = sut.WithConstraint(TestConstraint.First);
+            sut.ToString().Should().Be("SV_3: Held, First");
 
-            sut.SetConstraint(TestConstraint.Second);   // Override First to Second
-            sut.ToString().Should().Be("SV_1: Held, Second");
+            sut = sut.WithConstraint(TestConstraint.Second);   // Override First to Second
+            sut.ToString().Should().Be("SV_4: Held, Second");
 
-            sut.SetConstraint(DummyConstraint.Dummy);
-            sut.ToString().Should().Be("SV_1: Held, Second, Dummy");
+            sut = sut.WithConstraint(DummyConstraint.Dummy);
+            sut.ToString().Should().Be("SV_5: Held, Second, Dummy");
         }
 
         [TestMethod]
-        public void SetConstraint_Contains()
+        public void WithConstraint_Contains()
         {
-            var sut = new SymbolicValue(new SymbolicValueCounter());
-            sut.SetConstraint(TestConstraint.First);
+            var sut = new SymbolicValue(new()).WithConstraint(TestConstraint.First);
             sut.HasConstraint(TestConstraint.First).Should().BeTrue();
             sut.HasConstraint(TestConstraint.Second).Should().BeFalse();
             sut.HasConstraint(LockConstraint.Held).Should().BeFalse();
         }
 
         [TestMethod]
-        public void SetConstraint_Overrides()
+        public void WithConstraint_Overrides_IsImmutable()
         {
-            var sut = new SymbolicValue(new SymbolicValueCounter());
-            sut.SetConstraint(TestConstraint.First);
-            sut.SetConstraint(TestConstraint.Second);
-            sut.HasConstraint(TestConstraint.First).Should().BeFalse();
-            sut.HasConstraint(TestConstraint.Second).Should().BeTrue();
+            var one = new SymbolicValue(new()).WithConstraint(TestConstraint.First);
+            var two = one.WithConstraint(TestConstraint.Second);
+            one.HasConstraint(TestConstraint.First).Should().BeTrue();
+            two.HasConstraint(TestConstraint.First).Should().BeFalse();
+            two.HasConstraint(TestConstraint.Second).Should().BeTrue();
         }
 
         [TestMethod]
-        public void RemoveConstraint_RemovesOnlyTheSame()
+        public void WithoutConstraint_RemovesOnlyTheSame()
         {
-            var sut = new SymbolicValue(new SymbolicValueCounter());
-            sut.RemoveConstraint(TestConstraint.First);     // Do nothing
-            sut.SetConstraint(TestConstraint.First);
-            sut.RemoveConstraint(TestConstraint.Second);    // Do nothing
+            var sut = new SymbolicValue(new())
+                .WithoutConstraint(TestConstraint.First)    // Do nothing
+                .WithConstraint(TestConstraint.First)
+                .WithoutConstraint(TestConstraint.Second);  // Do nothing
             sut.HasConstraint(TestConstraint.First).Should().BeTrue();
-            sut.RemoveConstraint(TestConstraint.First);
+            sut = sut.WithoutConstraint(TestConstraint.First);
             sut.HasConstraint(TestConstraint.First).Should().BeFalse();
         }
 
         [TestMethod]
         public void HasConstraint_ByType()
         {
-            var sut = new SymbolicValue(new SymbolicValueCounter());
+            var sut = new SymbolicValue(new());
             sut.HasConstraint<TestConstraint>().Should().BeFalse();
-            sut.SetConstraint(TestConstraint.First);
+            sut = sut.WithConstraint(TestConstraint.First);
             sut.HasConstraint<TestConstraint>().Should().BeTrue();
             sut.HasConstraint<LockConstraint>().Should().BeFalse();
         }
@@ -116,9 +115,9 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void HasConstraint_ByValue()
         {
-            var sut = new SymbolicValue(new SymbolicValueCounter());
+            var sut = new SymbolicValue(new());
             sut.HasConstraint(TestConstraint.First).Should().BeFalse();
-            sut.SetConstraint(TestConstraint.First);
+            sut = sut.WithConstraint(TestConstraint.First);
             sut.HasConstraint(TestConstraint.First).Should().BeTrue();
             sut.HasConstraint(TestConstraint.Second).Should().BeFalse();
         }
@@ -130,9 +129,9 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             new SymbolicValue(counter).GetHashCode().Should().Be(0);
             new SymbolicValue(counter).GetHashCode().Should().Be(0);
             var sut = new SymbolicValue(counter);
-            sut.SetConstraint(TestConstraint.First);
+            sut = sut.WithConstraint(TestConstraint.First);
             sut.GetHashCode().Should().Be(0);
-            sut.SetConstraint(BoolConstraint.True);
+            sut = sut.WithConstraint(BoolConstraint.True);
             sut.GetHashCode().Should().Be(0);
         }
 
@@ -140,20 +139,12 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         public void Equals_ReturnsTrueForSameConstraints()
         {
             var counter = new SymbolicValueCounter();
-            var basicSingle = new SymbolicValue(counter);
-            var sameSingle = new SymbolicValue(counter);
-            var basicMore = new SymbolicValue(counter);
-            var sameMore = new SymbolicValue(counter);
-            var differentConstraintValue = new SymbolicValue(counter);
-            var differentConstraintType = new SymbolicValue(counter);
-            basicSingle.SetConstraint(TestConstraint.First);
-            sameSingle.SetConstraint(TestConstraint.First);
-            basicMore.SetConstraint(TestConstraint.First);
-            basicMore.SetConstraint(BoolConstraint.True);
-            sameMore.SetConstraint(TestConstraint.First);
-            sameMore.SetConstraint(BoolConstraint.True);
-            differentConstraintValue.SetConstraint(TestConstraint.Second);
-            differentConstraintType.SetConstraint(BoolConstraint.True);
+            var basicSingle = new SymbolicValue(counter).WithConstraint(TestConstraint.First);
+            var sameSingle = new SymbolicValue(counter).WithConstraint(TestConstraint.First);
+            var basicMore = new SymbolicValue(counter).WithConstraint(TestConstraint.First).WithConstraint(BoolConstraint.True);
+            var sameMore = new SymbolicValue(counter).WithConstraint(TestConstraint.First).WithConstraint(BoolConstraint.True);
+            var differentConstraintValue = new SymbolicValue(counter).WithConstraint(TestConstraint.Second);
+            var differentConstraintType = new SymbolicValue(counter).WithConstraint(BoolConstraint.True);
 
             basicSingle.Equals(basicSingle).Should().BeTrue();
             basicSingle.Equals(sameSingle).Should().BeTrue();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -20,7 +20,6 @@
 
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarAnalyzer.SymbolicExecution;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 using SonarAnalyzer.SymbolicExecution.Roslyn;
 using SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution;
@@ -62,13 +61,13 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             sut.ToString().Should().Be("SV_2: Held");
 
             sut = sut.WithConstraint(TestConstraint.First);
-            sut.ToString().Should().Be("SV_3: Held, First");
+            sut.ToString().Should().Be("SV_3: First, Held");
 
             sut = sut.WithConstraint(TestConstraint.Second);   // Override First to Second
             sut.ToString().Should().Be("SV_4: Held, Second");
 
             sut = sut.WithConstraint(DummyConstraint.Dummy);
-            sut.ToString().Should().Be("SV_5: Held, Second, Dummy");
+            sut.ToString().Should().Be("SV_5: Dummy, Held, Second");
         }
 
         [TestMethod]
@@ -123,16 +122,18 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
-        public void GetHashCode_AlwaysZero()
+        public void GetHashCode_ComputedFromConstraints()
         {
             var counter = new SymbolicValueCounter();
-            new SymbolicValue(counter).GetHashCode().Should().Be(0);
-            new SymbolicValue(counter).GetHashCode().Should().Be(0);
-            var sut = new SymbolicValue(counter);
-            sut = sut.WithConstraint(TestConstraint.First);
-            sut.GetHashCode().Should().Be(0);
-            sut = sut.WithConstraint(BoolConstraint.True);
-            sut.GetHashCode().Should().Be(0);
+            var empty1 = new SymbolicValue(counter);
+            var empty2 = new SymbolicValue(counter);
+            var basic = new SymbolicValue(counter).WithConstraint(TestConstraint.First);
+            var same = new SymbolicValue(counter).WithConstraint(TestConstraint.First);
+            var different = new SymbolicValue(counter).WithConstraint(BoolConstraint.True);
+            empty1.GetHashCode().Should().Be(empty2.GetHashCode()).And.Be(0);   // Hash seed for empty dictionary is zero
+            basic.GetHashCode().Should().Be(basic.GetHashCode()).And.NotBe(0);
+            basic.GetHashCode().Should().Be(same.GetHashCode());
+            basic.GetHashCode().Should().NotBe(different.GetHashCode());
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Conditions.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Conditions.cs
@@ -46,8 +46,8 @@ namespace Monitor_Conditions
 
         public void Method4()
         {
-            Monitor.Enter(obj); // FN
-            Monitor.Enter(other); // FN
+            Monitor.Enter(obj);     // Noncompliant
+            Monitor.Enter(other);   // Noncompliant
             if (condition)
             {
                 Monitor.Exit(obj);
@@ -190,7 +190,7 @@ namespace Monitor_Conditions
 
         public void Method16(string arg)
         {
-            Monitor.Enter(obj); // FN
+            Monitor.Enter(obj); // Noncompliant
             if (arg.Length == 16)
             {
                 Monitor.Exit(obj);
@@ -218,7 +218,7 @@ namespace Monitor_Conditions
 
         public void Method18(bool condition1, bool condition2)
         {
-            Monitor.Enter(obj); // FN
+            Monitor.Enter(obj); // Noncompliant
             if (condition)
             {
                 switch (condition1)
@@ -245,7 +245,7 @@ namespace Monitor_Conditions
 
         public void Method19()
         {
-            Monitor.Enter(obj); // FN
+            Monitor.Enter(obj); // Noncompliant
             if (condition)
             {
                 Monitor.Exit(obj);
@@ -268,7 +268,7 @@ namespace Monitor_Conditions
 
         public void Method21(string arg)
         {
-            Monitor.Enter(obj); // FN
+            Monitor.Enter(obj); // Noncompliant
             if (arg.Length == 16)
             {
                 Monitor.Exit(obj);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Loops.cs
@@ -130,7 +130,7 @@ namespace Monitor_Loops
 
         public void Method10(bool condition, List<byte> array)
         {
-            Monitor.Enter(obj); // FN
+            Monitor.Enter(obj); // Noncompliant
             do
             {
                 if (condition)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/SETestContext.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/SETestContext.cs
@@ -32,9 +32,12 @@ namespace SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution
 
         public SETestContext(string code, AnalyzerLanguage language, SymbolicCheck[] additionalChecks)
         {
+            const string Separator = "----------";
             var cfg = TestHelper.CompileCfg(code, language);
             var se = new RoslynSymbolicExecution(cfg, additionalChecks.Concat(new[] { Validator }).ToArray());
-            Console.WriteLine(CfgSerializer.Serialize(cfg));
+            Console.WriteLine(Separator);
+            Console.Write(CfgSerializer.Serialize(cfg));
+            Console.WriteLine(Separator);
             se.Execute();
         }
 


### PR DESCRIPTION
Fixes #5370

First commit explains what is wrong.
Key change is in `SymbolicValue`
`SymbolicContext.SetSymbolConstraint` is additional value.