### PR TITLE
S1939: Add support for record struct

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -148,7 +148,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     .Select(baseType => semanticModel.GetSymbolInfo(baseType.Type).Symbol as INamedTypeSymbol)
                     .WhereNotNull()
                     .Distinct()
-                    .ToLookup(x => x, x => x.AllInterfaces.AsEnumerable());
+                    .ToLookup(x => x.AllInterfaces.AsEnumerable());
 
         private static bool TryGetCollidingDeclaration(INamedTypeSymbol declaredType,
                                                        INamedTypeSymbol interfaceType,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -82,7 +82,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && baseTypeSymbol.Is(redundantType))
             {
                 var location = GetLocationWithToken(baseTypeSyntax, typeDeclaration.BaseList.Types);
-                context.ReportIssue(Diagnostic.Create(Rule, location, DiagnosticsProperties(redundantIndex: 0), message));
+                context.ReportIssue(Diagnostic.Create(Rule, location, DiagnosticsProperties(0), message));
             }
         }
 
@@ -109,7 +109,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         collidingDeclaration.ToMinimalDisplayString(context.SemanticModel, baseType.Type.SpanStart),
                         interfaceType.ToMinimalDisplayString(context.SemanticModel, baseType.Type.SpanStart));
 
-                    context.ReportIssue(Diagnostic.Create(Rule, location, DiagnosticsProperties(redundantIndex: i), message));
+                    context.ReportIssue(Diagnostic.Create(Rule, location, DiagnosticsProperties(i), message));
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             context.RegisterSyntaxNodeActionInNonGenerated(CheckEnum, SyntaxKind.EnumDeclaration);
             context.RegisterSyntaxNodeActionInNonGenerated(CheckInterface, SyntaxKind.InterfaceDeclaration);
-            context.RegisterSyntaxNodeActionInNonGenerated(CheckClassAndRecord, SyntaxKind.ClassDeclaration, SyntaxKindEx.RecordClassDeclaration);
+            context.RegisterSyntaxNodeActionInNonGenerated(CheckClassAndRecord, SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKindEx.RecordClassDeclaration);
         }
 
         private static void CheckClassAndRecord(SyntaxNodeAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -121,9 +121,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     .Distinct()
                     .ToMultiValueDictionary(x => x.AllInterfaces);
 
-        private static INamedTypeSymbol CollidingDeclaration(INamedTypeSymbol declaredType,
-                                                             INamedTypeSymbol interfaceType,
-                                                             MultiValueDictionary<INamedTypeSymbol, INamedTypeSymbol> interfaceMappings)
+        private static INamedTypeSymbol CollidingDeclaration(INamedTypeSymbol declaredType, INamedTypeSymbol interfaceType, MultiValueDictionary<INamedTypeSymbol, INamedTypeSymbol> interfaceMappings)
         {
             var collisionMapping = interfaceMappings.FirstOrDefault(x => x.Key.IsInterface() && x.Value.Contains(interfaceType));
             if (collisionMapping.Key is not null)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -75,9 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 var location = GetLocationWithToken(baseTypeSyntax, typeDeclaration.BaseList.Types);
                 context.ReportIssue(
-                    Diagnostic.Create(Rule, location,
-                                      ImmutableDictionary<string, string>.Empty.Add(RedundantIndexKey, "0"),
-                                      MessageObjectBase));
+                    Diagnostic.Create(Rule, location, DiagnosticsProperties(redundantIndex: 0), MessageObjectBase));
             }
 
             ReportRedundantInterfaces(context, typeDeclaration);
@@ -110,9 +108,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
 
             context.ReportIssue(
-                Diagnostic.Create(Rule, enumDeclaration.BaseList.GetLocation(),
-                                  ImmutableDictionary<string, string>.Empty.Add(RedundantIndexKey, "0"),
-                                  MessageEnum));
+                Diagnostic.Create(Rule, enumDeclaration.BaseList.GetLocation(), DiagnosticsProperties(redundantIndex: 0), MessageEnum));
         }
 
         private static void ReportRedundantInterfaces(SyntaxNodeAnalysisContext context, BaseTypeDeclarationSyntax typeDeclaration)
