### PR TITLE
Improve the performance of rules inheriting from DoNotCallMethodsBase

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DangerousGetHandleShouldNotBeCalled.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DangerousGetHandleShouldNotBeCalled.cs
@@ -30,8 +30,5 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class DangerousGetHandleShouldNotBeCalled : DangerousGetHandleShouldNotBeCalledBase<SyntaxKind, InvocationExpressionSyntax>
     {
         protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
-
-        protected override SyntaxToken? GetMethodCallIdentifier(InvocationExpressionSyntax invocation) =>
-            invocation.GetMethodCallIdentifier();
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCallExitMethods.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCallExitMethods.cs
@@ -48,6 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
             !invocationSyntax
                 .Ancestors()
                 .OfType<BaseMethodDeclarationSyntax>()
+                .Where(x => x.GetIdentifierOrDefault()?.ValueText == "Main")
                 .Select(m => semanticModel.GetDeclaredSymbol(m))
                 .Select(s => s.IsMainMethod())
                 .FirstOrDefault();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCallExitMethods.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCallExitMethods.cs
@@ -42,13 +42,10 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public DoNotCallExitMethods() : base(DiagnosticId) { }
 
-        protected override bool IsInValidContext(InvocationExpressionSyntax invocationSyntax,
-            SemanticModel semanticModel) =>
-            // Do not report if call is inside Main.
-            !invocationSyntax
-                .Ancestors()
-                .OfType<BaseMethodDeclarationSyntax>()
-                .Where(x => x.GetIdentifierOrDefault()?.ValueText == "Main")
+        protected override bool IsInValidContext(InvocationExpressionSyntax invocationSyntax, SemanticModel semanticModel) =>
+            // Do not report if call is inside Main or TopLevelStatement.
+            !invocationSyntax.Ancestors().OfType<GlobalStatementSyntax>().Any()
+            && !invocationSyntax.Ancestors().OfType<BaseMethodDeclarationSyntax>().Where(x => x.GetIdentifierOrDefault()?.ValueText == "Main")
                 .Select(m => semanticModel.GetDeclaredSymbol(m))
                 .Select(s => s.IsMainMethod())
                 .FirstOrDefault();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCallGCSuppressFinalize.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCallGCSuppressFinalize.cs
@@ -43,16 +43,17 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override bool ShouldReportOnMethodCall(InvocationExpressionSyntax invocation, SemanticModel semanticModel, MemberDescriptor memberDescriptor)
         {
-            var methodDeclaration = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-            if (methodDeclaration == null)
+            if (invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>() is not { } methodDeclaration
+                || (methodDeclaration.Identifier.ValueText != "Dispose"
+                    && methodDeclaration.Identifier.ValueText != "DisposeAsync"))
             {
                 // We want to report on all calls not made from a method
                 return true;
             }
 
-            var methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration);
-            return !methodSymbol.IsIDisposableDispose()
-                && !methodSymbol.IsIAsyncDisposableDisposeAsync();
+            return semanticModel.GetDeclaredSymbol(methodDeclaration) is var methodSymbol
+                   && !methodSymbol.IsIDisposableDispose()
+                   && !methodSymbol.IsIAsyncDisposableDisposeAsync();
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCallMethodsCsharpBase.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCallMethodsCsharpBase.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SonarAnalyzer.Helpers;
@@ -28,9 +27,6 @@ namespace SonarAnalyzer.Rules.CSharp
     public abstract class DoNotCallMethodsCSharpBase : DoNotCallMethodsBase<SyntaxKind, InvocationExpressionSyntax>
     {
         protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
-
-        protected sealed override SyntaxToken? GetMethodCallIdentifier(InvocationExpressionSyntax invocation) =>
-            invocation.GetMethodCallIdentifier();
 
         protected DoNotCallMethodsCSharpBase(string diagnosticId) : base(diagnosticId) { }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NormalizeStringsToUppercase.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NormalizeStringsToUppercase.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override bool ShouldReportOnMethodCall(InvocationExpressionSyntax invocation, SemanticModel semanticModel, MemberDescriptor memberDescriptor)
         {
-            var identifier = GetMethodCallIdentifier(invocation).Value.ValueText; // never null when we get here
+            var identifier = invocation.GetMethodCallIdentifier().Value.ValueText; // never null when we get here
             if (identifier == "ToLowerInvariant")
             {
                 return true;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadResumeOrSuspendShouldNotBeCalled.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadResumeOrSuspendShouldNotBeCalled.cs
@@ -30,8 +30,5 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class ThreadResumeOrSuspendShouldNotBeCalled : ThreadResumeOrSuspendShouldNotBeCalledBase<SyntaxKind, InvocationExpressionSyntax>
     {
         protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
-
-        protected override SyntaxToken? GetMethodCallIdentifier(InvocationExpressionSyntax invocation) =>
-            invocation.GetMethodCallIdentifier();
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DangerousGetHandleShouldNotBeCalled.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DangerousGetHandleShouldNotBeCalled.cs
@@ -30,8 +30,5 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class DangerousGetHandleShouldNotBeCalled : DangerousGetHandleShouldNotBeCalledBase<SyntaxKind, InvocationExpressionSyntax>
     {
         protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
-
-        protected override SyntaxToken? GetMethodCallIdentifier(InvocationExpressionSyntax invocation) =>
-            invocation.GetMethodCallIdentifier();
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ThreadResumeOrSuspendShouldNotBeCalled.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ThreadResumeOrSuspendShouldNotBeCalled.cs
@@ -30,8 +30,5 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class ThreadResumeOrSuspendShouldNotBeCalled : ThreadResumeOrSuspendShouldNotBeCalledBase<SyntaxKind, InvocationExpressionSyntax>
     {
         protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
-
-        protected override SyntaxToken? GetMethodCallIdentifier(InvocationExpressionSyntax invocation) =>
-            invocation.GetMethodCallIdentifier();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DoNotCallExitMethods.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DoNotCallExitMethods.CSharp9.cs
@@ -2,6 +2,13 @@
 
 Environment.Exit(0); // Compliant
 
+Action asd = () => Environment.Exit(0); // Noncompliant
+
+void LocalFunction()
+{
+    Environment.Exit(0); // Noncompliant
+}
+
 record R
 {
     public void Foo() => Environment.Exit(0); // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DoNotCallExitMethods.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DoNotCallExitMethods.CSharp9.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-Environment.Exit(0); // Noncompliant {{Remove this call to 'Environment.Exit' or ensure it is really required.}}
+Environment.Exit(0); // Compliant
 
 record R
 {


### PR DESCRIPTION
Fixes #3854
Fixes #4349

The testing of the performance included 4 runs each on 3 different projects. The sum of the times are the following:
akka 75.353 -> 21.673
efcore 116.028 -> 19.791
noda 18.35 -> 1.837
