### PR TITLE
S1192: Fix error message can contain control characters

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/StringLiteralShouldNotBeDuplicatedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/StringLiteralShouldNotBeDuplicatedBase.cs
@@ -87,9 +87,11 @@ namespace SonarAnalyzer.Rules
             {
                 var duplicates = item.ToList();
                 var firstToken = duplicates[0];
+                var messageText = new string(item.Key.Where(x => !char.IsControl(x)).ToArray()); // Strip of any control characters to not mess up the error message.
+                // alternative: var messageText = firstToken.Text.StripOfLeadingAndTrialingDoubleQuotes();
                 context.ReportIssue(Diagnostic.Create(rule, firstToken.GetLocation(),
                     duplicates.Skip(1).Select(x => x.GetLocation()),
-                    item.Key, duplicates.Count));
+                    messageText, duplicates.Count));
             }
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/StringLiteralShouldNotBeDuplicated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/StringLiteralShouldNotBeDuplicated.cs
@@ -108,7 +108,7 @@
     {
         // See https://github.com/SonarSource/sonar-dotnet/issues/2191
         private string ZZ_TRANS_PACKED_0 =
-            "\x0001\u0124\x0001\x0000\x0001\u0125\x0002\x0000\x0001\u0126\x0001\x0000\x0001\u0127\x0005\x0000" + // Noncompliant
+            "\x0001\u0124\x0001\x0000\x0001\u0125\x0002\x0000\x0001\u0126\x0001\x0000\x0001\u0127\x0005\x0000" + // Noncompliant {{Define a constant instead of using this literal 'ĤĥĦħ' 4 times.}}
             "\x0001\u0124\x0001\x0000\x0001\u0125\x0002\x0000\x0001\u0126\x0001\x0000\x0001\u0127\x0005\x0000" + // Secondary
             "\x0001\u0124\x0001\x0000\x0001\u0125\x0002\x0000\x0001\u0126\x0001\x0000\x0001\u0127\x0005\x0000" + // Secondary
             "\x0001\u0124\x0001\x0000\x0001\u0125\x0002\x0000\x0001\u0126\x0001\x0000\x0001\u0127\x0005\x0000";  // Secondary


### PR DESCRIPTION
Follow up to #5609 

Commit 4ae27ac41ac1f176ce6c8adb145d601f7dd4bc51 changed the error message to take the repeated text from the `SytntaxToken.ValueText` instead of `SytntaxToken.Text`. That way some unintended characters can sneek into the error message.