### PR TITLE
Fix S2222 FP: SpinLock.TryEnter followed by nested finally regions

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/Extensions/BasicBlockExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Extensions/BasicBlockExtensions.cs
@@ -30,14 +30,7 @@ namespace SonarAnalyzer.Extensions
             return enclosing.Kind == kind;
         }
 
-        public static ControlFlowRegion EnclosingNonLocalLifetimeRegion(this BasicBlock block)
-        {
-            var region = block.EnclosingRegion;
-            while (region.EnclosingRegion != null && region.Kind == ControlFlowRegionKind.LocalLifetime)
-            {
-                region = region.EnclosingRegion;
-            }
-            return region;
-        }
+        public static ControlFlowRegion EnclosingNonLocalLifetimeRegion(this BasicBlock block) =>
+            block.EnclosingRegion.EnclosingNonLocalLifetimeRegion();
     }
 }

--- a/analyzers/src/SonarAnalyzer.CFG/Extensions/ControlFlowRegionExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Extensions/ControlFlowRegionExtensions.cs
@@ -28,5 +28,14 @@ namespace SonarAnalyzer.Extensions
     {
         public static IEnumerable<BasicBlock> Blocks(this ControlFlowRegion region, ControlFlowGraph cfg) =>
             cfg.Blocks.Where((_, i) => region.FirstBlockOrdinal <= i && i <= region.LastBlockOrdinal);
+
+        public static ControlFlowRegion EnclosingNonLocalLifetimeRegion(this ControlFlowRegion region)
+        {
+            while (region.EnclosingRegion != null && region.Kind == ControlFlowRegionKind.LocalLifetime)
+            {
+                region = region.EnclosingRegion;
+            }
+            return region;
+        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CFG/LiveVariableAnalysis/RoslynLiveVariableAnalysis.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/LiveVariableAnalysis/RoslynLiveVariableAnalysis.cs
@@ -90,7 +90,7 @@ namespace SonarAnalyzer.CFG.LiveVariableAnalysis
                 }
                 else if (successor.Source.EnclosingRegion is { Kind: ControlFlowRegionKind.Finally } finallyRegion)
                 {
-                    BuildBranchesFinally(successor.Source);
+                    BuildBranchesFinally(successor.Source, finallyRegion);
                 }
             }
             if (block.IsEnclosedIn(ControlFlowRegionKind.Try))
@@ -102,7 +102,7 @@ namespace SonarAnalyzer.CFG.LiveVariableAnalysis
             }
         }
 
