### PR TITLE
Refactor RuleFinder

### DIFF
--- a/analyzers/src/SonarAnalyzer.Utilities/RuleDetailBuilder.cs
+++ b/analyzers/src/SonarAnalyzer.Utilities/RuleDetailBuilder.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Utilities
                 LanguageNames.VisualBasic => new ResourceManager("SonarAnalyzer.RspecStrings", typeof(Rules.VisualBasic.FlagsEnumZeroMember).Assembly),
                 _ => throw new InvalidOperationException("Unexpected language: " + language)
             };
-            return new RuleFinder()
+            return RuleFinder
                 .GetAnalyzerTypes(language)
                 .Select(x => (DiagnosticAnalyzer)Activator.CreateInstance(x))
                 .SelectMany(x => UniqueRuleIds(x).Select(id => new { Id = id, Type = x.GetType() }))

--- a/analyzers/src/SonarAnalyzer.Utilities/RuleFinder.cs
+++ b/analyzers/src/SonarAnalyzer.Utilities/RuleFinder.cs
@@ -30,7 +30,7 @@ using SonarAnalyzer.Rules;
 
 namespace SonarAnalyzer.Utilities
 {
-    public static class RuleFinder
+    internal static class RuleFinder
     {
         public static IEnumerable<Assembly> PackagedRuleAssemblies { get; } = new[]
             {
@@ -39,8 +39,8 @@ namespace SonarAnalyzer.Utilities
                 Assembly.Load(typeof(Rules.Common.DoNotInstantiateSharedClassesBase).Assembly.GetName())
             };
 
-        internal static IEnumerable<Type> RuleAnalyzerTypes { get; } // Rule-only, without utility analyzers
-        internal static IEnumerable<Type> UtilityAnalyzerTypes { get; }
+        public static IEnumerable<Type> RuleAnalyzerTypes { get; } // Rule-only, without utility analyzers
+        public static IEnumerable<Type> UtilityAnalyzerTypes { get; }
 
         static RuleFinder()
         {
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Utilities
         public static IEnumerable<Type> GetAnalyzerTypes(AnalyzerLanguage language) =>
             RuleAnalyzerTypes.Where(type => GetTargetLanguages(type).IsAlso(language));
 
-        internal static IEnumerable<DiagnosticAnalyzer> GetAnalyzers(AnalyzerLanguage language)
+        public static IEnumerable<DiagnosticAnalyzer> GetAnalyzers(AnalyzerLanguage language)
         {
             var analyzerTypes = PackagedRuleAssemblies.SelectMany(assembly => assembly.GetTypes())
                                                       .Where(type => !type.IsAbstract && typeof(SonarDiagnosticAnalyzer).IsAssignableFrom(type) && GetTargetLanguages(type).IsAlso(language));
@@ -68,13 +68,13 @@ namespace SonarAnalyzer.Utilities
             }
         }
 
-        internal static IEnumerable<Type> GetParameterlessAnalyzerTypes(AnalyzerLanguage language) =>
+        public static IEnumerable<Type> GetParameterlessAnalyzerTypes(AnalyzerLanguage language) =>
             RuleAnalyzerTypes.Where(type => !IsParameterized(type) && GetTargetLanguages(type).IsAlso(language));
 
-        internal static bool IsParameterized(Type analyzerType) =>
+        public static bool IsParameterized(Type analyzerType) =>
             analyzerType.GetProperties().Any(p => p.GetCustomAttributes<RuleParameterAttribute>().Any());
 
-        internal static AnalyzerLanguage GetTargetLanguages(MemberInfo analyzerType) =>
+        public static AnalyzerLanguage GetTargetLanguages(MemberInfo analyzerType) =>
             GetLanguages(analyzerType)
             .Aggregate(AnalyzerLanguage.None, (current, lang) => lang switch
                 {

--- a/analyzers/src/SonarAnalyzer.Utilities/RuleFinder.cs
+++ b/analyzers/src/SonarAnalyzer.Utilities/RuleFinder.cs
@@ -68,9 +68,6 @@ namespace SonarAnalyzer.Utilities
             }
         }
 
-        public static IEnumerable<Type> GetParameterlessAnalyzerTypes(AnalyzerLanguage language) =>
-            RuleAnalyzerTypes.Where(type => !IsParameterized(type) && TargetLanguage(type).IsAlso(language));
-
         public static bool IsParameterized(Type analyzerType) =>
             analyzerType.GetProperties().Any(p => p.GetCustomAttributes<RuleParameterAttribute>().Any());
 

--- a/analyzers/src/SonarAnalyzer.Utilities/RuleFinder.cs
+++ b/analyzers/src/SonarAnalyzer.Utilities/RuleFinder.cs
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.Utilities
         }
 
         public static bool IsParameterized(Type analyzerType) =>
-            analyzerType.GetProperties().Any(p => p.GetCustomAttributes<RuleParameterAttribute>().Any());
+            analyzerType.GetProperties().Any(x => x.GetCustomAttributes<RuleParameterAttribute>().Any());
 
         private static AnalyzerLanguage TargetLanguage(MemberInfo analyzerType)
         {

--- a/analyzers/src/SonarAnalyzer.Utilities/RuleFinder.cs
+++ b/analyzers/src/SonarAnalyzer.Utilities/RuleFinder.cs
@@ -30,7 +30,7 @@ using SonarAnalyzer.Rules;
 
 namespace SonarAnalyzer.Utilities
 {
-    public class RuleFinder
+    public static class RuleFinder
     {
         public static IEnumerable<Assembly> PackagedRuleAssemblies { get; } = new[]
             {
@@ -39,10 +39,10 @@ namespace SonarAnalyzer.Utilities
                 Assembly.Load(typeof(Rules.Common.DoNotInstantiateSharedClassesBase).Assembly.GetName())
             };
 
-        internal IEnumerable<Type> RuleAnalyzerTypes { get; } // Rule-only, without utility analyzers
-        internal IEnumerable<Type> UtilityAnalyzerTypes { get; }
+        internal static IEnumerable<Type> RuleAnalyzerTypes { get; } // Rule-only, without utility analyzers
+        internal static IEnumerable<Type> UtilityAnalyzerTypes { get; }
 
-        public RuleFinder()
+        static RuleFinder()
         {
             var all = PackagedRuleAssemblies
                 .SelectMany(assembly => assembly.GetTypes())
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Utilities
             UtilityAnalyzerTypes = all.Where(x => typeof(UtilityAnalyzerBase).IsAssignableFrom(x)).ToList();
         }
 
-        public IEnumerable<Type> GetAnalyzerTypes(AnalyzerLanguage language) =>
+        public static IEnumerable<Type> GetAnalyzerTypes(AnalyzerLanguage language) =>
             RuleAnalyzerTypes.Where(type => GetTargetLanguages(type).IsAlso(language));
 
         internal static IEnumerable<DiagnosticAnalyzer> GetAnalyzers(AnalyzerLanguage language)
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.Utilities
             }
         }
 
-        internal IEnumerable<Type> GetParameterlessAnalyzerTypes(AnalyzerLanguage language) =>
+        internal static IEnumerable<Type> GetParameterlessAnalyzerTypes(AnalyzerLanguage language) =>
             RuleAnalyzerTypes.Where(type => !IsParameterized(type) && GetTargetLanguages(type).IsAlso(language));
 
         internal static bool IsParameterized(Type analyzerType) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleFinderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleFinderTest.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -31,10 +30,6 @@ namespace SonarAnalyzer.UnitTest.Common
     [TestClass]
     public class RuleFinderTest
     {
-        [TestMethod]
-        public void GetPackagedRuleAssembly() =>
-            RuleFinder.PackagedRuleAssemblies.Should().HaveCount(3);
-
         [TestMethod]
         public void GetAnalyzerTypes()
         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleFinderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleFinderTest.cs
@@ -38,29 +38,25 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void GetParameterlessAnalyzerTypes()
         {
-            new RuleFinder().GetParameterlessAnalyzerTypes(AnalyzerLanguage.CSharp)
-                .Should().NotBeEmpty();
-            new RuleFinder().GetParameterlessAnalyzerTypes(AnalyzerLanguage.VisualBasic)
-                .Should().NotBeEmpty();
+            RuleFinder.GetParameterlessAnalyzerTypes(AnalyzerLanguage.CSharp).Should().NotBeEmpty();
+            RuleFinder.GetParameterlessAnalyzerTypes(AnalyzerLanguage.VisualBasic).Should().NotBeEmpty();
         }
 
         [TestMethod]
         public void GetAnalyzerTypes()
         {
-            var analyzers = new RuleFinder().GetAnalyzerTypes(AnalyzerLanguage.CSharp);
+            var analyzers = RuleFinder.GetAnalyzerTypes(AnalyzerLanguage.CSharp);
             analyzers.Should().Contain(typeof(EmptyStatement));
         }
 
         [TestMethod]
         public void GetAllAnalyzerTypes()
         {
-            var finder = new RuleFinder();
+            var countParameterless = RuleFinder.GetParameterlessAnalyzerTypes(AnalyzerLanguage.CSharp).Count();
+            RuleFinder.RuleAnalyzerTypes.Should().HaveCountGreaterThan(countParameterless);
 
-            var countParameterless = finder.GetParameterlessAnalyzerTypes(AnalyzerLanguage.CSharp).Count();
-            finder.RuleAnalyzerTypes.Should().HaveCountGreaterThan(countParameterless);
-
-            countParameterless = finder.GetParameterlessAnalyzerTypes(AnalyzerLanguage.VisualBasic).Count();
-            finder.RuleAnalyzerTypes.Should().HaveCountGreaterThan(countParameterless);
+            countParameterless = RuleFinder.GetParameterlessAnalyzerTypes(AnalyzerLanguage.VisualBasic).Count();
+            RuleFinder.RuleAnalyzerTypes.Should().HaveCountGreaterThan(countParameterless);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleFinderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleFinderTest.cs
@@ -36,13 +36,6 @@ namespace SonarAnalyzer.UnitTest.Common
             RuleFinder.PackagedRuleAssemblies.Should().HaveCount(3);
 
         [TestMethod]
-        public void GetParameterlessAnalyzerTypes()
-        {
-            RuleFinder.GetParameterlessAnalyzerTypes(AnalyzerLanguage.CSharp).Should().NotBeEmpty();
-            RuleFinder.GetParameterlessAnalyzerTypes(AnalyzerLanguage.VisualBasic).Should().NotBeEmpty();
-        }
-
-        [TestMethod]
         public void GetAnalyzerTypes()
         {
             var analyzers = RuleFinder.GetAnalyzerTypes(AnalyzerLanguage.CSharp);
@@ -52,10 +45,10 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void GetAllAnalyzerTypes()
         {
-            var countParameterless = RuleFinder.GetParameterlessAnalyzerTypes(AnalyzerLanguage.CSharp).Count();
+            var countParameterless = RuleFinder.GetAnalyzerTypes(AnalyzerLanguage.CSharp).Count(x => !RuleFinder.IsParameterized(x));
             RuleFinder.RuleAnalyzerTypes.Should().HaveCountGreaterThan(countParameterless);
 
-            countParameterless = RuleFinder.GetParameterlessAnalyzerTypes(AnalyzerLanguage.VisualBasic).Count();
+            countParameterless = RuleFinder.GetAnalyzerTypes(AnalyzerLanguage.VisualBasic).Count(x => !RuleFinder.IsParameterized(x));
             RuleFinder.RuleAnalyzerTypes.Should().HaveCountGreaterThan(countParameterless);
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleFinderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleFinderTest.cs
@@ -58,9 +58,5 @@ namespace SonarAnalyzer.UnitTest.Common
             countParameterless = RuleFinder.GetParameterlessAnalyzerTypes(AnalyzerLanguage.VisualBasic).Count();
             RuleFinder.RuleAnalyzerTypes.Should().HaveCountGreaterThan(countParameterless);
         }
-
-        [TestMethod]
-        public void GetTargetLanguagesThrowsIfTypeDoesNotHaveLanguageInfo() =>
-            Assert.ThrowsException<NotSupportedException>(() => RuleFinder.GetTargetLanguages(typeof(string)));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
@@ -72,11 +72,38 @@ namespace SonarAnalyzer.UnitTest.Common
         }
 
         [TestMethod]
-        public void SonarDiagnosticAnalyzer_IsUsedInAllRules()
+        public void AllAnalyzers_InheritSonarDiagnosticAnalyzer()
         {
-            foreach (var analyzer in RuleFinder.RuleAnalyzerTypes.Concat(RuleFinder.UtilityAnalyzerTypes).Where(x => x != typeof(SonarDiagnosticAnalyzer)))
+            foreach (var analyzer in RuleFinder.AllAnalyzerTypes)
             {
                 analyzer.Should().BeAssignableTo<SonarDiagnosticAnalyzer>($"{analyzer.Name} is not a subclass of SonarDiagnosticAnalyzer");
+            }
+        }
+
+        [TestMethod]
+        public void CodeFixes_InheritSonarCodeFix()
+        {
+            foreach (var codeFix in RuleFinder.CodeFixTypes)
+            {
+                codeFix.Should().BeAssignableTo<SonarCodeFix>($"{codeFix.Name} is not a subclass of SonarCodeFix");
+            }
+        }
+
+        [TestMethod]
+        public void Rules_WithDiagnosticAnalyzerAttribute_AreNotAbstract()
+        {
+            foreach (var analyzer in RuleFinder.AllAnalyzerTypes)
+            {
+                analyzer.IsAbstract.Should().BeFalse();
+            }
+        }
+
+        [TestMethod]
+        public void CodeFixes_WithExportCodeFixProviderAttribute_AreNotAbstract()
+        {
+            foreach (var codeFix in RuleFinder.CodeFixTypes)
+            {
+                codeFix.IsAbstract.Should().BeFalse();
             }
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void RulesDoNotThrow_CS()
         {
-            var analyzers = RuleFinder.GetAnalyzers(AnalyzerLanguage.CSharp).ToArray();
+            var analyzers = RuleFinder.CreateAnalyzers(AnalyzerLanguage.CSharp, true).ToArray();
 
             VerifyNoExceptionThrown(@"TestCases\RuleFailure\InvalidSyntax.cs", analyzers, CompilationErrorBehavior.Ignore);
             VerifyNoExceptionThrown(@"TestCases\RuleFailure\SpecialCases.cs", analyzers, CompilationErrorBehavior.Ignore);
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void RulesDoNotThrow_VB()
         {
-            var analyzers = RuleFinder.GetAnalyzers(AnalyzerLanguage.VisualBasic).ToArray();
+            var analyzers = RuleFinder.CreateAnalyzers(AnalyzerLanguage.VisualBasic, true).ToArray();
 
             VerifyNoExceptionThrown(@"TestCases\RuleFailure\InvalidSyntax.vb", analyzers, CompilationErrorBehavior.Ignore);
             VerifyNoExceptionThrown(@"TestCases\RuleFailure\SpecialCases.vb", analyzers, CompilationErrorBehavior.Ignore);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
@@ -24,7 +24,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Reflection;
 using System.Resources;
 using FluentAssertions;
 using Microsoft.CodeAnalysis;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void CodeFixes_Named_Properly()
         {
-            foreach (var codeFix in GetCodeFixTypes(RuleFinder.PackagedRuleAssemblies))
+            foreach (var codeFix in RuleFinder.CodeFixTypes)
             {
                 var analyzerName = codeFix.FullName.Replace("CodeFix", string.Empty);
                 codeFix.Assembly.GetType(analyzerName).Should().NotBeNull("CodeFix '{0}' has no matching DiagnosticAnalyzer.", codeFix.Name);
@@ -75,11 +75,7 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void SonarDiagnosticAnalyzer_IsUsedInAllRules()
         {
-            var analyzers = RuleFinder.PackagedRuleAssemblies
-                .SelectMany(assembly => assembly.GetTypes())
-                .Where(t => t.IsSubclassOf(typeof(DiagnosticAnalyzer)) && t != typeof(SonarDiagnosticAnalyzer));
-
-            foreach (var analyzer in analyzers)
+            foreach (var analyzer in RuleFinder.RuleAnalyzerTypes.Concat(RuleFinder.UtilityAnalyzerTypes).Where(x => x != typeof(SonarDiagnosticAnalyzer)))
             {
                 analyzer.Should().BeAssignableTo<SonarDiagnosticAnalyzer>($"{analyzer.Name} is not a subclass of SonarDiagnosticAnalyzer");
             }
@@ -250,9 +246,6 @@ namespace SonarAnalyzer.UnitTest.Common
 
         private static IEnumerable<DiagnosticDescriptor> SupportedDiagnostics(Type type) =>
             ((DiagnosticAnalyzer)Activator.CreateInstance(type)).SupportedDiagnostics;
-
-        private static IEnumerable<Type> GetCodeFixTypes(IEnumerable<Assembly> assemblies) =>
-            assemblies.SelectMany(x => x.GetTypes()).Where(x => x.IsSubclassOf(typeof(SonarCodeFix)) && !x.IsAbstract);
 
         private static bool IsSonarWay(DiagnosticDescriptor diagnostic) =>
             diagnostic.CustomTags.Contains(DiagnosticDescriptorBuilder.SonarWayTag);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
@@ -123,7 +123,7 @@ namespace SonarAnalyzer.UnitTest.Common
 
         [TestMethod]
         public void AllParameterizedRules_AreDisabledByDefault() =>
-            new RuleFinder().RuleAnalyzerTypes
+            RuleFinder.RuleAnalyzerTypes
                 .Where(RuleFinder.IsParameterized)
                 .Select(type => (DiagnosticAnalyzer)Activator.CreateInstance(type))
                 .SelectMany(analyzer => analyzer.SupportedDiagnostics)
@@ -134,7 +134,7 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void AllRulesEnabledByDefault_ContainSonarWayCustomTag()
         {
-            var descriptors = new RuleFinder().RuleAnalyzerTypes.SelectMany(SupportedDiagnostics)
+            var descriptors = RuleFinder.RuleAnalyzerTypes.SelectMany(SupportedDiagnostics)
                 // Security hotspots are enabled by default, but they will report issues only
                 // when their ID is contained in SonarLint.xml
                 .Where(descriptor => !IsSecurityHotspot(descriptor));
@@ -159,7 +159,7 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void DeprecatedRules_AreNotInSonarWay()
         {
-            foreach (var diagnostic in new RuleFinder().RuleAnalyzerTypes.SelectMany(SupportedDiagnostics).Where(IsDeprecated))
+            foreach (var diagnostic in RuleFinder.RuleAnalyzerTypes.SelectMany(SupportedDiagnostics).Where(IsDeprecated))
             {
                 IsSonarWay(diagnostic).Should().BeFalse($"{diagnostic.Id} is deprecated and should be removed from SonarWay.");
             }
@@ -168,7 +168,7 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void AllRules_DoNotHaveUtilityTag()
         {
-            foreach (var diagnostic in new RuleFinder().RuleAnalyzerTypes.SelectMany(SupportedDiagnostics))
+            foreach (var diagnostic in RuleFinder.RuleAnalyzerTypes.SelectMany(SupportedDiagnostics))
             {
                 diagnostic.CustomTags.Should().NotContain(DiagnosticDescriptorBuilder.UtilityTag);
             }
@@ -177,7 +177,7 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void UtilityAnalyzers_HaveUtilityTag()
         {
-            foreach (var diagnostic in new RuleFinder().UtilityAnalyzerTypes.SelectMany(SupportedDiagnostics))
+            foreach (var diagnostic in RuleFinder.UtilityAnalyzerTypes.SelectMany(SupportedDiagnostics))
             {
                 diagnostic.CustomTags.Should().Contain(DiagnosticDescriptorBuilder.UtilityTag);
             }
@@ -186,12 +186,12 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void AllRules_SonarWayTagPresenceMatchesIsEnabledByDefault()
         {
-            var parameterized = new RuleFinder().RuleAnalyzerTypes
+            var parameterized = RuleFinder.RuleAnalyzerTypes
                 .Where(RuleFinder.IsParameterized)
                 .SelectMany(type => ((DiagnosticAnalyzer)Activator.CreateInstance(type)).SupportedDiagnostics)
                 .ToHashSet();
 
-            foreach (var diagnostic in new RuleFinder().RuleAnalyzerTypes.SelectMany(SupportedDiagnostics))
+            foreach (var diagnostic in RuleFinder.RuleAnalyzerTypes.SelectMany(SupportedDiagnostics))
             {
                 if (IsSecurityHotspot(diagnostic))
                 {
@@ -246,7 +246,7 @@ namespace SonarAnalyzer.UnitTest.Common
         }
 
         private static IEnumerable<DiagnosticDescriptor> SupportedDiagnostics(AnalyzerLanguage language) =>
-            new RuleFinder().GetAnalyzerTypes(language).SelectMany(SupportedDiagnostics);
+            RuleFinder.GetAnalyzerTypes(language).SelectMany(SupportedDiagnostics);
 
         private static IEnumerable<DiagnosticDescriptor> SupportedDiagnostics(Type type) =>
             ((DiagnosticAnalyzer)Activator.CreateInstance(type)).SupportedDiagnostics;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/SecurityHotspotTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/SecurityHotspotTest.cs
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.UnitTest.Common
         }
 
         private static IEnumerable<SonarDiagnosticAnalyzer> GetHotspotAnalyzers(AnalyzerLanguage language) =>
-            new RuleFinder().GetAnalyzerTypes(language)
+            RuleFinder.GetAnalyzerTypes(language)
                 .Where(type => typeof(SonarDiagnosticAnalyzer).IsAssignableFrom(type))   // Avoid IRuleFactory and SE rules
                 .Select(type => (SonarDiagnosticAnalyzer)Activator.CreateInstance(type))
                 .Where(IsSecurityHotspot);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/GeneratedResourcesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/GeneratedResourcesTest.cs
@@ -68,8 +68,7 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
         }
 
         private static string[] SortedRulesFromTypes(AnalyzerLanguage language) =>
-            RuleFinder.GetAnalyzers(language)
-                .Where(x => x is not UtilityAnalyzerBase)
+            RuleFinder.CreateAnalyzers(language, false)
                 .SelectMany(x => x.SupportedDiagnostics.Select(descriptor => descriptor.Id))
                 .Distinct() // One class can have the same ruleId multiple times, see S3240, same ruleId can be in multiple classes (see InvalidCastToInterface)
                 .OrderBy(x => x)


### PR DESCRIPTION
Mechanical refactoring of RuleFinder class. This is a prerequisite for further structure cleanups.

It's internal state was always recomputed from something static, so I made the whole class static to avoid this. And did some cleanup about its weird usage and method structure.