### PR TITLE
Fix S2187 FP: Support test attributes deriving from `ITestBuilder` in NUnit

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -119,6 +119,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType NUnit_Framework_AssertionException = new("NUnit.Framework.AssertionException");
         internal static readonly KnownType NUnit_Framework_ExpectedExceptionAttribute = new("NUnit.Framework.ExpectedExceptionAttribute");
         internal static readonly KnownType NUnit_Framework_IgnoreAttribute = new("NUnit.Framework.IgnoreAttribute");
+        internal static readonly KnownType NUnit_Framework_ITestBuilderInterface = new("NUnit.Framework.Interfaces.ITestBuilder");
         internal static readonly KnownType NUnit_Framework_TestAttribute = new("NUnit.Framework.TestAttribute");
         internal static readonly KnownType NUnit_Framework_TestCaseAttribute = new("NUnit.Framework.TestCaseAttribute");
         internal static readonly KnownType NUnit_Framework_TestCaseSourceAttribute = new("NUnit.Framework.TestCaseSourceAttribute");

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/SymbolHelper.cs
@@ -217,6 +217,9 @@ namespace SonarAnalyzer.Helpers
         internal static bool AnyAttributeDerivesFromAny(this ISymbol symbol, ImmutableArray<KnownType> attributeTypes) =>
             symbol?.GetAttributes().Any(a => a.AttributeClass.DerivesFromAny(attributeTypes)) ?? false;
 
+        internal static bool AnyAttributeDerivesFromOrImplementsAny(this ISymbol symbol, ImmutableArray<KnownType> attributeTypesOrInterfaces) =>
+            symbol?.GetAttributes().Any(a => a.AttributeClass.DerivesOrImplementsAny(attributeTypesOrInterfaces)) ?? false;
+
         internal static bool IsKnownType(this SyntaxNode syntaxNode, KnownType knownType, SemanticModel semanticModel)
         {
             var symbolType = semanticModel.GetSymbolInfo(syntaxNode).Symbol.GetSymbolType();

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
@@ -36,7 +36,8 @@ namespace SonarAnalyzer.Helpers
                 KnownType.NUnit_Framework_TestAttribute,
                 KnownType.NUnit_Framework_TestCaseAttribute,
                 KnownType.NUnit_Framework_TestCaseSourceAttribute,
-                KnownType.NUnit_Framework_TheoryAttribute);
+                KnownType.NUnit_Framework_TheoryAttribute,
+                KnownType.NUnit_Framework_ITestBuilderInterface);
 
         public static readonly ImmutableArray<KnownType> KnownTestMethodAttributesOfxUnit = ImmutableArray.Create(
                 KnownType.Xunit_FactAttribute,
@@ -89,7 +90,7 @@ namespace SonarAnalyzer.Helpers
             classSymbol.AnyAttributeDerivesFromAny(KnownTestClassAttributes);
 
         public static bool IsTestMethod(this IMethodSymbol method) =>
-            method.AnyAttributeDerivesFromAny(KnownTestMethodAttributes);
+            method.AnyAttributeDerivesFromOrImplementsAny(KnownTestMethodAttributes);
 
         public static bool HasExpectedExceptionAttribute(this IMethodSymbol method) =>
             method.GetAttributes().Any(a => a.AttributeClass.IsAny(KnownExpectedExceptionAttributes));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestClassShouldHaveTestMethodTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestClassShouldHaveTestMethodTest.cs
@@ -41,6 +41,15 @@ namespace SonarAnalyzer.UnitTest.Rules
                 NuGetMetadataReference.NUnit(testFwkVersion));
 
         [DataTestMethod]
+        [DataRow("3.0.0")]
+        [DataRow(Constants.NuGetLatestVersion)]
+        public void TestClassShouldHaveTestMethod_NUnit3(string testFwkVersion) =>
+            OldVerifier.VerifyAnalyzer(
+                @"TestCases\TestClassShouldHaveTestMethod.NUnit3.cs",
+                new TestClassShouldHaveTestMethod(),
+                NuGetMetadataReference.NUnit(testFwkVersion));
+
+        [DataTestMethod]
         [DataRow("1.1.11")]
         [DataRow(Constants.NuGetLatestVersion)]
         public void TestClassShouldHaveTestMethod_MSTest(string testFwkVersion) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestClassShouldHaveTestMethodTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestClassShouldHaveTestMethodTest.cs
