### PR TITLE
S138:  Count static local functions nested in methods as units.

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldNotHaveTooManyLinesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MethodsShouldNotHaveTooManyLinesTest.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             CreateCSBuilder(2).AddSnippet(@"
 int i = 1; i++;
 
-void LocalFunction() // Noncompliant {{This top level local function has 4 lines, which is greater than the 2 lines authorized.}}
+void LocalFunction() // Noncompliant {{This local function has 4 lines, which is greater than the 2 lines authorized.}}
 {
     i++;
     i++;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldNotHaveTooManyLines.LocalFunctions.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldNotHaveTooManyLines.LocalFunctions.cs
@@ -20,6 +20,35 @@ namespace Tests.Diagnostics
                 i++;
                 i++;
             }
+
+            static void StaticLocalFunctionWithManyLines() // Noncompliant {{This static local function has 8 lines, which is greater than the 5 lines authorized.}}
+            {
+                int i = 0;
+                i++;
+                i++;
+                i++;
+                i++;
+                i++;
+                i++;
+                i++;
+            }
+        }
+
+        public void FooBar(int i) // Noncompliant {{This method 'FooBar' has 12 lines, which is greater than the 5 lines authorized. Split it into smaller methods.}}
+        {
+            Console.WriteLine(i);
+
+            void LocalFunctionWithManyLines()
+            {
+                int i = 0;
+                i++;
+                i++;
+                i++;
+                i++;
+                i++;
+                i++;
+                i++;
+            }
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldNotHaveTooManyLines_CustomValues.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodsShouldNotHaveTooManyLines_CustomValues.CSharp9.cs
@@ -3,7 +3,7 @@ i++;
 i++;
 i++;
 
-void LocalFunction() // Noncompliant {{This top level local function has 4 lines, which is greater than the 2 lines authorized.}}
+void LocalFunction() // Noncompliant {{This local function has 4 lines, which is greater than the 2 lines authorized.}}
 {
     i++;
     i++;
@@ -11,7 +11,7 @@ void LocalFunction() // Noncompliant {{This top level local function has 4 lines
     i++;
 }
 
-static void StaticLocalFunction() // Noncompliant {{This top level local function has 4 lines, which is greater than the 2 lines authorized.}}
+static void StaticLocalFunction() // Noncompliant {{This local function has 4 lines, which is greater than the 2 lines authorized.}}
 {
     int k = 1;
     k++;
@@ -25,14 +25,14 @@ void Compliant()
     i++;
 }
 
-void ABitLonger() // Noncompliant {{This top level local function has 3 lines, which is greater than the 2 lines authorized.}}
+void ABitLonger() // Noncompliant {{This local function has 3 lines, which is greater than the 2 lines authorized.}}
 {
     i++;
     i++;
     i++;
 }
 
-int Lambda(int a, int b, int c) => // Noncompliant {{This top level local function has 3 lines, which is greater than the 2 lines authorized.}}
+int Lambda(int a, int b, int c) => // Noncompliant {{This local function has 3 lines, which is greater than the 2 lines authorized.}}
     a
     + b
     + c;


### PR DESCRIPTION
Fixes partially #5680
