### PR TITLE
Improve performance for SymbolReferenceAnalyzer

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
@@ -29,15 +29,16 @@ namespace SonarAnalyzer.Helpers
 {
     internal sealed class CSharpFacade : ILanguageFacade<SyntaxKind>
     {
-        private static readonly Lazy<CSharpFacade> Singleton = new Lazy<CSharpFacade>(() => new CSharpFacade());
-        private static readonly Lazy<AssignmentFinder> AssignmentFinderLazy = new Lazy<AssignmentFinder>(() => new CSharpAssignmentFinder());
-        private static readonly Lazy<IExpressionNumericConverter> ExpressionNumericConverterLazy = new Lazy<IExpressionNumericConverter>(() => new CSharpExpressionNumericConverter());
-        private static readonly Lazy<SyntaxFacade<SyntaxKind>> SyntaxLazy = new Lazy<SyntaxFacade<SyntaxKind>>(() => new CSharpSyntaxFacade());
-        private static readonly Lazy<ISyntaxKindFacade<SyntaxKind>> SyntaxKindLazy = new Lazy<ISyntaxKindFacade<SyntaxKind>>(() => new CSharpSyntaxKindFacade());
-        private static readonly Lazy<ITrackerFacade<SyntaxKind>> TrackerLazy = new Lazy<ITrackerFacade<SyntaxKind>>(() => new CSharpTrackerFacade());
+        private static readonly Lazy<CSharpFacade> Singleton = new(() => new CSharpFacade());
+        private static readonly Lazy<AssignmentFinder> AssignmentFinderLazy = new(() => new CSharpAssignmentFinder());
+        private static readonly Lazy<IExpressionNumericConverter> ExpressionNumericConverterLazy = new(() => new CSharpExpressionNumericConverter());
+        private static readonly Lazy<SyntaxFacade<SyntaxKind>> SyntaxLazy = new(() => new CSharpSyntaxFacade());
+        private static readonly Lazy<ISyntaxKindFacade<SyntaxKind>> SyntaxKindLazy = new(() => new CSharpSyntaxKindFacade());
+        private static readonly Lazy<ITrackerFacade<SyntaxKind>> TrackerLazy = new(() => new CSharpTrackerFacade());
 
         public AssignmentFinder AssignmentFinder => AssignmentFinderLazy.Value;
         public StringComparison NameComparison => StringComparison.Ordinal;
+        public StringComparer StringComparer => StringComparer.Ordinal;
         public GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
         public IExpressionNumericConverter ExpressionNumericConverter => ExpressionNumericConverterLazy.Value;
         public SyntaxFacade<SyntaxKind> Syntax => SyntaxLazy.Value;

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Helpers
 
         public AssignmentFinder AssignmentFinder => AssignmentFinderLazy.Value;
         public StringComparison NameComparison => StringComparison.Ordinal;
-        public StringComparer StringComparer => StringComparer.Ordinal;
+        public StringComparer NameComparer => StringComparer.Ordinal;
         public GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
         public IExpressionNumericConverter ExpressionNumericConverter => ExpressionNumericConverterLazy.Value;
         public SyntaxFacade<SyntaxKind> Syntax => SyntaxLazy.Value;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/SymbolReferenceAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/SymbolReferenceAnalyzer.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override SyntaxNode GetBindableParent(SyntaxToken token) =>
             token.GetBindableParent();
 
-        protected override IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(SyntaxNode node, SemanticModel model) =>
+        protected override ReferenceInfo[] CreateDeclarationReferenceInfo(SyntaxNode node, SemanticModel model) =>
             node switch
             {
                 BaseTypeDeclarationSyntax typeDeclaration => new[] { CreateDeclarationReferenceInfo(node, typeDeclaration.Identifier, model) },
@@ -55,15 +55,15 @@ namespace SonarAnalyzer.Rules.CSharp
                 _ => null
             };
 
-        protected override IEnumerable<SyntaxNode> GetDeclarations(SyntaxNode node)
+        protected override IList<SyntaxNode> GetDeclarations(SyntaxNode node)
         {
             var walker = new DeclarationsFinder();
             walker.SafeVisit(node);
             return walker.Declarations;
         }
 
-        private static IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(VariableDeclarationSyntax declaration, SemanticModel model) =>
-            declaration.Variables.Select(x => CreateDeclarationReferenceInfo(x, x.Identifier, model));
+        private static ReferenceInfo[] CreateDeclarationReferenceInfo(VariableDeclarationSyntax declaration, SemanticModel model) =>
+            declaration.Variables.Select(x => CreateDeclarationReferenceInfo(x, x.Identifier, model)).ToArray();
 
         private static ReferenceInfo CreateDeclarationReferenceInfo(SyntaxNode node, SyntaxToken identifier, SemanticModel model) =>
             new(node, identifier, model.GetDeclaredSymbol(node), true);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/SymbolReferenceAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/SymbolReferenceAnalyzer.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -62,8 +61,6 @@ namespace SonarAnalyzer.Rules.CSharp
             walker.SafeVisit(node);
             return walker.Declarations;
         }
-
-        protected override StringComparer IdentifierComparer { get; } = StringComparer.Ordinal;
 
         private static IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(VariableDeclarationSyntax declaration, SemanticModel model) =>
             declaration.Variables.Select(x => CreateDeclarationReferenceInfo(x, x.Identifier, model));

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/SymbolReferenceAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/SymbolReferenceAnalyzer.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -25,6 +26,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
+using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.Rules.CSharp
 {
@@ -36,11 +38,68 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override SyntaxNode GetBindableParent(SyntaxToken token) =>
             token.GetBindableParent();
 
-        protected override SyntaxToken? GetSetKeyword(ISymbol valuePropertySymbol) =>
-            IsValuePropertyParameter(valuePropertySymbol)
-            && valuePropertySymbol.ContainingSymbol is IMethodSymbol methodSymbol
-            && methodSymbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() is AccessorDeclarationSyntax accessor
-                ? accessor.Keyword
-                : null;
+        protected override IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(SyntaxNode node, SemanticModel model) =>
+            node switch
+            {
+                BaseTypeDeclarationSyntax typeDeclaration => new[] { CreateDeclarationReferenceInfo(node, typeDeclaration.Identifier, model) },
+                VariableDeclarationSyntax variableDeclaration => CreateDeclarationReferenceInfo(variableDeclaration, model),
+                MethodDeclarationSyntax methodDeclaration => new[] { CreateDeclarationReferenceInfo(node, methodDeclaration.Identifier, model) },
+                ParameterSyntax parameterSyntax => new[] { CreateDeclarationReferenceInfo(node, parameterSyntax.Identifier, model) },
+                LocalDeclarationStatementSyntax localDeclarationStatement => CreateDeclarationReferenceInfo(localDeclarationStatement.Declaration, model),
+                PropertyDeclarationSyntax propertyDeclaration => new[] { CreateDeclarationReferenceInfo(node, propertyDeclaration.Identifier, model) },
+                TypeParameterSyntax typeParameterSyntax => new[] { CreateDeclarationReferenceInfo(node, typeParameterSyntax.Identifier, model) },
+                var localFunction when LocalFunctionStatementSyntaxWrapper.IsInstance(localFunction) =>
+                    new[] { CreateDeclarationReferenceInfo(node, ((LocalFunctionStatementSyntaxWrapper)localFunction).Identifier, model) },
+                var singleVariableDesignation when SingleVariableDesignationSyntaxWrapper.IsInstance(singleVariableDesignation) =>
+                    new[] { CreateDeclarationReferenceInfo(node, ((SingleVariableDesignationSyntaxWrapper)singleVariableDesignation).Identifier, model) },
+                _ => null
+            };
+
+        protected override IEnumerable<SyntaxNode> GetDeclarations(SyntaxNode node)
+        {
+            var walker = new DeclarationsFinder();
+            walker.SafeVisit(node);
+            return walker.Declarations;
+        }
+
+        private static IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(VariableDeclarationSyntax declaration, SemanticModel model) =>
+            declaration.Variables.Select(x => CreateDeclarationReferenceInfo(x, x.Identifier, model));
+
+        private static ReferenceInfo CreateDeclarationReferenceInfo(SyntaxNode node, SyntaxToken identifier, SemanticModel model) =>
+            new(node, identifier, model.GetDeclaredSymbol(node), true);
+
+        private sealed class DeclarationsFinder : SafeCSharpSyntaxWalker
+        {
+            private readonly ISet<ushort> declarationKinds = new HashSet<SyntaxKind>
+            {
+                SyntaxKind.ClassDeclaration,
+                SyntaxKind.DelegateDeclaration,
+                SyntaxKind.EnumDeclaration,
+                SyntaxKind.EventDeclaration,
+                SyntaxKind.InterfaceDeclaration,
+                SyntaxKind.LocalDeclarationStatement,
+                SyntaxKind.MethodDeclaration,
+                SyntaxKind.Parameter,
+                SyntaxKind.PropertyDeclaration,
+                SyntaxKind.StructDeclaration,
+                SyntaxKind.TypeParameter,
+                SyntaxKind.VariableDeclaration,
+                SyntaxKindEx.LocalFunctionStatement,
+                SyntaxKindEx.RecordClassDeclaration,
+                SyntaxKindEx.RecordStructDeclaration,
+                SyntaxKindEx.SingleVariableDesignation
+            }.Cast<ushort>().ToHashSet();
+
+            public readonly List<SyntaxNode> Declarations = new();
+
+            public override void Visit(SyntaxNode node)
+            {
+                if (declarationKinds.Contains((ushort)node.RawKind))
+                {
+                    Declarations.Add(node);
+                }
+                base.Visit(node);
+            }
+        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/SymbolReferenceAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/SymbolReferenceAnalyzer.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -61,6 +62,8 @@ namespace SonarAnalyzer.Rules.CSharp
             walker.SafeVisit(node);
             return walker.Declarations;
         }
+
+        protected override StringComparer IdentifierComparer { get; } = StringComparer.Ordinal;
 
         private static IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(VariableDeclarationSyntax declaration, SemanticModel model) =>
             declaration.Variables.Select(x => CreateDeclarationReferenceInfo(x, x.Identifier, model));

--- a/analyzers/src/SonarAnalyzer.Common/Facade/ILanguageFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/ILanguageFacade.cs
@@ -29,6 +29,7 @@ namespace SonarAnalyzer.Helpers
     {
         AssignmentFinder AssignmentFinder { get; }
         StringComparison NameComparison { get; }
+        StringComparer StringComparer { get; }
         GeneratedCodeRecognizer GeneratedCodeRecognizer { get; }
         IExpressionNumericConverter ExpressionNumericConverter { get; }
         ResourceManager RspecResources { get; }

--- a/analyzers/src/SonarAnalyzer.Common/Facade/ILanguageFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/ILanguageFacade.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Helpers
     {
         AssignmentFinder AssignmentFinder { get; }
         StringComparison NameComparison { get; }
-        StringComparer StringComparer { get; }
+        StringComparer NameComparer { get; }
         GeneratedCodeRecognizer GeneratedCodeRecognizer { get; }
         IExpressionNumericConverter ExpressionNumericConverter { get; }
         ResourceManager RspecResources { get; }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
@@ -84,8 +84,8 @@ namespace SonarAnalyzer.Rules
                     var currentDeclaration = declarationReferences[j];
                     if (currentDeclaration.Symbol != null)
                     {
-                        var list = references.GetOrAdd(currentDeclaration.Symbol, _ => new List<ReferenceInfo>());
-                        list.Add(currentDeclaration);
+                        references.GetOrAdd(currentDeclaration.Symbol, _ => new List<ReferenceInfo>())
+                            .Add(currentDeclaration);
                         knownNodes.Add(currentDeclaration.Node);
                         knownIdentifiers.Add(currentDeclaration.Identifier.ValueText);
                     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -40,6 +41,8 @@ namespace SonarAnalyzer.Rules
         protected abstract IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(SyntaxNode node, SemanticModel model);
 
         protected abstract IEnumerable<SyntaxNode> GetDeclarations(SyntaxNode node);
+
+        protected abstract StringComparer IdentifierComparer { get; }
 
         protected SymbolReferenceAnalyzerBase() : base(DiagnosticId, Title) { }
 
@@ -65,7 +68,7 @@ namespace SonarAnalyzer.Rules
         private IEnumerable<ReferenceInfo> GetReferences(SyntaxNode root, SemanticModel model)
         {
             var references = new List<ReferenceInfo>();
-            var knownIdentifiers = new HashSet<string>();
+            var knownIdentifiers = new HashSet<string>(IdentifierComparer);
 
             foreach (var declaration in GetDeclarations(root))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.Rules
         private IEnumerable<ReferenceInfo> GetReferences(SyntaxNode root, SemanticModel model)
         {
             var references = new HashSet<ReferenceInfo>();
-            var knownIdentifiers = new HashSet<string>(Language.StringComparer);
+            var knownIdentifiers = new HashSet<string>(Language.NameComparer);
 
             foreach (var declaration in GetDeclarations(root))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.Rules
 
         private IEnumerable<ReferenceInfo> GetReferences(SyntaxNode root, SemanticModel model)
         {
-            var references = new List<ReferenceInfo>();
+            var references = new HashSet<ReferenceInfo>();
             var knownIdentifiers = new HashSet<string>(IdentifierComparer);
 
             foreach (var declaration in GetDeclarations(root))
@@ -78,7 +78,7 @@ namespace SonarAnalyzer.Rules
                     continue;
                 }
 
-                foreach (var reference in declarationReferences.Where(x => references.All(y => x.Node != y.Node)))
+                foreach (var reference in declarationReferences)
                 {
                     references.Add(reference);
                     knownIdentifiers.Add(reference.Identifier.ValueText);
@@ -130,23 +130,6 @@ namespace SonarAnalyzer.Rules
         private static bool HasTooManyTokens(SyntaxTree syntaxTree) =>
             syntaxTree.GetRoot().DescendantTokens().Count() > TokenCountThreshold;
 
-        protected sealed class ReferenceInfo
-        {
-            public ISymbol Symbol { get; }
-
-            public SyntaxNode Node { get; }
-
-            public SyntaxToken Identifier { get; }
-
-            public bool IsDeclaration { get; }
-
-            public ReferenceInfo(SyntaxNode node, SyntaxToken identifier, ISymbol symbol, bool isDeclaration)
-            {
-                Node = node;
-                Identifier = identifier;
-                Symbol = symbol;
-                IsDeclaration = isDeclaration;
-            }
-        }
+        protected sealed record ReferenceInfo(SyntaxNode Node, SyntaxToken Identifier, ISymbol Symbol, bool IsDeclaration);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
@@ -42,8 +42,6 @@ namespace SonarAnalyzer.Rules
 
         protected abstract IEnumerable<SyntaxNode> GetDeclarations(SyntaxNode node);
 
-        protected abstract StringComparer IdentifierComparer { get; }
-
         protected SymbolReferenceAnalyzerBase() : base(DiagnosticId, Title) { }
 
         protected sealed override SymbolReferenceInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel)
@@ -68,7 +66,7 @@ namespace SonarAnalyzer.Rules
         private IEnumerable<ReferenceInfo> GetReferences(SyntaxNode root, SemanticModel model)
         {
             var references = new HashSet<ReferenceInfo>();
-            var knownIdentifiers = new HashSet<string>(IdentifierComparer);
+            var knownIdentifiers = new HashSet<string>(Language.StringComparer);
 
             foreach (var declaration in GetDeclarations(root))
             {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicFacade.cs
@@ -29,15 +29,16 @@ namespace SonarAnalyzer.Helpers
 {
     internal sealed class VisualBasicFacade : ILanguageFacade<SyntaxKind>
     {
-        private static readonly Lazy<VisualBasicFacade> Singleton = new Lazy<VisualBasicFacade>(() => new VisualBasicFacade());
-        private static readonly Lazy<AssignmentFinder> AssignmentFinderLazy = new Lazy<AssignmentFinder>(() => new VisualBasicAssignmentFinder());
-        private static readonly Lazy<IExpressionNumericConverter> ExpressionNumericConverterLazy = new Lazy<IExpressionNumericConverter>(() => new VisualBasicExpressionNumericConverter());
-        private static readonly Lazy<SyntaxFacade<SyntaxKind>> SyntaxLazy = new Lazy<SyntaxFacade<SyntaxKind>>(() => new VisualBasicSyntaxFacade());
-        private static readonly Lazy<ISyntaxKindFacade<SyntaxKind>> SyntaxKindLazy = new Lazy<ISyntaxKindFacade<SyntaxKind>>(() => new VisualBasicSyntaxKindFacade());
-        private static readonly Lazy<ITrackerFacade<SyntaxKind>> TrackerLazy = new Lazy<ITrackerFacade<SyntaxKind>>(() => new VisualBasicTrackerFacade());
+        private static readonly Lazy<VisualBasicFacade> Singleton = new(() => new VisualBasicFacade());
+        private static readonly Lazy<AssignmentFinder> AssignmentFinderLazy = new(() => new VisualBasicAssignmentFinder());
+        private static readonly Lazy<IExpressionNumericConverter> ExpressionNumericConverterLazy = new(() => new VisualBasicExpressionNumericConverter());
+        private static readonly Lazy<SyntaxFacade<SyntaxKind>> SyntaxLazy = new(() => new VisualBasicSyntaxFacade());
+        private static readonly Lazy<ISyntaxKindFacade<SyntaxKind>> SyntaxKindLazy = new(() => new VisualBasicSyntaxKindFacade());
+        private static readonly Lazy<ITrackerFacade<SyntaxKind>> TrackerLazy = new(() => new VisualBasicTrackerFacade());
 
         public AssignmentFinder AssignmentFinder => AssignmentFinderLazy.Value;
         public StringComparison NameComparison => StringComparison.OrdinalIgnoreCase;
+        public StringComparer StringComparer => StringComparer.OrdinalIgnoreCase;
         public GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
         public IExpressionNumericConverter ExpressionNumericConverter => ExpressionNumericConverterLazy.Value;
         public SyntaxFacade<SyntaxKind> Syntax => SyntaxLazy.Value;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicFacade.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Helpers
 
         public AssignmentFinder AssignmentFinder => AssignmentFinderLazy.Value;
         public StringComparison NameComparison => StringComparison.OrdinalIgnoreCase;
-        public StringComparer StringComparer => StringComparer.OrdinalIgnoreCase;
+        public StringComparer NameComparer => StringComparer.OrdinalIgnoreCase;
         public GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
         public IExpressionNumericConverter ExpressionNumericConverter => ExpressionNumericConverterLazy.Value;
         public SyntaxFacade<SyntaxKind> Syntax => SyntaxLazy.Value;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/SymbolReferenceAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/SymbolReferenceAnalyzer.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -58,6 +59,8 @@ namespace SonarAnalyzer.Rules.VisualBasic
             walker.SafeVisit(node);
             return walker.Declarations;
         }
+
+        protected override StringComparer IdentifierComparer { get; } = StringComparer.OrdinalIgnoreCase;
 
         private static IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(LocalDeclarationStatementSyntax declaration, SemanticModel model) =>
             declaration.Declarators.SelectMany(x => CreateDeclarationReferenceInfo(x, model));

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/SymbolReferenceAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/SymbolReferenceAnalyzer.cs
@@ -18,9 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
 
@@ -33,5 +36,70 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         protected override SyntaxNode GetBindableParent(SyntaxToken token) =>
             token.GetBindableParent();
+
+        protected override IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(SyntaxNode node, SemanticModel model) =>
+            node switch
+            {
+                TypeStatementSyntax typeStatement => new[] { CreateDeclarationReferenceInfo(node, typeStatement.Identifier, model) },
+                MethodStatementSyntax methodStatement => new[] { CreateDeclarationReferenceInfo(node, methodStatement.Identifier, model) },
+                EventStatementSyntax eventStatement => new[] { CreateDeclarationReferenceInfo(node, eventStatement.Identifier, model) },
+                FieldDeclarationSyntax fieldDeclaration => CreateDeclarationReferenceInfo(fieldDeclaration, model),
+                VariableDeclaratorSyntax variableDeclarator => CreateDeclarationReferenceInfo(variableDeclarator, model),
+                ParameterSyntax parameter => new[] { CreateDeclarationReferenceInfo(node, parameter.Identifier.Identifier, model) },
+                LocalDeclarationStatementSyntax localDeclaration => CreateDeclarationReferenceInfo(localDeclaration, model),
+                PropertyStatementSyntax propertyStatement => new[] { CreateDeclarationReferenceInfo(node, propertyStatement.Identifier, model) },
+                TypeParameterSyntax typeParameter => new[] { CreateDeclarationReferenceInfo(node, typeParameter.Identifier, model) },
+                _ => null
+            };
+
+        protected override IEnumerable<SyntaxNode> GetDeclarations(SyntaxNode node)
+        {
+            var walker = new DeclarationsFinder();
+            walker.SafeVisit(node);
+            return walker.Declarations;
+        }
+
+        private static IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(LocalDeclarationStatementSyntax declaration, SemanticModel model) =>
+            declaration.Declarators.SelectMany(x => CreateDeclarationReferenceInfo(x, model));
+
+        private static IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(FieldDeclarationSyntax fieldDeclaration, SemanticModel model) =>
+            fieldDeclaration.Declarators.SelectMany(x => CreateDeclarationReferenceInfo(x, model));
+
+        private static IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(VariableDeclaratorSyntax variableDeclarator, SemanticModel model) =>
+            variableDeclarator.Names.Select(x => CreateDeclarationReferenceInfo(x, x.Identifier, model));
+
+        private static ReferenceInfo CreateDeclarationReferenceInfo(SyntaxNode node, SyntaxToken identifier, SemanticModel model) =>
+            new(node, identifier, model.GetDeclaredSymbol(node), true);
+
+        private sealed class DeclarationsFinder : SafeVisualBasicSyntaxWalker
+        {
+            private readonly ISet<ushort> declarationKinds = new HashSet<SyntaxKind>
+            {
+                SyntaxKind.ClassStatement,
+                SyntaxKind.EnumStatement,
+                SyntaxKind.EventStatement,
+                SyntaxKind.FieldDeclaration,
+                SyntaxKind.FunctionStatement,
+                SyntaxKind.InterfaceStatement,
+                SyntaxKind.LocalDeclarationStatement,
+                SyntaxKind.Parameter,
+                SyntaxKind.PropertyStatement,
+                SyntaxKind.StructureStatement,
+                SyntaxKind.SubStatement,
+                SyntaxKind.TypeParameter,
+                SyntaxKind.VariableDeclarator
+            }.Cast<ushort>().ToHashSet();
+
+            public readonly List<SyntaxNode> Declarations = new();
+
+            public override void Visit(SyntaxNode node)
+            {
+                if (declarationKinds.Contains((ushort)node.RawKind))
+                {
+                    Declarations.Add(node);
+                }
+                base.Visit(node);
+            }
+        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/SymbolReferenceAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/SymbolReferenceAnalyzer.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -59,8 +58,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
             walker.SafeVisit(node);
             return walker.Declarations;
         }
-
-        protected override StringComparer IdentifierComparer { get; } = StringComparer.OrdinalIgnoreCase;
 
         private static IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(LocalDeclarationStatementSyntax declaration, SemanticModel model) =>
             declaration.Declarators.SelectMany(x => CreateDeclarationReferenceInfo(x, model));

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/SymbolReferenceAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/SymbolReferenceAnalyzer.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         protected override SyntaxNode GetBindableParent(SyntaxToken token) =>
             token.GetBindableParent();
 
-        protected override IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(SyntaxNode node, SemanticModel model) =>
+        protected override ReferenceInfo[] CreateDeclarationReferenceInfo(SyntaxNode node, SemanticModel model) =>
             node switch
             {
                 TypeStatementSyntax typeStatement => new[] { CreateDeclarationReferenceInfo(node, typeStatement.Identifier, model) },
@@ -52,21 +52,21 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 _ => null
             };
 
-        protected override IEnumerable<SyntaxNode> GetDeclarations(SyntaxNode node)
+        protected override IList<SyntaxNode> GetDeclarations(SyntaxNode node)
         {
             var walker = new DeclarationsFinder();
             walker.SafeVisit(node);
             return walker.Declarations;
         }
 
-        private static IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(LocalDeclarationStatementSyntax declaration, SemanticModel model) =>
-            declaration.Declarators.SelectMany(x => CreateDeclarationReferenceInfo(x, model));
+        private static ReferenceInfo[] CreateDeclarationReferenceInfo(LocalDeclarationStatementSyntax declaration, SemanticModel model) =>
+            declaration.Declarators.SelectMany(x => CreateDeclarationReferenceInfo(x, model)).ToArray();
 
-        private static IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(FieldDeclarationSyntax fieldDeclaration, SemanticModel model) =>
-            fieldDeclaration.Declarators.SelectMany(x => CreateDeclarationReferenceInfo(x, model));
+        private static ReferenceInfo[] CreateDeclarationReferenceInfo(FieldDeclarationSyntax fieldDeclaration, SemanticModel model) =>
+            fieldDeclaration.Declarators.SelectMany(x => CreateDeclarationReferenceInfo(x, model)).ToArray();
 
-        private static IEnumerable<ReferenceInfo> CreateDeclarationReferenceInfo(VariableDeclaratorSyntax variableDeclarator, SemanticModel model) =>
-            variableDeclarator.Names.Select(x => CreateDeclarationReferenceInfo(x, x.Identifier, model));
+        private static ReferenceInfo[] CreateDeclarationReferenceInfo(VariableDeclaratorSyntax variableDeclarator, SemanticModel model) =>
+            variableDeclarator.Names.Select(x => CreateDeclarationReferenceInfo(x, x.Identifier, model)).ToArray();
 
         private static ReferenceInfo CreateDeclarationReferenceInfo(SyntaxNode node, SyntaxToken identifier, SemanticModel model) =>
             new(node, identifier, model.GetDeclaredSymbol(node), true);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
@@ -93,6 +93,12 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataTestMethod]
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
+        public void Verify_MissingDeclaration_CS(ProjectType projectType) =>
+            Verify("MissingDeclaration.cs", projectType, 1, 3);
+
+        [DataTestMethod]
+        [DataRow(ProjectType.Product)]
+        [DataRow(ProjectType.Test)]
         public void Verify_Field_VB(ProjectType projectType) =>
             Verify("Field.vb", projectType, 4, 3, 6, 7);
 
@@ -106,7 +112,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void Verify_Tuples_VB(ProjectType projectType) =>
-            Verify("Tuples.vb", projectType, 6, 4, 8);
+            Verify("Tuples.vb", projectType, 4, 4, 8);
 
         [DataTestMethod]
         [DataRow(ProjectType.Product)]
@@ -124,7 +130,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void Verify_NamedType_CS(ProjectType projectType) =>
-            Verify("NamedType.cs", projectType, 4, 3, 7, 7); // 'var' and type name on the same line
+            Verify("NamedType.cs", projectType, 4, 3, 7);
 
         [DataTestMethod]
         [DataRow(ProjectType.Product)]
@@ -159,12 +165,6 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataTestMethod]
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
-        public void Verify_Setter_CS(ProjectType projectType) =>
-            Verify("Setter.cs", projectType, 4, 6, 8);
-
-        [DataTestMethod]
-        [DataRow(ProjectType.Product)]
-        [DataRow(ProjectType.Test)]
         public void Verify_TypeParameter_CS(ProjectType projectType) =>
             Verify("TypeParameter.cs", projectType, 5, 2, 4, 6);
 
@@ -173,13 +173,6 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow(ProjectType.Test)]
         public void Verify_TypeParameter_VB(ProjectType projectType) =>
             Verify("TypeParameter.vb", projectType, 5, 2, 4, 5);
-
-        [DataTestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
-        public void GetSetKeyword_ReturnsNull_VB(bool isTestProject) =>
-            // This path is unreachable for VB code
-            new TestSymbolReferenceAnalyzer_VB(null, isTestProject).TestGetSetKeyword(null).Should().BeNull();
 
         [TestMethod]
         public void Verify_TokenThreshold() =>
@@ -248,9 +241,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                 OutPath = outPath;
                 IsTestProject = isTestProject;
             }
-
-            public object TestGetSetKeyword(ISymbol valuePropertySymbol) =>
-                GetSetKeyword(valuePropertySymbol);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
@@ -46,11 +46,11 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void Verify_Method_PreciseLocation_CS(ProjectType projectType) =>
             Verify("Method.cs", projectType, references =>
             {
-                references.Select(x => x.Declaration.StartLine).Should().BeEquivalentTo(1, 3, 5);   // class 'Sample' on line 1, method 'Method' on line 3, method 'Go' on line 5
+                references.Select(x => x.Declaration.StartLine).Should().BeEquivalentTo(1, 3, 5, 7);   // class 'Sample' on line 1, method 'Method' on line 3, method 'method' on line 5 and method 'Go' on line 7
                 var methodDeclaration = references.Single(x => x.Declaration.StartLine == 3);
                 methodDeclaration.Declaration.Should().BeEquivalentTo(new TextRange { StartLine = 3, EndLine = 3, StartOffset = 16, EndOffset = 22 });
                 methodDeclaration.Reference.Should().HaveCount(1);
-                methodDeclaration.Reference.Single().Should().BeEquivalentTo(new TextRange { StartLine = 6, EndLine = 6, StartOffset = 8, EndOffset = 14 });
+                methodDeclaration.Reference.Single().Should().BeEquivalentTo(new TextRange { StartLine = 9, EndLine = 9, StartOffset = 8, EndOffset = 14 });
             });
 
         [DataTestMethod]
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 procedureDeclaration.Declaration.Should().BeEquivalentTo(new TextRange { StartLine = 3, EndLine = 3, StartOffset = 15, EndOffset = 21 });
                 procedureDeclaration.Reference.Should().HaveCount(2);
                 procedureDeclaration.Reference[0].Should().BeEquivalentTo(new TextRange { StartLine = 11, EndLine = 11, StartOffset = 8, EndOffset = 14 });
-                procedureDeclaration.Reference[1].Should().BeEquivalentTo(new TextRange { StartLine = 11, EndLine = 11, StartOffset = 8, EndOffset = 14 });
+                procedureDeclaration.Reference[1].Should().BeEquivalentTo(new TextRange { StartLine = 13, EndLine = 13, StartOffset = 8, EndOffset = 14 });
 
                 var functionDeclaration = references.Single(x => x.Declaration.StartLine == 6);
                 functionDeclaration.Declaration.Should().BeEquivalentTo(new TextRange { StartLine = 6, EndLine = 6, StartOffset = 13, EndOffset = 23 });
@@ -125,7 +125,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void Verify_Method_CS(ProjectType projectType) =>
-            Verify("Method.cs", projectType, 3, 3, 6);
+            Verify("Method.cs", projectType, 4, 3, 9);
 
         [DataTestMethod]
         [DataRow(ProjectType.Product)]
@@ -155,7 +155,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void Verify_Property_CS(ProjectType projectType) =>
-            Verify("Property.cs", projectType, 4, 3, 7, 8);
+            Verify("Property.cs", projectType, 5, 3, 9, 10);
 
         [DataTestMethod]
         [DataRow(ProjectType.Product)]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
@@ -63,8 +63,9 @@ namespace SonarAnalyzer.UnitTest.Rules
 
                 var procedureDeclaration = references.Single(x => x.Declaration.StartLine == 3);
                 procedureDeclaration.Declaration.Should().BeEquivalentTo(new TextRange { StartLine = 3, EndLine = 3, StartOffset = 15, EndOffset = 21 });
-                procedureDeclaration.Reference.Should().HaveCount(1);
-                procedureDeclaration.Reference.Single().Should().BeEquivalentTo(new TextRange { StartLine = 11, EndLine = 11, StartOffset = 8, EndOffset = 14 });
+                procedureDeclaration.Reference.Should().HaveCount(2);
+                procedureDeclaration.Reference[0].Should().BeEquivalentTo(new TextRange { StartLine = 11, EndLine = 11, StartOffset = 8, EndOffset = 14 });
+                procedureDeclaration.Reference[1].Should().BeEquivalentTo(new TextRange { StartLine = 11, EndLine = 11, StartOffset = 8, EndOffset = 14 });
 
                 var functionDeclaration = references.Single(x => x.Declaration.StartLine == 6);
                 functionDeclaration.Declaration.Should().BeEquivalentTo(new TextRange { StartLine = 6, EndLine = 6, StartOffset = 13, EndOffset = 23 });
@@ -160,7 +161,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void Verify_Property_VB(ProjectType projectType) =>
-            Verify("Property.vb", projectType, 4, 3, 6, 7);
+            Verify("Property.vb", projectType, 5, 3, 6, 7, 8);
 
         [DataTestMethod]
         [DataRow(ProjectType.Product)]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/SymbolReferenceAnalyzer/Method.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/SymbolReferenceAnalyzer/Method.cs
@@ -2,6 +2,11 @@
 {
     public void Method() { }
 
-    public void Go() =>
+    public void method() { }
+
+    public void Go()
+    {
         Method();
+        method();
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/SymbolReferenceAnalyzer/Method.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/SymbolReferenceAnalyzer/Method.vb
@@ -10,6 +10,7 @@
     Public Sub Go()
         Method()
         MyFunction()
+        mEthOd() ' Different case, same method
     End Sub
 
 End Class

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/SymbolReferenceAnalyzer/MissingDeclaration.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/SymbolReferenceAnalyzer/MissingDeclaration.cs
@@ -1,0 +1,7 @@
+﻿namespace Credentials
+{
+    public class Credentials
+    {
+    }
+}
+

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/SymbolReferenceAnalyzer/Property.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/SymbolReferenceAnalyzer/Property.cs
@@ -2,9 +2,12 @@
 {
     public int Property { get; set; }
 
+    public int property { get; set; }
+
     public void Go()
     {
         var x = Property;
         Property = 42;
+        property = 24;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/SymbolReferenceAnalyzer/Property.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/SymbolReferenceAnalyzer/Property.vb
@@ -5,6 +5,7 @@
     Public Sub Method()
         Dim n As String = Name
         Name = "John"
+        Dim x = name ' Different case, same property
     End Sub
 
 End Class


### PR DESCRIPTION
Rewrite the analyzer to work as much as possible at the syntax level by retrieving symbols only when strictly necessary.

Tested this rule on:
- akka.net - before: 0:02:49, after: 0:01:32, improvement: 45.94%
- efcore - before: 0:01:39, after: 0:01:04, improvement: 35.19%
- nodatime - before: 0:00:06, after:	0:00:04, improvement: 26.02%

Part of #4220