### PR TITLE
Reimplement KnownType matching to avoid string generation and calling `ToDisplayString`

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/AttributeSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/AttributeSyntaxExtensions.cs
@@ -34,8 +34,8 @@ namespace SonarAnalyzer.Extensions
             && SymbolHelper.IsKnownType(attribute, knownType, semanticModel);
 
         private static string GetShortNameWithoutAttributeSuffix(KnownType knownType) =>
-            knownType.ShortName == nameof(Attribute) || !knownType.ShortName.EndsWith(nameof(Attribute))
-                ? knownType.ShortName
-                : knownType.ShortName.Remove(knownType.ShortName.Length - AttributeLength);
+            knownType.TypeName == nameof(Attribute) || !knownType.TypeName.EndsWith(nameof(Attribute))
+                ? knownType.TypeName
+                : knownType.TypeName.Remove(knownType.TypeName.Length - AttributeLength);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/ObjectCreationExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/ObjectCreationExpressionSyntaxExtensions.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.Extensions
     internal static class ObjectCreationExpressionSyntaxExtensions
     {
         public static bool IsKnownType(this ObjectCreationExpressionSyntax objectCreation, KnownType knownType, SemanticModel semanticModel) =>
-            objectCreation.Type.GetName().EndsWith(knownType.ShortName)
+            objectCreation.Type.GetName().EndsWith(knownType.TypeName)
             && SymbolHelper.IsKnownType(objectCreation, knownType, semanticModel);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CertificateValidationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CertificateValidationCheck.cs
@@ -119,7 +119,5 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override SyntaxNode SyntaxFromReference(SyntaxReference reference) =>
             reference.GetSyntax();   // VB.NET has more complicated logic
-
-        private protected override KnownType GenericDelegateType() => KnownType.System_Func_T1_T2_T3_T4_TResult;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CompareNaN.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CompareNaN.cs
@@ -31,16 +31,14 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class CompareNaN : SonarDiagnosticAnalyzer
     {
-        internal const string DiagnosticId = "S2688";
+        private const string DiagnosticId = "S2688";
         private const string MessageFormat = "Use {0}.IsNaN() instead.";
 
-        private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-        protected override void Initialize(SonarAnalysisContext context)
-        {
+        protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>
                 {
@@ -49,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (TryGetFloatingPointType(binaryExpressionSyntax.Left, c.SemanticModel, out var floatingPointType) ||
                         TryGetFloatingPointType(binaryExpressionSyntax.Right, c.SemanticModel, out floatingPointType))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, binaryExpressionSyntax.GetLocation(), floatingPointType.TypeName));
+                        c.ReportIssue(Diagnostic.Create(Rule, binaryExpressionSyntax.GetLocation(), floatingPointType.TypeName));
                     }
                 },
                 SyntaxKind.GreaterThanExpression,
@@ -58,7 +56,6 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.LessThanOrEqualExpression,
                 SyntaxKind.EqualsExpression,
                 SyntaxKind.NotEqualsExpression);
-        }
 
         private static bool TryGetFloatingPointType(ExpressionSyntax expression, SemanticModel semanticModel, out KnownType floatingPointType)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterMissingOptionalCodeFix.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterMissingOptionalCodeFix.cs
@@ -51,8 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
 
             var semanticModel = await context.Document.GetSemanticModelAsync().ConfigureAwait(false);
-            var optionalAttribute = semanticModel?.Compilation?.GetTypeByMetadataName(
-                KnownType.System_Runtime_InteropServices_OptionalAttribute.TypeName);
+            var optionalAttribute = semanticModel?.Compilation?.GetTypeByMetadataName("System.Runtime.InteropServices.OptionalAttribute");
             if (optionalAttribute == null)
             {
                 return;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NonFlagsEnumInBitwiseOperationCodeFix.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NonFlagsEnumInBitwiseOperationCodeFix.cs
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 return;
             }
 
