### PR TITLE
Fix WhiteSource releaseability check

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -322,6 +322,8 @@ stages:
         env:
           WS_PRODUCTNAME: '$(WHITESOURCE_PRODUCTNAME)'
           WS_APIKEY: '$(WHITESOURCE_APIKEY)'
+          BUILD_NUMBER: '$(Build.BuildId)'
+          GIT_SHA: '$(Build.SourceVersion)'
 
     - job: runIntegrationTestsJob
       displayName: '.NET ITs'

--- a/scripts/whitesource/WhiteSource-Scan.ps1
+++ b/scripts/whitesource/WhiteSource-Scan.ps1
@@ -11,4 +11,4 @@ function Get-Version {
 $env:WS_PROJECTNAME = "$env:WS_PRODUCTNAME $(Get-Version)"
 
 Write-Host "Running the WhiteSource unified agent for $env:WS_PROJECTNAME..."
-& "$env:JAVA\bin\java.exe" -jar $env:WHITESOURCE_AGENT_PATH -c "$PSScriptRoot\wss-unified-agent.config"
+& "$env:JAVA\bin\java.exe" -jar $env:WHITESOURCE_AGENT_PATH -c "$PSScriptRoot\wss-unified-agent.config" -scanComment "buildNumber:$env:BUILD_NUMBER;gitSha:$env:GIT_SHA"


### PR DESCRIPTION
Same changes as here:
https://github.com/SonarSource/sonar-dotnet-autoscan/commit/d0ad37196d71a292472b4a530b707e1c7a0fe131

This PR uses a release branch name to force WhiteSource to run on PR as well. It is meant to be merged to master - that is unusual.