### PR TITLE
Rule S3459: Add exception for types decorated with `Serializable` attribute.

### DIFF
--- a/analyzers/rspec/cs/S3459_c#.html
+++ b/analyzers/rspec/cs/S3459_c#.html
@@ -27,4 +27,8 @@ class MyClass
   }
 }
 </pre>
+<h2>Exceptions</h2>
+<ul>
+  <li> Fields on types decorated with <code>System.SerializableAttribute</code> attribute. </li>
+</ul>
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NotAssignedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NotAssignedPrivateMember.cs
@@ -113,7 +113,8 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool TypeDefinitionShouldBeSkipped(ITypeSymbol namedType) =>
             !namedType.IsClassOrStruct()
             || HasStructLayoutAttribute(namedType)
-            || namedType.ContainingType != null;
+            || namedType.ContainingType != null
+            || namedType.HasAttribute(KnownType.System_SerializableAttribute);
 
         private static bool HasStructLayoutAttribute(ISymbol namedTypeSymbol) =>
             namedTypeSymbol.HasAttribute(KnownType.System_Runtime_InteropServices_StructLayoutAttribute);

--- a/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S3459.html
+++ b/analyzers/src/SonarAnalyzer.Utilities/Rules.Description/S3459.html
@@ -27,4 +27,8 @@ class MyClass
   }
 }
 </pre>
+<h2>Exceptions</h2>
+<ul>
+  <li> Fields on types decorated with <code>System.SerializableAttribute</code> attribute. </li>
+</ul>
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NotAssignedPrivateMember.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NotAssignedPrivateMember.cs
@@ -190,9 +190,9 @@ namespace Tests.Diagnostics
     [Serializable]
     public class SerializableClass
     {
-        private int field; // Noncompliant - FP, see: https://github.com/SonarSource/sonar-dotnet/issues/5451
+        private int field; // Compliant, see: https://github.com/SonarSource/sonar-dotnet/issues/5451
 
-        private int Prop { get; set; } // Noncompliant - FP, see: https://github.com/SonarSource/sonar-dotnet/issues/5451
+        private int Prop { get; set; } // Compliant, see: https://github.com/SonarSource/sonar-dotnet/issues/5451
 
         public void Print()
         {


### PR DESCRIPTION
Fixes #5451
