### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           RELEASE_SSH_KEY: ${{ secrets.RELEASE_SSH_KEY }}
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN }}
         # Put your action repo here
-        uses: SonarSource/gh-action_release/main@4.2.0
+        uses: SonarSource/gh-action_release/main@4.2.1
 
       - name: Check outputs
         if: always()
@@ -59,14 +59,14 @@ jobs:
         id: local_repo
         run: echo ::set-output name=dir::"$(mktemp -d repo.XXXXXXXX)"
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@4.2.0
+        uses: SonarSource/gh-action_release/download-build@4.2.1
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@4.2.0
+        uses: SonarSource/gh-action_release/maven-central-sync@4.2.1
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,23 +5,22 @@ on:
     types:
       - published
 
-env:
-  PYTHONUNBUFFERED: 1
-
 jobs:
-  sonar_release:
+  release:
     runs-on: ubuntu-latest
-    name: Start release process
+    name: Publish Release
     steps:
-      - name: LT release
-        id: lt_release
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
         with:
-          publish_to_binaries: true
-          distribute: true
-          attach_artifacts_to_github_release: true
-          slack_channel: team-lang-dotnet
+          aws-access-key-id: ${{ secrets.BINARIES_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BINARIES_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.BINARIES_AWS_REGION }}
+      - name: Release
+        id: release
         env:
           ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
+          BINARIES_AWS_DEPLOY: ${{ secrets.BINARIES_AWS_DEPLOY }}
           BURGRX_USER: ${{ secrets.BURGRX_USER }}
           BURGRX_PASSWORD: ${{ secrets.BURGRX_PASSWORD }}
           CIRRUS_TOKEN: ${{ secrets.CIRRUS_TOKEN }}
@@ -30,19 +29,22 @@ jobs:
           RELEASE_SSH_USER: ${{ secrets.RELEASE_SSH_USER }}
           RELEASE_SSH_KEY: ${{ secrets.RELEASE_SSH_KEY }}
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN }}
-        # Put your action repo here
         uses: SonarSource/gh-action_release/main@4.2.1
+        with:
+          publish_to_binaries: true
+          slack_channel: team-lang-dotnet
 
-      - name: Check outputs
+      - name: Release action results
         if: always()
         run: |
-          echo "${{ steps.lt_release.outputs.releasability }}"
-          echo "${{ steps.lt_release.outputs.release }}"
+          echo "${{ steps.release.outputs.releasability }}"
+          echo "${{ steps.release.outputs.release }}"
 
   maven-central-sync:
     runs-on: ubuntu-latest
+    name: Maven Central Sync
     needs:
-      - sonar_release
+      - release
     steps:
       - name: Setup JFrog CLI
         uses: jfrog/setup-jfrog-cli@v1.2.1
@@ -76,6 +78,7 @@ jobs:
         if: ${{ failure() || steps.maven-central-sync.outcome == 'failure' }}
         uses: 8398a7/action-slack@v3.13.0
         with:
+          text: 'Maven sync failed'
           status: failure
           fields: repo,author,eventName
         env:


### PR DESCRIPTION
Update version to 4.2.1.
Align with sample usage as much as we can: https://github.com/SonarSource/gh-action_release#usage

Removing `distribute` argument - doesn't exist any more.
Removing `attach_artifacts_to_github_release` argument - doesn't exist anymore, the work is done by AZP pipeline.
Renaming `lt_release` to `release` - aligning with the sample.

There exists `lt_release` in the sample and it's a cosmetic bug to be fixed.

Contrary to the sample, we use tags `@4.2.1` and not branches `@v4`.