@@ -145,8 +141,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     collidingDeclaration.ToMinimalDisplayString(context.SemanticModel, baseType.Type.SpanStart),
                     interfaceType.ToMinimalDisplayString(context.SemanticModel, baseType.Type.SpanStart));
 
-                context.ReportIssue(Diagnostic.Create(Rule, location,
-                    ImmutableDictionary<string, string>.Empty.Add(RedundantIndexKey, i.ToString(CultureInfo.InvariantCulture)), message));
+                context.ReportIssue(Diagnostic.Create(Rule, location, DiagnosticsProperties(redundantIndex: i), message));
             }
         }
 
@@ -229,5 +224,12 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static bool IsBaseListNullOrEmpty(BaseTypeDeclarationSyntax baseTypeDeclaration) =>
             baseTypeDeclaration.BaseList == null || !baseTypeDeclaration.BaseList.Types.Any();
+
+        private static ImmutableDictionary<string, string> DiagnosticsProperties(int redundantIndex)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, string>();
+            builder.Add(RedundantIndexKey, redundantIndex.ToString());
+            return builder.ToImmutable();
+        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -69,8 +69,6 @@ namespace SonarAnalyzer.Rules.CSharp
                         ReportRedundantBaseType(c, nonInterfaceDeclaration, KnownType.System_Object, MessageObjectBase);
                         ReportRedundantInterfaces(c, nonInterfaceDeclaration);
                         break;
-                    default:
-                        throw new InvalidOperationException($"node type {c.Node?.Kind()} not supported.");
                 }
             },
             SyntaxKind.EnumDeclaration,
@@ -173,9 +171,9 @@ namespace SonarAnalyzer.Rules.CSharp
             foreach (var interfaceMember in allMembersOfInterface)
             {
                 var classMember = declaredType.FindImplementationForInterfaceMember(interfaceMember);
-                if (classMember is not null
+                if (declaredType.FindImplementationForInterfaceMember(interfaceMember) is { } classMember
                     && (classMember.ContainingType.Equals(declaredType)
-                    || !classMember.ContainingType.Interfaces.SelectMany(x => AllInterfacesAndSelf(x)).Contains(interfaceType)))
+                    || !classMember.ContainingType.Interfaces.Any(x => AllInterfacesAndSelf(x).Contains(interfaceType))))
                 {
                     return false;
                 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -116,25 +116,25 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static ILookup<INamedTypeSymbol, INamedTypeSymbol> GetImplementedInterfaceMappings(BaseListSyntax baseList, SemanticModel semanticModel) =>
+        private static MultiValueDictionary<INamedTypeSymbol, INamedTypeSymbol> GetImplementedInterfaceMappings(BaseListSyntax baseList, SemanticModel semanticModel) =>
             baseList.Types
                     .Select(baseType => semanticModel.GetSymbolInfo(baseType.Type).Symbol as INamedTypeSymbol)
                     .WhereNotNull()
                     .Distinct()
-                    .ToLookup(x => x.AllInterfaces.AsEnumerable());
+                    .ToMultiValueDictionary(x => x.AllInterfaces);
 
         private static INamedTypeSymbol CollidingDeclaration(INamedTypeSymbol declaredType,
                                                              INamedTypeSymbol interfaceType,
-                                                             ILookup<INamedTypeSymbol, INamedTypeSymbol> interfaceMappings)
+                                                             MultiValueDictionary<INamedTypeSymbol, INamedTypeSymbol> interfaceMappings)
         {
-            var collisionMapping = interfaceMappings.FirstOrDefault(x => x.Key.IsInterface() && x.Contains(interfaceType));
-            if (collisionMapping?.Key is not null)
+            var collisionMapping = interfaceMappings.FirstOrDefault(x => x.Key.IsInterface() && x.Value.Contains(interfaceType));
+            if (collisionMapping.Key is not null)
             {
                 return collisionMapping.Key;
             }
 
             var baseClassMapping = interfaceMappings.FirstOrDefault(x => x.Key.IsClass());
-            if (baseClassMapping?.Key is null)
+            if (baseClassMapping.Key is null)
             {
                 return null;
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -74,8 +74,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (baseTypeSymbol.Is(KnownType.System_Object))
             {
                 var location = GetLocationWithToken(baseTypeSyntax, typeDeclaration.BaseList.Types);
-                context.ReportIssue(
-                    Diagnostic.Create(Rule, location, DiagnosticsProperties(redundantIndex: 0), MessageObjectBase));
+                context.ReportIssue(Diagnostic.Create(Rule, location, DiagnosticsProperties(redundantIndex: 0), MessageObjectBase));
             }
 
             ReportRedundantInterfaces(context, typeDeclaration);
@@ -107,8 +106,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 return;
             }
 
-            context.ReportIssue(
-                Diagnostic.Create(Rule, enumDeclaration.BaseList.GetLocation(), DiagnosticsProperties(redundantIndex: 0), MessageEnum));
+            context.ReportIssue(Diagnostic.Create(Rule, enumDeclaration.BaseList.GetLocation(), DiagnosticsProperties(redundantIndex: 0), MessageEnum));
         }
 
         private static void ReportRedundantInterfaces(SyntaxNodeAnalysisContext context, BaseTypeDeclarationSyntax typeDeclaration)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -62,13 +62,15 @@ namespace SonarAnalyzer.Rules.CSharp
                     case EnumDeclarationSyntax enumDeclaration:
                         ReportRedundantBaseType(c, enumDeclaration, KnownType.System_Int32, MessageEnum);
                         break;