-            var flagsAttributeType = semanticModel.Compilation.GetTypeByMetadataName(KnownType.System_FlagsAttribute.TypeName);
+            var flagsAttributeType = semanticModel.Compilation.GetTypeByMetadataName("System.FlagsAttribute");
             if (flagsAttributeType == null)
             {
                 return;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameterWithDefaultValueCodeFix.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameterWithDefaultValueCodeFix.cs
@@ -51,8 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             var semanticModel = await context.Document.GetSemanticModelAsync().ConfigureAwait(false);
 
-            var defaultParameterValueAttributeType = semanticModel?.Compilation?.GetTypeByMetadataName(
-                KnownType.System_Runtime_InteropServices_DefaultParameterValueAttribute.TypeName);
+            var defaultParameterValueAttributeType = semanticModel?.Compilation?.GetTypeByMetadataName("System.Runtime.InteropServices.DefaultParameterValueAttribute");
             if (defaultParameterValueAttributeType == null)
             {
                 return;

--- a/analyzers/src/SonarAnalyzer.CSharp/Wrappers/ObjectCreationFactory.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Wrappers/ObjectCreationFactory.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Wrappers
                 objectCreation = objectCreationExpressionSyntax;
 
             public bool IsKnownType(KnownType knownType, SemanticModel semanticModel) =>
-                objectCreation.Type.GetName().EndsWith(knownType.ShortName) && objectCreation.IsKnownType(knownType, semanticModel);
+                objectCreation.Type.GetName().EndsWith(knownType.TypeName) && objectCreation.IsKnownType(knownType, semanticModel);
 
             public string TypeAsString(SemanticModel semanticModel) =>
                 objectCreation.Type.ToString();

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownMethods.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownMethods.cs
@@ -41,13 +41,12 @@ namespace SonarAnalyzer.Helpers
 
             bool HasMainParameters() =>
                 methodSymbol.Parameters.Length == 0
-                || (methodSymbol.Parameters.Length == 1 && methodSymbol.Parameters[0].Type.IsAny(KnownType.System_String_Array, KnownType.System_String_Array_VB));
+                || (methodSymbol.Parameters.Length == 1 && methodSymbol.Parameters[0].Type.Is(KnownType.System_String_Array));
 
             bool HasMainReturnType() =>
                 methodSymbol.ReturnsVoid
                 || methodSymbol.ReturnType.IsAny(KnownType.System_Int32, KnownType.System_Threading_Tasks_Task)
-                || (
-                    methodSymbol.ReturnType.OriginalDefinition.Is(KnownType.System_Threading_Tasks_Task_T)
+                || (methodSymbol.ReturnType.OriginalDefinition.Is(KnownType.System_Threading_Tasks_Task_T)
                     && ((methodSymbol.ReturnType as INamedTypeSymbol)?.TypeArguments.FirstOrDefault().Is(KnownType.System_Int32) ?? false));
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.Implementation.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.Implementation.cs
@@ -1,0 +1,114 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace SonarAnalyzer.Helpers
+{
+    internal abstract partial class KnownType
+    {
+        public string TypeName { get; private init; }
+
+        internal abstract bool Matches(ITypeSymbol symbol);
+
+        internal sealed class RegularKnownType : KnownType
+        {
+            private readonly IList<string> namespaceParts;
+            private readonly string[] genericParameters;
+
+            public bool IsArray { get; init; }
+
+            internal RegularKnownType(string fullTypeName, params string[] genericParameters)
+            {
+                this.genericParameters = genericParameters ?? Array.Empty<string>();
+
+                var parts = fullTypeName.Split('.');
+                TypeName = parts[parts.Length - 1];
+                namespaceParts = new ArraySegment<string>(parts, 0, parts.Length - 1);
+            }
+
+            internal override bool Matches(ITypeSymbol symbol) =>
+                IsMatch(symbol)
+                || IsMatch(symbol.OriginalDefinition);
+
+            private bool IsMatch(ITypeSymbol symbol)
+            {
+                _ = symbol ?? throw new ArgumentNullException(nameof(symbol));
+                if (IsArray)
+                {
+                    if (symbol is IArrayTypeSymbol array)
+                    {
+                        symbol = array.ElementType;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                return symbol.Name == TypeName
+                       && NamespaceMatches(symbol)
+                       && GenericParametersMatch(symbol);
+            }
+
+            private bool GenericParametersMatch(ISymbol symbol) =>
+                symbol is INamedTypeSymbol namedType
+                    ? namedType.TypeParameters.Select(x => x.Name).SequenceEqual(genericParameters)
+                    : !genericParameters.Any();
+
+            private bool NamespaceMatches(ISymbol symbol)
+            {
+                // For performance reason we want to avoid building full namespace as a string to compare it with the expected value.
+                var currentNamespace = symbol.ContainingNamespace;
+                var index = namespaceParts.Count - 1;
+
+                while (currentNamespace != null && !string.IsNullOrEmpty(currentNamespace.Name) && index >= 0)
+                {
+                    if (currentNamespace.Name != namespaceParts[index])
+                    {
+                        return false;
+                    }
+
+                    currentNamespace = currentNamespace.ContainingNamespace;
+                    index--;
+                }
+
+                return index == -1 && string.IsNullOrEmpty(currentNamespace?.Name);
+            }
+        }
+
+        internal sealed class SpecialKnownType : KnownType
+        {
+            private readonly SpecialType specialType;
+
+            public SpecialKnownType(SpecialType specialType, string typeName)
+            {
+                this.specialType = specialType;
+                TypeName = typeName;
+            }
+
+            internal override bool Matches(ITypeSymbol symbol) =>
+                symbol.SpecialType == specialType
+                || symbol.OriginalDefinition.SpecialType == specialType;
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -18,14 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace SonarAnalyzer.Helpers
 {
-    internal sealed class KnownType
+    internal abstract partial class KnownType
     {
 #pragma warning disable S103    // Lines should not be too long
 #pragma warning disable SA1310  // FieldNamesMustNotContainUnderscore
@@ -35,514 +33,510 @@ namespace SonarAnalyzer.Helpers
 
         #region Known types
 
-        internal static readonly KnownType Void = new(SpecialType.System_Void, "void");
-
-        internal static readonly KnownType Azure_Messaging_ServiceBus_Administration_ServiceBusAdministrationClient = new("Azure.Messaging.ServiceBus.Administration.ServiceBusAdministrationClient");
-        internal static readonly KnownType Azure_Messaging_ServiceBus_ServiceBusClient = new("Azure.Messaging.ServiceBus.ServiceBusClient");
-        internal static readonly KnownType Azure_Storage_Blobs_BlobServiceClient = new("Azure.Storage.Blobs.BlobServiceClient");
-        internal static readonly KnownType Azure_Storage_Queues_QueueServiceClient = new("Azure.Storage.Queues.QueueServiceClient");
-        internal static readonly KnownType Azure_Storage_Files_Shares_ShareServiceClient = new("Azure.Storage.Files.Shares.ShareServiceClient");
-        internal static readonly KnownType Azure_Storage_Files_DataLake_DataLakeServiceClient = new("Azure.Storage.Files.DataLake.DataLakeServiceClient");
-        internal static readonly KnownType Azure_ResourceManager_ArmClient = new("Azure.ResourceManager.ArmClient");
-        internal static readonly KnownType FluentAssertions_Execution_AssertionScope = new("FluentAssertions.Execution.AssertionScope");
-        internal static readonly KnownType JWT_Builder_JwtBuilder = new("JWT.Builder.JwtBuilder");
-        internal static readonly KnownType JWT_IJwtDecoder = new("JWT.IJwtDecoder");
-        internal static readonly KnownType JWT_JwtDecoderExtensions = new("JWT.JwtDecoderExtensions");
-        internal static readonly KnownType log4net_Config_XmlConfigurator = new("log4net.Config.XmlConfigurator");
-        internal static readonly KnownType log4net_Config_DOMConfigurator = new("log4net.Config.DOMConfigurator");
-        internal static readonly KnownType log4net_Config_BasicConfigurator = new("log4net.Config.BasicConfigurator");
-        internal static readonly KnownType Microsoft_AspNet_SignalR_Hub = new("Microsoft.AspNet.SignalR.Hub");
-        internal static readonly KnownType Microsoft_AspNetCore_Builder_DeveloperExceptionPageExtensions = new("Microsoft.AspNetCore.Builder.DeveloperExceptionPageExtensions");
-        internal static readonly KnownType Microsoft_AspNetCore_Builder_DatabaseErrorPageExtensions = new("Microsoft.AspNetCore.Builder.DatabaseErrorPageExtensions");
-        internal static readonly KnownType Microsoft_AspNetCore_Cors_Infrastructure_CorsPolicyBuilder = new("Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder");
-        internal static readonly KnownType Microsoft_AspNetCore_Hosting_HostingEnvironmentExtensions = new("Microsoft.AspNetCore.Hosting.HostingEnvironmentExtensions");
-        internal static readonly KnownType Microsoft_AspNetCore_Hosting_WebHostBuilderExtensions = new("Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions");
-        internal static readonly KnownType Microsoft_AspNetCore_Http_CookieOptions = new("Microsoft.AspNetCore.Http.CookieOptions");
-        internal static readonly KnownType Microsoft_AspNetCore_Http_HeaderDictionaryExtensions = new("Microsoft.AspNetCore.Http.HeaderDictionaryExtensions");
-        internal static readonly KnownType Microsoft_AspNetCore_Http_IHeaderDictionary = new("Microsoft.AspNetCore.Http.IHeaderDictionary");
-        internal static readonly KnownType Microsoft_AspNetCore_Http_IRequestCookieCollection = new("Microsoft.AspNetCore.Http.IRequestCookieCollection");
-        internal static readonly KnownType Microsoft_AspNetCore_Http_IResponseCookies = new("Microsoft.AspNetCore.Http.IResponseCookies");
-        internal static readonly KnownType Microsoft_AspNetCore_Mvc_Controller = new("Microsoft.AspNetCore.Mvc.Controller");
-        internal static readonly KnownType Microsoft_AspNetCore_Mvc_ControllerBase = new("Microsoft.AspNetCore.Mvc.ControllerBase");
-        internal static readonly KnownType Microsoft_AspNetCore_Mvc_ControllerAttribute = new("Microsoft.AspNetCore.Mvc.ControllerAttribute");
-        internal static readonly KnownType Microsoft_AspNetCore_Mvc_DisableRequestSizeLimitAttribute = new("Microsoft.AspNetCore.Mvc.DisableRequestSizeLimitAttribute");
-        internal static readonly KnownType Microsoft_AspNetCore_Mvc_FromServicesAttribute = new("Microsoft.AspNetCore.Mvc.FromServicesAttribute");
-        internal static readonly KnownType Microsoft_AspNetCore_Mvc_IgnoreAntiforgeryTokenAttribute = new("Microsoft.AspNetCore.Mvc.IgnoreAntiforgeryTokenAttribute");
-        internal static readonly KnownType Microsoft_AspNetCore_Mvc_NonActionAttribute = new("Microsoft.AspNetCore.Mvc.NonActionAttribute");
-        internal static readonly KnownType Microsoft_AspNetCore_Mvc_NonControllerAttribute = new("Microsoft.AspNetCore.Mvc.NonControllerAttribute");
-        internal static readonly KnownType Microsoft_AspNetCore_Mvc_RequestFormLimitsAttribute = new("Microsoft.AspNetCore.Mvc.RequestFormLimitsAttribute");
-        internal static readonly KnownType Microsoft_AspNetCore_Mvc_RequestSizeLimitAttribute = new("Microsoft.AspNetCore.Mvc.RequestSizeLimitAttribute");
-        internal static readonly KnownType Microsoft_AspNetCore_Razor_Hosting_RazorCompiledItemAttribute = new("Microsoft.AspNetCore.Razor.Hosting.RazorCompiledItemAttribute");
-        internal static readonly KnownType Microsoft_Azure_Cosmos_CosmosClient = new("Microsoft.Azure.Cosmos.CosmosClient");
-        internal static readonly KnownType Microsoft_Azure_Documents_Client_DocumentClient = new("Microsoft.Azure.Documents.Client.DocumentClient");
-        internal static readonly KnownType Microsoft_Azure_ServiceBus_Management_ManagementClient = new("Microsoft.Azure.ServiceBus.Management.ManagementClient");
-        internal static readonly KnownType Microsoft_Azure_ServiceBus_QueueClient = new("Microsoft.Azure.ServiceBus.QueueClient");
-        internal static readonly KnownType Microsoft_Azure_ServiceBus_SessionClient = new("Microsoft.Azure.ServiceBus.SessionClient");
-        internal static readonly KnownType Microsoft_Azure_ServiceBus_SubscriptionClient = new("Microsoft.Azure.ServiceBus.SubscriptionClient");
-        internal static readonly KnownType Microsoft_Azure_ServiceBus_TopicClient = new("Microsoft.Azure.ServiceBus.TopicClient");
-        internal static readonly KnownType Microsoft_Azure_WebJobs_Extensions_DurableTask_IDurableEntityClient = new("Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient");
-        internal static readonly KnownType Microsoft_Azure_WebJobs_Extensions_DurableTask_IDurableEntityContext = new("Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext");
-        internal static readonly KnownType Microsoft_Azure_WebJobs_Extensions_DurableTask_IDurableOrchestrationContext = new("Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext");
-        internal static readonly KnownType Microsoft_Azure_WebJobs_FunctionNameAttribute = new("Microsoft.Azure.WebJobs.FunctionNameAttribute");
-        internal static readonly KnownType Microsoft_Data_Sqlite_SqliteCommand = new("Microsoft.Data.Sqlite.SqliteCommand");
-        internal static readonly KnownType Microsoft_EntityFrameworkCore_DbContextOptionsBuilder = new("Microsoft.EntityFrameworkCore.DbContextOptionsBuilder");
-        internal static readonly KnownType Microsoft_EntityFrameworkCore_Migrations_Migration = new("Microsoft.EntityFrameworkCore.Migrations.Migration");
-        internal static readonly KnownType Microsoft_EntityFrameworkCore_MySQLDbContextOptionsExtensions = new("Microsoft.EntityFrameworkCore.MySQLDbContextOptionsExtensions");
-        internal static readonly KnownType Microsoft_EntityFrameworkCore_NpgsqlDbContextOptionsExtensions = new("Microsoft.EntityFrameworkCore.NpgsqlDbContextOptionsExtensions");
-        internal static readonly KnownType Microsoft_EntityFrameworkCore_NpgsqlDbContextOptionsBuilderExtensions = new("Microsoft.EntityFrameworkCore.NpgsqlDbContextOptionsBuilderExtensions");
-        internal static readonly KnownType Microsoft_EntityFrameworkCore_OracleDbContextOptionsExtensions = new("Microsoft.EntityFrameworkCore.OracleDbContextOptionsExtensions");
-        internal static readonly KnownType Microsoft_EntityFrameworkCore_RawSqlString = new("Microsoft.EntityFrameworkCore.RawSqlString");
-        internal static readonly KnownType Microsoft_EntityFrameworkCore_RelationalDatabaseFacadeExtensions = new("Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions");
-        internal static readonly KnownType Microsoft_EntityFrameworkCore_RelationalQueryableExtensions = new("Microsoft.EntityFrameworkCore.RelationalQueryableExtensions");
-        internal static readonly KnownType Microsoft_EntityFrameworkCore_SqliteDbContextOptionsBuilderExtensions = new("Microsoft.EntityFrameworkCore.SqliteDbContextOptionsBuilderExtensions");
-        internal static readonly KnownType Microsoft_EntityFrameworkCore_SqlServerDbContextOptionsExtensions = new("Microsoft.EntityFrameworkCore.SqlServerDbContextOptionsExtensions");
-        internal static readonly KnownType Microsoft_Extensions_DependencyInjection_LoggingServiceCollectionExtensions = new("Microsoft.Extensions.DependencyInjection.LoggingServiceCollectionExtensions");
-        internal static readonly KnownType Microsoft_Extensions_Hosting_HostEnvironmentEnvExtensions = new("Microsoft.Extensions.Hosting.HostEnvironmentEnvExtensions");
-        internal static readonly KnownType Microsoft_Extensions_Logging_AzureAppServicesLoggerFactoryExtensions = new("Microsoft.Extensions.Logging.AzureAppServicesLoggerFactoryExtensions");
-        internal static readonly KnownType Microsoft_Extensions_Logging_ConsoleLoggerExtensions = new("Microsoft.Extensions.Logging.ConsoleLoggerExtensions");
-        internal static readonly KnownType Microsoft_Extensions_Logging_DebugLoggerFactoryExtensions = new("Microsoft.Extensions.Logging.DebugLoggerFactoryExtensions");
-        internal static readonly KnownType Microsoft_Extensions_Logging_EventLoggerFactoryExtensions = new("Microsoft.Extensions.Logging.EventLoggerFactoryExtensions");
-        internal static readonly KnownType Microsoft_Extensions_Logging_EventSourceLoggerFactoryExtensions = new("Microsoft.Extensions.Logging.EventSourceLoggerFactoryExtensions");
-        internal static readonly KnownType Microsoft_Extensions_Logging_ILogger = new("Microsoft.Extensions.Logging.ILogger");
-        internal static readonly KnownType Microsoft_Extensions_Logging_ILoggerFactory = new("Microsoft.Extensions.Logging.ILoggerFactory");
-        internal static readonly KnownType Microsoft_Extensions_Logging_LoggerExtensions = new("Microsoft.Extensions.Logging.LoggerExtensions");
-        internal static readonly KnownType Microsoft_Extensions_Primitives_StringValues = new("Microsoft.Extensions.Primitives.StringValues");
-        internal static readonly KnownType Microsoft_Net_Http_Headers_HeaderNames = new("Microsoft.Net.Http.Headers.HeaderNames");
-        internal static readonly KnownType Microsoft_VisualBasic_Interaction = new("Microsoft.VisualBasic.Interaction");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_Assert = new("Microsoft.VisualStudio.TestTools.UnitTesting.Assert");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_AssertFailedException = new("Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_ExpectedExceptionAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.ExpectedExceptionAttribute");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_IgnoreAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.IgnoreAttribute");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestClassAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestMethodAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_DataTestMethodAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.DataTestMethodAttribute");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_WorkItemAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.WorkItemAttribute");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_AssemblyCleanupAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyCleanupAttribute");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_AssemblyInitializeAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyInitializeAttribute");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_ClassCleanupAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupAttribute");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_ClassInitializeAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.ClassInitializeAttribute");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestCleanupAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.TestCleanupAttribute");
-        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestInitializeAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.TestInitializeAttribute");
-        internal static readonly KnownType Microsoft_Web_XmlTransform_XmlFileInfoDocument = new("Microsoft.Web.XmlTransform.XmlFileInfoDocument");
-        internal static readonly KnownType Microsoft_Web_XmlTransform_XmlTransformableDocument = new("Microsoft.Web.XmlTransform.XmlTransformableDocument");
-        internal static readonly KnownType Mono_Unix_FileAccessPermissions = new("Mono.Unix.FileAccessPermissions");
-        internal static readonly KnownType MySql_Data_MySqlClient_MySqlDataAdapter = new("MySql.Data.MySqlClient.MySqlDataAdapter");
-        internal static readonly KnownType MySql_Data_MySqlClient_MySqlCommand = new("MySql.Data.MySqlClient.MySqlCommand");
-        internal static readonly KnownType MySql_Data_MySqlClient_MySqlHelper = new("MySql.Data.MySqlClient.MySqlHelper");
-        internal static readonly KnownType MySql_Data_MySqlClient_MySqlScript = new("MySql.Data.MySqlClient.MySqlScript");
-        internal static readonly KnownType Nancy_Cookies_NancyCookie = new("Nancy.Cookies.NancyCookie");
-        internal static readonly KnownType NFluent_Check = new("NFluent.Check");
-        internal static readonly KnownType NFluent_FluentCheckException = new("NFluent.FluentCheckException");
-        internal static readonly KnownType NFluent_Kernel_FluentCheckException = new("NFluent.Kernel.FluentCheckException");
-        internal static readonly KnownType NLog_LogManager = new("NLog.LogManager");
-        internal static readonly KnownType NUnit_Framework_Assert = new("NUnit.Framework.Assert");
-        internal static readonly KnownType NUnit_Framework_AssertionException = new("NUnit.Framework.AssertionException");
-        internal static readonly KnownType NUnit_Framework_ExpectedExceptionAttribute = new("NUnit.Framework.ExpectedExceptionAttribute");
-        internal static readonly KnownType NUnit_Framework_IgnoreAttribute = new("NUnit.Framework.IgnoreAttribute");
-        internal static readonly KnownType NUnit_Framework_ITestBuilderInterface = new("NUnit.Framework.Interfaces.ITestBuilder");
-        internal static readonly KnownType NUnit_Framework_TestAttribute = new("NUnit.Framework.TestAttribute");
-        internal static readonly KnownType NUnit_Framework_TestCaseAttribute = new("NUnit.Framework.TestCaseAttribute");
-        internal static readonly KnownType NUnit_Framework_TestCaseSourceAttribute = new("NUnit.Framework.TestCaseSourceAttribute");
-        internal static readonly KnownType NUnit_Framework_TestFixtureAttribute = new("NUnit.Framework.TestFixtureAttribute");
-        internal static readonly KnownType NUnit_Framework_TheoryAttribute = new("NUnit.Framework.TheoryAttribute");
-        internal static readonly KnownType Org_BouncyCastle_Asn1_Nist_NistNamedCurves = new("Org.BouncyCastle.Asn1.Nist.NistNamedCurves");
-        internal static readonly KnownType Org_BouncyCastle_Asn1_Sec_SecNamedCurves = new("Org.BouncyCastle.Asn1.Sec.SecNamedCurves");
-        internal static readonly KnownType Org_BouncyCastle_Asn1_TeleTrust_TeleTrusTNamedCurves = new("Org.BouncyCastle.Asn1.TeleTrust.TeleTrusTNamedCurves");
-        internal static readonly KnownType Org_BouncyCastle_Asn1_X9_ECNamedCurveTable = new("Org.BouncyCastle.Asn1.X9.ECNamedCurveTable");
-        internal static readonly KnownType Org_BouncyCastle_Asn1_X9_X962NamedCurves = new("Org.BouncyCastle.Asn1.X9.X962NamedCurves");
-        internal static readonly KnownType Org_BouncyCastle_Crypto_Engines_AesFastEngine = new("Org.BouncyCastle.Crypto.Engines.AesFastEngine");
-        internal static readonly KnownType Org_BouncyCastle_Crypto_Generators_DHParametersGenerator = new("Org.BouncyCastle.Crypto.Generators.DHParametersGenerator");
-        internal static readonly KnownType Org_BouncyCastle_Crypto_Generators_DsaParametersGenerator = new("Org.BouncyCastle.Crypto.Generators.DsaParametersGenerator");
-        internal static readonly KnownType Org_BouncyCastle_Crypto_Parameters_RsaKeyGenerationParameters = new("Org.BouncyCastle.Crypto.Parameters.RsaKeyGenerationParameters");
-        internal static readonly KnownType Serilog_LoggerConfiguration = new("Serilog.LoggerConfiguration");
-        internal static readonly KnownType System_Action = new("System.Action");
-        internal static readonly KnownType System_Action_T = new("System.Action<T>");
-        internal static readonly KnownType System_Action_T1_T2 = new("System.Action<T1, T2>");
-        internal static readonly KnownType System_Action_T1_T2_T3 = new("System.Action<T1, T2, T3>");
-        internal static readonly KnownType System_Action_T1_T2_T3_T4 = new("System.Action<T1, T2, T3, T4>");
-        internal static readonly KnownType System_Activator = new("System.Activator");
-        internal static readonly KnownType System_ApplicationException = new("System.ApplicationException");
-        internal static readonly KnownType System_AppDomain = new("System.AppDomain");
-        internal static readonly KnownType System_ArgumentException = new("System.ArgumentException");
-        internal static readonly KnownType System_ArgumentNullException = new("System.ArgumentNullException");
-        internal static readonly KnownType System_ArgumentOutOfRangeException = new("System.ArgumentOutOfRangeException");
-        internal static readonly KnownType System_Array = new(SpecialType.System_Array, "System.Array");
-        internal static readonly KnownType System_Attribute = new("System.Attribute");
-        internal static readonly KnownType System_AttributeUsageAttribute = new("System.AttributeUsageAttribute");
-        internal static readonly KnownType System_Boolean = new(SpecialType.System_Boolean, "bool");
-        internal static readonly KnownType System_Byte = new(SpecialType.System_Byte, "byte");
-        internal static readonly KnownType System_Byte_Array = new("byte[]");
-        internal static readonly KnownType System_Char = new(SpecialType.System_Char, "char");
-        internal static readonly KnownType System_CLSCompliantAttribute = new("System.CLSCompliantAttribute");
-        internal static readonly KnownType System_CodeDom_Compiler_GeneratedCodeAttribute = new("System.CodeDom.Compiler.GeneratedCodeAttribute");
-        internal static readonly KnownType System_Collections_CollectionBase = new("System.Collections.CollectionBase");
-        internal static readonly KnownType System_Collections_DictionaryBase = new("System.Collections.DictionaryBase");
-        internal static readonly KnownType System_Collections_Generic_Dictionary_TKey_TValue = new("System.Collections.Generic.Dictionary<TKey, TValue>");
-        internal static readonly KnownType System_Collections_Generic_HashSet_T = new("System.Collections.Generic.HashSet<T>");
-        internal static readonly KnownType System_Collections_Generic_IAsyncEnumerable_T = new("System.Collections.Generic.IAsyncEnumerable<T>");
-        internal static readonly KnownType System_Collections_Generic_ICollection_T = new(SpecialType.System_Collections_Generic_ICollection_T, "System.Collections.Generic.ICollection<T>");
-        internal static readonly KnownType System_Collections_Generic_IDictionary_TKey_TValue = new("System.Collections.Generic.IDictionary<TKey, TValue>");
-        internal static readonly KnownType System_Collections_Generic_IDictionary_TKey_TValue_VB = new("System.Collections.Generic.IDictionary(Of TKey, TValue)");
-        internal static readonly KnownType System_Collections_Generic_IEnumerable_T = new(SpecialType.System_Collections_Generic_IEnumerable_T, "System.Collections.Generic.IEnumerable<T>");
-        internal static readonly KnownType System_Collections_Generic_IList_T = new(SpecialType.System_Collections_Generic_IList_T, "System.Collections.Generic.IList<T>");
-        internal static readonly KnownType System_Collections_Generic_IReadOnlyCollection_T = new(SpecialType.System_Collections_Generic_IReadOnlyCollection_T, "System.Collections.Generic.IReadOnlyCollection<T>");
-        internal static readonly KnownType System_Collections_Generic_ISet_T = new("System.Collections.Generic.ISet<T>");
-        internal static readonly KnownType System_Collections_Generic_KeyValuePair_TKey_TValue = new("System.Collections.Generic.KeyValuePair<TKey, TValue>");
-        internal static readonly KnownType System_Collections_Generic_List_T = new("System.Collections.Generic.List<T>");
-        internal static readonly KnownType System_Collections_Generic_Queue_T = new("System.Collections.Generic.Queue<T>");
-        internal static readonly KnownType System_Collections_Generic_Stack_T = new("System.Collections.Generic.Stack<T>");
-        internal static readonly KnownType System_Collections_ICollection = new("System.Collections.ICollection");
-        internal static readonly KnownType System_Collections_IEnumerable = new(SpecialType.System_Collections_IEnumerable, "System.Collections.IEnumerable");
-        internal static readonly KnownType System_Collections_IList = new("System.Collections.IList");
-        internal static readonly KnownType System_Collections_Immutable_IImmutableArray_T = new("System.Collections.Immutable.IImmutableArray<T>");
-        internal static readonly KnownType System_Collections_Immutable_IImmutableDictionary_TKey_TValue = new("System.Collections.Immutable.IImmutableDictionary<TKey, TValue>");
-        internal static readonly KnownType System_Collections_Immutable_IImmutableList_T = new("System.Collections.Immutable.IImmutableList<T>");
-        internal static readonly KnownType System_Collections_Immutable_IImmutableQueue_T = new("System.Collections.Immutable.IImmutableQueue<T>");
-        internal static readonly KnownType System_Collections_Immutable_IImmutableSet_T = new("System.Collections.Immutable.IImmutableSet<T>");
-        internal static readonly KnownType System_Collections_Immutable_IImmutableStack_T = new("System.Collections.Immutable.IImmutableStack<T>");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableArray = new("System.Collections.Immutable.ImmutableArray");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableArray_T = new("System.Collections.Immutable.ImmutableArray<T>");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableDictionary = new("System.Collections.Immutable.ImmutableDictionary");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableDictionary_TKey_TValue = new("System.Collections.Immutable.ImmutableDictionary<TKey, TValue>");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableHashSet = new("System.Collections.Immutable.ImmutableHashSet");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableHashSet_T = new("System.Collections.Immutable.ImmutableHashSet<T>");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableList = new("System.Collections.Immutable.ImmutableList");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableList_T = new("System.Collections.Immutable.ImmutableList<T>");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableQueue = new("System.Collections.Immutable.ImmutableQueue");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableQueue_T = new("System.Collections.Immutable.ImmutableQueue<T>");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableSortedDictionary = new("System.Collections.Immutable.ImmutableSortedDictionary");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableSortedDictionary_TKey_TValue = new("System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableSortedSet = new("System.Collections.Immutable.ImmutableSortedSet");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableSortedSet_T = new("System.Collections.Immutable.ImmutableSortedSet<T>");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableStack = new("System.Collections.Immutable.ImmutableStack");
-        internal static readonly KnownType System_Collections_Immutable_ImmutableStack_T = new("System.Collections.Immutable.ImmutableStack<T>");
-        internal static readonly KnownType System_Collections_ObjectModel_Collection_T = new("System.Collections.ObjectModel.Collection<T>");
-        internal static readonly KnownType System_Collections_ObjectModel_ObservableCollection_T = new("System.Collections.ObjectModel.ObservableCollection<T>");
-        internal static readonly KnownType System_Collections_ObjectModel_ReadOnlyCollection_T = new("System.Collections.ObjectModel.ReadOnlyCollection<T>");
-        internal static readonly KnownType System_Collections_ObjectModel_ReadOnlyDictionary_TKey_TValue = new("System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>");
-        internal static readonly KnownType System_Collections_Queue = new("System.Collections.Queue");
-        internal static readonly KnownType System_Collections_ReadOnlyCollectionBase = new("System.Collections.ReadOnlyCollectionBase");
-        internal static readonly KnownType System_Collections_SortedList = new("System.Collections.SortedList");
-        internal static readonly KnownType System_Collections_Stack = new("System.Collections.Stack");
-        internal static readonly KnownType System_Collections_Specialized_NameObjectCollectionBase = new("System.Collections.Specialized.NameObjectCollectionBase");
-        internal static readonly KnownType System_Collections_Specialized_NameValueCollection = new("System.Collections.Specialized.NameValueCollection");
-        internal static readonly KnownType System_Composition_ExportAttribute = new("System.Composition.ExportAttribute");
-        internal static readonly KnownType System_ComponentModel_DefaultValueAttribute = new("System.ComponentModel.DefaultValueAttribute");
-        internal static readonly KnownType System_ComponentModel_EditorBrowsableAttribute = new("System.ComponentModel.EditorBrowsableAttribute");
-        internal static readonly KnownType System_ComponentModel_LocalizableAttribute = new("System.ComponentModel.LocalizableAttribute");
-        internal static readonly KnownType System_ComponentModel_Composition_CreationPolicy = new("System.ComponentModel.Composition.CreationPolicy");
-        internal static readonly KnownType System_ComponentModel_Composition_ExportAttribute = new("System.ComponentModel.Composition.ExportAttribute");
-        internal static readonly KnownType System_ComponentModel_Composition_InheritedExportAttribute = new("System.ComponentModel.Composition.InheritedExportAttribute");
-        internal static readonly KnownType System_ComponentModel_Composition_PartCreationPolicyAttribute = new("System.ComponentModel.Composition.PartCreationPolicyAttribute");
-        internal static readonly KnownType System_Configuration_ConfigXmlDocument = new("System.Configuration.ConfigXmlDocument");
-        internal static readonly KnownType System_Console = new("System.Console");
-        internal static readonly KnownType System_Data_Common_CommandTrees_DbExpression = new("System.Data.Common.CommandTrees.DbExpression");
-        internal static readonly KnownType System_Data_DataSet = new("System.Data.DataSet");
-        internal static readonly KnownType System_Data_DataTable = new("System.Data.DataTable");
-        internal static readonly KnownType System_Data_Odbc_OdbcCommand = new("System.Data.Odbc.OdbcCommand");
-        internal static readonly KnownType System_Data_Odbc_OdbcDataAdapter = new("System.Data.Odbc.OdbcDataAdapter");
-        internal static readonly KnownType System_Data_OracleClient_OracleCommand = new("System.Data.OracleClient.OracleCommand");
-        internal static readonly KnownType System_Data_OracleClient_OracleDataAdapter = new("System.Data.OracleClient.OracleDataAdapter");
-        internal static readonly KnownType System_Data_SqlClient_SqlCommand = new("System.Data.SqlClient.SqlCommand");
-        internal static readonly KnownType System_Data_SqlClient_SqlDataAdapter = new("System.Data.SqlClient.SqlDataAdapter");
-        internal static readonly KnownType System_Data_Sqlite_SqliteCommand = new("System.Data.SQLite.SQLiteCommand");
-        internal static readonly KnownType System_Data_Sqlite_SQLiteDataAdapter = new("System.Data.SQLite.SQLiteDataAdapter");
-        internal static readonly KnownType System_Data_SqlServerCe_SqlCeCommand = new("System.Data.SqlServerCe.SqlCeCommand");
-        internal static readonly KnownType System_Data_SqlServerCe_SqlCeDataAdapter = new("System.Data.SqlServerCe.SqlCeDataAdapter");
-        internal static readonly KnownType System_DateTime = new(SpecialType.System_DateTime, "DateTime");
-        internal static readonly KnownType System_DateTimeOffset = new("System.DateTimeOffset");
-        internal static readonly KnownType System_Decimal = new(SpecialType.System_Decimal, "decimal");
-        internal static readonly KnownType System_Delegate = new("System.Delegate");
-        internal static readonly KnownType System_Diagnostics_CodeAnalysis_ExcludeFromCodeCoverageAttribute = new("System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute");
-        internal static readonly KnownType System_Diagnostics_CodeAnalysis_SuppressMessageAttribute = new("System.Diagnostics.CodeAnalysis.SuppressMessageAttribute");
-        internal static readonly KnownType System_Diagnostics_ConditionalAttribute = new("System.Diagnostics.ConditionalAttribute");
-        internal static readonly KnownType System_Diagnostics_Contracts_PureAttribute = new("System.Diagnostics.Contracts.PureAttribute");
-        internal static readonly KnownType System_Diagnostics_Debug = new("System.Diagnostics.Debug");
-        internal static readonly KnownType System_Diagnostics_DebuggerDisplayAttribute = new("System.Diagnostics.DebuggerDisplayAttribute");
-        internal static readonly KnownType System_Diagnostics_Process = new("System.Diagnostics.Process");
-        internal static readonly KnownType System_Diagnostics_ProcessStartInfo = new("System.Diagnostics.ProcessStartInfo");
-        internal static readonly KnownType System_Diagnostics_Trace = new("System.Diagnostics.Trace");
-        internal static readonly KnownType System_Diagnostics_TraceSource = new("System.Diagnostics.TraceSource");
-        internal static readonly KnownType System_DirectoryServices_AuthenticationTypes = new("System.DirectoryServices.AuthenticationTypes");
-        internal static readonly KnownType System_DirectoryServices_DirectoryEntry = new("System.DirectoryServices.DirectoryEntry");
-        internal static readonly KnownType System_Double = new(SpecialType.System_Double, "double");
-        internal static readonly KnownType System_Drawing_Bitmap = new("System.Drawing.Bitmap");
-        internal static readonly KnownType System_Drawing_Image = new("System.Drawing.Image");
-        internal static readonly KnownType System_DuplicateWaitObjectException = new("System.DuplicateWaitObjectException");
-        internal static readonly KnownType System_Enum = new(SpecialType.System_Enum, "Enum");
-        internal static readonly KnownType System_Environment = new("System.Environment");
-        internal static readonly KnownType System_EventArgs = new("System.EventArgs");
-        internal static readonly KnownType System_EventHandler = new("System.EventHandler");
-        internal static readonly KnownType System_EventHandler_TEventArgs = new("System.EventHandler<TEventArgs>");
-        internal static readonly KnownType System_Exception = new("System.Exception");
-        internal static readonly KnownType System_ExecutionEngineException = new("System.ExecutionEngineException");
-        internal static readonly KnownType System_FlagsAttribute = new("System.FlagsAttribute");
-        internal static readonly KnownType System_Func_TResult = new("System.Func<TResult>");
-        internal static readonly KnownType System_Func_T_TResult = new("System.Func<T, TResult>");
-        internal static readonly KnownType System_Func_T1_T2_TResult = new("System.Func<T1, T2, TResult>");
-        internal static readonly KnownType System_Func_T1_T2_T3_TResult = new("System.Func<T1, T2, T3, TResult>");
-        internal static readonly KnownType System_Func_T1_T2_T3_T4_TResult = new("System.Func<T1, T2, T3, T4, TResult>");
-        internal static readonly KnownType System_Func_T1_T2_T3_T4_TResult_VB = new("System.Func(Of In T1, In T2, In T3, In T4, Out TResult)");
-        internal static readonly KnownType System_GC = new("System.GC");
-        internal static readonly KnownType System_Globalization_CompareOptions = new("System.Globalization.CompareOptions");
-        internal static readonly KnownType System_Globalization_CultureInfo = new("System.Globalization.CultureInfo");
-        internal static readonly KnownType System_Guid = new("System.Guid");
-        internal static readonly KnownType System_IAsyncDisposable = new("System.IAsyncDisposable");
-        internal static readonly KnownType System_IComparable = new("System.IComparable");
-        internal static readonly KnownType System_IComparable_T = new("System.IComparable<T>");
-        internal static readonly KnownType System_IdentityModel_Tokens_SecurityTokenHandler = new("System.IdentityModel.Tokens.SecurityTokenHandler");
-        internal static readonly KnownType System_IDisposable = new(SpecialType.System_IDisposable, "System.IDisposable");
-        internal static readonly KnownType System_IEquatable_T = new("System.IEquatable<T>");
-        internal static readonly KnownType System_IFormatProvider = new("System.IFormatProvider");
-        internal static readonly KnownType System_Index = new("System.Index");
-        internal static readonly KnownType System_IndexOutOfRangeException = new("System.IndexOutOfRangeException");
-        internal static readonly KnownType System_Int16 = new(SpecialType.System_Int16, "short");
-        internal static readonly KnownType System_Int32 = new(SpecialType.System_Int32, "int");
-        internal static readonly KnownType System_Int64 = new(SpecialType.System_Int64, "long");
-        internal static readonly KnownType System_IntPtr = new(SpecialType.System_IntPtr, "IntPtr");
-        internal static readonly KnownType System_InvalidOperationException = new("System.InvalidOperationException");
-        internal static readonly KnownType System_IO_Compression_ZipFile = new("System.IO.Compression.ZipFile");
-        internal static readonly KnownType System_IO_Compression_ZipFileExtensions = new("System.IO.Compression.ZipFileExtensions");
-        internal static readonly KnownType System_IO_FileStream = new("System.IO.FileStream");
-        internal static readonly KnownType System_IO_Path = new("System.IO.Path");
-        internal static readonly KnownType System_IO_Stream = new("System.IO.Stream");
-        internal static readonly KnownType System_IO_StreamReader = new("System.IO.StreamReader");
-        internal static readonly KnownType System_IO_StreamWriter = new("System.IO.StreamWriter");
-        internal static readonly KnownType System_IO_TextWriter = new("System.IO.TextWriter");
-        internal static readonly KnownType System_Lazy = new("System.Lazy<T>");
-        internal static readonly KnownType System_Linq_Enumerable = new("System.Linq.Enumerable");
-        internal static readonly KnownType System_Linq_Expressions_Expression_T = new("System.Linq.Expressions.Expression<TDelegate>");
-        internal static readonly KnownType System_Linq_ImmutableArrayExtensions = new("System.Linq.ImmutableArrayExtensions");
-        internal static readonly KnownType System_MarshalByRefObject = new("System.MarshalByRefObject");
-        internal static readonly KnownType System_MTAThreadAttribute = new("System.MTAThreadAttribute");
-        internal static readonly KnownType System_Net_FtpWebRequest = new("System.Net.FtpWebRequest");
-        internal static readonly KnownType System_Net_Http_Headers_HttpHeaders = new("System.Net.Http.Headers.HttpHeaders");
-        internal static readonly KnownType System_Net_Http_HttpClient = new("System.Net.Http.HttpClient");
-        internal static readonly KnownType System_Net_Http_HttpClientHandler = new("System.Net.Http.HttpClientHandler");
-        internal static readonly KnownType System_Net_Mail_SmtpClient = new("System.Net.Mail.SmtpClient");
-        internal static readonly KnownType System_Net_NetworkCredential = new("System.Net.NetworkCredential");
-        internal static readonly KnownType System_Net_Security_RemoteCertificateValidationCallback = new("System.Net.Security.RemoteCertificateValidationCallback");
-        internal static readonly KnownType System_Net_Security_SslPolicyErrors = new("System.Net.Security.SslPolicyErrors");
-        internal static readonly KnownType System_Net_SecurityProtocolType = new("System.Net.SecurityProtocolType");
-        internal static readonly KnownType System_Net_Sockets_Socket = new("System.Net.Sockets.Socket");
-        internal static readonly KnownType System_Net_Sockets_TcpClient = new("System.Net.Sockets.TcpClient");
-        internal static readonly KnownType System_Net_Sockets_UdpClient = new("System.Net.Sockets.UdpClient");
-        internal static readonly KnownType System_Net_WebClient = new("System.Net.WebClient");
-        internal static readonly KnownType System_NotImplementedException = new("System.NotImplementedException");
-        internal static readonly KnownType System_NotSupportedException = new("System.NotSupportedException");
-        internal static readonly KnownType System_Nullable_T = new(SpecialType.System_Nullable_T, "System.Nullable<T>");
-        internal static readonly KnownType System_NullReferenceException = new("System.NullReferenceException");
-        internal static readonly KnownType System_Object = new(SpecialType.System_Object, "object");
-        internal static readonly KnownType System_ObsoleteAttribute = new("System.ObsoleteAttribute");
-        internal static readonly KnownType System_OutOfMemoryException = new("System.OutOfMemoryException");
-        internal static readonly KnownType System_Random = new("System.Random");
-        internal static readonly KnownType System_Range = new("System.Range");
-        internal static readonly KnownType System_Reflection_Assembly = new("System.Reflection.Assembly");
-        internal static readonly KnownType System_Reflection_BindingFlags = new("System.Reflection.BindingFlags");
-        internal static readonly KnownType System_Reflection_AssemblyVersionAttribute = new("System.Reflection.AssemblyVersionAttribute");
-        internal static readonly KnownType System_Reflection_MemberInfo = new("System.Reflection.MemberInfo");
-        internal static readonly KnownType System_Reflection_Module = new("System.Reflection.Module");
-        internal static readonly KnownType System_Reflection_ParameterInfo = new("System.Reflection.ParameterInfo");
-        internal static readonly KnownType System_Resources_NeutralResourcesLanguageAttribute = new("System.Resources.NeutralResourcesLanguageAttribute");
-        internal static readonly KnownType System_Runtime_CompilerServices_CallerFilePathAttribute = new("System.Runtime.CompilerServices.CallerFilePathAttribute");
-        internal static readonly KnownType System_Runtime_CompilerServices_CallerLineNumberAttribute = new("System.Runtime.CompilerServices.CallerLineNumberAttribute");
-        internal static readonly KnownType System_Runtime_CompilerServices_CallerMemberNameAttribute = new("System.Runtime.CompilerServices.CallerMemberNameAttribute");
-        internal static readonly KnownType System_Runtime_CompilerServices_InternalsVisibleToAttribute = new("System.Runtime.CompilerServices.InternalsVisibleToAttribute");
-        internal static readonly KnownType System_Runtime_CompilerServices_ModuleInitializerAttribute = new("System.Runtime.CompilerServices.ModuleInitializerAttribute");
-        internal static readonly KnownType System_Runtime_CompilerServices_ValueTaskAwaiter = new("System.Runtime.CompilerServices.ValueTaskAwaiter");
-        internal static readonly KnownType System_Runtime_CompilerServices_ValueTaskAwaiter_TResult = new("System.Runtime.CompilerServices.ValueTaskAwaiter<TResult>");
-        internal static readonly KnownType System_Runtime_CompilerServices_TaskAwaiter = new("System.Runtime.CompilerServices.TaskAwaiter");
-        internal static readonly KnownType System_Runtime_CompilerServices_TaskAwaiter_TResult = new("System.Runtime.CompilerServices.TaskAwaiter<TResult>");
-        internal static readonly KnownType System_Runtime_InteropServices_ComImportAttribute = new("System.Runtime.InteropServices.ComImportAttribute");
-        internal static readonly KnownType System_Runtime_InteropServices_ComVisibleAttribute = new("System.Runtime.InteropServices.ComVisibleAttribute");
-        internal static readonly KnownType System_Runtime_InteropServices_DefaultParameterValueAttribute = new("System.Runtime.InteropServices.DefaultParameterValueAttribute");
-        internal static readonly KnownType System_Runtime_InteropServices_DllImportAttribute = new("System.Runtime.InteropServices.DllImportAttribute");
-        internal static readonly KnownType System_Runtime_InteropServices_HandleRef = new("System.Runtime.InteropServices.HandleRef");
-        internal static readonly KnownType System_Runtime_InteropServices_InterfaceTypeAttribute = new("System.Runtime.InteropServices.InterfaceTypeAttribute");
-        internal static readonly KnownType System_Runtime_InteropServices_OptionalAttribute = new("System.Runtime.InteropServices.OptionalAttribute");
-        internal static readonly KnownType System_Runtime_InteropServices_SafeHandle = new("System.Runtime.InteropServices.SafeHandle");
-        internal static readonly KnownType System_Runtime_InteropServices_StructLayoutAttribute = new("System.Runtime.InteropServices.StructLayoutAttribute");
-        internal static readonly KnownType System_Runtime_Serialization_DataMemberAttribute = new("System.Runtime.Serialization.DataMemberAttribute");
-        internal static readonly KnownType System_Runtime_Serialization_Formatters_Binary_BinaryFormatter = new("System.Runtime.Serialization.Formatters.Binary.BinaryFormatter");
-        internal static readonly KnownType System_Runtime_Serialization_Formatters_Soap_SoapFormatter = new("System.Runtime.Serialization.Formatters.Soap.SoapFormatter");
-        internal static readonly KnownType System_Runtime_Serialization_ISerializable = new("System.Runtime.Serialization.ISerializable");
-        internal static readonly KnownType System_Runtime_Serialization_IDeserializationCallback = new("System.Runtime.Serialization.IDeserializationCallback");
-        internal static readonly KnownType System_Runtime_Serialization_NetDataContractSerializer = new("System.Runtime.Serialization.NetDataContractSerializer");
-        internal static readonly KnownType System_Runtime_Serialization_OnDeserializedAttribute = new("System.Runtime.Serialization.OnDeserializedAttribute");
-        internal static readonly KnownType System_Runtime_Serialization_OnDeserializingAttribute = new("System.Runtime.Serialization.OnDeserializingAttribute");
-        internal static readonly KnownType System_Runtime_Serialization_OnSerializedAttribute = new("System.Runtime.Serialization.OnSerializedAttribute");
-        internal static readonly KnownType System_Runtime_Serialization_OnSerializingAttribute = new("System.Runtime.Serialization.OnSerializingAttribute");
-        internal static readonly KnownType System_Runtime_Serialization_OptionalFieldAttribute = new("System.Runtime.Serialization.OptionalFieldAttribute");
-        internal static readonly KnownType System_Runtime_Serialization_SerializationInfo = new("System.Runtime.Serialization.SerializationInfo");
-        internal static readonly KnownType System_Runtime_Serialization_StreamingContext = new("System.Runtime.Serialization.StreamingContext");
-        internal static readonly KnownType System_SByte = new(SpecialType.System_SByte, "sbyte");
-        internal static readonly KnownType System_Security_AccessControl_FileSystemAccessRule = new("System.Security.AccessControl.FileSystemAccessRule");
-        internal static readonly KnownType System_Security_AccessControl_FileSystemSecurity = new("System.Security.AccessControl.FileSystemSecurity");
-        internal static readonly KnownType System_Security_AllowPartiallyTrustedCallersAttribute = new("System.Security.AllowPartiallyTrustedCallersAttribute");
-        internal static readonly KnownType System_Security_Authentication_SslProtocols = new("System.Security.Authentication.SslProtocols");
-        internal static readonly KnownType System_Security_Cryptography_AesManaged = new("System.Security.Cryptography.AesManaged");
-        internal static readonly KnownType System_Security_Cryptography_AsymmetricAlgorithm = new("System.Security.Cryptography.AsymmetricAlgorithm");
-        internal static readonly KnownType System_Security_Cryptography_AsymmetricKeyExchangeDeformatter = new("System.Security.Cryptography.AsymmetricKeyExchangeDeformatter");
-        internal static readonly KnownType System_Security_Cryptography_AsymmetricKeyExchangeFormatter = new("System.Security.Cryptography.AsymmetricKeyExchangeFormatter");
-        internal static readonly KnownType System_Security_Cryptography_AsymmetricSignatureDeformatter = new("System.Security.Cryptography.AsymmetricSignatureDeformatter");
-        internal static readonly KnownType System_Security_Cryptography_AsymmetricSignatureFormatter = new("System.Security.Cryptography.AsymmetricSignatureFormatter");
-        internal static readonly KnownType System_Security_Cryptography_CryptoConfig = new("System.Security.Cryptography.CryptoConfig");
-        internal static readonly KnownType System_Security_Cryptography_CspParameters = new("System.Security.Cryptography.CspParameters");
-        internal static readonly KnownType System_Security_Cryptography_DES = new("System.Security.Cryptography.DES");
-        internal static readonly KnownType System_Security_Cryptography_DeriveBytes = new("System.Security.Cryptography.DeriveBytes");
-        internal static readonly KnownType System_Security_Cryptography_DSA = new("System.Security.Cryptography.DSA");
-        internal static readonly KnownType System_Security_Cryptography_DSACryptoServiceProvider = new("System.Security.Cryptography.DSACryptoServiceProvider");
-        internal static readonly KnownType System_Security_Cryptography_ECDiffieHellman = new("System.Security.Cryptography.ECDiffieHellman");
-        internal static readonly KnownType System_Security_Cryptography_ECDsa = new("System.Security.Cryptography.ECDsa");
-        internal static readonly KnownType System_Security_Cryptography_HashAlgorithm = new("System.Security.Cryptography.HashAlgorithm");
-        internal static readonly KnownType System_Security_Cryptography_HMAC = new("System.Security.Cryptography.HMAC");
-        internal static readonly KnownType System_Security_Cryptography_HMACMD5 = new("System.Security.Cryptography.HMACMD5");
-        internal static readonly KnownType System_Security_Cryptography_HMACRIPEMD160 = new("System.Security.Cryptography.HMACRIPEMD160");
-        internal static readonly KnownType System_Security_Cryptography_HMACSHA1 = new("System.Security.Cryptography.HMACSHA1");
-        internal static readonly KnownType System_Security_Cryptography_ICryptoTransform = new("System.Security.Cryptography.ICryptoTransform");
-        internal static readonly KnownType System_Security_Cryptography_KeyedHashAlgorithm = new("System.Security.Cryptography.KeyedHashAlgorithm");
-        internal static readonly KnownType System_Security_Cryptography_MD5 = new("System.Security.Cryptography.MD5");
-        internal static readonly KnownType System_Security_Cryptography_PasswordDeriveBytes = new("System.Security.Cryptography.PasswordDeriveBytes");
-        internal static readonly KnownType System_Security_Cryptography_RC2 = new("System.Security.Cryptography.RC2");
-        internal static readonly KnownType System_Security_Cryptography_RandomNumberGenerator = new("System.Security.Cryptography.RandomNumberGenerator");
-        internal static readonly KnownType System_Security_Cryptography_Rfc2898DeriveBytes = new("System.Security.Cryptography.Rfc2898DeriveBytes");
-        internal static readonly KnownType System_Security_Cryptography_RIPEMD160 = new("System.Security.Cryptography.RIPEMD160");
-        internal static readonly KnownType System_Security_Cryptography_RNGCryptoServiceProvider = new("System.Security.Cryptography.RNGCryptoServiceProvider");
-        internal static readonly KnownType System_Security_Cryptography_RSA = new("System.Security.Cryptography.RSA");
-        internal static readonly KnownType System_Security_Cryptography_RSACryptoServiceProvider = new("System.Security.Cryptography.RSACryptoServiceProvider");
-        internal static readonly KnownType System_Security_Cryptography_SHA1 = new("System.Security.Cryptography.SHA1");
-        internal static readonly KnownType System_Security_Cryptography_SymmetricAlgorithm = new("System.Security.Cryptography.SymmetricAlgorithm");
-        internal static readonly KnownType System_Security_Cryptography_TripleDES = new("System.Security.Cryptography.TripleDES");
-        internal static readonly KnownType System_Security_Cryptography_X509Certificates_X509Certificate2 = new("System.Security.Cryptography.X509Certificates.X509Certificate2");
-        internal static readonly KnownType System_Security_Cryptography_X509Certificates_X509Chain = new("System.Security.Cryptography.X509Certificates.X509Chain");
-        internal static readonly KnownType System_Security_Permissions_CodeAccessSecurityAttribute = new("System.Security.Permissions.CodeAccessSecurityAttribute");
-        internal static readonly KnownType System_Security_Permissions_PrincipalPermission = new("System.Security.Permissions.PrincipalPermission");
-        internal static readonly KnownType System_Security_Permissions_PrincipalPermissionAttribute = new("System.Security.Permissions.PrincipalPermissionAttribute");
-        internal static readonly KnownType System_Security_PermissionSet = new("System.Security.PermissionSet");
-        internal static readonly KnownType System_Security_Principal_IIdentity = new("System.Security.Principal.IIdentity");
-        internal static readonly KnownType System_Security_Principal_IPrincipal = new("System.Security.Principal.IPrincipal");
-        internal static readonly KnownType System_Security_Principal_NTAccount = new("System.Security.Principal.NTAccount");
-        internal static readonly KnownType System_Security_Principal_SecurityIdentifier = new("System.Security.Principal.SecurityIdentifier");
-        internal static readonly KnownType System_Security_Principal_WindowsIdentity = new("System.Security.Principal.WindowsIdentity");
-        internal static readonly KnownType System_Security_SecurityCriticalAttribute = new("System.Security.SecurityCriticalAttribute");
-        internal static readonly KnownType System_Security_SecuritySafeCriticalAttribute = new("System.Security.SecuritySafeCriticalAttribute");
-        internal static readonly KnownType System_SerializableAttribute = new("System.SerializableAttribute");
-        internal static readonly KnownType System_ServiceModel_OperationContractAttribute = new("System.ServiceModel.OperationContractAttribute");
-        internal static readonly KnownType System_ServiceModel_ServiceContractAttribute = new("System.ServiceModel.ServiceContractAttribute");
-        internal static readonly KnownType System_Single = new(SpecialType.System_Single, "float");
-        internal static readonly KnownType System_StackOverflowException = new("System.StackOverflowException");
-        internal static readonly KnownType System_STAThreadAttribute = new("System.STAThreadAttribute");
-        internal static readonly KnownType System_String = new(SpecialType.System_String, "string");
-        internal static readonly KnownType System_String_Array = new("string[]");
-        internal static readonly KnownType System_String_Array_VB = new("String()");
-        internal static readonly KnownType System_StringComparison = new("System.StringComparison");
-        internal static readonly KnownType System_SystemException = new("System.SystemException");
-        internal static readonly KnownType System_Text_RegularExpressions_Regex = new("System.Text.RegularExpressions.Regex");
-        internal static readonly KnownType System_Text_StringBuilder = new("System.Text.StringBuilder");
-        internal static readonly KnownType System_Threading_Monitor = new("System.Threading.Monitor");
-        internal static readonly KnownType System_Threading_Mutex = new("System.Threading.Mutex");
-        internal static readonly KnownType System_Threading_ReaderWriterLock = new("System.Threading.ReaderWriterLock");
-        internal static readonly KnownType System_Threading_ReaderWriterLockSlim = new("System.Threading.ReaderWriterLockSlim");
-        internal static readonly KnownType System_Threading_SpinLock = new("System.Threading.SpinLock");
-        internal static readonly KnownType System_Threading_Tasks_Task = new("System.Threading.Tasks.Task");
-        internal static readonly KnownType System_Threading_Tasks_Task_T = new("System.Threading.Tasks.Task<TResult>");
-        internal static readonly KnownType System_Threading_Tasks_TaskFactory = new("System.Threading.Tasks.TaskFactory");
-        internal static readonly KnownType System_Threading_Tasks_ValueTask = new("System.Threading.Tasks.ValueTask");
-        internal static readonly KnownType System_Threading_Tasks_ValueTask_TResult = new("System.Threading.Tasks.ValueTask<TResult>");
-        internal static readonly KnownType System_Threading_Thread = new("System.Threading.Thread");
-        internal static readonly KnownType System_Threading_WaitHandle = new("System.Threading.WaitHandle");
-        internal static readonly KnownType System_ThreadStaticAttribute = new("System.ThreadStaticAttribute");
-        internal static readonly KnownType System_Type = new("System.Type");
-        internal static readonly KnownType System_UInt16 = new(SpecialType.System_UInt16, "ushort");
-        internal static readonly KnownType System_UInt32 = new(SpecialType.System_UInt32, "uint");
-        internal static readonly KnownType System_UInt64 = new(SpecialType.System_UInt64, "ulong");
-        internal static readonly KnownType System_UIntPtr = new(SpecialType.System_UIntPtr, "UIntPtr");
-        internal static readonly KnownType System_Uri = new("System.Uri");
-        internal static readonly KnownType System_ValueType = new(SpecialType.System_ValueType, "ValueType");
-        internal static readonly KnownType System_Web_HttpApplication = new("System.Web.HttpApplication");
-        internal static readonly KnownType System_Web_HttpCookie = new("System.Web.HttpCookie");
-        internal static readonly KnownType System_Web_HttpContext = new("System.Web.HttpContext");
-        internal static readonly KnownType System_Web_HttpResponse = new("System.Web.HttpResponse");
-        internal static readonly KnownType System_Web_HttpResponseBase = new("System.Web.HttpResponseBase");
-        internal static readonly KnownType System_Web_Http_ApiController = new("System.Web.Http.ApiController");
-        internal static readonly KnownType System_Web_Http_Cors_EnableCorsAttribute = new("System.Web.Http.Cors.EnableCorsAttribute");
-        internal static readonly KnownType System_Web_Mvc_NonActionAttribute = new("System.Web.Mvc.NonActionAttribute");
-        internal static readonly KnownType System_Web_Mvc_Controller = new("System.Web.Mvc.Controller");
-        internal static readonly KnownType System_Web_Mvc_HttpPostAttribute = new("System.Web.Mvc.HttpPostAttribute");
-        internal static readonly KnownType System_Web_Mvc_ValidateInputAttribute = new("System.Web.Mvc.ValidateInputAttribute");
-        internal static readonly KnownType System_Web_Script_Serialization_JavaScriptSerializer = new("System.Web.Script.Serialization.JavaScriptSerializer");
-        internal static readonly KnownType System_Web_Script_Serialization_JavaScriptTypeResolver = new("System.Web.Script.Serialization.JavaScriptTypeResolver");
-        internal static readonly KnownType System_Web_Script_Serialization_SimpleTypeResolver = new("System.Web.Script.Serialization.SimpleTypeResolver");
-        internal static readonly KnownType System_Web_UI_LosFormatter = new("System.Web.UI.LosFormatter");
-        internal static readonly KnownType System_Windows_DependencyObject = new("System.Windows.DependencyObject");
-        internal static readonly KnownType System_Windows_Forms_Application = new("System.Windows.Forms.Application");
-        internal static readonly KnownType System_Windows_Markup_ConstructorArgumentAttribute = new("System.Windows.Markup.ConstructorArgumentAttribute");
-        internal static readonly KnownType System_Xml_Serialization_XmlElementAttribute = new("System.Xml.Serialization.XmlElementAttribute");
-        internal static readonly KnownType System_Xml_XmlDocument = new("System.Xml.XmlDocument");
-        internal static readonly KnownType System_Xml_XmlDataDocument = new("System.Xml.XmlDataDocument");
-        internal static readonly KnownType System_Xml_XmlNode = new("System.Xml.XmlNode");
-        internal static readonly KnownType System_Xml_XPath_XPathDocument = new("System.Xml.XPath.XPathDocument");
-        internal static readonly KnownType System_Xml_XmlReader = new("System.Xml.XmlReader");
-        internal static readonly KnownType System_Xml_XmlReaderSettings = new("System.Xml.XmlReaderSettings");
-        internal static readonly KnownType System_Xml_XmlUrlResolver = new("System.Xml.XmlUrlResolver");
-        internal static readonly KnownType System_Xml_XmlTextReader = new("System.Xml.XmlTextReader");
-        internal static readonly KnownType System_Xml_Resolvers_XmlPreloadedResolver = new("System.Xml.Resolvers.XmlPreloadedResolver");
-        internal static readonly KnownType NSubstitute_SubstituteExtensions = new("NSubstitute.SubstituteExtensions");
-        internal static readonly KnownType NSubstitute_Received = new("NSubstitute.Received");
-        internal static readonly ImmutableArray<KnownType> SystemActionVariants =
+        internal static readonly KnownType Void = new SpecialKnownType(SpecialType.System_Void, "void");
+        internal static readonly KnownType Azure_Messaging_ServiceBus_Administration_ServiceBusAdministrationClient = new RegularKnownType("Azure.Messaging.ServiceBus.Administration.ServiceBusAdministrationClient");
+        internal static readonly KnownType Azure_Messaging_ServiceBus_ServiceBusClient = new RegularKnownType("Azure.Messaging.ServiceBus.ServiceBusClient");
+        internal static readonly KnownType Azure_Storage_Blobs_BlobServiceClient = new RegularKnownType("Azure.Storage.Blobs.BlobServiceClient");
+        internal static readonly KnownType Azure_Storage_Queues_QueueServiceClient = new RegularKnownType("Azure.Storage.Queues.QueueServiceClient");
+        internal static readonly KnownType Azure_Storage_Files_Shares_ShareServiceClient = new RegularKnownType("Azure.Storage.Files.Shares.ShareServiceClient");
+        internal static readonly KnownType Azure_Storage_Files_DataLake_DataLakeServiceClient = new RegularKnownType("Azure.Storage.Files.DataLake.DataLakeServiceClient");
+        internal static readonly KnownType Azure_ResourceManager_ArmClient = new RegularKnownType("Azure.ResourceManager.ArmClient");
+        internal static readonly KnownType FluentAssertions_Execution_AssertionScope = new RegularKnownType("FluentAssertions.Execution.AssertionScope");
+        internal static readonly KnownType JWT_Builder_JwtBuilder = new RegularKnownType("JWT.Builder.JwtBuilder");
+        internal static readonly KnownType JWT_IJwtDecoder = new RegularKnownType("JWT.IJwtDecoder");
+        internal static readonly KnownType JWT_JwtDecoderExtensions = new RegularKnownType("JWT.JwtDecoderExtensions");
+        internal static readonly KnownType log4net_Config_XmlConfigurator = new RegularKnownType("log4net.Config.XmlConfigurator");
+        internal static readonly KnownType log4net_Config_DOMConfigurator = new RegularKnownType("log4net.Config.DOMConfigurator");
+        internal static readonly KnownType log4net_Config_BasicConfigurator = new RegularKnownType("log4net.Config.BasicConfigurator");
+        internal static readonly KnownType Microsoft_AspNet_SignalR_Hub = new RegularKnownType("Microsoft.AspNet.SignalR.Hub");
+        internal static readonly KnownType Microsoft_AspNetCore_Builder_DeveloperExceptionPageExtensions = new RegularKnownType("Microsoft.AspNetCore.Builder.DeveloperExceptionPageExtensions");
+        internal static readonly KnownType Microsoft_AspNetCore_Builder_DatabaseErrorPageExtensions = new RegularKnownType("Microsoft.AspNetCore.Builder.DatabaseErrorPageExtensions");
+        internal static readonly KnownType Microsoft_AspNetCore_Cors_Infrastructure_CorsPolicyBuilder = new RegularKnownType("Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder");
+        internal static readonly KnownType Microsoft_AspNetCore_Hosting_HostingEnvironmentExtensions = new RegularKnownType("Microsoft.AspNetCore.Hosting.HostingEnvironmentExtensions");
+        internal static readonly KnownType Microsoft_AspNetCore_Hosting_WebHostBuilderExtensions = new RegularKnownType("Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions");
+        internal static readonly KnownType Microsoft_AspNetCore_Http_CookieOptions = new RegularKnownType("Microsoft.AspNetCore.Http.CookieOptions");
+        internal static readonly KnownType Microsoft_AspNetCore_Http_HeaderDictionaryExtensions = new RegularKnownType("Microsoft.AspNetCore.Http.HeaderDictionaryExtensions");
+        internal static readonly KnownType Microsoft_AspNetCore_Http_IHeaderDictionary = new RegularKnownType("Microsoft.AspNetCore.Http.IHeaderDictionary");
+        internal static readonly KnownType Microsoft_AspNetCore_Http_IRequestCookieCollection = new RegularKnownType("Microsoft.AspNetCore.Http.IRequestCookieCollection");
+        internal static readonly KnownType Microsoft_AspNetCore_Http_IResponseCookies = new RegularKnownType("Microsoft.AspNetCore.Http.IResponseCookies");
+        internal static readonly KnownType Microsoft_AspNetCore_Mvc_Controller = new RegularKnownType("Microsoft.AspNetCore.Mvc.Controller");
+        internal static readonly KnownType Microsoft_AspNetCore_Mvc_ControllerBase = new RegularKnownType("Microsoft.AspNetCore.Mvc.ControllerBase");
+        internal static readonly KnownType Microsoft_AspNetCore_Mvc_ControllerAttribute = new RegularKnownType("Microsoft.AspNetCore.Mvc.ControllerAttribute");
+        internal static readonly KnownType Microsoft_AspNetCore_Mvc_DisableRequestSizeLimitAttribute = new RegularKnownType("Microsoft.AspNetCore.Mvc.DisableRequestSizeLimitAttribute");
+        internal static readonly KnownType Microsoft_AspNetCore_Mvc_FromServicesAttribute = new RegularKnownType("Microsoft.AspNetCore.Mvc.FromServicesAttribute");
+        internal static readonly KnownType Microsoft_AspNetCore_Mvc_IgnoreAntiforgeryTokenAttribute = new RegularKnownType("Microsoft.AspNetCore.Mvc.IgnoreAntiforgeryTokenAttribute");
+        internal static readonly KnownType Microsoft_AspNetCore_Mvc_NonActionAttribute = new RegularKnownType("Microsoft.AspNetCore.Mvc.NonActionAttribute");
+        internal static readonly KnownType Microsoft_AspNetCore_Mvc_NonControllerAttribute = new RegularKnownType("Microsoft.AspNetCore.Mvc.NonControllerAttribute");
+        internal static readonly KnownType Microsoft_AspNetCore_Mvc_RequestFormLimitsAttribute = new RegularKnownType("Microsoft.AspNetCore.Mvc.RequestFormLimitsAttribute");
+        internal static readonly KnownType Microsoft_AspNetCore_Mvc_RequestSizeLimitAttribute = new RegularKnownType("Microsoft.AspNetCore.Mvc.RequestSizeLimitAttribute");
+        internal static readonly KnownType Microsoft_AspNetCore_Razor_Hosting_RazorCompiledItemAttribute = new RegularKnownType("Microsoft.AspNetCore.Razor.Hosting.RazorCompiledItemAttribute");
+        internal static readonly KnownType Microsoft_Azure_Cosmos_CosmosClient = new RegularKnownType("Microsoft.Azure.Cosmos.CosmosClient");
+        internal static readonly KnownType Microsoft_Azure_Documents_Client_DocumentClient = new RegularKnownType("Microsoft.Azure.Documents.Client.DocumentClient");
+        internal static readonly KnownType Microsoft_Azure_ServiceBus_Management_ManagementClient = new RegularKnownType("Microsoft.Azure.ServiceBus.Management.ManagementClient");
+        internal static readonly KnownType Microsoft_Azure_ServiceBus_QueueClient = new RegularKnownType("Microsoft.Azure.ServiceBus.QueueClient");
+        internal static readonly KnownType Microsoft_Azure_ServiceBus_SessionClient = new RegularKnownType("Microsoft.Azure.ServiceBus.SessionClient");
+        internal static readonly KnownType Microsoft_Azure_ServiceBus_SubscriptionClient = new RegularKnownType("Microsoft.Azure.ServiceBus.SubscriptionClient");
+        internal static readonly KnownType Microsoft_Azure_ServiceBus_TopicClient = new RegularKnownType("Microsoft.Azure.ServiceBus.TopicClient");
+        internal static readonly KnownType Microsoft_Azure_WebJobs_Extensions_DurableTask_IDurableEntityClient = new RegularKnownType("Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityClient");
+        internal static readonly KnownType Microsoft_Azure_WebJobs_Extensions_DurableTask_IDurableEntityContext = new RegularKnownType("Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableEntityContext");
+        internal static readonly KnownType Microsoft_Azure_WebJobs_Extensions_DurableTask_IDurableOrchestrationContext = new RegularKnownType("Microsoft.Azure.WebJobs.Extensions.DurableTask.IDurableOrchestrationContext");
+        internal static readonly KnownType Microsoft_Azure_WebJobs_FunctionNameAttribute = new RegularKnownType("Microsoft.Azure.WebJobs.FunctionNameAttribute");
+        internal static readonly KnownType Microsoft_Data_Sqlite_SqliteCommand = new RegularKnownType("Microsoft.Data.Sqlite.SqliteCommand");
+        internal static readonly KnownType Microsoft_EntityFrameworkCore_DbContextOptionsBuilder = new RegularKnownType("Microsoft.EntityFrameworkCore.DbContextOptionsBuilder");
+        internal static readonly KnownType Microsoft_EntityFrameworkCore_Migrations_Migration = new RegularKnownType("Microsoft.EntityFrameworkCore.Migrations.Migration");
+        internal static readonly KnownType Microsoft_EntityFrameworkCore_MySQLDbContextOptionsExtensions = new RegularKnownType("Microsoft.EntityFrameworkCore.MySQLDbContextOptionsExtensions");
+        internal static readonly KnownType Microsoft_EntityFrameworkCore_NpgsqlDbContextOptionsExtensions = new RegularKnownType("Microsoft.EntityFrameworkCore.NpgsqlDbContextOptionsExtensions");
+        internal static readonly KnownType Microsoft_EntityFrameworkCore_NpgsqlDbContextOptionsBuilderExtensions = new RegularKnownType("Microsoft.EntityFrameworkCore.NpgsqlDbContextOptionsBuilderExtensions");
+        internal static readonly KnownType Microsoft_EntityFrameworkCore_OracleDbContextOptionsExtensions = new RegularKnownType("Microsoft.EntityFrameworkCore.OracleDbContextOptionsExtensions");
+        internal static readonly KnownType Microsoft_EntityFrameworkCore_RawSqlString = new RegularKnownType("Microsoft.EntityFrameworkCore.RawSqlString");
+        internal static readonly KnownType Microsoft_EntityFrameworkCore_RelationalDatabaseFacadeExtensions = new RegularKnownType("Microsoft.EntityFrameworkCore.RelationalDatabaseFacadeExtensions");
+        internal static readonly KnownType Microsoft_EntityFrameworkCore_RelationalQueryableExtensions = new RegularKnownType("Microsoft.EntityFrameworkCore.RelationalQueryableExtensions");
+        internal static readonly KnownType Microsoft_EntityFrameworkCore_SqliteDbContextOptionsBuilderExtensions = new RegularKnownType("Microsoft.EntityFrameworkCore.SqliteDbContextOptionsBuilderExtensions");
+        internal static readonly KnownType Microsoft_EntityFrameworkCore_SqlServerDbContextOptionsExtensions = new RegularKnownType("Microsoft.EntityFrameworkCore.SqlServerDbContextOptionsExtensions");
+        internal static readonly KnownType Microsoft_Extensions_DependencyInjection_LoggingServiceCollectionExtensions = new RegularKnownType("Microsoft.Extensions.DependencyInjection.LoggingServiceCollectionExtensions");
+        internal static readonly KnownType Microsoft_Extensions_Hosting_HostEnvironmentEnvExtensions = new RegularKnownType("Microsoft.Extensions.Hosting.HostEnvironmentEnvExtensions");
+        internal static readonly KnownType Microsoft_Extensions_Logging_AzureAppServicesLoggerFactoryExtensions = new RegularKnownType("Microsoft.Extensions.Logging.AzureAppServicesLoggerFactoryExtensions");
+        internal static readonly KnownType Microsoft_Extensions_Logging_ConsoleLoggerExtensions = new RegularKnownType("Microsoft.Extensions.Logging.ConsoleLoggerExtensions");
+        internal static readonly KnownType Microsoft_Extensions_Logging_DebugLoggerFactoryExtensions = new RegularKnownType("Microsoft.Extensions.Logging.DebugLoggerFactoryExtensions");
+        internal static readonly KnownType Microsoft_Extensions_Logging_EventLoggerFactoryExtensions = new RegularKnownType("Microsoft.Extensions.Logging.EventLoggerFactoryExtensions");
+        internal static readonly KnownType Microsoft_Extensions_Logging_EventSourceLoggerFactoryExtensions = new RegularKnownType("Microsoft.Extensions.Logging.EventSourceLoggerFactoryExtensions");
+        internal static readonly KnownType Microsoft_Extensions_Logging_ILogger = new RegularKnownType("Microsoft.Extensions.Logging.ILogger");
+        internal static readonly KnownType Microsoft_Extensions_Logging_ILoggerFactory = new RegularKnownType("Microsoft.Extensions.Logging.ILoggerFactory");
+        internal static readonly KnownType Microsoft_Extensions_Logging_LoggerExtensions = new RegularKnownType("Microsoft.Extensions.Logging.LoggerExtensions");
+        internal static readonly KnownType Microsoft_Extensions_Primitives_StringValues = new RegularKnownType("Microsoft.Extensions.Primitives.StringValues");
+        internal static readonly KnownType Microsoft_Net_Http_Headers_HeaderNames = new RegularKnownType("Microsoft.Net.Http.Headers.HeaderNames");
+        internal static readonly KnownType Microsoft_VisualBasic_Interaction = new RegularKnownType("Microsoft.VisualBasic.Interaction");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_Assert = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.Assert");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_AssertFailedException = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_ExpectedExceptionAttribute = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.ExpectedExceptionAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_IgnoreAttribute = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.IgnoreAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestClassAttribute = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestMethodAttribute = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_DataTestMethodAttribute = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.DataTestMethodAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_WorkItemAttribute = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.WorkItemAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_AssemblyCleanupAttribute = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyCleanupAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_AssemblyInitializeAttribute = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyInitializeAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_ClassCleanupAttribute = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_ClassInitializeAttribute = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.ClassInitializeAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestCleanupAttribute = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.TestCleanupAttribute");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestInitializeAttribute = new RegularKnownType("Microsoft.VisualStudio.TestTools.UnitTesting.TestInitializeAttribute");
+        internal static readonly KnownType Microsoft_Web_XmlTransform_XmlFileInfoDocument = new RegularKnownType("Microsoft.Web.XmlTransform.XmlFileInfoDocument");
+        internal static readonly KnownType Microsoft_Web_XmlTransform_XmlTransformableDocument = new RegularKnownType("Microsoft.Web.XmlTransform.XmlTransformableDocument");
+        internal static readonly KnownType Mono_Unix_FileAccessPermissions = new RegularKnownType("Mono.Unix.FileAccessPermissions");
+        internal static readonly KnownType MySql_Data_MySqlClient_MySqlDataAdapter = new RegularKnownType("MySql.Data.MySqlClient.MySqlDataAdapter");
+        internal static readonly KnownType MySql_Data_MySqlClient_MySqlCommand = new RegularKnownType("MySql.Data.MySqlClient.MySqlCommand");
+        internal static readonly KnownType MySql_Data_MySqlClient_MySqlHelper = new RegularKnownType("MySql.Data.MySqlClient.MySqlHelper");
+        internal static readonly KnownType MySql_Data_MySqlClient_MySqlScript = new RegularKnownType("MySql.Data.MySqlClient.MySqlScript");
+        internal static readonly KnownType Nancy_Cookies_NancyCookie = new RegularKnownType("Nancy.Cookies.NancyCookie");
+        internal static readonly KnownType NFluent_Check = new RegularKnownType("NFluent.Check");
+        internal static readonly KnownType NFluent_FluentCheckException = new RegularKnownType("NFluent.FluentCheckException");
+        internal static readonly KnownType NFluent_Kernel_FluentCheckException = new RegularKnownType("NFluent.Kernel.FluentCheckException");
+        internal static readonly KnownType NLog_LogManager = new RegularKnownType("NLog.LogManager");
+        internal static readonly KnownType NUnit_Framework_Assert = new RegularKnownType("NUnit.Framework.Assert");
+        internal static readonly KnownType NUnit_Framework_AssertionException = new RegularKnownType("NUnit.Framework.AssertionException");
+        internal static readonly KnownType NUnit_Framework_ExpectedExceptionAttribute = new RegularKnownType("NUnit.Framework.ExpectedExceptionAttribute");
+        internal static readonly KnownType NUnit_Framework_IgnoreAttribute = new RegularKnownType("NUnit.Framework.IgnoreAttribute");
+        internal static readonly KnownType NUnit_Framework_ITestBuilderInterface = new RegularKnownType("NUnit.Framework.Interfaces.ITestBuilder");
+        internal static readonly KnownType NUnit_Framework_TestAttribute = new RegularKnownType("NUnit.Framework.TestAttribute");
+        internal static readonly KnownType NUnit_Framework_TestCaseAttribute = new RegularKnownType("NUnit.Framework.TestCaseAttribute");
+        internal static readonly KnownType NUnit_Framework_TestCaseSourceAttribute = new RegularKnownType("NUnit.Framework.TestCaseSourceAttribute");
+        internal static readonly KnownType NUnit_Framework_TestFixtureAttribute = new RegularKnownType("NUnit.Framework.TestFixtureAttribute");
+        internal static readonly KnownType NUnit_Framework_TheoryAttribute = new RegularKnownType("NUnit.Framework.TheoryAttribute");
+        internal static readonly KnownType Org_BouncyCastle_Asn1_Nist_NistNamedCurves = new RegularKnownType("Org.BouncyCastle.Asn1.Nist.NistNamedCurves");
+        internal static readonly KnownType Org_BouncyCastle_Asn1_Sec_SecNamedCurves = new RegularKnownType("Org.BouncyCastle.Asn1.Sec.SecNamedCurves");
+        internal static readonly KnownType Org_BouncyCastle_Asn1_TeleTrust_TeleTrusTNamedCurves = new RegularKnownType("Org.BouncyCastle.Asn1.TeleTrust.TeleTrusTNamedCurves");
+        internal static readonly KnownType Org_BouncyCastle_Asn1_X9_ECNamedCurveTable = new RegularKnownType("Org.BouncyCastle.Asn1.X9.ECNamedCurveTable");
+        internal static readonly KnownType Org_BouncyCastle_Asn1_X9_X962NamedCurves = new RegularKnownType("Org.BouncyCastle.Asn1.X9.X962NamedCurves");
+        internal static readonly KnownType Org_BouncyCastle_Crypto_Engines_AesFastEngine = new RegularKnownType("Org.BouncyCastle.Crypto.Engines.AesFastEngine");
+        internal static readonly KnownType Org_BouncyCastle_Crypto_Generators_DHParametersGenerator = new RegularKnownType("Org.BouncyCastle.Crypto.Generators.DHParametersGenerator");
+        internal static readonly KnownType Org_BouncyCastle_Crypto_Generators_DsaParametersGenerator = new RegularKnownType("Org.BouncyCastle.Crypto.Generators.DsaParametersGenerator");
+        internal static readonly KnownType Org_BouncyCastle_Crypto_Parameters_RsaKeyGenerationParameters = new RegularKnownType("Org.BouncyCastle.Crypto.Parameters.RsaKeyGenerationParameters");
+        internal static readonly KnownType Serilog_LoggerConfiguration = new RegularKnownType("Serilog.LoggerConfiguration");
+        internal static readonly KnownType System_Action = new RegularKnownType("System.Action");
+        internal static readonly KnownType System_Action_T = new RegularKnownType("System.Action", "T");
+        internal static readonly KnownType System_Action_T1_T2 = new RegularKnownType("System.Action", "T1", "T2");
+        internal static readonly KnownType System_Action_T1_T2_T3 = new RegularKnownType("System.Action", "T1", "T2", "T3");
+        internal static readonly KnownType System_Action_T1_T2_T3_T4 = new RegularKnownType("System.Action", "T1", "T2", "T3", "T4");
+        internal static readonly KnownType System_Activator = new RegularKnownType("System.Activator");
+        internal static readonly KnownType System_ApplicationException = new RegularKnownType("System.ApplicationException");
+        internal static readonly KnownType System_AppDomain = new RegularKnownType("System.AppDomain");
+        internal static readonly KnownType System_ArgumentException = new RegularKnownType("System.ArgumentException");
+        internal static readonly KnownType System_ArgumentNullException = new RegularKnownType("System.ArgumentNullException");
+        internal static readonly KnownType System_ArgumentOutOfRangeException = new RegularKnownType("System.ArgumentOutOfRangeException");
+        internal static readonly KnownType System_Array = new SpecialKnownType(SpecialType.System_Array, "System.Array");
+        internal static readonly KnownType System_Attribute = new RegularKnownType("System.Attribute");
+        internal static readonly KnownType System_AttributeUsageAttribute = new RegularKnownType("System.AttributeUsageAttribute");
+        internal static readonly KnownType System_Boolean = new SpecialKnownType(SpecialType.System_Boolean, "bool");
+        internal static readonly KnownType System_Byte = new SpecialKnownType(SpecialType.System_Byte, "byte");
+        internal static readonly KnownType System_Byte_Array = new RegularKnownType("System.Byte") { IsArray = true };
+        internal static readonly KnownType System_Char = new SpecialKnownType(SpecialType.System_Char, "char");
+        internal static readonly KnownType System_CLSCompliantAttribute = new RegularKnownType("System.CLSCompliantAttribute");
+        internal static readonly KnownType System_CodeDom_Compiler_GeneratedCodeAttribute = new RegularKnownType("System.CodeDom.Compiler.GeneratedCodeAttribute");
+        internal static readonly KnownType System_Collections_CollectionBase = new RegularKnownType("System.Collections.CollectionBase");
+        internal static readonly KnownType System_Collections_DictionaryBase = new RegularKnownType("System.Collections.DictionaryBase");
+        internal static readonly KnownType System_Collections_Generic_Dictionary_TKey_TValue = new RegularKnownType("System.Collections.Generic.Dictionary", "TKey", "TValue");
+        internal static readonly KnownType System_Collections_Generic_HashSet_T = new RegularKnownType("System.Collections.Generic.HashSet", "T");
+        internal static readonly KnownType System_Collections_Generic_IAsyncEnumerable_T = new RegularKnownType("System.Collections.Generic.IAsyncEnumerable", "T");
+        internal static readonly KnownType System_Collections_Generic_ICollection_T = new SpecialKnownType(SpecialType.System_Collections_Generic_ICollection_T, "System.Collections.Generic.ICollection<T>");
+        internal static readonly KnownType System_Collections_Generic_IDictionary_TKey_TValue = new RegularKnownType("System.Collections.Generic.IDictionary", "TKey", "TValue");
+        internal static readonly KnownType System_Collections_Generic_IEnumerable_T = new SpecialKnownType(SpecialType.System_Collections_Generic_IEnumerable_T, "System.Collections.Generic.IEnumerable<T>");
+        internal static readonly KnownType System_Collections_Generic_IList_T = new SpecialKnownType(SpecialType.System_Collections_Generic_IList_T, "System.Collections.Generic.IList<T>");
+        internal static readonly KnownType System_Collections_Generic_IReadOnlyCollection_T = new SpecialKnownType(SpecialType.System_Collections_Generic_IReadOnlyCollection_T, "System.Collections.Generic.IReadOnlyCollection<T>");
+        internal static readonly KnownType System_Collections_Generic_ISet_T = new RegularKnownType("System.Collections.Generic.ISet", "T");
+        internal static readonly KnownType System_Collections_Generic_KeyValuePair_TKey_TValue = new RegularKnownType("System.Collections.Generic.KeyValuePair", "TKey", "TValue");
+        internal static readonly KnownType System_Collections_Generic_List_T = new RegularKnownType("System.Collections.Generic.List", "T");
+        internal static readonly KnownType System_Collections_Generic_Queue_T = new RegularKnownType("System.Collections.Generic.Queue", "T");
+        internal static readonly KnownType System_Collections_Generic_Stack_T = new RegularKnownType("System.Collections.Generic.Stack", "T");
+        internal static readonly KnownType System_Collections_ICollection = new RegularKnownType("System.Collections.ICollection");
+        internal static readonly KnownType System_Collections_IEnumerable = new SpecialKnownType(SpecialType.System_Collections_IEnumerable, "System.Collections.IEnumerable");
+        internal static readonly KnownType System_Collections_IList = new RegularKnownType("System.Collections.IList");
+        internal static readonly KnownType System_Collections_Immutable_IImmutableArray_T = new RegularKnownType("System.Collections.Immutable.IImmutableArray", "T");
+        internal static readonly KnownType System_Collections_Immutable_IImmutableDictionary_TKey_TValue = new RegularKnownType("System.Collections.Immutable.IImmutableDictionary", "TKey", "TValue");
+        internal static readonly KnownType System_Collections_Immutable_IImmutableList_T = new RegularKnownType("System.Collections.Immutable.IImmutableList", "T");
+        internal static readonly KnownType System_Collections_Immutable_IImmutableQueue_T = new RegularKnownType("System.Collections.Immutable.IImmutableQueue", "T");
+        internal static readonly KnownType System_Collections_Immutable_IImmutableSet_T = new RegularKnownType("System.Collections.Immutable.IImmutableSet", "T");
+        internal static readonly KnownType System_Collections_Immutable_IImmutableStack_T = new RegularKnownType("System.Collections.Immutable.IImmutableStack", "T");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableArray = new RegularKnownType("System.Collections.Immutable.ImmutableArray");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableArray_T = new RegularKnownType("System.Collections.Immutable.ImmutableArray", "T");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableDictionary = new RegularKnownType("System.Collections.Immutable.ImmutableDictionary");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableDictionary_TKey_TValue = new RegularKnownType("System.Collections.Immutable.ImmutableDictionary", "TKey", "TValue");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableHashSet = new RegularKnownType("System.Collections.Immutable.ImmutableHashSet");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableHashSet_T = new RegularKnownType("System.Collections.Immutable.ImmutableHashSet", "T");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableList = new RegularKnownType("System.Collections.Immutable.ImmutableList");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableList_T = new RegularKnownType("System.Collections.Immutable.ImmutableList", "T");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableQueue = new RegularKnownType("System.Collections.Immutable.ImmutableQueue");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableQueue_T = new RegularKnownType("System.Collections.Immutable.ImmutableQueue", "T");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableSortedDictionary = new RegularKnownType("System.Collections.Immutable.ImmutableSortedDictionary");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableSortedDictionary_TKey_TValue = new RegularKnownType("System.Collections.Immutable.ImmutableSortedDictionary", "TKey", "TValue");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableSortedSet = new RegularKnownType("System.Collections.Immutable.ImmutableSortedSet");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableSortedSet_T = new RegularKnownType("System.Collections.Immutable.ImmutableSortedSet", "T");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableStack = new RegularKnownType("System.Collections.Immutable.ImmutableStack");
+        internal static readonly KnownType System_Collections_Immutable_ImmutableStack_T = new RegularKnownType("System.Collections.Immutable.ImmutableStack", "T");
+        internal static readonly KnownType System_Collections_ObjectModel_Collection_T = new RegularKnownType("System.Collections.ObjectModel.Collection", "T");
+        internal static readonly KnownType System_Collections_ObjectModel_ObservableCollection_T = new RegularKnownType("System.Collections.ObjectModel.ObservableCollection", "T");
+        internal static readonly KnownType System_Collections_ObjectModel_ReadOnlyCollection_T = new RegularKnownType("System.Collections.ObjectModel.ReadOnlyCollection", "T");
+        internal static readonly KnownType System_Collections_ObjectModel_ReadOnlyDictionary_TKey_TValue = new RegularKnownType("System.Collections.ObjectModel.ReadOnlyDictionary", "TKey", "TValue");
+        internal static readonly KnownType System_Collections_Queue = new RegularKnownType("System.Collections.Queue");
+        internal static readonly KnownType System_Collections_ReadOnlyCollectionBase = new RegularKnownType("System.Collections.ReadOnlyCollectionBase");
+        internal static readonly KnownType System_Collections_SortedList = new RegularKnownType("System.Collections.SortedList");
+        internal static readonly KnownType System_Collections_Stack = new RegularKnownType("System.Collections.Stack");
+        internal static readonly KnownType System_Collections_Specialized_NameObjectCollectionBase = new RegularKnownType("System.Collections.Specialized.NameObjectCollectionBase");
+        internal static readonly KnownType System_Collections_Specialized_NameValueCollection = new RegularKnownType("System.Collections.Specialized.NameValueCollection");
+        internal static readonly KnownType System_Composition_ExportAttribute = new RegularKnownType("System.Composition.ExportAttribute");
+        internal static readonly KnownType System_ComponentModel_DefaultValueAttribute = new RegularKnownType("System.ComponentModel.DefaultValueAttribute");
+        internal static readonly KnownType System_ComponentModel_EditorBrowsableAttribute = new RegularKnownType("System.ComponentModel.EditorBrowsableAttribute");
+        internal static readonly KnownType System_ComponentModel_LocalizableAttribute = new RegularKnownType("System.ComponentModel.LocalizableAttribute");
+        internal static readonly KnownType System_ComponentModel_Composition_CreationPolicy = new RegularKnownType("System.ComponentModel.Composition.CreationPolicy");
+        internal static readonly KnownType System_ComponentModel_Composition_ExportAttribute = new RegularKnownType("System.ComponentModel.Composition.ExportAttribute");
+        internal static readonly KnownType System_ComponentModel_Composition_InheritedExportAttribute = new RegularKnownType("System.ComponentModel.Composition.InheritedExportAttribute");
+        internal static readonly KnownType System_ComponentModel_Composition_PartCreationPolicyAttribute = new RegularKnownType("System.ComponentModel.Composition.PartCreationPolicyAttribute");
+        internal static readonly KnownType System_Configuration_ConfigXmlDocument = new RegularKnownType("System.Configuration.ConfigXmlDocument");
+        internal static readonly KnownType System_Console = new RegularKnownType("System.Console");
+        internal static readonly KnownType System_Data_Common_CommandTrees_DbExpression = new RegularKnownType("System.Data.Common.CommandTrees.DbExpression");
+        internal static readonly KnownType System_Data_DataSet = new RegularKnownType("System.Data.DataSet");
+        internal static readonly KnownType System_Data_DataTable = new RegularKnownType("System.Data.DataTable");
+        internal static readonly KnownType System_Data_Odbc_OdbcCommand = new RegularKnownType("System.Data.Odbc.OdbcCommand");
+        internal static readonly KnownType System_Data_Odbc_OdbcDataAdapter = new RegularKnownType("System.Data.Odbc.OdbcDataAdapter");
+        internal static readonly KnownType System_Data_OracleClient_OracleCommand = new RegularKnownType("System.Data.OracleClient.OracleCommand");
+        internal static readonly KnownType System_Data_OracleClient_OracleDataAdapter = new RegularKnownType("System.Data.OracleClient.OracleDataAdapter");
+        internal static readonly KnownType System_Data_SqlClient_SqlCommand = new RegularKnownType("System.Data.SqlClient.SqlCommand");
+        internal static readonly KnownType System_Data_SqlClient_SqlDataAdapter = new RegularKnownType("System.Data.SqlClient.SqlDataAdapter");
+        internal static readonly KnownType System_Data_Sqlite_SqliteCommand = new RegularKnownType("System.Data.SQLite.SQLiteCommand");
+        internal static readonly KnownType System_Data_Sqlite_SQLiteDataAdapter = new RegularKnownType("System.Data.SQLite.SQLiteDataAdapter");
+        internal static readonly KnownType System_Data_SqlServerCe_SqlCeCommand = new RegularKnownType("System.Data.SqlServerCe.SqlCeCommand");
+        internal static readonly KnownType System_Data_SqlServerCe_SqlCeDataAdapter = new RegularKnownType("System.Data.SqlServerCe.SqlCeDataAdapter");
+        internal static readonly KnownType System_DateTime = new SpecialKnownType(SpecialType.System_DateTime, "DateTime");
+        internal static readonly KnownType System_DateTimeOffset = new RegularKnownType("System.DateTimeOffset");
+        internal static readonly KnownType System_Decimal = new SpecialKnownType(SpecialType.System_Decimal, "decimal");
+        internal static readonly KnownType System_Delegate = new RegularKnownType("System.Delegate");
+        internal static readonly KnownType System_Diagnostics_CodeAnalysis_ExcludeFromCodeCoverageAttribute = new RegularKnownType("System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute");
+        internal static readonly KnownType System_Diagnostics_CodeAnalysis_SuppressMessageAttribute = new RegularKnownType("System.Diagnostics.CodeAnalysis.SuppressMessageAttribute");
+        internal static readonly KnownType System_Diagnostics_ConditionalAttribute = new RegularKnownType("System.Diagnostics.ConditionalAttribute");
+        internal static readonly KnownType System_Diagnostics_Contracts_PureAttribute = new RegularKnownType("System.Diagnostics.Contracts.PureAttribute");
+        internal static readonly KnownType System_Diagnostics_Debug = new RegularKnownType("System.Diagnostics.Debug");
+        internal static readonly KnownType System_Diagnostics_DebuggerDisplayAttribute = new RegularKnownType("System.Diagnostics.DebuggerDisplayAttribute");
+        internal static readonly KnownType System_Diagnostics_Process = new RegularKnownType("System.Diagnostics.Process");
+        internal static readonly KnownType System_Diagnostics_ProcessStartInfo = new RegularKnownType("System.Diagnostics.ProcessStartInfo");
+        internal static readonly KnownType System_Diagnostics_Trace = new RegularKnownType("System.Diagnostics.Trace");
+        internal static readonly KnownType System_Diagnostics_TraceSource = new RegularKnownType("System.Diagnostics.TraceSource");
+        internal static readonly KnownType System_DirectoryServices_AuthenticationTypes = new RegularKnownType("System.DirectoryServices.AuthenticationTypes");
+        internal static readonly KnownType System_DirectoryServices_DirectoryEntry = new RegularKnownType("System.DirectoryServices.DirectoryEntry");
+        internal static readonly KnownType System_Double = new SpecialKnownType(SpecialType.System_Double, "double");
+        internal static readonly KnownType System_Drawing_Bitmap = new RegularKnownType("System.Drawing.Bitmap");
+        internal static readonly KnownType System_Drawing_Image = new RegularKnownType("System.Drawing.Image");
+        internal static readonly KnownType System_DuplicateWaitObjectException = new RegularKnownType("System.DuplicateWaitObjectException");
+        internal static readonly KnownType System_Enum = new SpecialKnownType(SpecialType.System_Enum, "Enum");
+        internal static readonly KnownType System_Environment = new RegularKnownType("System.Environment");
+        internal static readonly KnownType System_EventArgs = new RegularKnownType("System.EventArgs");
+        internal static readonly KnownType System_EventHandler = new RegularKnownType("System.EventHandler");
+        internal static readonly KnownType System_EventHandler_TEventArgs = new RegularKnownType("System.EventHandler", "TEventArgs");
+        internal static readonly KnownType System_Exception = new RegularKnownType("System.Exception");
+        internal static readonly KnownType System_ExecutionEngineException = new RegularKnownType("System.ExecutionEngineException");
+        internal static readonly KnownType System_FlagsAttribute = new RegularKnownType("System.FlagsAttribute");
+        internal static readonly KnownType System_Func_TResult = new RegularKnownType("System.Func", "TResult");
+        internal static readonly KnownType System_Func_T_TResult = new RegularKnownType("System.Func", "T", "TResult");
+        internal static readonly KnownType System_Func_T1_T2_TResult = new RegularKnownType("System.Func", "T1", "T2", "TResult");
+        internal static readonly KnownType System_Func_T1_T2_T3_TResult = new RegularKnownType("System.Func", "T1", "T2", "T3", "TResult");
+        internal static readonly KnownType System_Func_T1_T2_T3_T4_TResult = new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "TResult");
+        internal static readonly KnownType System_GC = new RegularKnownType("System.GC");
+        internal static readonly KnownType System_Globalization_CompareOptions = new RegularKnownType("System.Globalization.CompareOptions");
+        internal static readonly KnownType System_Globalization_CultureInfo = new RegularKnownType("System.Globalization.CultureInfo");
+        internal static readonly KnownType System_Guid = new RegularKnownType("System.Guid");
+        internal static readonly KnownType System_IAsyncDisposable = new RegularKnownType("System.IAsyncDisposable");
+        internal static readonly KnownType System_IComparable = new RegularKnownType("System.IComparable");
+        internal static readonly KnownType System_IComparable_T = new RegularKnownType("System.IComparable", "T");
+        internal static readonly KnownType System_IdentityModel_Tokens_SecurityTokenHandler = new RegularKnownType("System.IdentityModel.Tokens.SecurityTokenHandler");
+        internal static readonly KnownType System_IDisposable = new SpecialKnownType(SpecialType.System_IDisposable, "System.IDisposable");
+        internal static readonly KnownType System_IEquatable_T = new RegularKnownType("System.IEquatable", "T");
+        internal static readonly KnownType System_IFormatProvider = new RegularKnownType("System.IFormatProvider");
+        internal static readonly KnownType System_Index = new RegularKnownType("System.Index");
+        internal static readonly KnownType System_IndexOutOfRangeException = new RegularKnownType("System.IndexOutOfRangeException");
+        internal static readonly KnownType System_Int16 = new SpecialKnownType(SpecialType.System_Int16, "short");
+        internal static readonly KnownType System_Int32 = new SpecialKnownType(SpecialType.System_Int32, "int");
+        internal static readonly KnownType System_Int64 = new SpecialKnownType(SpecialType.System_Int64, "long");
+        internal static readonly KnownType System_IntPtr = new SpecialKnownType(SpecialType.System_IntPtr, "IntPtr");
+        internal static readonly KnownType System_InvalidOperationException = new RegularKnownType("System.InvalidOperationException");
+        internal static readonly KnownType System_IO_Compression_ZipFile = new RegularKnownType("System.IO.Compression.ZipFile");
+        internal static readonly KnownType System_IO_Compression_ZipFileExtensions = new RegularKnownType("System.IO.Compression.ZipFileExtensions");
+        internal static readonly KnownType System_IO_FileStream = new RegularKnownType("System.IO.FileStream");
+        internal static readonly KnownType System_IO_Path = new RegularKnownType("System.IO.Path");
+        internal static readonly KnownType System_IO_Stream = new RegularKnownType("System.IO.Stream");
+        internal static readonly KnownType System_IO_StreamReader = new RegularKnownType("System.IO.StreamReader");
+        internal static readonly KnownType System_IO_StreamWriter = new RegularKnownType("System.IO.StreamWriter");
+        internal static readonly KnownType System_IO_TextWriter = new RegularKnownType("System.IO.TextWriter");
+        internal static readonly KnownType System_Lazy = new RegularKnownType("System.Lazy", "T");
+        internal static readonly KnownType System_Linq_Enumerable = new RegularKnownType("System.Linq.Enumerable");
+        internal static readonly KnownType System_Linq_Expressions_Expression_T = new RegularKnownType("System.Linq.Expressions.Expression", "TDelegate");
+        internal static readonly KnownType System_Linq_ImmutableArrayExtensions = new RegularKnownType("System.Linq.ImmutableArrayExtensions");
+        internal static readonly KnownType System_MarshalByRefObject = new RegularKnownType("System.MarshalByRefObject");
+        internal static readonly KnownType System_MTAThreadAttribute = new RegularKnownType("System.MTAThreadAttribute");
+        internal static readonly KnownType System_Net_FtpWebRequest = new RegularKnownType("System.Net.FtpWebRequest");
+        internal static readonly KnownType System_Net_Http_Headers_HttpHeaders = new RegularKnownType("System.Net.Http.Headers.HttpHeaders");
+        internal static readonly KnownType System_Net_Http_HttpClient = new RegularKnownType("System.Net.Http.HttpClient");
+        internal static readonly KnownType System_Net_Http_HttpClientHandler = new RegularKnownType("System.Net.Http.HttpClientHandler");
+        internal static readonly KnownType System_Net_Mail_SmtpClient = new RegularKnownType("System.Net.Mail.SmtpClient");
+        internal static readonly KnownType System_Net_NetworkCredential = new RegularKnownType("System.Net.NetworkCredential");
+        internal static readonly KnownType System_Net_Security_RemoteCertificateValidationCallback = new RegularKnownType("System.Net.Security.RemoteCertificateValidationCallback");
+        internal static readonly KnownType System_Net_Security_SslPolicyErrors = new RegularKnownType("System.Net.Security.SslPolicyErrors");
+        internal static readonly KnownType System_Net_SecurityProtocolType = new RegularKnownType("System.Net.SecurityProtocolType");
+        internal static readonly KnownType System_Net_Sockets_Socket = new RegularKnownType("System.Net.Sockets.Socket");
+        internal static readonly KnownType System_Net_Sockets_TcpClient = new RegularKnownType("System.Net.Sockets.TcpClient");
+        internal static readonly KnownType System_Net_Sockets_UdpClient = new RegularKnownType("System.Net.Sockets.UdpClient");
+        internal static readonly KnownType System_Net_WebClient = new RegularKnownType("System.Net.WebClient");
+        internal static readonly KnownType System_NotImplementedException = new RegularKnownType("System.NotImplementedException");
+        internal static readonly KnownType System_NotSupportedException = new RegularKnownType("System.NotSupportedException");
+        internal static readonly KnownType System_Nullable_T = new SpecialKnownType(SpecialType.System_Nullable_T, "System.Nullable<T>");
+        internal static readonly KnownType System_NullReferenceException = new RegularKnownType("System.NullReferenceException");
+        internal static readonly KnownType System_Object = new SpecialKnownType(SpecialType.System_Object, "object");
+        internal static readonly KnownType System_ObsoleteAttribute = new RegularKnownType("System.ObsoleteAttribute");
+        internal static readonly KnownType System_OutOfMemoryException = new RegularKnownType("System.OutOfMemoryException");
+        internal static readonly KnownType System_Random = new RegularKnownType("System.Random");
+        internal static readonly KnownType System_Range = new RegularKnownType("System.Range");
+        internal static readonly KnownType System_Reflection_Assembly = new RegularKnownType("System.Reflection.Assembly");
+        internal static readonly KnownType System_Reflection_BindingFlags = new RegularKnownType("System.Reflection.BindingFlags");
+        internal static readonly KnownType System_Reflection_AssemblyVersionAttribute = new RegularKnownType("System.Reflection.AssemblyVersionAttribute");
+        internal static readonly KnownType System_Reflection_MemberInfo = new RegularKnownType("System.Reflection.MemberInfo");
+        internal static readonly KnownType System_Reflection_Module = new RegularKnownType("System.Reflection.Module");
+        internal static readonly KnownType System_Reflection_ParameterInfo = new RegularKnownType("System.Reflection.ParameterInfo");
+        internal static readonly KnownType System_Resources_NeutralResourcesLanguageAttribute = new RegularKnownType("System.Resources.NeutralResourcesLanguageAttribute");
+        internal static readonly KnownType System_Runtime_CompilerServices_CallerFilePathAttribute = new RegularKnownType("System.Runtime.CompilerServices.CallerFilePathAttribute");
+        internal static readonly KnownType System_Runtime_CompilerServices_CallerLineNumberAttribute = new RegularKnownType("System.Runtime.CompilerServices.CallerLineNumberAttribute");
+        internal static readonly KnownType System_Runtime_CompilerServices_CallerMemberNameAttribute = new RegularKnownType("System.Runtime.CompilerServices.CallerMemberNameAttribute");
+        internal static readonly KnownType System_Runtime_CompilerServices_InternalsVisibleToAttribute = new RegularKnownType("System.Runtime.CompilerServices.InternalsVisibleToAttribute");
+        internal static readonly KnownType System_Runtime_CompilerServices_ModuleInitializerAttribute = new RegularKnownType("System.Runtime.CompilerServices.ModuleInitializerAttribute");
+        internal static readonly KnownType System_Runtime_CompilerServices_ValueTaskAwaiter = new RegularKnownType("System.Runtime.CompilerServices.ValueTaskAwaiter");
+        internal static readonly KnownType System_Runtime_CompilerServices_ValueTaskAwaiter_TResult = new RegularKnownType("System.Runtime.CompilerServices.ValueTaskAwaiter", "TResult");
+        internal static readonly KnownType System_Runtime_CompilerServices_TaskAwaiter = new RegularKnownType("System.Runtime.CompilerServices.TaskAwaiter");
+        internal static readonly KnownType System_Runtime_CompilerServices_TaskAwaiter_TResult = new RegularKnownType("System.Runtime.CompilerServices.TaskAwaiter", "TResult");
+        internal static readonly KnownType System_Runtime_InteropServices_ComImportAttribute = new RegularKnownType("System.Runtime.InteropServices.ComImportAttribute");
+        internal static readonly KnownType System_Runtime_InteropServices_ComVisibleAttribute = new RegularKnownType("System.Runtime.InteropServices.ComVisibleAttribute");
+        internal static readonly KnownType System_Runtime_InteropServices_DefaultParameterValueAttribute = new RegularKnownType("System.Runtime.InteropServices.DefaultParameterValueAttribute");
+        internal static readonly KnownType System_Runtime_InteropServices_DllImportAttribute = new RegularKnownType("System.Runtime.InteropServices.DllImportAttribute");
+        internal static readonly KnownType System_Runtime_InteropServices_HandleRef = new RegularKnownType("System.Runtime.InteropServices.HandleRef");
+        internal static readonly KnownType System_Runtime_InteropServices_InterfaceTypeAttribute = new RegularKnownType("System.Runtime.InteropServices.InterfaceTypeAttribute");
+        internal static readonly KnownType System_Runtime_InteropServices_OptionalAttribute = new RegularKnownType("System.Runtime.InteropServices.OptionalAttribute");
+        internal static readonly KnownType System_Runtime_InteropServices_SafeHandle = new RegularKnownType("System.Runtime.InteropServices.SafeHandle");
+        internal static readonly KnownType System_Runtime_InteropServices_StructLayoutAttribute = new RegularKnownType("System.Runtime.InteropServices.StructLayoutAttribute");
+        internal static readonly KnownType System_Runtime_Serialization_DataMemberAttribute = new RegularKnownType("System.Runtime.Serialization.DataMemberAttribute");
+        internal static readonly KnownType System_Runtime_Serialization_Formatters_Binary_BinaryFormatter = new RegularKnownType("System.Runtime.Serialization.Formatters.Binary.BinaryFormatter");
+        internal static readonly KnownType System_Runtime_Serialization_Formatters_Soap_SoapFormatter = new RegularKnownType("System.Runtime.Serialization.Formatters.Soap.SoapFormatter");
+        internal static readonly KnownType System_Runtime_Serialization_ISerializable = new RegularKnownType("System.Runtime.Serialization.ISerializable");
+        internal static readonly KnownType System_Runtime_Serialization_IDeserializationCallback = new RegularKnownType("System.Runtime.Serialization.IDeserializationCallback");
+        internal static readonly KnownType System_Runtime_Serialization_NetDataContractSerializer = new RegularKnownType("System.Runtime.Serialization.NetDataContractSerializer");
+        internal static readonly KnownType System_Runtime_Serialization_OnDeserializedAttribute = new RegularKnownType("System.Runtime.Serialization.OnDeserializedAttribute");
+        internal static readonly KnownType System_Runtime_Serialization_OnDeserializingAttribute = new RegularKnownType("System.Runtime.Serialization.OnDeserializingAttribute");
+        internal static readonly KnownType System_Runtime_Serialization_OnSerializedAttribute = new RegularKnownType("System.Runtime.Serialization.OnSerializedAttribute");
+        internal static readonly KnownType System_Runtime_Serialization_OnSerializingAttribute = new RegularKnownType("System.Runtime.Serialization.OnSerializingAttribute");
+        internal static readonly KnownType System_Runtime_Serialization_OptionalFieldAttribute = new RegularKnownType("System.Runtime.Serialization.OptionalFieldAttribute");
+        internal static readonly KnownType System_Runtime_Serialization_SerializationInfo = new RegularKnownType("System.Runtime.Serialization.SerializationInfo");
+        internal static readonly KnownType System_Runtime_Serialization_StreamingContext = new RegularKnownType("System.Runtime.Serialization.StreamingContext");
+        internal static readonly KnownType System_SByte = new SpecialKnownType(SpecialType.System_SByte, "sbyte");
+        internal static readonly KnownType System_Security_AccessControl_FileSystemAccessRule = new RegularKnownType("System.Security.AccessControl.FileSystemAccessRule");
+        internal static readonly KnownType System_Security_AccessControl_FileSystemSecurity = new RegularKnownType("System.Security.AccessControl.FileSystemSecurity");
+        internal static readonly KnownType System_Security_AllowPartiallyTrustedCallersAttribute = new RegularKnownType("System.Security.AllowPartiallyTrustedCallersAttribute");
+        internal static readonly KnownType System_Security_Authentication_SslProtocols = new RegularKnownType("System.Security.Authentication.SslProtocols");
+        internal static readonly KnownType System_Security_Cryptography_AesManaged = new RegularKnownType("System.Security.Cryptography.AesManaged");
+        internal static readonly KnownType System_Security_Cryptography_AsymmetricAlgorithm = new RegularKnownType("System.Security.Cryptography.AsymmetricAlgorithm");
+        internal static readonly KnownType System_Security_Cryptography_AsymmetricKeyExchangeDeformatter = new RegularKnownType("System.Security.Cryptography.AsymmetricKeyExchangeDeformatter");
+        internal static readonly KnownType System_Security_Cryptography_AsymmetricKeyExchangeFormatter = new RegularKnownType("System.Security.Cryptography.AsymmetricKeyExchangeFormatter");
+        internal static readonly KnownType System_Security_Cryptography_AsymmetricSignatureDeformatter = new RegularKnownType("System.Security.Cryptography.AsymmetricSignatureDeformatter");
+        internal static readonly KnownType System_Security_Cryptography_AsymmetricSignatureFormatter = new RegularKnownType("System.Security.Cryptography.AsymmetricSignatureFormatter");
+        internal static readonly KnownType System_Security_Cryptography_CryptoConfig = new RegularKnownType("System.Security.Cryptography.CryptoConfig");
+        internal static readonly KnownType System_Security_Cryptography_CspParameters = new RegularKnownType("System.Security.Cryptography.CspParameters");
+        internal static readonly KnownType System_Security_Cryptography_DES = new RegularKnownType("System.Security.Cryptography.DES");
+        internal static readonly KnownType System_Security_Cryptography_DeriveBytes = new RegularKnownType("System.Security.Cryptography.DeriveBytes");
+        internal static readonly KnownType System_Security_Cryptography_DSA = new RegularKnownType("System.Security.Cryptography.DSA");
+        internal static readonly KnownType System_Security_Cryptography_DSACryptoServiceProvider = new RegularKnownType("System.Security.Cryptography.DSACryptoServiceProvider");
+        internal static readonly KnownType System_Security_Cryptography_ECDiffieHellman = new RegularKnownType("System.Security.Cryptography.ECDiffieHellman");
+        internal static readonly KnownType System_Security_Cryptography_ECDsa = new RegularKnownType("System.Security.Cryptography.ECDsa");
+        internal static readonly KnownType System_Security_Cryptography_HashAlgorithm = new RegularKnownType("System.Security.Cryptography.HashAlgorithm");
+        internal static readonly KnownType System_Security_Cryptography_HMAC = new RegularKnownType("System.Security.Cryptography.HMAC");
+        internal static readonly KnownType System_Security_Cryptography_HMACMD5 = new RegularKnownType("System.Security.Cryptography.HMACMD5");
+        internal static readonly KnownType System_Security_Cryptography_HMACRIPEMD160 = new RegularKnownType("System.Security.Cryptography.HMACRIPEMD160");
+        internal static readonly KnownType System_Security_Cryptography_HMACSHA1 = new RegularKnownType("System.Security.Cryptography.HMACSHA1");
+        internal static readonly KnownType System_Security_Cryptography_ICryptoTransform = new RegularKnownType("System.Security.Cryptography.ICryptoTransform");
+        internal static readonly KnownType System_Security_Cryptography_KeyedHashAlgorithm = new RegularKnownType("System.Security.Cryptography.KeyedHashAlgorithm");
+        internal static readonly KnownType System_Security_Cryptography_MD5 = new RegularKnownType("System.Security.Cryptography.MD5");
+        internal static readonly KnownType System_Security_Cryptography_PasswordDeriveBytes = new RegularKnownType("System.Security.Cryptography.PasswordDeriveBytes");
+        internal static readonly KnownType System_Security_Cryptography_RC2 = new RegularKnownType("System.Security.Cryptography.RC2");
+        internal static readonly KnownType System_Security_Cryptography_RandomNumberGenerator = new RegularKnownType("System.Security.Cryptography.RandomNumberGenerator");
+        internal static readonly KnownType System_Security_Cryptography_Rfc2898DeriveBytes = new RegularKnownType("System.Security.Cryptography.Rfc2898DeriveBytes");
+        internal static readonly KnownType System_Security_Cryptography_RIPEMD160 = new RegularKnownType("System.Security.Cryptography.RIPEMD160");
+        internal static readonly KnownType System_Security_Cryptography_RNGCryptoServiceProvider = new RegularKnownType("System.Security.Cryptography.RNGCryptoServiceProvider");
+        internal static readonly KnownType System_Security_Cryptography_RSA = new RegularKnownType("System.Security.Cryptography.RSA");
+        internal static readonly KnownType System_Security_Cryptography_RSACryptoServiceProvider = new RegularKnownType("System.Security.Cryptography.RSACryptoServiceProvider");
+        internal static readonly KnownType System_Security_Cryptography_SHA1 = new RegularKnownType("System.Security.Cryptography.SHA1");
+        internal static readonly KnownType System_Security_Cryptography_SymmetricAlgorithm = new RegularKnownType("System.Security.Cryptography.SymmetricAlgorithm");
+        internal static readonly KnownType System_Security_Cryptography_TripleDES = new RegularKnownType("System.Security.Cryptography.TripleDES");
+        internal static readonly KnownType System_Security_Cryptography_X509Certificates_X509Certificate2 = new RegularKnownType("System.Security.Cryptography.X509Certificates.X509Certificate2");
+        internal static readonly KnownType System_Security_Cryptography_X509Certificates_X509Chain = new RegularKnownType("System.Security.Cryptography.X509Certificates.X509Chain");
+        internal static readonly KnownType System_Security_Permissions_CodeAccessSecurityAttribute = new RegularKnownType("System.Security.Permissions.CodeAccessSecurityAttribute");
+        internal static readonly KnownType System_Security_Permissions_PrincipalPermission = new RegularKnownType("System.Security.Permissions.PrincipalPermission");
+        internal static readonly KnownType System_Security_Permissions_PrincipalPermissionAttribute = new RegularKnownType("System.Security.Permissions.PrincipalPermissionAttribute");
+        internal static readonly KnownType System_Security_PermissionSet = new RegularKnownType("System.Security.PermissionSet");
+        internal static readonly KnownType System_Security_Principal_IIdentity = new RegularKnownType("System.Security.Principal.IIdentity");
+        internal static readonly KnownType System_Security_Principal_IPrincipal = new RegularKnownType("System.Security.Principal.IPrincipal");
+        internal static readonly KnownType System_Security_Principal_NTAccount = new RegularKnownType("System.Security.Principal.NTAccount");
+        internal static readonly KnownType System_Security_Principal_SecurityIdentifier = new RegularKnownType("System.Security.Principal.SecurityIdentifier");
+        internal static readonly KnownType System_Security_Principal_WindowsIdentity = new RegularKnownType("System.Security.Principal.WindowsIdentity");
+        internal static readonly KnownType System_Security_SecurityCriticalAttribute = new RegularKnownType("System.Security.SecurityCriticalAttribute");
+        internal static readonly KnownType System_Security_SecuritySafeCriticalAttribute = new RegularKnownType("System.Security.SecuritySafeCriticalAttribute");
+        internal static readonly KnownType System_SerializableAttribute = new RegularKnownType("System.SerializableAttribute");
+        internal static readonly KnownType System_ServiceModel_OperationContractAttribute = new RegularKnownType("System.ServiceModel.OperationContractAttribute");
+        internal static readonly KnownType System_ServiceModel_ServiceContractAttribute = new RegularKnownType("System.ServiceModel.ServiceContractAttribute");
+        internal static readonly KnownType System_Single = new SpecialKnownType(SpecialType.System_Single, "float");
+        internal static readonly KnownType System_StackOverflowException = new RegularKnownType("System.StackOverflowException");
+        internal static readonly KnownType System_STAThreadAttribute = new RegularKnownType("System.STAThreadAttribute");
+        internal static readonly KnownType System_String = new SpecialKnownType(SpecialType.System_String, "string");
+        internal static readonly KnownType System_String_Array = new RegularKnownType("System.String") { IsArray = true};
+        internal static readonly KnownType System_StringComparison = new RegularKnownType("System.StringComparison");
+        internal static readonly KnownType System_SystemException = new RegularKnownType("System.SystemException");
+        internal static readonly KnownType System_Text_RegularExpressions_Regex = new RegularKnownType("System.Text.RegularExpressions.Regex");
+        internal static readonly KnownType System_Text_StringBuilder = new RegularKnownType("System.Text.StringBuilder");
+        internal static readonly KnownType System_Threading_Monitor = new RegularKnownType("System.Threading.Monitor");
+        internal static readonly KnownType System_Threading_Mutex = new RegularKnownType("System.Threading.Mutex");
+        internal static readonly KnownType System_Threading_ReaderWriterLock = new RegularKnownType("System.Threading.ReaderWriterLock");
+        internal static readonly KnownType System_Threading_ReaderWriterLockSlim = new RegularKnownType("System.Threading.ReaderWriterLockSlim");
+        internal static readonly KnownType System_Threading_SpinLock = new RegularKnownType("System.Threading.SpinLock");
+        internal static readonly KnownType System_Threading_Tasks_Task = new RegularKnownType("System.Threading.Tasks.Task");
+        internal static readonly KnownType System_Threading_Tasks_Task_T = new RegularKnownType("System.Threading.Tasks.Task", "TResult");
+        internal static readonly KnownType System_Threading_Tasks_TaskFactory = new RegularKnownType("System.Threading.Tasks.TaskFactory");
+        internal static readonly KnownType System_Threading_Tasks_ValueTask = new RegularKnownType("System.Threading.Tasks.ValueTask");
+        internal static readonly KnownType System_Threading_Tasks_ValueTask_TResult = new RegularKnownType("System.Threading.Tasks.ValueTask", "TResult");
+        internal static readonly KnownType System_Threading_Thread = new RegularKnownType("System.Threading.Thread");
+        internal static readonly KnownType System_Threading_WaitHandle = new RegularKnownType("System.Threading.WaitHandle");
+        internal static readonly KnownType System_ThreadStaticAttribute = new RegularKnownType("System.ThreadStaticAttribute");
+        internal static readonly KnownType System_Type = new RegularKnownType("System.Type");
+        internal static readonly KnownType System_UInt16 = new SpecialKnownType(SpecialType.System_UInt16, "ushort");
+        internal static readonly KnownType System_UInt32 = new SpecialKnownType(SpecialType.System_UInt32, "uint");
+        internal static readonly KnownType System_UInt64 = new SpecialKnownType(SpecialType.System_UInt64, "ulong");
+        internal static readonly KnownType System_UIntPtr = new SpecialKnownType(SpecialType.System_UIntPtr, "UIntPtr");
+        internal static readonly KnownType System_Uri = new RegularKnownType("System.Uri");
+        internal static readonly KnownType System_ValueType = new SpecialKnownType(SpecialType.System_ValueType, "ValueType");
+        internal static readonly KnownType System_Web_HttpApplication = new RegularKnownType("System.Web.HttpApplication");
+        internal static readonly KnownType System_Web_HttpCookie = new RegularKnownType("System.Web.HttpCookie");
+        internal static readonly KnownType System_Web_HttpContext = new RegularKnownType("System.Web.HttpContext");
+        internal static readonly KnownType System_Web_HttpResponse = new RegularKnownType("System.Web.HttpResponse");
+        internal static readonly KnownType System_Web_HttpResponseBase = new RegularKnownType("System.Web.HttpResponseBase");
+        internal static readonly KnownType System_Web_Http_ApiController = new RegularKnownType("System.Web.Http.ApiController");
+        internal static readonly KnownType System_Web_Http_Cors_EnableCorsAttribute = new RegularKnownType("System.Web.Http.Cors.EnableCorsAttribute");
+        internal static readonly KnownType System_Web_Mvc_NonActionAttribute = new RegularKnownType("System.Web.Mvc.NonActionAttribute");
+        internal static readonly KnownType System_Web_Mvc_Controller = new RegularKnownType("System.Web.Mvc.Controller");
+        internal static readonly KnownType System_Web_Mvc_HttpPostAttribute = new RegularKnownType("System.Web.Mvc.HttpPostAttribute");
+        internal static readonly KnownType System_Web_Mvc_ValidateInputAttribute = new RegularKnownType("System.Web.Mvc.ValidateInputAttribute");
+        internal static readonly KnownType System_Web_Script_Serialization_JavaScriptSerializer = new RegularKnownType("System.Web.Script.Serialization.JavaScriptSerializer");
+        internal static readonly KnownType System_Web_Script_Serialization_JavaScriptTypeResolver = new RegularKnownType("System.Web.Script.Serialization.JavaScriptTypeResolver");
+        internal static readonly KnownType System_Web_Script_Serialization_SimpleTypeResolver = new RegularKnownType("System.Web.Script.Serialization.SimpleTypeResolver");
+        internal static readonly KnownType System_Web_UI_LosFormatter = new RegularKnownType("System.Web.UI.LosFormatter");
+        internal static readonly KnownType System_Windows_DependencyObject = new RegularKnownType("System.Windows.DependencyObject");
+        internal static readonly KnownType System_Windows_Forms_Application = new RegularKnownType("System.Windows.Forms.Application");
+        internal static readonly KnownType System_Windows_Markup_ConstructorArgumentAttribute = new RegularKnownType("System.Windows.Markup.ConstructorArgumentAttribute");
+        internal static readonly KnownType System_Xml_Serialization_XmlElementAttribute = new RegularKnownType("System.Xml.Serialization.XmlElementAttribute");
+        internal static readonly KnownType System_Xml_XmlDocument = new RegularKnownType("System.Xml.XmlDocument");
+        internal static readonly KnownType System_Xml_XmlDataDocument = new RegularKnownType("System.Xml.XmlDataDocument");
+        internal static readonly KnownType System_Xml_XmlNode = new RegularKnownType("System.Xml.XmlNode");
+        internal static readonly KnownType System_Xml_XPath_XPathDocument = new RegularKnownType("System.Xml.XPath.XPathDocument");
+        internal static readonly KnownType System_Xml_XmlReader = new RegularKnownType("System.Xml.XmlReader");
+        internal static readonly KnownType System_Xml_XmlReaderSettings = new RegularKnownType("System.Xml.XmlReaderSettings");
+        internal static readonly KnownType System_Xml_XmlUrlResolver = new RegularKnownType("System.Xml.XmlUrlResolver");
+        internal static readonly KnownType System_Xml_XmlTextReader = new RegularKnownType("System.Xml.XmlTextReader");
+        internal static readonly KnownType System_Xml_Resolvers_XmlPreloadedResolver = new RegularKnownType("System.Xml.Resolvers.XmlPreloadedResolver");
+        internal static readonly KnownType NSubstitute_SubstituteExtensions = new RegularKnownType("NSubstitute.SubstituteExtensions");
+        internal static readonly KnownType NSubstitute_Received = new RegularKnownType("NSubstitute.Received");
+        internal static readonly ImmutableArray<RegularKnownType> SystemActionVariants =
             ImmutableArray.Create(
-                new KnownType("System.Action"),
-                new KnownType("System.Action<T>"),
-                new KnownType("System.Action<T1, T2>"),
-                new KnownType("System.Action<T1, T2, T3>"),
-                new KnownType("System.Action<T1, T2, T3, T4>"),
-                new KnownType("System.Action<T1, T2, T3, T4, T5>"),
-                new KnownType("System.Action<T1, T2, T3, T4, T5, T6>"),
-                new KnownType("System.Action<T1, T2, T3, T4, T5, T6, T7>"),
-                new KnownType("System.Action<T1, T2, T3, T4, T5, T6, T7, T8>"),
-                new KnownType("System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9>"),
-                new KnownType("System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>"),
-                new KnownType("System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>"),
-                new KnownType("System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>"),
-                new KnownType("System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>"),
-                new KnownType("System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>"),
-                new KnownType("System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>"),
-                new KnownType("System.Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>"));
-        internal static readonly ImmutableArray<KnownType> SystemFuncVariants =
+                new RegularKnownType("System.Action"),
+                new RegularKnownType("System.Action", "T"),
+                new RegularKnownType("System.Action", "T1", "T2"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4", "T5"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4", "T5", "T6"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4", "T5", "T6", "T7"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "T11"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "T11", "T12"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "T11", "T12", "T13"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "T11", "T12", "T13", "T14"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "T11", "T12", "T13", "T14", "T15"),
+                new RegularKnownType("System.Action", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "T11", "T12", "T13", "T14", "T15", "T16"));
+        internal static readonly ImmutableArray<RegularKnownType> SystemFuncVariants =
             ImmutableArray.Create(
-                new KnownType("System.Func<TResult>"),
-                new KnownType("System.Func<T, TResult>"),
-                new KnownType("System.Func<T1, T2, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, T5, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, T5, T6, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, T5, T6, T7, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>"),
-                new KnownType("System.Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>"));
+                new RegularKnownType("System.Func", "TResult"),
+                new RegularKnownType("System.Func", "T", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "T5", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "T5", "T6", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "T11", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "T11", "T12", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "T11", "T12", "T13", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "T11", "T12", "T13", "T14", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "T11", "T12", "T13", "T14", "T15", "TResult"),
+                new RegularKnownType("System.Func", "T1", "T2", "T3", "T4", "T5", "T6", "T7", "T8", "T9", "T10", "T11", "T12", "T13", "T14", "T15", "T16", "TResult"));
         internal static readonly ImmutableArray<KnownType> SystemTasks =
             ImmutableArray.Create(
                 System_Threading_Tasks_Task,
                 System_Threading_Tasks_Task_T,
                 System_Threading_Tasks_ValueTask_TResult);
-        internal static readonly KnownType Sytem_Resources_ResourceManager = new("System.Resources.ResourceManager");
-        internal static readonly KnownType UnityEditor_AssetModificationProcessor = new("UnityEditor.AssetModificationProcessor");
-        internal static readonly KnownType UnityEditor_AssetPostprocessor = new("UnityEditor.AssetPostprocessor");
-        internal static readonly KnownType UnityEngine_MonoBehaviour = new("UnityEngine.MonoBehaviour");
-        internal static readonly KnownType UnityEngine_ScriptableObject = new("UnityEngine.ScriptableObject");
-        internal static readonly KnownType Xunit_Assert = new("Xunit.Assert");
-        internal static readonly KnownType Xunit_Sdk_AssertException = new("Xunit.Sdk.AssertException");
-        internal static readonly KnownType Xunit_FactAttribute = new("Xunit.FactAttribute");
-        internal static readonly KnownType Xunit_Sdk_XunitException = new("Xunit.Sdk.XunitException");
-        internal static readonly KnownType Xunit_TheoryAttribute = new("Xunit.TheoryAttribute");
-        internal static readonly KnownType LegacyXunit_TheoryAttribute = new("Xunit.Extensions.TheoryAttribute");
+        internal static readonly KnownType Sytem_Resources_ResourceManager = new RegularKnownType("System.Resources.ResourceManager");
+        internal static readonly KnownType UnityEditor_AssetModificationProcessor = new RegularKnownType("UnityEditor.AssetModificationProcessor");
+        internal static readonly KnownType UnityEditor_AssetPostprocessor = new RegularKnownType("UnityEditor.AssetPostprocessor");
+        internal static readonly KnownType UnityEngine_MonoBehaviour = new RegularKnownType("UnityEngine.MonoBehaviour");
+        internal static readonly KnownType UnityEngine_ScriptableObject = new RegularKnownType("UnityEngine.ScriptableObject");
+        internal static readonly KnownType Xunit_Assert = new RegularKnownType("Xunit.Assert");
+        internal static readonly KnownType Xunit_Sdk_AssertException = new RegularKnownType("Xunit.Sdk.AssertException");
+        internal static readonly KnownType Xunit_FactAttribute = new RegularKnownType("Xunit.FactAttribute");
+        internal static readonly KnownType Xunit_Sdk_XunitException = new RegularKnownType("Xunit.Sdk.XunitException");
+        internal static readonly KnownType Xunit_TheoryAttribute = new RegularKnownType("Xunit.TheoryAttribute");
+        internal static readonly KnownType LegacyXunit_TheoryAttribute = new RegularKnownType("Xunit.Extensions.TheoryAttribute");
         internal static readonly ImmutableArray<KnownType> CallerInfoAttributes =
             ImmutableArray.Create(
                 System_Runtime_CompilerServices_CallerFilePathAttribute,
@@ -598,28 +592,5 @@ namespace SonarAnalyzer.Helpers
 #pragma warning restore SA1311  // Static readonly fields should begin with upper-case letter
 #pragma warning restore SA1307  // Field 'log4net_Config_XmlConfigurator' should begin with upper-case letter
 #pragma warning restore SA1304  // Non-private readonly fields should begin with upper-case letter
-
-        private readonly bool isSpecialType;
-        private readonly SpecialType specialType;
-        private readonly Lazy<string> shortName;
-
-        public string TypeName { get; }
-        public string ShortName => shortName.Value;
-
-        private KnownType(string typeName) : this(SpecialType.None, typeName) { }
-
-        private KnownType(SpecialType specialType, string typeName)
-        {
-            this.specialType = specialType;
-            TypeName = typeName;
-            shortName = new Lazy<string>(() => typeName.Split('.').Last());
-            isSpecialType = specialType != SpecialType.None;
-        }
-
-        internal bool Matches(string type) =>
-            !isSpecialType && TypeName == type;
-
-        internal bool Matches(SpecialType type) =>
-            isSpecialType && specialType == type;
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/MemberDescriptor.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/MemberDescriptor.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Helpers
         }
 
         public override string ToString() =>
-            $"{ContainingType.ShortName}.{Name}";
+            $"{ContainingType.TypeName}.{Name}";
 
         public bool IsMatch(string memberName, ITypeSymbol containingType, StringComparison nameComparison) =>
             HasSameName(memberName, Name, nameComparison)

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/TypeHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/TypeHelper.cs
@@ -48,13 +48,7 @@ namespace SonarAnalyzer.Helpers
         #region TypeName
 
         public static bool Is(this ITypeSymbol typeSymbol, KnownType type) =>
-            typeSymbol != null && IsMatch(typeSymbol, type);
-
-        private static bool IsMatch(ITypeSymbol typeSymbol, KnownType type) =>
-            type.Matches(typeSymbol.SpecialType)
-            || type.Matches(typeSymbol.OriginalDefinition.SpecialType)
-            || type.Matches(typeSymbol.ToDisplayString())
-            || type.Matches(typeSymbol.OriginalDefinition.ToDisplayString());
+            typeSymbol != null && type.Matches(typeSymbol);
 
         public static bool IsAny(this ITypeSymbol typeSymbol, params KnownType[] types)
         {
@@ -66,7 +60,7 @@ namespace SonarAnalyzer.Helpers
             // For is twice as fast as foreach on ImmutableArray so don't use Linq here
             for (var i = 0; i < types.Length; i++)
             {
-                if (IsMatch(typeSymbol, types[i]))
+                if (types[i].Matches(typeSymbol))
                 {
                     return true;
                 }
@@ -85,7 +79,7 @@ namespace SonarAnalyzer.Helpers
             // For is twice as fast as foreach on ImmutableArray so don't use Linq here
             for (var i = 0; i < types.Length; i++)
             {
-                if (IsMatch(typeSymbol, types[i]))
+                if (types[i].Matches(typeSymbol))
                 {
                     return true;
                 }
@@ -118,7 +112,7 @@ namespace SonarAnalyzer.Helpers
             typeSymbol is { }
             && typeSymbol.AllInterfaces.Any(symbol => symbol.ConstructedFrom.Is(type));
 
-        public static bool Implements(this ITypeSymbol typeSymbol, ITypeSymbol type) =>
+        private static bool Implements(this ITypeSymbol typeSymbol, ISymbol type) =>
             typeSymbol is { }
             && typeSymbol.AllInterfaces.Any(symbol => symbol.ConstructedFrom.Equals(type));
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
@@ -64,7 +64,6 @@ namespace SonarAnalyzer.Rules
         protected abstract SyntaxNode LocalVariableScope(TVariableSyntax variable);
         protected abstract SyntaxNode ExtractArgumentExpressionNode(SyntaxNode expression);
         protected abstract SyntaxNode SyntaxFromReference(SyntaxReference reference);
-        private protected abstract KnownType GenericDelegateType();
 
         protected override string MessageFormat => "Enable server certificate validation on this SSL/TLS connection";
 
@@ -162,13 +161,13 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private bool IsValidationDelegateType(ITypeSymbol type)
+        private static bool IsValidationDelegateType(ITypeSymbol type)
         {
             if (type.Is(KnownType.System_Net_Security_RemoteCertificateValidationCallback))
             {
                 return true;
             }
-            if (type is INamedTypeSymbol namedSymbol && type.OriginalDefinition.Is(GenericDelegateType()))
+            if (type is INamedTypeSymbol namedSymbol && type.OriginalDefinition.Is(KnownType.System_Func_T1_T2_T3_T4_TResult))
             {
                 // HttpClientHandler.ServerCertificateCustomValidationCallback uses Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool>
                 // We're actually looking for Func<Any Sender, X509Certificate2, X509Chain, SslPolicyErrors, bool>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/UsingCookiesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/UsingCookiesBase.cs
@@ -70,9 +70,7 @@ namespace SonarAnalyzer.Rules
                 inv.MatchMethod(new MemberDescriptor(KnownType.Microsoft_AspNetCore_Http_IResponseCookies, "Append")));
 
             inv.Track(input,
-                inv.MatchMethod(
-                    new MemberDescriptor(KnownType.System_Collections_Generic_IDictionary_TKey_TValue, "Add"),
-                    new MemberDescriptor(KnownType.System_Collections_Generic_IDictionary_TKey_TValue_VB, "Add")),
+                inv.MatchMethod(new MemberDescriptor(KnownType.System_Collections_Generic_IDictionary_TKey_TValue, "Add")),
                 inv.ArgumentAtIndexIsAny(0, "Set-Cookie"),
                 inv.MethodHasParameters(2),
                 inv.IsIHeadersDictionary());

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Metrics/VisualBasicExecutableLinesMetric.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Metrics/VisualBasicExecutableLinesMetric.cs
@@ -64,10 +64,9 @@ namespace SonarAnalyzer.Metrics.VisualBasic
                 var attributeName = attribute?.Name?.ToString() ?? string.Empty;
 
                 // Check the attribute name without the attribute suffix OR the full name of the attribute
-                return attributeName.EndsWith(
-                        KnownType.System_Diagnostics_CodeAnalysis_ExcludeFromCodeCoverageAttribute.ShortName.Substring(0,
-                            KnownType.System_Diagnostics_CodeAnalysis_ExcludeFromCodeCoverageAttribute.ShortName.Length - 9), StringComparison.Ordinal) ||
-                    attributeName.EndsWith(KnownType.System_Diagnostics_CodeAnalysis_ExcludeFromCodeCoverageAttribute.ShortName, StringComparison.Ordinal);
+                var excludeCoverageName = KnownType.System_Diagnostics_CodeAnalysis_ExcludeFromCodeCoverageAttribute.TypeName;
+                return attributeName.EndsWith(excludeCoverageName.Substring(0, excludeCoverageName.Length - 9), StringComparison.Ordinal)
+                    || attributeName.EndsWith(excludeCoverageName, StringComparison.Ordinal);
             }
 
             private bool FindExecutableLines(SyntaxNode node)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CertificateValidationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CertificateValidationCheck.cs
@@ -135,7 +135,5 @@ namespace SonarAnalyzer.Rules.VisualBasic
             var syntax = reference.GetSyntax();
             return syntax is MethodStatementSyntax ? syntax.Parent : syntax;
         }
-
-        private protected override KnownType GenericDelegateType() => KnownType.System_Func_T1_T2_T3_T4_TResult_VB;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/KnownTypeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/KnownTypeTest.cs
@@ -1,0 +1,101 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using CS = Microsoft.CodeAnalysis.CSharp.Syntax;
+using VB = Microsoft.CodeAnalysis.VisualBasic.Syntax;
+
+namespace SonarAnalyzer.UnitTest.Helpers;
+
+[TestClass]
+public class KnownTypeTest
+{
+    [TestMethod]
+    public void Matches_TypeSymbolIsNull_ThrowsArgumentNullException() =>
+        new KnownType.RegularKnownType("typeName").Invoking(x => x.Matches(null)).Should().Throw<ArgumentNullException>();
+
+    [DataTestMethod]
+    [DataRow("System.Action", true, "System.Action", false)]
+    [DataRow("System.DateTime", false, "System.Action", false)]
+    [DataRow("System.Collections.ArrayList", true, "System.Collections.ArrayList", false)]
+    [DataRow("System.Threading.Timer", false, "System.Timers.Timer", false)]
+    [DataRow("string[]", true, "System.String", true)]
+    [DataRow("System.String[]", true, "System.String", true)]
+    [DataRow("byte[]", true, "System.Byte", true)]
+    [DataRow("System.Byte[]", true, "System.Byte", true)]
+    [DataRow("System.Exception[]", false, "Exceptions.Exception", true)]
+    [DataRow("System.Action[]", false, "System.Action", false)]
+    [DataRow("System.Action<T>", false, "System.Action", false)]
+    [DataRow("System.Action<T>", true, "System.Action", false, "T")]
+    [DataRow("System.Action<T1>", false, "System.Action", true, "T2")]
+    [DataRow("System.Action<T1, T2>", true, "System.Action", false, "T1", "T2")]
+    [DataRow("System.Action<T1, T2>", false, "System.Action", true, "T1", "T2")]
+    [DataRow("System.Action<T1, T2>", false, "System.Action", false, "T2", "T1")]
+    [DataRow("System.Action<T1, T2>", false, "System.Action", true, "T1")]
+    [DataRow("System.Action", false, "System.Action", false, "T")]
+    [DataRow("System.Action<T>", false, "System.Action", true, "T")]
+    public void Matches_TypeSymbol_CS(string symbolName, bool expectedMatch, string fullTypeName, bool isArray, params string[] genericParameters) =>
+        new KnownType.RegularKnownType(fullTypeName, genericParameters) { IsArray = isArray }
+            .Matches(GetSymbol_CS(symbolName))
+            .Should().Be(expectedMatch);
+
+    [DataTestMethod]
+    [DataRow("System.Collections.Generic.IDictionary(Of TKey, TValue)", false, "System.Collections.Generic.IDictionary", false)]
+    [DataRow("System.Collections.Generic.IDictionary(Of TKey, TValue)", false, "System.Collections.Generic.IDictionary", false, "TKey")]
+    [DataRow("System.Collections.Generic.IDictionary(Of TKey, TValue)", true, "System.Collections.Generic.IDictionary", false, "TKey", "TValue")]
+    [DataRow("System.Collections.Generic.IDictionary(Of TKey, TValue)", false, "System.Collections.Generic.IDictionary", false, "TValue", "TKey")]
+    [DataRow("string()", true, "System.String", true)]
+    [DataRow("string()", false, "System.Byte", true)]
+    public void Matches_TypeSymbol_VB(string symbolName, bool expectedMatch, string fullTypeName, bool isArray, params string[] genericParameters) =>
+        new KnownType.RegularKnownType(fullTypeName, genericParameters) { IsArray = isArray }
+            .Matches(GetSymbol_VB(symbolName))
+            .Should().Be(expectedMatch);
+
+    [DataTestMethod]
+    [DataRow("string", true, SpecialType.System_String, "string")]
+    [DataRow("byte", false, SpecialType.System_String, "string")]
+    public void Matches_TypeSymbol_SpecialType_CSharp(string expectedSymbol, bool expectedMatch, SpecialType specialType, string typeName) =>
+        new KnownType.SpecialKnownType(specialType, typeName)
+            .Matches(GetSymbol_CS(expectedSymbol))
+            .Should().Be(expectedMatch);
+
+    [DataTestMethod]
+    [DataRow("string", true, SpecialType.System_String, "string")]
+    [DataRow("byte", false, SpecialType.System_String, "string")]
+    public void Matches_TypeSymbol_SpecialType_VisualBasic(string expectedSymbol, bool expectedMatch, SpecialType specialType, string typeName) =>
+        new KnownType.SpecialKnownType(specialType, typeName)
+            .Matches(GetSymbol_VB(expectedSymbol))
+            .Should().Be(expectedMatch);
+
+    private static ITypeSymbol GetSymbol_CS(string type)
+    {
+        var (tree, model) = TestHelper.CompileCS($@"
+namespace Exceptions {{ public class Exception {{ }} }}
+public class Test<T, T1, T2, T3> {{ public {type} Value; }}");
+        var expression = tree.GetRoot().DescendantNodes().OfType<CS.VariableDeclaratorSyntax>().Single();
+        return model.GetDeclaredSymbol(expression).GetSymbolType();
+    }
+
+    private static ITypeSymbol GetSymbol_VB(string type)
+    {
+        var (tree, model) = TestHelper.CompileVB($"Public Class Test(Of TKey, TValue) : Public Value As {type} : End Class");
+        var expression = tree.GetRoot().DescendantNodes().OfType<VB.ModifiedIdentifierSyntax>().Single();
+        return model.GetDeclaredSymbol(expression).GetSymbolType();
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/TypeHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/TypeHelperTest.cs
@@ -55,11 +55,8 @@ namespace SonarAnalyzer.UnitTest.Helpers
         [TestMethod]
         public void Type_DerivesOrImplementsAny()
         {
-            var ctor = typeof(KnownType).GetConstructors(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-                .Single(m => m.GetParameters().Length == 1);
-
-            var baseType = (KnownType)ctor.Invoke(new object[] { "NS.Base" });
-            var interfaceType = (KnownType)ctor.Invoke(new object[] { "NS.IInterface" });
+            var baseType = (KnownType)new KnownType.RegularKnownType("NS.Base");
+            var interfaceType = (KnownType)new KnownType.RegularKnownType("NS.IInterface");
 
             var derived1Type = semanticModel.GetDeclaredSymbol(derivedClassDeclaration1) as INamedTypeSymbol;
             var derived2Type = semanticModel.GetDeclaredSymbol(derivedClassDeclaration2) as INamedTypeSymbol;
@@ -74,10 +71,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
         [TestMethod]
         public void Type_Is()
         {
-            var ctor = typeof(KnownType).GetConstructors(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-                .Single(m => m.GetParameters().Length == 1);
-
-            var baseKnownType = (KnownType)ctor.Invoke(new object[] { "NS.Base" });
+            var baseKnownType = (KnownType)new KnownType.RegularKnownType("NS.Base");
             var baseKnownTypes = ImmutableArray.Create(new[] { baseKnownType });
 
             var baseType = semanticModel.GetDeclaredSymbol(baseClassDeclaration) as INamedTypeSymbol;


### PR DESCRIPTION
Fix #5692