### PR TITLE
Remove usage of concurrent collections from rules

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantDeclaration.cs
@@ -117,10 +117,11 @@ namespace SonarAnalyzer.Rules.CSharp
 
             foreach (var parameter in lambda.ParameterList.Parameters)
             {
-                context.ReportIssue(Diagnostic.Create(Rule,
-                                                                     parameter.Type.GetLocation(),
-                                                                     ImmutableDictionary<string, string>.Empty.Add(DiagnosticTypeKey, RedundancyType.LambdaParameterType.ToString()),
-                                                                     "type specification"));
+                context.ReportIssue(Diagnostic.Create(
+                    Rule,
+                    parameter.Type.GetLocation(),
+                    ImmutableDictionary<string, string>.Empty.Add(DiagnosticTypeKey, RedundancyType.LambdaParameterType.ToString()),
+                    "type specification"));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SetLocaleForDataTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SetLocaleForDataTypes.cs
@@ -19,7 +19,7 @@
  */
 
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -51,17 +51,18 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterCompilationStartAction(
                 compilationStartContext =>
                 {
-                    var symbolsWhereTypeIsCreated = new ConcurrentBag<NodeAndSymbol>();
-                    var symbolsWhereLocaleIsSet = new ConcurrentBag<ISymbol>();
+                    var symbolsWhereTypeIsCreated = new HashSet<NodeAndSymbol>();
+                    var symbolsWhereLocaleIsSet = new HashSet<ISymbol>();
 
-                    compilationStartContext.RegisterSyntaxNodeActionInNonGenerated(ProcessObjectCreations(symbolsWhereTypeIsCreated),
-                                                                                   SyntaxKind.ObjectCreationExpression,
-                                                                                   SyntaxKindEx.ImplicitObjectCreationExpression);
+                    compilationStartContext.RegisterSyntaxNodeActionInNonGenerated(
+                        ProcessObjectCreations(symbolsWhereTypeIsCreated),
+                        SyntaxKind.ObjectCreationExpression,
+                        SyntaxKindEx.ImplicitObjectCreationExpression);
                     compilationStartContext.RegisterSyntaxNodeActionInNonGenerated(ProcessSimpleAssignments(symbolsWhereLocaleIsSet), SyntaxKind.SimpleAssignmentExpression);
                     compilationStartContext.RegisterCompilationEndAction(ProcessCollectedSymbols(symbolsWhereTypeIsCreated, symbolsWhereLocaleIsSet));
                 });
 
-        private static Action<SyntaxNodeAnalysisContext> ProcessObjectCreations(ConcurrentBag<NodeAndSymbol> symbolsWhereTypeIsCreated) =>
+        private static Action<SyntaxNodeAnalysisContext> ProcessObjectCreations(HashSet<NodeAndSymbol> symbolsWhereTypeIsCreated) =>
             c =>
             {
                 if (GetSymbolFromConstructorInvocation(c.Node, c.SemanticModel) is ITypeSymbol objectType
@@ -78,7 +79,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             };
 
-        private static Action<SyntaxNodeAnalysisContext> ProcessSimpleAssignments(ConcurrentBag<ISymbol> symbolsWhereLocaleIsSet) =>
+        private static Action<SyntaxNodeAnalysisContext> ProcessSimpleAssignments(HashSet<ISymbol> symbolsWhereLocaleIsSet) =>
             c =>
             {
                 var assignmentExpression = (AssignmentExpressionSyntax)c.Node;
@@ -95,8 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             };
 
-        private static Action<CompilationAnalysisContext> ProcessCollectedSymbols(ConcurrentBag<NodeAndSymbol> symbolsWhereTypeIsCreated,
-                                                                                  ConcurrentBag<ISymbol> symbolsWhereLocaleIsSet) =>
+        private static Action<CompilationAnalysisContext> ProcessCollectedSymbols(HashSet<NodeAndSymbol> symbolsWhereTypeIsCreated, HashSet<ISymbol> symbolsWhereLocaleIsSet) =>
             c =>
             {
                 foreach (var invalidCreation in symbolsWhereTypeIsCreated.Where(x => !symbolsWhereLocaleIsSet.Contains(x.Symbol)))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SetLocaleForDataTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SetLocaleForDataTypes.cs
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     compilationStartContext.RegisterCompilationEndAction(ProcessCollectedSymbols(symbolsWhereTypeIsCreated, symbolsWhereLocaleIsSet));
                 });
 
-        private static Action<SyntaxNodeAnalysisContext> ProcessObjectCreations(HashSet<NodeAndSymbol> symbolsWhereTypeIsCreated) =>
+        private static Action<SyntaxNodeAnalysisContext> ProcessObjectCreations(ISet<NodeAndSymbol> symbolsWhereTypeIsCreated) =>
             c =>
             {
                 if (GetSymbolFromConstructorInvocation(c.Node, c.SemanticModel) is ITypeSymbol objectType
@@ -79,14 +79,14 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             };
 
-        private static Action<SyntaxNodeAnalysisContext> ProcessSimpleAssignments(HashSet<ISymbol> symbolsWhereLocaleIsSet) =>
+        private static Action<SyntaxNodeAnalysisContext> ProcessSimpleAssignments(ISet<ISymbol> symbolsWhereLocaleIsSet) =>
             c =>
             {
                 var assignmentExpression = (AssignmentExpressionSyntax)c.Node;
 
                 if (GetPropertySymbol(assignmentExpression, c.SemanticModel) is { } propertySymbol
-                    && propertySymbol.ContainingType.IsAny(CheckedTypes)
-                    && propertySymbol.Name == "Locale")
+                    && propertySymbol.Name == "Locale"
+                    && propertySymbol.ContainingType.IsAny(CheckedTypes))
                 {
                     var variableSymbol = GetAccessedVariable(assignmentExpression, c.SemanticModel);
                     if (variableSymbol != null)
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             };
 
-        private static Action<CompilationAnalysisContext> ProcessCollectedSymbols(HashSet<NodeAndSymbol> symbolsWhereTypeIsCreated, HashSet<ISymbol> symbolsWhereLocaleIsSet) =>
+        private static Action<CompilationAnalysisContext> ProcessCollectedSymbols(ICollection<NodeAndSymbol> symbolsWhereTypeIsCreated, ICollection<ISymbol> symbolsWhereLocaleIsSet) =>
             c =>
             {
                 foreach (var invalidCreation in symbolsWhereTypeIsCreated.Where(x => !symbolsWhereLocaleIsSet.Contains(x.Symbol)))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -19,7 +19,6 @@
  */
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -64,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     // Collect potentially removable internal types from the project to evaluate when
                     // the compilation is over, depending on whether InternalsVisibleTo attribute is present
                     // or not.
-                    var removableInternalTypes = new ConcurrentBag<ISymbol>();
+                    var removableInternalTypes = new HashSet<ISymbol>();
 
                     c.RegisterSymbolAction(cc => NamedSymbolAction(cc, removableInternalTypes), SymbolKind.NamedType);
                     c.RegisterCompilationEndAction(
@@ -92,7 +91,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         });
                 });
 
