### PR TITLE
Fix VB.NET BC42376: An instance of analyzer SymbolicExecutionRunner cannot be created

### DIFF
--- a/analyzers/packaging/SonarAnalyzer.CSharp.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.CSharp.nuspec
@@ -22,10 +22,10 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="Binaries\Google.Protobuf.dll" target="analyzers" />
-    <file src="Binaries\SonarAnalyzer.dll" target="analyzers" />
-    <file src="Binaries\SonarAnalyzer.CFG.dll" target="analyzers" />
-    <file src="Binaries\SonarAnalyzer.CSharp.dll" target="analyzers" />
+    <file src="binaries\Google.Protobuf.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.CFG.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.CSharp.dll" target="analyzers" />
     <file src="tools-cs\*.ps1" target="tools\" />
     <file src="logos\sonarsource_64.png" target="images\" />
     <file src="..\..\THIRD-PARTY-NOTICES.txt" target="license\" />

--- a/analyzers/packaging/SonarAnalyzer.CSharp.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.CSharp.nuspec
@@ -22,10 +22,10 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="..\src\SonarAnalyzer.CSharp\bin\Release\net46\SonarAnalyzer.CFG.dll" target="analyzers" />
-    <file src="..\src\SonarAnalyzer.CSharp\bin\Release\net46\SonarAnalyzer.dll" target="analyzers" />
-    <file src="..\src\SonarAnalyzer.CSharp\bin\Release\net46\SonarAnalyzer.CSharp.dll" target="analyzers" />
-    <file src="..\src\SonarAnalyzer.CSharp\bin\Release\net46\Google.Protobuf.dll" target="analyzers" />
+    <file src="Binaries\Google.Protobuf.dll" target="analyzers" />
+    <file src="Binaries\SonarAnalyzer.dll" target="analyzers" />
+    <file src="Binaries\SonarAnalyzer.CFG.dll" target="analyzers" />
+    <file src="Binaries\SonarAnalyzer.CSharp.dll" target="analyzers" />
     <file src="tools-cs\*.ps1" target="tools\" />
     <file src="logos\sonarsource_64.png" target="images\" />
     <file src="..\..\THIRD-PARTY-NOTICES.txt" target="license\" />

--- a/analyzers/packaging/SonarAnalyzer.VisualBasic.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.VisualBasic.nuspec
@@ -22,9 +22,10 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="..\src\SonarAnalyzer.VisualBasic\bin\Release\net46\SonarAnalyzer.dll" target="analyzers" />
-    <file src="..\src\SonarAnalyzer.VisualBasic\bin\Release\net46\SonarAnalyzer.VisualBasic.dll" target="analyzers" />
-    <file src="..\src\SonarAnalyzer.VisualBasic\bin\Release\net46\Google.Protobuf.dll" target="analyzers" />
+    <file src="Binaries\Google.Protobuf.dll" target="analyzers" />
+    <file src="Binaries\SonarAnalyzer.dll" target="analyzers" />
+    <file src="Binaries\SonarAnalyzer.CFG.dll" target="analyzers" />
+    <file src="Binaries\SonarAnalyzer.VisualBasic.dll" target="analyzers" />
     <file src="tools-vbnet\*.ps1" target="tools\" />
     <file src="logos\sonarsource_64.png" target="images\" />
     <file src="..\..\THIRD-PARTY-NOTICES.txt" target="license\" />

--- a/analyzers/packaging/SonarAnalyzer.VisualBasic.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.VisualBasic.nuspec
@@ -22,10 +22,10 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="Binaries\Google.Protobuf.dll" target="analyzers" />
-    <file src="Binaries\SonarAnalyzer.dll" target="analyzers" />
-    <file src="Binaries\SonarAnalyzer.CFG.dll" target="analyzers" />
-    <file src="Binaries\SonarAnalyzer.VisualBasic.dll" target="analyzers" />
+    <file src="binaries\Google.Protobuf.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.CFG.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.VisualBasic.dll" target="analyzers" />
     <file src="tools-vbnet\*.ps1" target="tools\" />
     <file src="logos\sonarsource_64.png" target="images\" />
     <file src="..\..\THIRD-PARTY-NOTICES.txt" target="license\" />

--- a/analyzers/packaging/tools-cs/install.ps1
+++ b/analyzers/packaging/tools-cs/install.ps1
@@ -45,10 +45,10 @@ $analyzersPath = Join-Path $analyzersPath "analyzers"
 $analyzerFilePath = Join-Path $analyzersPath "Google.Protobuf.dll"
 $project.Object.AnalyzerReferences.Add($analyzerFilePath)
 
-$analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.CFG.dll"
+$analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.dll"
 $project.Object.AnalyzerReferences.Add($analyzerFilePath)
 
