### PR TITLE
Improve contributing-analyzer.md

### DIFF
--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -119,6 +119,20 @@ When running the build and doing the Roslyn analysis, when hitting the `Debugger
 
 After the debug session, remove the `Debugger.Launch()` line.
 
+### Java ITs
+
+**Internal only**
+
+* Use IntelliJ IDEA
+* Open the root folder of the repo
+* Make sure the `its`, `sonar-csharp-plugin`, `sonar-dotnet-shared-library`, and `sonar-vbnet-plugin` folders are marked with a blue square. Search for `pom.xml` in the folders and make it a maven project if not.
+* Add the following environment variables (user)
+  * **ARTIFACTORY_URL** https://repox.jfrog.io/repox
+  * **ARTIFACTORY_USER** your repox.jfrog username (see e.g. orchestrator.properties)
+  * **ARTIFACTORY_PASSWORD** the api key for repox.jfrog (see e.g. orchestrator.properties)
+* Create `settings.xml` in the `%USERPROFILE%\.m2` directory. A template can be found in the "Developer box" section in the extranet. Change the username and password settings with the values from the environment variables above.
+* Run `mvn install clean -DskipTests=true` in the respective directories (pom.xml)
+* Use the IDE to run unit tests in the projects.
 
 ## Contributing
 

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -126,7 +126,7 @@ After the debug session, remove the `Debugger.Launch()` line.
 
 * Use IntelliJ IDEA
 * Open the root folder of the repo
-* Make sure the `its`, `sonar-csharp-plugin`, `sonar-dotnet-shared-library`, and `sonar-vbnet-plugin` folders are marked with a blue square. Search for `pom.xml` in the folders and make it a maven project if not.
+* Make sure the `its`, `sonar-csharp-plugin`, `sonar-dotnet-shared-library`, and `sonar-vbnet-plugin` folders are are imported as Maven modules (indicated by a blue square). Search for `pom.xml` in the folders and make it a maven project if not.
 * Add the following environment variables (user)
   * **ARTIFACTORY_URL** https://repox.jfrog.io/repox
   * **ARTIFACTORY_USER** your repox.jfrog username (see e.g. orchestrator.properties)

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -133,7 +133,7 @@ After the debug session, remove the `Debugger.Launch()` line.
   * **ARTIFACTORY_USER** your repox.jfrog username (see e.g. orchestrator.properties)
   * **ARTIFACTORY_PASSWORD** the api key for repox.jfrog (see e.g. orchestrator.properties)
 * Create `settings.xml` in the `%USERPROFILE%\.m2` directory. A template can be found in the [Developer box section in the extranet](https://xtranet-sonarsource.atlassian.net/wiki/spaces/DEV/pages/776711/Developer+Box#Maven-Settings). Change the username and password settings with the values from the environment variables above.
-* Run `mvn install clean -DskipTests=true` in the respective directories (pom.xml)
+* Run `mvn install clean -DskipTests=true` in the respective directories (pom.xml). To build all artefacts run `.\scripts\build\dev-build.ps1 -buildJava`
 * Use the IDE to run unit tests in the projects.
 
 ## Contributing

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -132,7 +132,7 @@ After the debug session, remove the `Debugger.Launch()` line.
   * **ARTIFACTORY_URL** https://repox.jfrog.io/repox
   * **ARTIFACTORY_USER** your repox.jfrog username (see e.g. orchestrator.properties)
   * **ARTIFACTORY_PASSWORD** the api key for repox.jfrog (see e.g. orchestrator.properties)
-* Create `settings.xml` in the `%USERPROFILE%\.m2` directory. A template can be found in the "Developer box" section in the extranet. Change the username and password settings with the values from the environment variables above.
+* Create `settings.xml` in the `%USERPROFILE%\.m2` directory. A template can be found in the [Developer box section in the extranet](https://xtranet-sonarsource.atlassian.net/wiki/spaces/DEV/pages/776711/Developer+Box#Maven-Settings). Change the username and password settings with the values from the environment variables above.
 * Run `mvn install clean -DskipTests=true` in the respective directories (pom.xml)
 * Use the IDE to run unit tests in the projects.
 

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -26,7 +26,7 @@ In general, it is best to run commands from the Visual Studio Developer Command 
     - .NET Compiler Platform SDK
 1. Install also:
     - [.NET Core 3.1 SDK](https://dotnet.microsoft.com/en-us/download/dotnet)
-    - .NET 3.5 SDK (SP1) TODO: Add link to dotNetFx35setup.exe
+    - .NET 3.5 SDK (SP1) from [Microsoft download center](https://www.microsoft.com/en-us/download/details.aspx?id=21)
     - Install Visual Studio 2019 and check these SDKs in the *individual components* tab
         - .NET framework 4 targeting pack
         - .NET framework 4.5 targeting pack

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -37,14 +37,14 @@ In general, it is best to run commands from the Visual Studio Developer Command 
     - **Sonarsource internal only** These two steps require access to SonarSource internal resources and are not possible for external contributers
         - **ORCHESTRATOR_CONFIG_URL** - url to orchestrator.properties file (for integration tests) in uri form (i.e. file:///c:/something/orchestrator.properties). See also: [Documentation in the orchestrator repository](https://github.com/sonarsource/orchestrator#configuration)
         - **RULE_API_PATH** - path to folder containing the rule api jar. The rule api jar can be found at [repox.jfrog search](https://repox.jfrog.io/ui/artifactSearchResults?name=rule-api&type=artifacts) or [repox.jfrog private releases](https://repox.jfrog.io/ui/native/sonarsource-private-releases/com/sonarsource/rule-api/rule-api/)
-    - **PATH** - the system **PATH** variable must contain:
-        - the path to the dotnet core installation folder (System: `C:\Program Files\dotnet\`)
-        - the path to the MSBuild bin folder (System: `C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin`)
-        - the path to the visual studo installer folder (for vswhere.exe) (System: `C:\Program Files (x86)\Microsoft Visual Studio\Installer`)
-        - the path to the nuget executable folder ((System: `C:\Program Files\nuget`)
-        - the path to the JDK bin folder (System: `C:\Program Files\Java\jdk-11.0.2\bin`)
-        - %M2_HOME%\bin
-        - the path to the SonarScanner for .NET folder and to the Scanner CLI ([SonarScanner download](https://github.com/SonarSource/sonar-scanner-msbuild/releases))
+    - **PATH** - the **PATH** variable must contain (either *system* or *user* scope):
+        - [*System*] the path to the dotnet core installation folder (`C:\Program Files\dotnet\`)
+        - [*System*] the path to the MSBuild bin folder (`C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin`)
+        - [*System*] the path to the visual studo installer folder (for vswhere.exe) (`C:\Program Files (x86)\Microsoft Visual Studio\Installer`)
+        - [*System*] the path to the nuget executable folder (`C:\Program Files\nuget`)
+        - [*System*] the path to the JDK bin folder (`C:\Program Files\Java\jdk-11.0.2\bin`)
+        - [*System*] %M2_HOME%\bin (`C:\Program Files\JetBrains\IntelliJ IDEA\plugins\maven\lib\maven3\bin`)
+        - [*System*] the path to the SonarScanner for .NET folder and to the Scanner CLI ([SonarScanner download](https://github.com/SonarSource/sonar-scanner-msbuild/releases))
 1. Open `analyzers/SonarAnalyzer.sln`
 
 ## Running Tests

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -34,8 +34,9 @@ In general, it is best to run commands from the Visual Studio Developer Command 
     - **JAVA_HOME** (e.g. `C:\Program Files\Java\jdk-11.0.2`)
     - **MSBUILD_PATH** - path to the MSBuild.exe executable (MSBuild 16 e.g. `C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe`)
     - **NUGET_PATH** - path to the nuget.exe executable (related to the [plugin integration tests](./contributing-plugin.md#integration-tests))
-    - **ORCHESTRATOR_CONFIG_URL** - url to orchestrator.properties file (for integration tests) in uri form (i.e. file:///c:/something/orchestrator.properties). TODO: where to get the file, where to place it and document to put that variable in "user" instead of "system"
-    - **RULE_API_PATH** - path to folder containing the rule api jar. The rule api jar can be found at [repox.jfrog](https://repox.jfrog.io/ui/artifactSearchResults?name=rule-api&type=artifacts)
+    - **Sonarsource internal only** These two steps require access to SonarSource internal resources and are not possible for external contributers
+        - **ORCHESTRATOR_CONFIG_URL** - url to orchestrator.properties file (for integration tests) in uri form (i.e. file:///c:/something/orchestrator.properties). See also: [Documentation in the orchestrator repository](https://github.com/sonarsource/orchestrator#configuration)
+        - **RULE_API_PATH** - path to folder containing the rule api jar. The rule api jar can be found at [repox.jfrog search](https://repox.jfrog.io/ui/artifactSearchResults?name=rule-api&type=artifacts) or [repox.jfrog private releases](https://repox.jfrog.io/ui/native/sonarsource-private-releases/com/sonarsource/rule-api/rule-api/)
     - **PATH** - the system **PATH** variable must contain:
         - the path to the dotnet core installation folder (System: `C:\Program Files\dotnet\`)
         - the path to the MSBuild bin folder (System: `C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin`)

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -17,28 +17,33 @@ In general, it is best to run commands from the Visual Studio Developer Command 
     - ASP.NET and web development
     - .NET desktop development
     - Visual Studio extension development
-1. Ensure to install Individual components:
+1. Ensure to install *Individual components*:
     - .NET Framework 4.8 SDK
     - .NET Framework 4.8 Targeting pack
+    - .NET Framework 4.7.2 Targeting pack
+    - .NET Framework 4.6 Targeting pack
     - .NET SDK
     - .NET Compiler Platform SDK
 1. Install also:
-    - .NET Core 3.1 SDK
-    - .NET 3.5 SDK (SP1)
+    - [.NET Core 3.1 SDK](https://dotnet.microsoft.com/en-us/download/dotnet)
+    - .NET 3.5 SDK (SP1) TODO: Add link to dotNetFx35setup.exe
+    - Install Visual Studio 2019 and check these SDKs in the *individual components* tab
+        - .NET framework 4 targeting pack
+        - .NET framework 4.5 targeting pack
 1. The following environment variables must be set:
-    - **JAVA_HOME**
-    - **MSBUILD_PATH** - path to the MSBuild.exe executable (MSBuild 16)
+    - **JAVA_HOME** (e.g. `C:\Program Files\Java\jdk-11.0.2`)
+    - **MSBUILD_PATH** - path to the MSBuild.exe executable (MSBuild 16 e.g. `C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe`)
     - **NUGET_PATH** - path to the nuget.exe executable (related to the [plugin integration tests](./contributing-plugin.md#integration-tests))
-    - **ORCHESTRATOR_CONFIG_URL** - url to orchestrator.properties file (for integration tests) in uri form (i.e. file:///c:/something/orchestrator.properties)
-    - **RULE_API_PATH** - path to folder containing the rule api jar
+    - **ORCHESTRATOR_CONFIG_URL** - url to orchestrator.properties file (for integration tests) in uri form (i.e. file:///c:/something/orchestrator.properties). TODO: where to get the file, where to place it and document to put that variable in "user" instead of "system"
+    - **RULE_API_PATH** - path to folder containing the rule api jar. The rule api jar can be found at [repox.jfrog](https://repox.jfrog.io/ui/artifactSearchResults?name=rule-api&type=artifacts)
     - **PATH** - the system **PATH** variable must contain:
-        - the path to the dotnet core installation folder
-        - the path to the MSBuild bin folder
-        - the path to the visual studo installer folder (for vswhere.exe)
-        - the path to the nuget executable folder (e.g. C:\Program Files\nuget)
-        - the path to the JDK bin folder
+        - the path to the dotnet core installation folder (System: `C:\Program Files\dotnet\`)
+        - the path to the MSBuild bin folder (System: `C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin`)
+        - the path to the visual studo installer folder (for vswhere.exe) (System: `C:\Program Files (x86)\Microsoft Visual Studio\Installer`)
+        - the path to the nuget executable folder ((System: `C:\Program Files\nuget`)
+        - the path to the JDK bin folder (System: `C:\Program Files\Java\jdk-11.0.2\bin`)
         - %M2_HOME%\bin
-        - the path to the SonarScanner for .NET folder and to the Scanner CLI
+        - the path to the SonarScanner for .NET folder and to the Scanner CLI ([SonarScanner download](https://github.com/SonarSource/sonar-scanner-msbuild/releases))
 1. Open `analyzers/SonarAnalyzer.sln`
 
 ## Running Tests

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -37,14 +37,14 @@ In general, it is best to run commands from the Visual Studio Developer Command 
     - **Sonarsource internal only** These two steps require access to SonarSource internal resources and are not possible for external contributers
         - **ORCHESTRATOR_CONFIG_URL** - url to orchestrator.properties file (for integration tests) in uri form (i.e. file:///c:/something/orchestrator.properties). See also: [Documentation in the orchestrator repository](https://github.com/sonarsource/orchestrator#configuration)
         - **RULE_API_PATH** - path to folder containing the rule api jar. The rule api jar can be found at [repox.jfrog search](https://repox.jfrog.io/ui/artifactSearchResults?name=rule-api&type=artifacts) or [repox.jfrog private releases](https://repox.jfrog.io/ui/native/sonarsource-private-releases/com/sonarsource/rule-api/rule-api/)
-    - **PATH** - the **PATH** variable must contain (either *system* or *user* scope):
-        - [*System*] the path to the dotnet core installation folder (`C:\Program Files\dotnet\`)
-        - [*System*] the path to the MSBuild bin folder (`C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin`)
-        - [*System*] the path to the visual studo installer folder (for vswhere.exe) (`C:\Program Files (x86)\Microsoft Visual Studio\Installer`)
-        - [*System*] the path to the nuget executable folder (`C:\Program Files\nuget`)
-        - [*System*] the path to the JDK bin folder (`C:\Program Files\Java\jdk-11.0.2\bin`)
-        - [*System*] %M2_HOME%\bin (`C:\Program Files\JetBrains\IntelliJ IDEA\plugins\maven\lib\maven3\bin` [Maven cli](https://maven.apache.org/install.html). Here installed via IntelliJ IDEA.)
-        - [*System*] the path to the SonarScanner for .NET folder and to the Scanner CLI ([SonarScanner download](https://github.com/SonarSource/sonar-scanner-msbuild/releases))
+    - **PATH** - the **PATH** variable must contain (*system* scope):
+        - dotnet core installation folder (`C:\Program Files\dotnet\`)
+        - MSBuild bin folder (`C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin`)
+        - visual studo installer folder (for vswhere.exe) (`C:\Program Files (x86)\Microsoft Visual Studio\Installer`)
+        - nuget executable folder (`C:\Program Files\nuget`)
+        - JDK bin folder (`C:\Program Files\Java\jdk-11.0.2\bin`)
+        - %M2_HOME%\bin (`C:\Program Files\JetBrains\IntelliJ IDEA\plugins\maven\lib\maven3\bin` [Maven cli](https://maven.apache.org/install.html). Here installed via IntelliJ IDEA.)
+        - SonarScanner for .NET folder and to the Scanner CLI ([SonarScanner download](https://github.com/SonarSource/sonar-scanner-msbuild/releases))
 1. Open `analyzers/SonarAnalyzer.sln`
 
 ## Running Tests

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -125,8 +125,9 @@ After the debug session, remove the `Debugger.Launch()` line.
 **Internal only**
 
 * Use IntelliJ IDEA
-* Open the root folder of the repo
-* Make sure the `its`, `sonar-csharp-plugin`, `sonar-dotnet-shared-library`, and `sonar-vbnet-plugin` folders are are imported as Maven modules (indicated by a blue square). Search for `pom.xml` in the folders and make it a maven project if not.
+  * Follow the [Code Style Configuration for Intellij](https://github.com/SonarSource/sonar-developer-toolset#code-style-configuration-for-intellij) instructions
+  * Open the root folder of the repo
+  * Make sure the `its`, `sonar-csharp-plugin`, `sonar-dotnet-shared-library`, and `sonar-vbnet-plugin` folders are are imported as Maven modules (indicated by a blue square). Search for `pom.xml` in the folders and make it a maven project if not.
 * Add the following environment variables (user)
   * **ARTIFACTORY_URL** https://repox.jfrog.io/repox
   * **ARTIFACTORY_USER** your repox.jfrog username (see e.g. orchestrator.properties)

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -43,7 +43,7 @@ In general, it is best to run commands from the Visual Studio Developer Command 
         - [*System*] the path to the visual studo installer folder (for vswhere.exe) (`C:\Program Files (x86)\Microsoft Visual Studio\Installer`)
         - [*System*] the path to the nuget executable folder (`C:\Program Files\nuget`)
         - [*System*] the path to the JDK bin folder (`C:\Program Files\Java\jdk-11.0.2\bin`)
-        - [*System*] %M2_HOME%\bin (`C:\Program Files\JetBrains\IntelliJ IDEA\plugins\maven\lib\maven3\bin`)
+        - [*System*] %M2_HOME%\bin (`C:\Program Files\JetBrains\IntelliJ IDEA\plugins\maven\lib\maven3\bin` [Maven cli](https://maven.apache.org/install.html). Here installed via IntelliJ IDEA.)
         - [*System*] the path to the SonarScanner for .NET folder and to the Scanner CLI ([SonarScanner download](https://github.com/SonarSource/sonar-scanner-msbuild/releases))
 1. Open `analyzers/SonarAnalyzer.sln`
 
@@ -128,7 +128,7 @@ After the debug session, remove the `Debugger.Launch()` line.
   * Follow the [Code Style Configuration for Intellij](https://github.com/SonarSource/sonar-developer-toolset#code-style-configuration-for-intellij) instructions
   * Open the root folder of the repo
   * Make sure the `its`, `sonar-csharp-plugin`, `sonar-dotnet-shared-library`, and `sonar-vbnet-plugin` folders are are imported as Maven modules (indicated by a blue square). Search for `pom.xml` in the folders and make it a maven project if not.
-* Add the following environment variables (user)
+* Add the following environment variables (*user* scope)
   * **ARTIFACTORY_URL** https://repox.jfrog.io/repox
   * **ARTIFACTORY_USER** your repox.jfrog username (see e.g. orchestrator.properties)
   * **ARTIFACTORY_PASSWORD** the api key for repox.jfrog (see e.g. orchestrator.properties)


### PR DESCRIPTION
Improve the pre-requirements section the documentation with respect to
* VS 2022
* Locations of artifacts required (e.g. `orchestrator.properties` or `rule-api.jar`)