-        private static void NamedSymbolAction(SymbolAnalysisContext context, ConcurrentBag<ISymbol> removableInternalTypes)
+        private static void NamedSymbolAction(SymbolAnalysisContext context, HashSet<ISymbol> removableInternalTypes)
         {
             var namedType = (INamedTypeSymbol)context.Symbol;
             var privateSymbols = new HashSet<ISymbol>();
@@ -111,7 +110,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool GatherSymbols(INamedTypeSymbol namedType,
                                           Compilation compilation,
                                           HashSet<ISymbol> privateSymbols,
-                                          ConcurrentBag<ISymbol> internalSymbols,
+                                          HashSet<ISymbol> internalSymbols,
                                           BidirectionalDictionary<ISymbol, SyntaxNode> fieldLikeSymbols)
         {
             if (namedType.ContainingType != null
@@ -293,7 +292,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static void CopyRetrievedSymbols(CSharpRemovableSymbolWalker removableSymbolCollector,
                                                  HashSet<ISymbol> privateSymbols,
-                                                 ConcurrentBag<ISymbol> internalSymbols,
+                                                 HashSet<ISymbol> internalSymbols,
                                                  BidirectionalDictionary<ISymbol, SyntaxNode> fieldLikeSymbols)
         {
             privateSymbols.AddRange(removableSymbolCollector.PrivateSymbols);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -298,10 +298,7 @@ namespace SonarAnalyzer.Rules.CSharp
             privateSymbols.AddRange(removableSymbolCollector.PrivateSymbols);
 
             // Keep the removable internal types for when the compilation ends
-            foreach (var internalSymbol in removableSymbolCollector.InternalSymbols)
-            {
-                internalSymbols.Add(internalSymbol);
-            }
+            internalSymbols.AddRange(removableSymbolCollector.InternalSymbols);
 
             foreach (var keyValuePair in removableSymbolCollector.FieldLikeSymbols)
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -76,7 +75,7 @@ namespace SonarAnalyzer.Rules
             context.RegisterCompilationStartAction(
                 c =>
                 {
-                    var attributesOverTheLimit = new ConcurrentDictionary<SyntaxNode, Attributes>();
+                    var attributesOverTheLimit = new Dictionary<SyntaxNode, Attributes>();
 
                     c.RegisterSyntaxNodeActionInNonGenerated(
                         Language.GeneratedCodeRecognizer,
@@ -96,7 +95,7 @@ namespace SonarAnalyzer.Rules
             attributeName.Equals(RequestSizeLimit, Language.NameComparison)
             || attributeName.Equals(RequestSizeLimitAttribute, Language.NameComparison);
 
-        private void CollectAttributesOverTheLimit(SyntaxNodeAnalysisContext context, ConcurrentDictionary<SyntaxNode, Attributes> attributesOverTheLimit)
+        private void CollectAttributesOverTheLimit(SyntaxNodeAnalysisContext context, Dictionary<SyntaxNode, Attributes> attributesOverTheLimit)
         {
             if (!IsEnabled(context.Options))
             {
@@ -118,14 +117,13 @@ namespace SonarAnalyzer.Rules
             if ((requestSizeLimit != null || requestFormLimits != null)
                 && GetMethodLocalFunctionOrClassDeclaration(attribute) is { } declaration)
             {
-                attributesOverTheLimit.AddOrUpdate(
-                    declaration,
-                    new Attributes(requestFormLimits, requestSizeLimit),
-                    (_, attributes) => new Attributes(requestFormLimits, requestSizeLimit, attributes));
+                attributesOverTheLimit[declaration] = attributesOverTheLimit.TryGetValue(declaration, out var existingAttribute)
+                    ? new Attributes(requestFormLimits, requestSizeLimit, existingAttribute)
+                    : new Attributes(requestFormLimits, requestSizeLimit);
             }
         }
 
-        private void ReportOnCollectedAttributes(CompilationAnalysisContext context, ConcurrentDictionary<SyntaxNode, Attributes> attributesOverTheLimit)
+        private void ReportOnCollectedAttributes(CompilationAnalysisContext context, Dictionary<SyntaxNode, Attributes> attributesOverTheLimit)
         {
             foreach (var invalidAttributes in attributesOverTheLimit.Values)
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.Rules
             attributeName.Equals(RequestSizeLimit, Language.NameComparison)
             || attributeName.Equals(RequestSizeLimitAttribute, Language.NameComparison);
 
-        private void CollectAttributesOverTheLimit(SyntaxNodeAnalysisContext context, Dictionary<SyntaxNode, Attributes> attributesOverTheLimit)
+        private void CollectAttributesOverTheLimit(SyntaxNodeAnalysisContext context, IDictionary<SyntaxNode, Attributes> attributesOverTheLimit)
         {
             if (!IsEnabled(context.Options))
             {
@@ -123,7 +123,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void ReportOnCollectedAttributes(CompilationAnalysisContext context, Dictionary<SyntaxNode, Attributes> attributesOverTheLimit)
+        private void ReportOnCollectedAttributes(CompilationAnalysisContext context, IDictionary<SyntaxNode, Attributes> attributesOverTheLimit)
         {
             foreach (var invalidAttributes in attributesOverTheLimit.Values)
             {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SetLocaleForDataTypesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SetLocaleForDataTypesTest.cs
@@ -28,27 +28,32 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class SetLocaleForDataTypesTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<SetLocaleForDataTypes>();
+
         [TestMethod]
         public void SetLocaleForDataTypes() =>
-            OldVerifier.VerifyAnalyzer(
-                @"TestCases\SetLocaleForDataTypes.cs",
-                new SetLocaleForDataTypes(),
-                MetadataReferenceFacade.SystemData);
+            builder.AddPaths("SetLocaleForDataTypes.cs")
+                .AddReferences(MetadataReferenceFacade.SystemData)
+                .Verify();
 
 #if NET
+
         [TestMethod]
         public void SetLocaleForDataTypes_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Console(
-                @"TestCases\SetLocaleForDataTypes.CSharp9.cs",
-                new SetLocaleForDataTypes(),
-                MetadataReferenceFacade.SystemData);
+            builder.AddPaths("SetLocaleForDataTypes.CSharp9.cs")
+                .WithTopLevelStatements()
+                .AddReferences(MetadataReferenceFacade.SystemData)
+                .WithOptions(ParseOptionsHelper.FromCSharp9)
+                .Verify();
 
         [TestMethod]
         public void SetLocaleForDataTypes_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Console(
-                @"TestCases\SetLocaleForDataTypes.CSharp10.cs",
-                new SetLocaleForDataTypes(),
-                MetadataReferenceFacade.SystemData);
+            builder.AddPaths("SetLocaleForDataTypes.CSharp10.cs")
+                .WithTopLevelStatements()
+                .AddReferences(MetadataReferenceFacade.SystemData)
+                .WithOptions(ParseOptionsHelper.FromCSharp10)
+                .Verify();
+
 #endif
     }
 }


### PR DESCRIPTION
As for the other performance tests I did 4 runs on Akka, EfCore and Noda projects.  The sum of the execution time of the 3 rules changed, RequestsWithExcessiveLength, SetLocaleForDataTypes and UnusedPrivateMember with and without the changes are the following:
akka:  28.47 -> 32.893
efcore: 36.698 -> 37.362
noda: 15.455 -> 13.409