-$analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.dll"
+$analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.CFG.dll"
 $project.Object.AnalyzerReferences.Add($analyzerFilePath)
 
 $analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.CSharp.dll"

--- a/analyzers/packaging/tools-cs/uninstall.ps1
+++ b/analyzers/packaging/tools-cs/uninstall.ps1
@@ -22,14 +22,14 @@ try {
 catch {
 }
 
-$analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.CFG.dll"
+$analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.dll"
 try {
     $project.Object.AnalyzerReferences.Remove($analyzerFilePath)
 }
 catch {
 }
 
-$analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.dll"
+$analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.CFG.dll"
 try {
     $project.Object.AnalyzerReferences.Remove($analyzerFilePath)
 }

--- a/analyzers/packaging/tools-vbnet/install.ps1
+++ b/analyzers/packaging/tools-vbnet/install.ps1
@@ -48,5 +48,8 @@ $project.Object.AnalyzerReferences.Add($analyzerFilePath)
 $analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.dll"
 $project.Object.AnalyzerReferences.Add($analyzerFilePath)
 
+$analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.CFG.dll"
+$project.Object.AnalyzerReferences.Add($analyzerFilePath)
+
 $analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.VisualBasic.dll"
 $project.Object.AnalyzerReferences.Add($analyzerFilePath)

--- a/analyzers/packaging/tools-vbnet/uninstall.ps1
+++ b/analyzers/packaging/tools-vbnet/uninstall.ps1
@@ -29,6 +29,13 @@ try {
 catch {
 }
 
+$analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.CFG.dll"
+try {
+    $project.Object.AnalyzerReferences.Remove($analyzerFilePath)
+}
+catch {
+}
+
 $analyzerFilePath = Join-Path $analyzersPath "SonarAnalyzer.VisualBasic.dll"
 try {
     $project.Object.AnalyzerReferences.Remove($analyzerFilePath)

--- a/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -50,10 +50,10 @@
 
   <Target Name="CopyBinaries" AfterTargets="Build" DependsOnTargets="SignDlls" Condition=" '$(TargetFramework)' == 'NET46' ">
     <ItemGroup>
+      <BinariesToCopy Include="$(OutputPath)\Google.Protobuf.dll" />
       <BinariesToCopy Include="$(OutputPath)\SonarAnalyzer.dll" />
       <BinariesToCopy Include="$(OutputPath)\SonarAnalyzer.CFG.dll" />
       <BinariesToCopy Include="$(OutputPath)\SonarAnalyzer.CSharp.dll" />
-      <BinariesToCopy Include="$(OutputPath)\Google.Protobuf.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(BinariesFolder)" />
   </Target>

--- a/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SonarAnalyzer.CFG\SonarAnalyzer.CFG.csproj" />
+    <!-- We need to update NuGet and JAR packaging after changing references -->
     <ProjectReference Include="..\SonarAnalyzer.Common\SonarAnalyzer.Common.csproj" />
   </ItemGroup>
 

--- a/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- We need to update NuGet and JAR packaging after changing references -->
     <ProjectReference Include="..\SonarAnalyzer.CFG\SonarAnalyzer.CFG.csproj" />
   </ItemGroup>
 

--- a/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/packages.lock.json
@@ -925,7 +925,6 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.2",
           "SonarAnalyzer": "1.0.0",
-          "SonarAnalyzer.CFG": "1.0.0",
           "System.Collections.Immutable": "1.1.37",
           "System.Text.RegularExpressions": "4.3.1"
         }
@@ -1920,7 +1919,6 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.2",
           "SonarAnalyzer": "1.0.0",
-          "SonarAnalyzer.CFG": "1.0.0",
           "System.Collections.Immutable": "1.1.37",
           "System.Text.RegularExpressions": "4.3.1"
         }

--- a/analyzers/src/SonarAnalyzer.Utilities/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.Utilities/packages.lock.json
@@ -382,7 +382,6 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.2",
           "SonarAnalyzer": "1.0.0",
-          "SonarAnalyzer.CFG": "1.0.0",
           "System.Collections.Immutable": "1.1.37",
           "System.Text.RegularExpressions": "4.3.1"
         }
@@ -1333,7 +1332,6 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.2",
           "SonarAnalyzer": "1.0.0",
-          "SonarAnalyzer.CFG": "1.0.0",
           "System.Collections.Immutable": "1.1.37",
           "System.Text.RegularExpressions": "4.3.1"
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
@@ -29,9 +29,10 @@
 
   <Target Name="CopyBinaries" AfterTargets="Build" DependsOnTargets="SignDlls" Condition=" '$(TargetFramework)' == 'NET46' ">
     <ItemGroup>