-                    case TypeDeclarationSyntax nonInterfaceDeclaration when nonInterfaceDeclaration is not { RawKind: (int)SyntaxKind.InterfaceDeclaration }:
-                        ReportRedundantBaseType(c, nonInterfaceDeclaration, KnownType.System_Object, MessageObjectBase);
-                        ReportRedundantInterfaces(c, nonInterfaceDeclaration);
-                        break;
                     case InterfaceDeclarationSyntax interfaceDeclaration:
                         ReportRedundantInterfaces(c, interfaceDeclaration);
                         break;
+                    case TypeDeclarationSyntax nonInterfaceDeclaration:
+                        ReportRedundantBaseType(c, nonInterfaceDeclaration, KnownType.System_Object, MessageObjectBase);
+                        ReportRedundantInterfaces(c, nonInterfaceDeclaration);
+                        break;
+                    default:
+                        throw new InvalidOperationException($"node type {c.Node?.Kind()} not supported.");
                 }
             },
             SyntaxKind.EnumDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -45,8 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageAlreadyImplements = "'{0}' implements '{1}' so '{1}' can be removed from the inheritance list.";
         private const string MessageFormat = "{0}";
 
-        private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
@@ -81,11 +80,8 @@ namespace SonarAnalyzer.Rules.CSharp
         private static void ReportRedundantBaseType(SyntaxNodeAnalysisContext context, BaseTypeDeclarationSyntax typeDeclaration, KnownType redundantType, string message)
         {
             var baseTypeSyntax = typeDeclaration.BaseList.Types.First().Type;
-            if (context.SemanticModel.GetSymbolInfo(baseTypeSyntax).Symbol is not ITypeSymbol baseTypeSymbol)
-            {
-                return;
-            }
-            if (baseTypeSymbol.Is(redundantType))
+            if (context.SemanticModel.GetSymbolInfo(baseTypeSyntax).Symbol is ITypeSymbol baseTypeSymbol
+                && baseTypeSymbol.Is(redundantType))
             {
                 var location = GetLocationWithToken(baseTypeSyntax, typeDeclaration.BaseList.Types);
                 context.ReportIssue(Diagnostic.Create(Rule, location, DiagnosticsProperties(redundantIndex: 0), message));

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -172,11 +172,7 @@ namespace SonarAnalyzer.Rules.CSharp
             return Location.Create(type.SyntaxTree, span);
         }
 
-        private static ImmutableDictionary<string, string> DiagnosticsProperties(int redundantIndex)
-        {
-            var builder = ImmutableDictionary.CreateBuilder<string, string>();
-            builder.Add(RedundantIndexKey, redundantIndex.ToString());
-            return builder.ToImmutable();
-        }
+        private static ImmutableDictionary<string, string> DiagnosticsProperties(int redundantIndex) =>
+            ImmutableDictionary.Create<string, string>().Add(RedundantIndexKey, redundantIndex.ToString());
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -66,13 +66,11 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 return;
             }
