### PR TITLE
Support out, ref and ByRef in SE

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using StyleCop.Analyzers.Lightup;
+
+namespace SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors
+{
+    internal static class Invocation
+    {
+        public static ProgramState Process(SymbolicContext context, IArgumentOperationWrapper argument) =>
+            argument.Parameter.RefKind != Microsoft.CodeAnalysis.RefKind.None && argument.Value.TrackedSymbol() is { } symbol
+                ? context.State.SetSymbolValue(symbol, null)
+                : context.State;
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -133,6 +133,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         private static ProgramState ProcessOperation(SymbolicContext context) =>
             context.Operation.Instance.Kind switch
             {
+                OperationKindEx.Argument => Invocation.Process(context, IArgumentOperationWrapper.FromOperation(context.Operation.Instance)),
                 OperationKindEx.Conversion => Conversion.Process(context, IConversionOperationWrapper.FromOperation(context.Operation.Instance)),
                 OperationKindEx.FieldReference => References.Process(context, IFieldReferenceOperationWrapper.FromOperation(context.Operation.Instance)),
                 OperationKindEx.LocalReference => References.Process(context, ILocalReferenceOperationWrapper.FromOperation(context.Operation.Instance)),

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -170,5 +170,17 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
                 @"ExpressionStatement: Tag(""b"", b);");
             validator.ValidateTag("b", x => x.HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
         }
+
+        [TestMethod]
+        public void Argument_Ref_ResetsConstraints_CS() =>
+            SETestContext.CreateCS(@"var b = true; Main(boolParameter, ref b); Tag(""B"", b);", ", ref bool outParam").Validator.ValidateTag("B", x => x.Should().BeNull());
+
+        [TestMethod]
+        public void Argument_Out_ResetsConstraints_CS() =>
+            SETestContext.CreateCS(@"var b = true; Main(boolParameter, out b); Tag(""B"", b); outParam = false;", ", out bool outParam").Validator.ValidateTag("B", x => x.Should().BeNull());
+
+        [TestMethod]
+        public void Argument_ByRef_ResetConstraints_VB() =>
+            SETestContext.CreateVB(@"Dim B As Boolean = True : Main(BoolParameter, B) : Tag(""B"", B)", ", ByRef ByRefParam As Boolean").Validator.ValidateTag("B", x => x.Should().BeNull());
     }
 }


### PR DESCRIPTION
Prerequisite for #5308

We need to remove constraints from symbols that are subject to `out`, `ref` and `ByRef` calls because their value is unknown from that point.