-      <BinariesToCopy Include="$(OutputPath)\SonarAnalyzer.VisualBasic.dll" />
-      <BinariesToCopy Include="$(OutputPath)\SonarAnalyzer.dll" />
       <BinariesToCopy Include="$(OutputPath)\Google.Protobuf.dll" />
+      <BinariesToCopy Include="$(OutputPath)\SonarAnalyzer.dll" />
+      <BinariesToCopy Include="$(OutputPath)\SonarAnalyzer.CFG.dll" />
+      <BinariesToCopy Include="$(OutputPath)\SonarAnalyzer.VisualBasic.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(BinariesFolder)" />
   </Target>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- We need to update NuGet and JAR packaging after changing references -->
     <ProjectReference Include="..\SonarAnalyzer.Common\SonarAnalyzer.Common.csproj" />
   </ItemGroup>
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/packages.lock.json
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/packages.lock.json
@@ -428,7 +428,6 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.2",
           "SonarAnalyzer": "1.0.0",
-          "SonarAnalyzer.CFG": "1.0.0",
           "System.Collections.Immutable": "1.1.37",
           "System.Text.RegularExpressions": "4.3.1"
         }
@@ -2037,7 +2036,6 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.2",
           "SonarAnalyzer": "1.0.0",
-          "SonarAnalyzer.CFG": "1.0.0",
           "System.Collections.Immutable": "1.1.37",
           "System.Text.RegularExpressions": "4.3.1"
         }

