### PR TITLE
Remove RuleDetail.CodeFixTitles

### DIFF
--- a/analyzers/src/SonarAnalyzer.Utilities/RuleDescriptors/RuleDetail.cs
+++ b/analyzers/src/SonarAnalyzer.Utilities/RuleDescriptors/RuleDetail.cs
@@ -49,10 +49,9 @@ namespace SonarAnalyzer.RuleDescriptors
         public string Remediation { get; }
         public string RemediationCost { get; }
         public List<string> Tags { get; }
-        public List<RuleParameter> Parameters { get; } = new();
-        public List<string> CodeFixTitles { get; } = new();
+        public List<RuleParameter> Parameters { get; }
 
-        public RuleDetail(AnalyzerLanguage language, ResourceManager resources, string id)
+        public RuleDetail(AnalyzerLanguage language, ResourceManager resources, string id, IEnumerable<RuleParameter> parameters)
         {
             Key = id;
             Type = BackwardsCompatibleType(resources.GetString($"{id}_Type"));
@@ -64,6 +63,7 @@ namespace SonarAnalyzer.RuleDescriptors
             Remediation = SonarQubeRemediationFunction(resources.GetString($"{id}_Remediation"));
             RemediationCost = resources.GetString($"{id}_RemediationCost");
             Tags = resources.GetString($"{id}_Tags").Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+            Parameters = parameters.ToList();
         }
 
         // SonarQube before 7.3 supports only 3 types of issues: BUG, CODE_SMELL and VULNERABILITY.

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
@@ -48,17 +48,8 @@ namespace SonarAnalyzer.UnitTest.Common
         {
             foreach (var codeFix in GetCodeFixTypes(RuleFinder.PackagedRuleAssemblies))
             {
-                var analyzerName = codeFix.FullName.Replace(RuleDetailBuilder.CodeFixSuffix, string.Empty);
+                var analyzerName = codeFix.FullName.Replace("CodeFix", string.Empty);
                 codeFix.Assembly.GetType(analyzerName).Should().NotBeNull("CodeFix '{0}' has no matching DiagnosticAnalyzer.", codeFix.Name);
-            }
-        }
-
-        [TestMethod]
-        public void CodeFixes_Have_Title()
-        {
-            foreach (var codeFix in GetCodeFixTypes(RuleFinder.PackagedRuleAssemblies))
-            {
-                RuleDetailBuilder.CodeFixTitles(codeFix).Should().NotBeEmpty("CodeFix '{0}' has no title field.", codeFix.Name);
             }
         }
 


### PR DESCRIPTION
Property `RuleDetail.CodeFixTitles` is very difficult to generate. And it was not used at all.

This is part of bigger cleanup around RSPEC handling.