@@ -18,9 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#if NET
-using System.Linq;
-#endif
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.UnitTest.MetadataReferences;
@@ -31,41 +28,44 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class TestClassShouldHaveTestMethodTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<TestClassShouldHaveTestMethod>();
+
         [DataTestMethod]
         [DataRow("2.5.7.10213")]
         [DataRow(Constants.NuGetLatestVersion)]
         public void TestClassShouldHaveTestMethod_NUnit(string testFwkVersion) =>
-            OldVerifier.VerifyAnalyzer(
-                @"TestCases\TestClassShouldHaveTestMethod.NUnit.cs",
-                new TestClassShouldHaveTestMethod(),
-                NuGetMetadataReference.NUnit(testFwkVersion));
+            builder
+                .AddPaths("TestClassShouldHaveTestMethod.NUnit.cs")
+                .AddReferences(NuGetMetadataReference.NUnit(testFwkVersion))
+                .Verify();
 
         [DataTestMethod]
         [DataRow("3.0.0")]
         [DataRow(Constants.NuGetLatestVersion)]
         public void TestClassShouldHaveTestMethod_NUnit3(string testFwkVersion) =>
-            OldVerifier.VerifyAnalyzer(
-                @"TestCases\TestClassShouldHaveTestMethod.NUnit3.cs",
-                new TestClassShouldHaveTestMethod(),
-                NuGetMetadataReference.NUnit(testFwkVersion));
+            builder
+                .AddPaths("TestClassShouldHaveTestMethod.NUnit3.cs")
+                .AddReferences(NuGetMetadataReference.NUnit(testFwkVersion))
+                .Verify();
 
         [DataTestMethod]
         [DataRow("1.1.11")]
         [DataRow(Constants.NuGetLatestVersion)]
         public void TestClassShouldHaveTestMethod_MSTest(string testFwkVersion) =>
-            OldVerifier.VerifyAnalyzer(
-                @"TestCases\TestClassShouldHaveTestMethod.MsTest.cs",
-                new TestClassShouldHaveTestMethod(),
-                NuGetMetadataReference.MSTestTestFramework(testFwkVersion));
+            builder
+                .AddPaths("TestClassShouldHaveTestMethod.MsTest.cs")
+                .AddReferences(NuGetMetadataReference.MSTestTestFramework(testFwkVersion))
+                .Verify();
 
 #if NET
         [DataTestMethod]
         public void TestClassShouldHaveTestMethod_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(
-                @"TestCases\TestClassShouldHaveTestMethod.CSharp9.cs",
-                new TestClassShouldHaveTestMethod(),
-                NuGetMetadataReference.MSTestTestFramework(Constants.NuGetLatestVersion)
-                    .Concat(NuGetMetadataReference.NUnit(Constants.NuGetLatestVersion)));
+            builder
+                .WithOptions(ParseOptionsHelper.FromCSharp9)
+                .AddPaths("TestClassShouldHaveTestMethod.CSharp9.cs")
+                .AddReferences(NuGetMetadataReference.MSTestTestFramework(Constants.NuGetLatestVersion))
+                .AddReferences(NuGetMetadataReference.NUnit(Constants.NuGetLatestVersion))
+                .Verify();
 #endif
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestClassShouldHaveTestMethod.NUnit3.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestClassShouldHaveTestMethod.NUnit3.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace ImplementsTestBuilder
+{
+    public class CustomTestAttribute : Attribute, ITestBuilder
+    {
+        public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite) => throw new NotImplementedException();
+    }
+
+    public class DerivedCustomTestAttribute : CustomTestAttribute { }
+
+    public interface IWrongInterface { }
+
+    public class FakeAttribute : Attribute, IWrongInterface { }
+
+    [TestFixture]
+    public class Fixture
+    {
+        [CustomTest]
+        public void Foo() { }
+    }
+
+    [TestFixture]
+    public class Fixture2
+    {
+        [DerivedCustomTest]
+        public void Bar() { }
+    }
+
+    [TestFixture]
+    public class Fixture3 // Noncompliant
+//               ^^^^^^^^
+    {
+        [FakeAttribute]
+        public void Baz() { }
+    }
+}


### PR DESCRIPTION
Fixes #5564