-        private void BuildBranchesFinally(BasicBlock source)
+        private void BuildBranchesFinally(BasicBlock source, ControlFlowRegion finallyRegion)
         {
             foreach (var trySuccessor in TryRegionSuccessors(source.EnclosingRegion))
             {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/LiveVariableAnalysis/RoslynLiveVariableAnalysisTest.TryCatchFinally.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/LiveVariableAnalysis/RoslynLiveVariableAnalysisTest.TryCatchFinally.cs
@@ -786,6 +786,38 @@ Method(2);";
         }
 
         [TestMethod]
+        public void Finally_Nested_NoInstructionBetweenFinally_LiveIn()
+        {
+            var code = @"
+var outer = 42;
+var inner = 42;
+try
+{
+    try
+    {
+        Method(0);
+    }
+    finally
+    {
+        Method(inner);
+    }
+    // No action here, finally branch is crossing both regions
+}
+finally
+{
+    Method(outer);
+}
+Method(2);";
+            var context = CreateContextCS(code);
+            context.ValidateEntry();
+            context.Validate("Method(0);", new LiveIn("inner", "outer"), new LiveOut("inner", "outer"));
+            context.Validate("Method(inner);", new LiveIn("inner" /*FIXME:, "outer"), new LiveOut("outer"*/));
+            context.Validate("Method(outer);", new LiveIn("outer"));
+            context.Validate("Method(2);");
+            context.ValidateExit();
+        }
+
+        [TestMethod]
         public void Finally_InvalidSyntax_LiveIn()
         {
             /*    Entry 0

--- a/analyzers/tests/SonarAnalyzer.UnitTest/LiveVariableAnalysis/RoslynLiveVariableAnalysisTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/LiveVariableAnalysis/RoslynLiveVariableAnalysisTest.cs
@@ -973,8 +973,11 @@ End Class";
 
             public Context(string code, AnalyzerLanguage language, string localFunctionName = null)
             {
+                const string Separator = "----------";
                 Cfg = TestHelper.CompileCfg(code, language, code.Contains("// Error CS"), localFunctionName);
+                Console.WriteLine(Separator);
                 Console.WriteLine(CfgSerializer.Serialize(Cfg));
+                Console.WriteLine(Separator);
                 Lva = new RoslynLiveVariableAnalysis(Cfg);
             }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.RoslynCfg.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.RoslynCfg.cs
@@ -335,11 +335,11 @@ namespace Tests.Diagnostics
             {
                 Use(used);
             }
-            for(var i = 0; i < 10; i++)
+            for (var i = 0; i < 10; i++)
             {
                 Console.Write("-");
             }
-            for(var i = 0; i < 10; i++)
+            for (var i = 0; i < 10; i++)
             {
                 Use(i);
             }
@@ -522,7 +522,7 @@ namespace Tests.Diagnostics
         public int UsedAsOutInstance()
         {
             var list = new List<int>(); // Noncompliant
-            if(InvokeOut(out list))
+            if (InvokeOut(out list))
             {
                 return list.Count;
             }
@@ -563,6 +563,68 @@ namespace Tests.Diagnostics
             }
 
             return null;
+        }
+
+        private void ForEach_AssignedBefore_UsedAfter(string[] args)
+        {
+            var value = 42;
+            foreach (var arg in args)
+            {
+                Console.WriteLine("Something else");
+            }
+            Use(value);
+        }
+
+        private void ForEach_AssignedBefore_UsedAfterNested(string[] args)
+        {
+            foreach(var outer in args)
+            {
+                var value = 42;     // Noncompliant FP
+                foreach (var inner in args)
+                {
+                    Console.WriteLine("Something else");
+                }
+                Use(value);
+            }
+        }
+
+        private int ForEach_AssignedIn_UsedAfter(string[] args)
+        {
+            var value = -1;
+            foreach (var arg in args)
+            {
+                if (arg == null)
+                    value = 0;
+            }
+            return value;
+        }
+
+        private void ForEach_AssignedIn_UsedAfter_Nested(string[] args)
+        {
+            foreach(var outer in args)
+            {
+                var ret = false;
+                foreach (var inner in args)
+                {
+                    if (inner == null)
+                        ret = true;     // Noncompliant FP
+                }
+                Use(ret);
+            }
+        }
+
+        private void ForEach_NestedLock_AssignedIn_UsedAfter(string[] args)
+        {
+            lock (args)
+            {
+                var ret = false;
+                foreach (var arg in args)
+                {
+                    if (arg == null)
+                        ret = true;     // Noncompliant FP
+                }
+                Use(ret);
+            }
         }
 
         public void Unused()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.RoslynCfg.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.RoslynCfg.cs
@@ -579,7 +579,7 @@ namespace Tests.Diagnostics
         {
             foreach(var outer in args)
             {
-                var value = 42;     // Noncompliant FP
+                var value = 42;
                 foreach (var inner in args)
                 {
                     Console.WriteLine("Something else");
@@ -607,7 +607,7 @@ namespace Tests.Diagnostics
                 foreach (var inner in args)
                 {
                     if (inner == null)
-                        ret = true;     // Noncompliant FP
+                        ret = true;
                 }
                 Use(ret);
             }
@@ -621,7 +621,7 @@ namespace Tests.Diagnostics
                 foreach (var arg in args)
                 {
                     if (arg == null)
-                        ret = true;     // Noncompliant FP
+                        ret = true;
                 }
                 Use(ret);
             }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.SpinLock.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.SpinLock.cs
@@ -106,7 +106,7 @@ namespace SpinLock_Type
             bool lockTaken = false;
             try
             {
-                spinLock.TryEnter(ref lockTaken);   // Noncompliant FP
+                spinLock.TryEnter(ref lockTaken);
                 foreach (var arg in args)
                 {
                 }
@@ -126,7 +126,7 @@ namespace SpinLock_Type
             bool lockTaken = false;
             try
             {
-                spinLock.TryEnter(ref lockTaken);   // Noncompliant FP
+                spinLock.TryEnter(ref lockTaken);
                 try
                 {
                     Console.Write("X");


### PR DESCRIPTION
Fixes #5522

The `Successors` and `Predecessors` method pair became too complex and need bigger refactoring that I'll try to do in another PR. This change is just a focused update to fix the problem.

The key idea is that we need to join nested `finally` blocks directly in both directions (predecessors and successors), in case there are not other blocks and instructions between them.
```
try
{
	  try
	  {
	  }
	  finally
	  {
          // Successors(of this block) needs to be connected directly to the next finally
	  }
      // Nothing here
}
finally
{
          // Prececessors(of this block) needs to be connected directly to the previous finally
}
```