### PR TITLE
Do not delete .vs from rspec.ps1

### DIFF
--- a/scripts/rspec/rspec.ps1
+++ b/scripts/rspec/rspec.ps1
@@ -347,11 +347,6 @@ if ($className -And $ruleKey) {
        UpdateTestEntry $vbRuleData
        GenerateBaseClassIfSecondLanguage
     }
-
-    $vsTempFolder = "${sonaranalyzerPath}\\.vs"
-    if (Test-Path $vsTempFolder) {
-        Remove-Item -Recurse -Force $vsTempFolder
-    }
 }
 
 # Generate RspecStrings.resx using the new metadata


### PR DESCRIPTION
This was used to clear .vs cache after creating new files and updating resources. 

It is not needed in VS2022.
It often fails because of locked files.