### PR TITLE
S4041: Add support for record structs

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
@@ -59,8 +59,8 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
             {
                 if (!c.IsRedundantPositionalRecordContext()
-                        && IsDeclaredPublic(c.SemanticModel, c.Node)
                         && CSharpFacade.Instance.Syntax.NodeIdentifier(c.Node) is { } identifier
+                        && IsDeclaredPublic(c.SemanticModel, c.Node)
                         && FrameworkNamespaces.Contains(identifier.ValueText))
                 {
                     c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.ValueText));

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
@@ -59,9 +59,9 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
             {
                 if (!c.IsRedundantPositionalRecordContext()
-                        && CSharpFacade.Instance.Syntax.NodeIdentifier(c.Node) is { } identifier
-                        && IsDeclaredPublic(c.SemanticModel, c.Node)
-                        && FrameworkNamespaces.Contains(identifier.ValueText))
+                    && CSharpFacade.Instance.Syntax.NodeIdentifier(c.Node) is { } identifier
+                    && IsDeclaredPublic(c.SemanticModel, c.Node)
+                    && FrameworkNamespaces.Contains(identifier.ValueText))
                 {
                     c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.ValueText));
                 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
@@ -40,8 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         // Based on https://msdn.microsoft.com/en-us/library/gg145045%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396
-        private static readonly ISet<string> FrameworkNamespaces =
-            new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
+        private static readonly ISet<string> FrameworkNamespaces = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
             {
                 "Accessibility", "Activities", "AddIn", "Build", "CodeDom", "Collections",
                 "Componentmodel", "Configuration", "CSharp", "CustomMarshalers", "Data",
@@ -61,7 +60,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 if (!c.IsRedundantPositionalRecordContext()
                     && c.Node.NodeIdentifier() is { } identifier
                     && FrameworkNamespaces.Contains(identifier.ValueText)
-                    && IsDeclaredPublic(c.SemanticModel, c.Node))
+                    && c.SemanticModel.GetDeclaredSymbol(c.Node)?.DeclaredAccessibility == Accessibility.Public)
                 {
                     c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.ValueText));
                 }
@@ -73,8 +72,5 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKindEx.RecordClassDeclaration,
             SyntaxKindEx.RecordStructDeclaration,
             SyntaxKind.StructDeclaration);
-
-        private static bool IsDeclaredPublic(SemanticModel semanticModel, SyntaxNode declaration) =>
-            semanticModel.GetDeclaredSymbol(declaration)?.DeclaredAccessibility == Accessibility.Public;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         // Based on https://msdn.microsoft.com/en-us/library/gg145045%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396
         private static readonly ISet<string> FrameworkNamespaces =
-            new SortedSet<string>(StringComparer.InvariantCultureIgnoreCase)
+            new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
             {
                 "Accessibility", "Activities", "AddIn", "Build", "CodeDom", "Collections",
                 "Componentmodel", "Configuration", "CSharp", "CustomMarshalers", "Data",
@@ -59,9 +59,9 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
             {
                 if (!c.IsRedundantPositionalRecordContext()
-                    && CSharpFacade.Instance.Syntax.NodeIdentifier(c.Node) is { } identifier
-                    && IsDeclaredPublic(c.SemanticModel, c.Node)
-                    && FrameworkNamespaces.Contains(identifier.ValueText))
+                    && c.Node.NodeIdentifier() is { } identifier
+                    && FrameworkNamespaces.Contains(identifier.ValueText)
+                    && IsDeclaredPublic(c.SemanticModel, c.Node))
                 {
                     c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.ValueText));
                 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TypeNamesShouldNotMatchNamespacesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TypeNamesShouldNotMatchNamespacesTest.cs
