### PR TITLE
S3898: Add support for record struct

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ValueTypeShouldImplementIEquatableTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ValueTypeShouldImplementIEquatableTest.cs
@@ -27,16 +27,19 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class ValueTypeShouldImplementIEquatableTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<ValueTypeShouldImplementIEquatable>();
+
         [TestMethod]
         public void ValueTypeShouldImplementIEquatable() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\ValueTypeShouldImplementIEquatable.cs", new ValueTypeShouldImplementIEquatable(), ParseOptionsHelper.FromCSharp8);
+            builder.AddPaths("ValueTypeShouldImplementIEquatable.cs").WithOptions(ParseOptionsHelper.FromCSharp8).Verify();
 
 #if NET
+
         [TestMethod]
         public void ValueTypeShouldImplementIEquatable_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(
-                @"TestCases\ValueTypeShouldImplementIEquatable.CSharp10.cs",
-                new ValueTypeShouldImplementIEquatable());
+            builder.AddPaths("ValueTypeShouldImplementIEquatable.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+
 #endif
+
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ValueTypeShouldImplementIEquatable.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ValueTypeShouldImplementIEquatable.CSharp10.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Tests.Diagnostics
 {
-    record struct MyStruct // FN
+    record struct MyStruct // Compliant. Record struct implement IEquatable by definition
     {
     }
 


### PR DESCRIPTION
[S3898](https://sonarsource.github.io/rspec/#/rspec/S3898) Implement 'IEquatable<T>' in value type '{0}'.

Record struct was marked as a false negative, but because records automatically implement IEquatable this was actually wrong. I marked it as compliant.