### PR TITLE
Run mvn sonar just once

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -443,7 +443,7 @@ stages:
       - task: Maven@3
         displayName: 'Maven verify, UTs with SonarCloud'
         inputs:
-          goals: 'verify sonar:sonar'
+          goals: 'verify'
           options: -B --settings $(mavenSettings.secureFilePath) -Pcoverage -Dsonar.projectVersion=$(SONAR_PROJECT_VERSION)
           publishJUnitResults: true
           testResultsFiles: '**/surefire-reports/TEST-*.xml'


### PR DESCRIPTION
Fixes master broken build, because we run sonar analysis twice

`mvn sonar:sonar` and  `sonarQubeRunAnalysis: true`

Attention for the reviewer: git blame shows that I introduced the 2nd analysis in #3018 to fix a code coverage issue. We must ensure there's no regression regarding code coverage before merging. 