### PR TITLE
Implement the AnalysisWarningsSensor

### DIFF
--- a/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/CSharpPlugin.java
+++ b/sonar-csharp-plugin/src/main/java/org/sonar/plugins/csharp/CSharpPlugin.java
@@ -21,6 +21,7 @@ package org.sonar.plugins.csharp;
 
 import org.sonar.api.Plugin;
 import org.sonarsource.dotnet.shared.plugins.AbstractPropertyDefinitions;
+import org.sonarsource.dotnet.shared.plugins.AnalysisWarningsSensor;
 import org.sonarsource.dotnet.shared.plugins.CodeCoverageProvider;
 import org.sonarsource.dotnet.shared.plugins.DotNetPluginMetadata;
 import org.sonarsource.dotnet.shared.plugins.DotNetSensor;
@@ -78,6 +79,7 @@ public class CSharpPlugin implements Plugin {
       WrongEncodingFileFilter.class,
       GeneratedFileFilter.class,
       // importers / exporters
+      AnalysisWarningsSensor.class,
       ProtobufDataImporter.class,
       RoslynDataImporter.class,
       RoslynProfileExporter.class,

--- a/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/CSharpPluginTest.java
+++ b/sonar-csharp-plugin/src/test/java/org/sonar/plugins/csharp/CSharpPluginTest.java
@@ -29,6 +29,7 @@ import org.sonar.api.SonarRuntime;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
+import org.sonarsource.dotnet.shared.plugins.AnalysisWarningsSensor;
 import org.sonarsource.dotnet.shared.plugins.CodeCoverageProvider;
 import org.sonarsource.dotnet.shared.plugins.DotNetSensor;
 import org.sonarsource.dotnet.shared.plugins.EncodingPerFile;
@@ -59,6 +60,7 @@ public class CSharpPluginTest {
     List extensions = context.getExtensions();
 
     Object[] expectedExtensions = new Object[] {
+      AnalysisWarningsSensor.class,
       CSharp.class,
       CSharpGlobalProtobufFileProcessor.class,
       CSharpLanguageConfiguration.class,

--- a/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/AnalysisWarningsSensor.java
+++ b/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/AnalysisWarningsSensor.java
@@ -1,0 +1,113 @@
+/*
+ * SonarSource :: .NET :: Shared library
+ * Copyright (C) 2014-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.dotnet.shared.plugins;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.notifications.AnalysisWarnings;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class AnalysisWarningsSensor implements Sensor {
+
+  private static final Logger LOG = Loggers.get(AnalysisWarningsSensor.class);
+  private static final String SUFFIX = ".sonar";
+  private static final Gson GSON = new Gson();
+
+  private static final Pattern AnalysisWarningsPattern = Pattern.compile("AnalysisWarnings\\..*\\.json");
+  private final DotNetPluginMetadata metadata;
+  private final Configuration configuration;
+  private final AnalysisWarnings analysisWarnings;
+
+  public AnalysisWarningsSensor(Configuration configuration, DotNetPluginMetadata metadata, AnalysisWarnings analysisWarnings){
+    this.configuration = configuration;
+    this.metadata = metadata;
+    this.analysisWarnings = analysisWarnings;
+  }
+
+  @Override
+  public void describe(SensorDescriptor descriptor) {
+    String name = String.format("%s Analysis Warnings import", metadata.shortLanguageName());
+    descriptor.name(name);
+  }
+
+  @Override
+  public void execute(SensorContext sensorContext) {
+    // Working directory folder is constructed from SonarOutputDir + ".sonar". We have to remove the suffix and search for valid configuration files.
+    // e.g.
+    //    .sonarqube\out\AnalysisWarnings.AutoScan.json
+    //    .sonarqube\out\AnalysisWarnings.Scanner.json
+    configuration
+      .get("sonar.working.directory")
+      .filter(s -> s.endsWith(SUFFIX))
+      .map(AnalysisWarningsSensor::getOutputDir)
+      .map(AnalysisWarningsSensor::getFilePaths)
+      .ifPresent(this::publishMessages);
+  }
+
+  private static Path getOutputDir(String workingDirectory) {
+    return Paths.get(workingDirectory).getParent();
+  }
+
+  private static Stream<Path> getFilePaths(Path outputDirectory) {
+    try {
+      return Files.find(outputDirectory, 1, (path, attributes) -> AnalysisWarningsPattern.matcher(path.toFile().getName()).matches());
+    } catch (IOException exception) {
+      LOG.warn("Error occurred while loading analysis analysis warnings", exception);
+      return Stream.empty();
+    }
+  }
+
+  private void publishMessages(Stream<Path> paths) {
+    Type collectionType = new TypeToken<List<Warning>>(){}.getType();
+    paths.forEach(path -> {
+      try (InputStream is = Files.newInputStream(path)) {
+        List<Warning> warnings = GSON.fromJson(new InputStreamReader(is, StandardCharsets.UTF_8), collectionType);
+        warnings.forEach(message -> analysisWarnings.addUnique(message.getText()));
+      } catch (Exception exception) {
+        LOG.error("Error occurred while publishing analysis warnings", exception);
+      }
+    });
+  }
+
+  private static class Warning {
+    private String text = "";
+
+    public String getText() {
+      return text;
+    }
+  }
+}

--- a/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/AnalysisWarningsSensorTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonarsource/dotnet/shared/plugins/AnalysisWarningsSensorTest.java
@@ -1,0 +1,179 @@
+/*
+ * SonarSource :: .NET :: Shared library
+ * Copyright (C) 2014-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.dotnet.shared.plugins;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.notifications.AnalysisWarnings;
+import org.sonar.api.utils.log.LogTester;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AnalysisWarningsSensorTest {
+  private static final String LANG_KEY = "LANG_KEY";
+  private static final String SHORT_LANG_NAME = "SHORT_LANG_NAME";
+
+  private static File basePath;
+  private static File sonarFolder;
+  private static AnalysisWarnings analysisWarningsMock;
+  private static DotNetPluginMetadata pluginMetadataMock;
+  private static Configuration configurationMock;
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Rule
+  public LogTester logTester = new LogTester();
+
+  @Before
+  public void before() throws IOException {
+    basePath = temp.newFolder();
+    sonarFolder = new File(basePath, ".sonar");
+    configurationMock = mock(Configuration.class);
+    analysisWarningsMock = mock(AnalysisWarnings.class);
+    pluginMetadataMock = mock(DotNetPluginMetadata.class);
+    when(pluginMetadataMock.languageKey()).thenReturn(LANG_KEY);
+    when(pluginMetadataMock.shortLanguageName()).thenReturn(SHORT_LANG_NAME);
+  }
+
+  @Test
+  public void should_describe() {
+    DefaultSensorDescriptor sensorDescriptor = new DefaultSensorDescriptor();
+    AnalysisWarningsSensor sensor = new AnalysisWarningsSensor(configurationMock, pluginMetadataMock, analysisWarningsMock);
+    sensor.describe(sensorDescriptor);
+
+    assertThat(sensorDescriptor.name()).isEqualTo(SHORT_LANG_NAME + " Analysis Warnings import");
+    assertThat(sensorDescriptor.languages()).isEmpty();
+  }
+
+  @Test
+  public void execute_noWorkingDir_doesNotCallAdd() throws IOException {
+    AnalysisWarningsSensor sensor = new AnalysisWarningsSensor(configurationMock, pluginMetadataMock, analysisWarningsMock);
+    sensor.execute(SensorContextTester.create(temp.newFolder()));
+
+    verify(analysisWarningsMock, never()).addUnique(anyString());
+  }
+
+  @Test
+  public void execute_workingDirWithoutSonarSuffix_doesNotCallAdd() throws IOException {
+    when(configurationMock.get("sonar.working.directory")).thenReturn(Optional.of("wrong"));
+
+    AnalysisWarningsSensor sensor = new AnalysisWarningsSensor(configurationMock, pluginMetadataMock, analysisWarningsMock);
+    sensor.execute(SensorContextTester.create(temp.newFolder()));
+
+    verify(analysisWarningsMock, never()).addUnique(anyString());
+  }
+
+  @Test
+  public void execute_missingWorkingDir_doesNotCallAdd() throws IOException {
+    when(configurationMock.get("sonar.working.directory")).thenReturn(Optional.of("wrong\\.sonar"));
+
+    AnalysisWarningsSensor sensor = new AnalysisWarningsSensor(configurationMock, pluginMetadataMock, analysisWarningsMock);
+    sensor.execute(SensorContextTester.create(temp.newFolder()));
+
+    verify(analysisWarningsMock, never()).addUnique(anyString());
+    assertThat(logTester.logs()).containsExactly("Error occurred while loading analysis analysis warnings");
+  }
+
+  @Test
+  public void execute_workingDirWithNoMatchingFiles_doesNotCallAdd() throws IOException {
+    File unrelatedFile = new File(basePath, "otherFile.json");
+    unrelatedFile.createNewFile();
+
+    when(configurationMock.get("sonar.working.directory")).thenReturn(Optional.of(sonarFolder.getAbsolutePath()));
+
+    AnalysisWarningsSensor sensor = new AnalysisWarningsSensor(configurationMock, pluginMetadataMock, analysisWarningsMock);
+    sensor.execute(SensorContextTester.create(basePath));
+
+    verify(analysisWarningsMock, never()).addUnique(anyString());
+    assertThat(logTester.logs()).isEmpty();
+  }
+
+  @Test
+  public void execute_workingDirWithWithMatchingFile_addWarnings() throws IOException {
+    copyFile("AnalysisWarnings.AutoScan.json");
+
+    when(configurationMock.get("sonar.working.directory")).thenReturn(Optional.of(sonarFolder.getAbsolutePath()));
+
+    AnalysisWarningsSensor sensor = new AnalysisWarningsSensor(configurationMock, pluginMetadataMock, analysisWarningsMock);
+    sensor.execute(SensorContextTester.create(basePath));
+
+    verify(analysisWarningsMock, times(1)).addUnique("First message");
+    verify(analysisWarningsMock, times(1)).addUnique("Second message");
+    verify(analysisWarningsMock, times(2)).addUnique(anyString());
+    assertThat(logTester.logs()).isEmpty();
+  }
+
+  @Test
+  public void execute_workingDirWithWithMatchingFiles_addWarnings() throws IOException {
+    copyFile("AnalysisWarnings.AutoScan.json");
+    copyFile("AnalysisWarnings.Scanner.json");
+
+    when(configurationMock.get("sonar.working.directory")).thenReturn(Optional.of(sonarFolder.getAbsolutePath()));
+
+    AnalysisWarningsSensor sensor = new AnalysisWarningsSensor(configurationMock, pluginMetadataMock, analysisWarningsMock);
+    sensor.execute(SensorContextTester.create(basePath));
+
+    verify(analysisWarningsMock, times(1)).addUnique("First message");
+    verify(analysisWarningsMock, times(1)).addUnique("Second message");
+    verify(analysisWarningsMock, times(1)).addUnique("Scanner message");
+    verify(analysisWarningsMock, times(3)).addUnique(anyString());
+    assertThat(logTester.logs()).isEmpty();
+  }
+
+  @Test
+  public void execute_errorWhenCallingService_addWarnings_logsError() throws IOException {
+    copyFile("AnalysisWarnings.AutoScan.json");
+
+    when(configurationMock.get("sonar.working.directory")).thenReturn(Optional.of(sonarFolder.getAbsolutePath()));
+    doThrow(RuntimeException.class).when(analysisWarningsMock).addUnique(anyString());
+
+    AnalysisWarningsSensor sensor = new AnalysisWarningsSensor(configurationMock, pluginMetadataMock, analysisWarningsMock);
+    sensor.execute(SensorContextTester.create(basePath));
+
+    assertThat(logTester.logs()).containsExactly("Error occurred while publishing analysis warnings");
+  }
+
+  private void copyFile(String fileName) throws IOException {
+    Path sourcePath = Paths.get("src/test/resources/analysisWarnings/" + fileName);
+    Path targetPath = Paths.get(basePath.getAbsolutePath(), fileName);
+    Files.copy(sourcePath, targetPath, StandardCopyOption.REPLACE_EXISTING);
+  }
+}

--- a/sonar-dotnet-shared-library/src/test/resources/analysisWarnings/AnalysisWarnings.AutoScan.json
+++ b/sonar-dotnet-shared-library/src/test/resources/analysisWarnings/AnalysisWarnings.AutoScan.json
@@ -1,0 +1,8 @@
+[
+  {
+    "text": "First message"
+  },
+  {
+    "text": "Second message"
+  }
+]

--- a/sonar-dotnet-shared-library/src/test/resources/analysisWarnings/AnalysisWarnings.Scanner.json
+++ b/sonar-dotnet-shared-library/src/test/resources/analysisWarnings/AnalysisWarnings.Scanner.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Scanner message"
+  }
+]

--- a/sonar-vbnet-plugin/src/main/java/org/sonar/plugins/vbnet/VbNetPlugin.java
+++ b/sonar-vbnet-plugin/src/main/java/org/sonar/plugins/vbnet/VbNetPlugin.java
@@ -21,6 +21,7 @@ package org.sonar.plugins.vbnet;
 
 import org.sonar.api.Plugin;
 import org.sonarsource.dotnet.shared.plugins.AbstractPropertyDefinitions;
+import org.sonarsource.dotnet.shared.plugins.AnalysisWarningsSensor;
 import org.sonarsource.dotnet.shared.plugins.CodeCoverageProvider;
 import org.sonarsource.dotnet.shared.plugins.DotNetPluginMetadata;
 import org.sonarsource.dotnet.shared.plugins.DotNetSensor;
@@ -78,6 +79,7 @@ public class VbNetPlugin implements Plugin {
       GeneratedFileFilter.class,
       WrongEncodingFileFilter.class,
       // importers / exporters
+      AnalysisWarningsSensor.class,
       ProtobufDataImporter.class,
       RoslynDataImporter.class,
       RoslynProfileExporter.class,

--- a/sonar-vbnet-plugin/src/test/java/org/sonar/plugins/vbnet/VbNetPluginTest.java
+++ b/sonar-vbnet-plugin/src/test/java/org/sonar/plugins/vbnet/VbNetPluginTest.java
@@ -29,6 +29,7 @@ import org.sonar.api.SonarRuntime;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
+import org.sonarsource.dotnet.shared.plugins.AnalysisWarningsSensor;
 import org.sonarsource.dotnet.shared.plugins.CodeCoverageProvider;
 import org.sonarsource.dotnet.shared.plugins.DotNetSensor;
 import org.sonarsource.dotnet.shared.plugins.EncodingPerFile;
@@ -59,6 +60,7 @@ public class VbNetPluginTest {
     List extensions = context.getExtensions();
 
     Object[] expectedExtensions = new Object[] {
+      AnalysisWarningsSensor.class,
       DotNetSensor.class,
       EncodingPerFile.class,
       FileTypeSensor.class,
@@ -71,12 +73,12 @@ public class VbNetPluginTest {
       RoslynDataImporter.class,
       RoslynProfileExporter.class,
       SonarLintProfileExporter.class,
-      VbNetPlugin.METADATA,
       VbNet.class,
-      VbNetSonarRulesDefinition.class,
+      VbNetGlobalProtobufFileProcessor.class,
       VbNetLanguageConfiguration.class,
       VbNetModuleConfiguration.class,
-      VbNetGlobalProtobufFileProcessor.class,
+      VbNetPlugin.METADATA,
+      VbNetSonarRulesDefinition.class,
       WrongEncodingFileFilter.class
     };
 


### PR DESCRIPTION
This sensor is responsible for importing all the warnings raised by the auto-scan analysis or S4NET and pushing them to SonarCloud/SonarQube.

We expect the files to have the following format: `.sonarqube\out\AnalysisWarnings.<product>.json`.

e.g.
```
.sonarqube\out\AnalysisWarnings.AutoScan.json
.sonarqube\out\AnalysisWarnings.Scanner.json
```