--- a/its/src/test/java/com/sonar/it/csharp/Tests.java
+++ b/its/src/test/java/com/sonar/it/csharp/Tests.java
@@ -76,7 +76,7 @@ public class Tests {
   @ClassRule
   public static final Orchestrator ORCHESTRATOR = Orchestrator.builderEnv()
     .setSonarVersion(TestUtils.replaceLtsVersion(System.getProperty("sonar.runtimeVersion", "DEV")))
-    .addPlugin(TestUtils.getPluginLocation("sonar-csharp-plugin"))
+    .addPlugin(TestUtils.getPluginLocation("sonar-csharp-plugin")) // Do not add VB.NET here, use shared project instead
     .setEdition(Edition.DEVELOPER)
     .restoreProfileAtStartup(FileLocation.of("profiles/no_rule.xml"))
     .restoreProfileAtStartup(FileLocation.of("profiles/class_name.xml"))
@@ -97,7 +97,7 @@ public class Tests {
   }
 
   @BeforeClass
-  public static void deleteLocalCache(){
+  public static void deleteLocalCache() {
     TestUtils.deleteLocalCache();
   }
 

--- a/its/src/test/java/com/sonar/it/shared/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/shared/TestUtils.java
@@ -82,7 +82,8 @@ public class TestUtils {
   public static void verifyGuiTestOnlyProjectAnalysisWarning(Orchestrator orchestrator, BuildResult buildResult, String language) {
     Ce.Task task = TestUtils.getAnalysisWarningsTask(orchestrator, buildResult);
     assertThat(task.getStatus()).isEqualTo(Ce.TaskStatus.SUCCESS);
-    assertThat(task.getWarningsList()).containsExactly("Your project contains only TEST-code for language " + language + " and no MAIN-code for any language, so only TEST-code related results are imported. " +
+    assertThat(task.getWarningsList()).containsExactly("Your project contains only TEST-code for language " + language
+      + " and no MAIN-code for any language, so only TEST-code related results are imported. " +
       "Many of our rules (e.g. vulnerabilities) are raised only on MAIN-code. " +
       "Read more about how the SonarScanner for .NET detects test projects: https://github.com/SonarSource/sonar-scanner-msbuild/wiki/Analysis-of-product-projects-vs.-test-projects");
   }
@@ -152,7 +153,7 @@ public class TestUtils {
     Path msBuildPath = getMsBuildPath(orch);
 
     List<String> argumentList = new ArrayList<>(Arrays.asList(arguments));
-    argumentList.add("/warnaserror:AD0001;CS8032");
+    argumentList.add("/warnaserror:AD0001;CS8032;BC42376");
 
     Command command = Command.create(msBuildPath.toString())
       .addArguments(argumentList)

--- a/its/src/test/java/com/sonar/it/shared/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/shared/TestUtils.java
@@ -83,9 +83,10 @@ public class TestUtils {
     Ce.Task task = TestUtils.getAnalysisWarningsTask(orchestrator, buildResult);
     assertThat(task.getStatus()).isEqualTo(Ce.TaskStatus.SUCCESS);
     assertThat(task.getWarningsList()).containsExactly("Your project contains only TEST-code for language " + language
-      + " and no MAIN-code for any language, so only TEST-code related results are imported. " +
-      "Many of our rules (e.g. vulnerabilities) are raised only on MAIN-code. " +
-      "Read more about how the SonarScanner for .NET detects test projects: https://github.com/SonarSource/sonar-scanner-msbuild/wiki/Analysis-of-product-projects-vs.-test-projects");
+      + " and no MAIN-code for any language, so only TEST-code related results are imported. "
+      + "Many of our rules (e.g. vulnerabilities) are raised only on MAIN-code. "
+      + "Read more about how the SonarScanner for .NET detects test projects: "
+      + "https://github.com/SonarSource/sonar-scanner-msbuild/wiki/Analysis-of-product-projects-vs.-test-projects");
   }
 
   private static Ce.Task getAnalysisWarningsTask(Orchestrator orchestrator, BuildResult buildResult) {

--- a/its/src/test/java/com/sonar/it/vbnet/Tests.java
+++ b/its/src/test/java/com/sonar/it/vbnet/Tests.java
@@ -60,7 +60,6 @@ public class Tests {
   @ClassRule
   public static final Orchestrator ORCHESTRATOR = Orchestrator.builderEnv()
     .setSonarVersion(TestUtils.replaceLtsVersion(System.getProperty("sonar.runtimeVersion", "DEV")))
-    .addPlugin(TestUtils.getPluginLocation("sonar-csharp-plugin"))
     .addPlugin(TestUtils.getPluginLocation("sonar-vbnet-plugin"))
     .restoreProfileAtStartup(FileLocation.of("profiles/vbnet_no_rule.xml"))
     .restoreProfileAtStartup(FileLocation.of("profiles/vbnet_class_name.xml"))
@@ -75,7 +74,7 @@ public class Tests {
   }
 
   @BeforeClass
-  public static void deleteLocalCache(){
+  public static void deleteLocalCache() {
     TestUtils.deleteLocalCache();
   }
 

--- a/its/src/test/java/com/sonar/it/vbnet/Tests.java
+++ b/its/src/test/java/com/sonar/it/vbnet/Tests.java
@@ -60,7 +60,7 @@ public class Tests {
   @ClassRule
   public static final Orchestrator ORCHESTRATOR = Orchestrator.builderEnv()
     .setSonarVersion(TestUtils.replaceLtsVersion(System.getProperty("sonar.runtimeVersion", "DEV")))
-    .addPlugin(TestUtils.getPluginLocation("sonar-vbnet-plugin"))
+    .addPlugin(TestUtils.getPluginLocation("sonar-vbnet-plugin")) // Do not add C# here, use shared project instead
     .restoreProfileAtStartup(FileLocation.of("profiles/vbnet_no_rule.xml"))
     .restoreProfileAtStartup(FileLocation.of("profiles/vbnet_class_name.xml"))
     .build();

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -246,10 +246,10 @@
                     <!-- ITs requires the SonarAnalyzer-VERSION.zip to be present so don't remove these lines -->
                     <copy todir="${sonarAnalyzer.workDirectory}/SonarAnalyzer.CSharp">
                       <fileset dir="${project.build.directory}/../../analyzers/packaging/binaries/">
+                        <include name="Google.Protobuf.dll"/>
                         <include name="SonarAnalyzer.dll"/>
                         <include name="SonarAnalyzer.CFG.dll"/>
                         <include name="SonarAnalyzer.CSharp.dll"/>
-                        <include name="Google.Protobuf.dll"/>
                       </fileset>
                       <fileset dir="${project.build.directory}/../..">
                         <include name="THIRD-PARTY-NOTICES.txt"/>

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -209,8 +209,8 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>4100000</maxsize>
-                  <minsize>4000000</minsize>
+                  <maxsize>4200000</maxsize>
+                  <minsize>4100000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -248,9 +248,10 @@
                     <!-- ITs requires the SonarAnalyzer-VERSION.zip to be present so don't remove these lines -->
                     <copy todir="${sonarAnalyzer.workDirectory}/SonarAnalyzer.VisualBasic">
                       <fileset dir="${project.build.directory}/../../analyzers/packaging/binaries/">
-                        <include name="SonarAnalyzer.dll"/>
-                        <include name="SonarAnalyzer.VisualBasic.dll"/>
                         <include name="Google.Protobuf.dll"/>
+                        <include name="SonarAnalyzer.dll"/>
+                        <include name="SonarAnalyzer.CFG.dll"/>
+                        <include name="SonarAnalyzer.VisualBasic.dll"/>
                       </fileset>
                       <fileset dir="${project.build.directory}/../..">
                         <include name="THIRD-PARTY-NOTICES.txt"/>


### PR DESCRIPTION
Fixes #5436