@@ -27,20 +27,20 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class TypeNamesShouldNotMatchNamespacesTest
     {
-        private static readonly VerifierBuilder Builder = new VerifierBuilder<TypeNamesShouldNotMatchNamespaces>();
+        private readonly VerifierBuilder builder = new VerifierBuilder<TypeNamesShouldNotMatchNamespaces>();
 
         [TestMethod]
         public void TypeNamesShouldNotMatchNamespaces() =>
-            Builder.AddPaths("TypeNamesShouldNotMatchNamespaces.cs").Verify();
+            builder.AddPaths("TypeNamesShouldNotMatchNamespaces.cs").Verify();
 
 #if NET
         [TestMethod]
         public void TypeNamesShouldNotMatchNamespaces_CSharp9() =>
-            Builder.AddPaths("TypeNamesShouldNotMatchNamespaces.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
+            builder.AddPaths("TypeNamesShouldNotMatchNamespaces.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void TypeNamesShouldNotMatchNamespaces_CSharp10() =>
-            Builder.AddPaths("TypeNamesShouldNotMatchNamespaces.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).WithConcurrentAnalysis(false).Verify();
+            builder.AddPaths("TypeNamesShouldNotMatchNamespaces.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).WithConcurrentAnalysis(false).Verify();
 
 #endif
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TypeNamesShouldNotMatchNamespacesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TypeNamesShouldNotMatchNamespacesTest.cs
@@ -27,18 +27,20 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class TypeNamesShouldNotMatchNamespacesTest
     {
+        private static readonly VerifierBuilder Builder = new VerifierBuilder<TypeNamesShouldNotMatchNamespaces>();
+
         [TestMethod]
         public void TypeNamesShouldNotMatchNamespaces() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\TypeNamesShouldNotMatchNamespaces.cs", new TypeNamesShouldNotMatchNamespaces());
+            Builder.AddPaths("TypeNamesShouldNotMatchNamespaces.cs").Verify();
 
 #if NET
         [TestMethod]
         public void TypeNamesShouldNotMatchNamespaces_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\TypeNamesShouldNotMatchNamespaces.CSharp9.cs", new TypeNamesShouldNotMatchNamespaces());
+            Builder.AddPaths("TypeNamesShouldNotMatchNamespaces.CSharp9.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
         [TestMethod]
         public void TypeNamesShouldNotMatchNamespaces_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(@"TestCases\TypeNamesShouldNotMatchNamespaces.CSharp10.cs", new TypeNamesShouldNotMatchNamespaces());
+            Builder.AddPaths("TypeNamesShouldNotMatchNamespaces.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).WithConcurrentAnalysis(false).Verify();
 
 #endif
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TypeNamesShouldNotMatchNamespacesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TypeNamesShouldNotMatchNamespacesTest.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void TypeNamesShouldNotMatchNamespaces_CSharp10() =>
-            builder.AddPaths("TypeNamesShouldNotMatchNamespaces.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).WithConcurrentAnalysis(false).Verify();
+            builder.AddPaths("TypeNamesShouldNotMatchNamespaces.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
 
 #endif
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TypeNamesShouldNotMatchNamespaces.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TypeNamesShouldNotMatchNamespaces.CSharp10.cs
@@ -1,6 +1,4 @@
-﻿namespace Tests.Diagnostics;
-
-public record struct Web { } // Noncompliant
+﻿public record struct Web { } // Noncompliant
 public record struct IO(string Parameter) { } // Noncompliant
 
 public record class Accessibility { } // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TypeNamesShouldNotMatchNamespaces.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TypeNamesShouldNotMatchNamespaces.CSharp10.cs
@@ -1,4 +1,4 @@
 ﻿namespace Tests.Diagnostics;
 
-public record struct Web { } // FN
+public record struct Web { } // Noncompliant
 public record class Accessibility { } // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TypeNamesShouldNotMatchNamespaces.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TypeNamesShouldNotMatchNamespaces.CSharp10.cs
@@ -1,4 +1,6 @@
 ﻿namespace Tests.Diagnostics;
 
 public record struct Web { } // Noncompliant
+public record struct IO(string Parameter) { } // Noncompliant
+
 public record class Accessibility { } // Noncompliant


### PR DESCRIPTION
~Blocked by ##5577 `CSharpFacade.Instance.Syntax.NodeIdentifier` should be replaced by a call to the C# syntax extension method.~