### PR TITLE
S138 exclude local static functions when they are in other methods.

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveTooManyLines.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveTooManyLines.cs
@@ -74,7 +74,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override IEnumerable<SyntaxToken> GetMethodTokens(BaseMethodDeclarationSyntax baseMethodDeclaration) =>
             baseMethodDeclaration.ExpressionBody()?.Expression?.DescendantTokens()
-                ?? baseMethodDeclaration.Body?.Statements.SelectMany(s => s.DescendantTokens())
+                ?? baseMethodDeclaration.Body?.Statements.Where(s => !IsStaticLocalFunctionSyntaxNode(s)).SelectMany(s => s.DescendantTokens())
                 ?? Enumerable.Empty<SyntaxToken>();
 
         protected override SyntaxToken? GetMethodIdentifierToken(BaseMethodDeclarationSyntax baseMethodDeclaration) =>
@@ -115,5 +115,9 @@ namespace SonarAnalyzer.Rules.CSharp
             GetMethodTokens(wrapper).SelectMany(x => x.GetLineNumbers())
                                     .Distinct()
                                     .LongCount();
+
+        private static bool IsStaticLocalFunctionSyntaxNode(SyntaxNode node) =>
+            node.IsKind(SyntaxKindEx.LocalFunctionStatement)
+            && ((LocalFunctionStatementSyntaxWrapper)node).Modifiers.Any(SyntaxKind.StaticKeyword);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldNotHaveTooManyLinesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldNotHaveTooManyLinesTest.cs
@@ -36,8 +36,14 @@ namespace SonarAnalyzer.UnitTest.Rules
 
 #if NET
         [TestMethod]
+        public void MethodsShouldNotHaveTooManyLines_LocalFunctions() =>
+            OldVerifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\MethodsShouldNotHaveTooManyLines.LocalFunctions.cs", new CS.MethodsShouldNotHaveTooManyLines { Max = 4 });
+
+
+        [TestMethod]
         public void MethodsShouldNotHaveTooManyLines_CustomValues_CSharp9() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\MethodsShouldNotHaveTooManyLines_CustomValues.CSharp9.cs", new CS.MethodsShouldNotHaveTooManyLines { Max = 2 });
+    OldVerifier.VerifyAnalyzerFromCSharp9Console(@"TestCases\MethodsShouldNotHaveTooManyLines_CustomValues.CSharp9.cs", new CS.MethodsShouldNotHaveTooManyLines { Max = 2 });
+
 
         [TestMethod]
         public void MethodsShouldNotHaveTooManyLines_CustomValues_CSharp10() =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldNotHaveTooManyLinesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldNotHaveTooManyLinesTest.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 #if NET
         [TestMethod]
         public void MethodsShouldNotHaveTooManyLines_LocalFunctions() =>
-            OldVerifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\MethodsShouldNotHaveTooManyLines.LocalFunctions.cs", new CS.MethodsShouldNotHaveTooManyLines { Max = 4 });
+            OldVerifier.VerifyAnalyzerFromCSharp9Library(@"TestCases\MethodsShouldNotHaveTooManyLines.LocalFunctions.cs", new CS.MethodsShouldNotHaveTooManyLines { Max = 5 });
 
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldNotHaveTooManyLines.LocalFunctions.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldNotHaveTooManyLines.LocalFunctions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Tests.Diagnostics
+{
+    public class Foo
+    {
+        public void Bar(int i) // Noncompliant {{This method 'Bat' has 12 lines, which is greater than the 4 lines authorized. Split it into smaller methods.}}
+        {
+            Console.WriteLine(i);
+
+            void LocalFunction(int x)
+            {
+                Console.WriteLine(x);
+            }
+
+            static void StaticLocalFunction()
+            {
+                int i = 0;
+                i++;
+                i++;
+                i++;
+            }
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldNotHaveTooManyLines.LocalFunctions.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldNotHaveTooManyLines.LocalFunctions.cs
@@ -4,7 +4,7 @@ namespace Tests.Diagnostics
 {
     public class Foo
     {
-        public void Bar(int i) // Noncompliant {{This method 'Bat' has 12 lines, which is greater than the 4 lines authorized. Split it into smaller methods.}}
+        public void Bar(int i) // Compliant, because we do not count the local static functions lines.
         {
             Console.WriteLine(i);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldNotHaveTooManyLines_CustomValues.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldNotHaveTooManyLines_CustomValues.CSharp9.cs
@@ -11,6 +11,15 @@ void LocalFunction() // Noncompliant {{This top level local function has 4 lines
     i++;
 }
 
+static void StaticLocalFunction() // Noncompliant {{This top level local function has 4 lines, which is greater than the 2 lines authorized.}}
+{
+    int k = 1;
+    k++;
+    k++;
+    k++;
+}
+
+
 void Compliant()
 {
     i++;


### PR DESCRIPTION
Fixes partially  #5625