-
             var baseTypeSyntax = typeDeclaration.BaseList.Types.First().Type;
             if (context.SemanticModel.GetSymbolInfo(baseTypeSyntax).Symbol is not ITypeSymbol baseTypeSymbol)
             {
                 return;
             }
-
             if (baseTypeSymbol.Is(KnownType.System_Object))
             {
                 var location = GetLocationWithToken(baseTypeSyntax, typeDeclaration.BaseList.Types);
@@ -165,8 +163,8 @@ namespace SonarAnalyzer.Rules.CSharp
                                                        out INamedTypeSymbol collidingDeclaration)
         {
             var collisionMapping = interfaceMappings
-                .Where(i => i.Key.IsInterface())
-                .FirstOrDefault(v => v.Value.Contains(interfaceType));
+                .Where(x => x.Key.IsInterface())
+                .FirstOrDefault(x => x.Value.Contains(interfaceType));
 
             if (collisionMapping.Key != null)
             {
@@ -174,7 +172,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 return true;
             }
 
-            var baseClassMapping = interfaceMappings.FirstOrDefault(i => i.Key.IsClass());
+            var baseClassMapping = interfaceMappings.FirstOrDefault(x => x.Key.IsClass());
             if (baseClassMapping.Key == null)
             {
                 collidingDeclaration = null;
@@ -188,7 +186,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool CanInterfaceBeRemovedBasedOnMembers(INamedTypeSymbol declaredType, INamedTypeSymbol interfaceType)
         {
             var allMembersOfInterface = interfaceType.AllInterfaces.Concat(new[] { interfaceType })
-                .SelectMany(i => i.GetMembers())
+                .SelectMany(x => x.GetMembers())
                 .ToList();
 
             if (!allMembersOfInterface.Any())
@@ -201,7 +199,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 var classMember = declaredType.FindImplementationForInterfaceMember(interfaceMember);
                 if (classMember != null
                     && (classMember.ContainingType.Equals(declaredType)
-                    || !classMember.ContainingType.Interfaces.SelectMany(i => i.AllInterfaces.Concat(new[] { i })).Contains(interfaceType)))
+                    || !classMember.ContainingType.Interfaces.SelectMany(x => x.AllInterfaces.Concat(new[] { x })).Contains(interfaceType)))
                 {
                     return false;
                 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -145,9 +145,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static bool CanInterfaceBeRemovedBasedOnMembers(INamedTypeSymbol declaredType, INamedTypeSymbol interfaceType)
         {
-            var allMembersOfInterface = AllInterfacesAndSelf(interfaceType)
-                .SelectMany(x => x.GetMembers())
-                .ToList();
+            var allMembersOfInterface = AllInterfacesAndSelf(interfaceType).SelectMany(x => x.GetMembers()).ToImmutableArray();
 
             if (!allMembersOfInterface.Any())
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -18,10 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -162,7 +162,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 if (declaredType.FindImplementationForInterfaceMember(interfaceMember) is { } classMember
                     && (classMember.ContainingType.Equals(declaredType)
-                    || !classMember.ContainingType.Interfaces.Any(x => AllInterfacesAndSelf(x).Contains(interfaceType))))
+                        || !classMember.ContainingType.Interfaces.Any(x => AllInterfacesAndSelf(x).Contains(interfaceType))))
                 {
                     return false;
                 }
@@ -175,22 +175,11 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static Location GetLocationWithToken(TypeSyntax type, SeparatedSyntaxList<BaseTypeSyntax> baseTypes)
         {
-            int start;
-            int end;
+            var span = baseTypes.Count == 1 || baseTypes.First().Type != type
+                ? TextSpan.FromBounds(type.GetFirstToken().GetPreviousToken().Span.Start, type.Span.End)
+                : TextSpan.FromBounds(type.SpanStart, type.GetLastToken().GetNextToken().Span.End);
 
-            if (baseTypes.Count == 1
-                || baseTypes.First().Type != type)
-            {
-                start = type.GetFirstToken().GetPreviousToken().Span.Start;
-                end = type.Span.End;
-            }
-            else
-            {
-                start = type.SpanStart;
-                end = type.GetLastToken().GetNextToken().Span.End;
-            }
-
-            return Location.Create(type.SyntaxTree, new TextSpan(start, end - start));
+            return Location.Create(type.SyntaxTree, span);
         }
 
         private static ImmutableDictionary<string, string> DiagnosticsProperties(int redundantIndex)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -170,7 +170,6 @@ namespace SonarAnalyzer.Rules.CSharp
 
             foreach (var interfaceMember in allMembersOfInterface)
             {
-                var classMember = declaredType.FindImplementationForInterfaceMember(interfaceMember);
                 if (declaredType.FindImplementationForInterfaceMember(interfaceMember) is { } classMember
                     && (classMember.ContainingType.Equals(declaredType)
                     || !classMember.ContainingType.Interfaces.Any(x => AllInterfacesAndSelf(x).Contains(interfaceType))))

--- a/analyzers/src/SonarAnalyzer.Common/Common/MultiValueDictionary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/MultiValueDictionary.cs
@@ -47,7 +47,8 @@ namespace SonarAnalyzer.Common
 
         private Func<ICollection<TValue>> UnderlyingCollectionFactory { get; set; } = () => new List<TValue>();
 
-        public void Add(TKey key, TValue value) => AddWithKey(key, value);
+        public void Add(TKey key, TValue value) =>
+            AddWithKey(key, value);
 
         public void AddWithKey(TKey key, TValue value)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Common/MultiValueDictionary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/MultiValueDictionary.cs
@@ -92,7 +92,6 @@ namespace SonarAnalyzer.Common
             this IEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             Func<TSource, ICollection<TElement>> elementSelector)
-            where TSource : Tuple<TKey, ICollection<TElement>>
         {
             var dictionary = new MultiValueDictionary<TKey, TElement>();
             foreach (var item in source)

--- a/analyzers/src/SonarAnalyzer.Common/Common/MultiValueDictionary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/MultiValueDictionary.cs
@@ -19,11 +19,8 @@
  */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.Serialization;
 
 namespace SonarAnalyzer.Common

--- a/analyzers/src/SonarAnalyzer.Common/Common/MultiValueDictionary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/MultiValueDictionary.cs
@@ -19,8 +19,11 @@
  */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.Serialization;
 
 namespace SonarAnalyzer.Common
@@ -39,20 +42,15 @@ namespace SonarAnalyzer.Common
         }
 
         public static MultiValueDictionary<TKey, TValue> Create<TUnderlying>()
-            where TUnderlying : ICollection<TValue>, new()
-        {
-            return new MultiValueDictionary<TKey, TValue>
+            where TUnderlying : ICollection<TValue>, new() =>
+            new MultiValueDictionary<TKey, TValue>
             {
                 UnderlyingCollectionFactory = () => new TUnderlying()
             };
-        }
 
         private Func<ICollection<TValue>> UnderlyingCollectionFactory { get; set; } = () => new List<TValue>();
 
-        public void Add(TKey key, TValue value)
-        {
-            AddWithKey(key, value);
-        }
+        public void Add(TKey key, TValue value) => AddWithKey(key, value);
 
         public void AddWithKey(TKey key, TValue value)
         {
@@ -99,6 +97,61 @@ namespace SonarAnalyzer.Common
                 dictionary.Add(keySelector(item), elementSelector(item));
             }
             return dictionary;
+        }
+
+        public static ILookup<TKey, TElement> ToLookup<TSource, TKey, TElement>(this IEnumerable<TSource> source,
+                                                                                Func<TSource, TKey> keySelector,
+                                                                                Func<TSource, IEnumerable<TElement>> elementsSelector) =>
+            new Lookup<TKey, TElement>(source.ToDictionary(keySelector, elementsSelector));
+
+        public static ILookup<TKey, TElement> ToLookup<TKey, TElement>(this IReadOnlyDictionary<TKey, IEnumerable<TElement>> source) =>
+            new Lookup<TKey, TElement>(source);
+
+        private sealed class Lookup<TKey, TElement> : ILookup<TKey, TElement>
+        {
+            public Lookup(IReadOnlyDictionary<TKey, IEnumerable<TElement>> source)
+            {
+                Source = source;
+            }
+            private IReadOnlyDictionary<TKey, IEnumerable<TElement>> Source { get; }
+
+            public IEnumerable<TElement> this[TKey key] => Source[key];
+
+            public int Count => Source.Count;
+
+            public bool Contains(TKey key) => Source.ContainsKey(key);
+            public IEnumerator<IGrouping<TKey, TElement>> GetEnumerator() => new Enumerator(this);
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            private readonly struct Enumerator : IEnumerator<IGrouping<TKey, TElement>>
+            {
+                public Enumerator(Lookup<TKey, TElement> lookup)
+                {
+                    DictEnumerator = lookup.Source.GetEnumerator();
+                }
+                private IEnumerator<KeyValuePair<TKey, IEnumerable<TElement>>> DictEnumerator { get; }
+
+                public IGrouping<TKey, TElement> Current => new Grouping(DictEnumerator.Current.Key, DictEnumerator.Current.Value);
+
+                public void Dispose() => DictEnumerator.Dispose();
+                public bool MoveNext() => DictEnumerator.MoveNext();
+                public void Reset() => DictEnumerator.Reset();
+                object IEnumerator.Current => Current;
+
+                private readonly struct Grouping : IGrouping<TKey, TElement>
+                {
+                    public Grouping(TKey key, IEnumerable<TElement> value)
+                    {
+                        Key = key;
+                        Value = value;
+                    }
+
+                    public TKey Key { get; }
+                    private IEnumerable<TElement> Value { get; }
+                    public IEnumerator<TElement> GetEnumerator() => Value.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.Common/Common/MultiValueDictionary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/MultiValueDictionary.cs
@@ -99,6 +99,9 @@ namespace SonarAnalyzer.Common
             return dictionary;
         }
 
+        public static ILookup<TSource, TElement> ToLookup<TSource, TElement>(this IEnumerable<TSource> source, Func<TSource, IEnumerable<TElement>> elementsSelector) =>
+            source.ToLookup(x => x, elementsSelector);
+
         public static ILookup<TKey, TElement> ToLookup<TSource, TKey, TElement>(this IEnumerable<TSource> source,
                                                                                 Func<TSource, TKey> keySelector,
                                                                                 Func<TSource, IEnumerable<TElement>> elementsSelector) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RedundantInheritanceListTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RedundantInheritanceListTest.cs
@@ -41,7 +41,11 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void RedundantInheritanceList_CSharp9_CodeFix() =>
-            builder.AddPaths("RedundantInheritanceList.CSharp9.cs").WithCodeFixedPaths("RedundantInheritanceList.CSharp9.Fixed.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
+            builder.AddPaths("RedundantInheritanceList.CSharp9.cs")
+                .WithCodeFix<RedundantInheritanceListCodeFix>()
+                .WithCodeFixedPaths("RedundantInheritanceList.CSharp9.Fixed.cs")
+                .WithOptions(ParseOptionsHelper.FromCSharp9)
+                .VerifyCodeFix();
 
         [TestMethod]
         public void RedundantInheritanceList_CSharp10() =>
@@ -49,12 +53,19 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void RedundantInheritanceList_CSharp10_CodeFix() =>
-            builder.AddPaths("RedundantInheritanceList.CSharp10.cs").WithCodeFixedPaths("RedundantInheritanceList.CSharp10.Fixed.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+            builder.AddPaths("RedundantInheritanceList.CSharp10.cs")
+                .WithCodeFix<RedundantInheritanceListCodeFix>()
+                .WithCodeFixedPaths("RedundantInheritanceList.CSharp10.Fixed.cs")
+                .WithOptions(ParseOptionsHelper.FromCSharp10)
+                .VerifyCodeFix();
 
 #endif
 
         [TestMethod]
         public void RedundantInheritanceList_CodeFix() =>
-            builder.AddPaths("RedundantInheritanceList.cs").WithCodeFixedPaths("RedundantInheritanceList.Fixed.cs").Verify();
+            builder.AddPaths("RedundantInheritanceList.cs")
+                .WithCodeFix<RedundantInheritanceListCodeFix>()
+                .WithCodeFixedPaths("RedundantInheritanceList.Fixed.cs")
+                .VerifyCodeFix();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RedundantInheritanceListTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RedundantInheritanceListTest.cs
@@ -27,34 +27,33 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class RedundantInheritanceListTest
     {
-        private readonly VerifierBuilder builder = new VerifierBuilder<RedundantInheritanceList>();
+        private readonly VerifierBuilder rule = new VerifierBuilder<RedundantInheritanceList>();
+        private readonly VerifierBuilder codeFix = new VerifierBuilder<RedundantInheritanceList>().WithCodeFix<RedundantInheritanceListCodeFix>();
 
         [TestMethod]
         public void RedundantInheritanceList() =>
-            builder.AddPaths("RedundantInheritanceList.cs").Verify();
+            rule.AddPaths("RedundantInheritanceList.cs").Verify();
 
 #if NET
 
         [TestMethod]
         public void RedundantInheritanceList_CSharp9() =>
-            builder.AddPaths("RedundantInheritanceList.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
+            rule.AddPaths("RedundantInheritanceList.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void RedundantInheritanceList_CSharp9_CodeFix() =>
-            builder.AddPaths("RedundantInheritanceList.CSharp9.cs")
-                .WithCodeFix<RedundantInheritanceListCodeFix>()
+            codeFix.AddPaths("RedundantInheritanceList.CSharp9.cs")
                 .WithCodeFixedPaths("RedundantInheritanceList.CSharp9.Fixed.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp9)
                 .VerifyCodeFix();
 
         [TestMethod]
         public void RedundantInheritanceList_CSharp10() =>
-            builder.AddPaths("RedundantInheritanceList.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+            rule.AddPaths("RedundantInheritanceList.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
 
         [TestMethod]
         public void RedundantInheritanceList_CSharp10_CodeFix() =>
-            builder.AddPaths("RedundantInheritanceList.CSharp10.cs")
-                .WithCodeFix<RedundantInheritanceListCodeFix>()
+            codeFix.AddPaths("RedundantInheritanceList.CSharp10.cs")
                 .WithCodeFixedPaths("RedundantInheritanceList.CSharp10.Fixed.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .VerifyCodeFix();
@@ -63,8 +62,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void RedundantInheritanceList_CodeFix() =>
-            builder.AddPaths("RedundantInheritanceList.cs")
-                .WithCodeFix<RedundantInheritanceListCodeFix>()
+            codeFix.AddPaths("RedundantInheritanceList.cs")
                 .WithCodeFixedPaths("RedundantInheritanceList.Fixed.cs")
                 .VerifyCodeFix();
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RedundantInheritanceListTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RedundantInheritanceListTest.cs
@@ -27,42 +27,34 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class RedundantInheritanceListTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<RedundantInheritanceList>();
+
         [TestMethod]
         public void RedundantInheritanceList() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\RedundantInheritanceList.cs", new RedundantInheritanceList());
+            builder.AddPaths("RedundantInheritanceList.cs").Verify();
 
 #if NET
+
         [TestMethod]
         public void RedundantInheritanceList_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\RedundantInheritanceList.CSharp9.cs", new RedundantInheritanceList());
+            builder.AddPaths("RedundantInheritanceList.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void RedundantInheritanceList_CSharp9_CodeFix() =>
-            OldVerifier.VerifyCodeFix<RedundantInheritanceListCodeFix>(
-                @"TestCases\RedundantInheritanceList.CSharp9.cs",
-                @"TestCases\RedundantInheritanceList.CSharp9.Fixed.cs",
-                new RedundantInheritanceList(),
-                ParseOptionsHelper.FromCSharp9);
+            builder.AddPaths("RedundantInheritanceList.CSharp9.cs").WithCodeFixedPaths("RedundantInheritanceList.CSharp9.Fixed.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void RedundantInheritanceList_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(@"TestCases\RedundantInheritanceList.CSharp10.cs", new RedundantInheritanceList());
+            builder.AddPaths("RedundantInheritanceList.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
 
         [TestMethod]
         public void RedundantInheritanceList_CSharp10_CodeFix() =>
-            OldVerifier.VerifyCodeFix<RedundantInheritanceListCodeFix>(
-                @"TestCases\RedundantInheritanceList.CSharp10.cs",
-                @"TestCases\RedundantInheritanceList.CSharp10.Fixed.cs",
-                new RedundantInheritanceList(),
-                ParseOptionsHelper.FromCSharp10);
+            builder.AddPaths("RedundantInheritanceList.CSharp10.cs").WithCodeFixedPaths("RedundantInheritanceList.CSharp10.Fixed.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
 
 #endif
 
         [TestMethod]
         public void RedundantInheritanceList_CodeFix() =>
-            OldVerifier.VerifyCodeFix<RedundantInheritanceListCodeFix>(
-                @"TestCases\RedundantInheritanceList.cs",
-                @"TestCases\RedundantInheritanceList.Fixed.cs",
-                new RedundantInheritanceList());
+            builder.AddPaths("RedundantInheritanceList.cs").WithCodeFixedPaths("RedundantInheritanceList.Fixed.cs").Verify();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RedundantInheritanceList.CSharp10.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RedundantInheritanceList.CSharp10.Fixed.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 
-record Record { } // Fixed
-
-record struct RedunantInterfaceImpl : IContract, IBaseContract { } // FN
-
-record struct RedunantInterfaceImplPositionalRecord(int SomeProperty) : IContract, IBaseContract { } // FN
+interface IBaseContract { }
 
 interface IContract : IBaseContract { }
 
-interface IBaseContract { }
+record Record { } // Fixed
+
+record struct RedunantInterfaceImpl : IContract { } // Fixed
+
+record struct RedunantInterfaceImplPositionalRecord(int SomeProperty) : IContract { } // Fixed

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RedundantInheritanceList.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RedundantInheritanceList.CSharp10.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 
-record Record : Object { } // Noncompliant
-
-record struct RedunantInterfaceImpl : IContract, IBaseContract { } // FN
-
-record struct RedunantInterfaceImplPositionalRecord(int SomeProperty) : IContract, IBaseContract { } // FN
+interface IBaseContract { }
 
 interface IContract : IBaseContract { }
 
-interface IBaseContract { }
+record Record : Object { } // Noncompliant
+
+record struct RedunantInterfaceImpl : IContract, IBaseContract { } // Noncompliant
+
+record struct RedunantInterfaceImplPositionalRecord(int SomeProperty) : IContract, IBaseContract { } // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RedundantInheritanceList.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RedundantInheritanceList.Fixed.cs
@@ -146,5 +146,5 @@ namespace Tests.Diagnostics
     {
     }
 
-    struct RedunantInterfaceImpl : IA, IBase { } // FN
+    struct RedunantInterfaceImpl : IA { } // Fixed
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RedundantInheritanceList.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RedundantInheritanceList.cs
@@ -158,5 +158,6 @@ namespace Tests.Diagnostics
     {
     }
 
-    struct RedunantInterfaceImpl : IA, IBase { } // FN
+    struct RedunantInterfaceImpl : IA, IBase { } // Noncompliant {{'IA' implements 'IBase' so 'IBase' can be removed from the inheritance list.}}
+    //                               ^^^^^^^
 }


### PR DESCRIPTION
This PR includes a custom `ILookup` [implementation ](https://github.com/SonarSource/sonar-dotnet/pull/5606/files#diff-9837ebf1cf25978507ec848d843b6111fcdd1bd439a16db052842099a6cd055cR102-R157). It replaces the MultiValueDictionary used here. There is nothing wrong with MultiValueDictionary and it is used in multiple other places too. `ILookup` is just better suited for the intent here. I implemented my own `ILookup` because the `ToLookup` extension method would have introduced a big overhead.
I don't think it is worth to keep my custom `Lookup` implementation, as it basically does the same as the existing MultiValueDictionary. I left it for the moment in case you see value in keeping it.