### PR TITLE
Fix false positive on S4581 new expression

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -54,12 +54,12 @@ namespace SonarAnalyzer.Helpers.Facade
 
         public override bool IsNullLiteral(SyntaxNode node) => node.IsNullLiteral();
 
-        public override IEnumerable<SyntaxNode> ArgumentExpressions(SyntaxNode node) =>
-            node switch
+        public override IEnumerable<SyntaxNode> ArgumentExpressions(SyntaxNode node) => node switch
             {
                 ObjectCreationExpressionSyntax creation => creation.ArgumentList?.Arguments.Select(x => x.Expression) ?? Enumerable.Empty<SyntaxNode>(),
                 null => Enumerable.Empty<SyntaxNode>(),
-                var _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(node) => Enumerable.Empty<SyntaxNode>(),
+                var _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(node)
+                    => ((ImplicitObjectCreationExpressionSyntaxWrapper)node).ArgumentList?.Arguments.Select(x => x.Expression) ?? Enumerable.Empty<SyntaxNode>(),
                 _ => throw InvalidOperation(node, nameof(ArgumentExpressions))
             };
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PreferGuidEmpty.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PreferGuidEmpty.CSharp9.cs
@@ -5,6 +5,8 @@ namespace Tests.Diagnostics
 {
     public class Program
     {
+        public static readonly Guid Global = new("54972F01-2A74-4D09-AA7C-359E9C5A5B5A"); // Compliant
+
         public void Foo()
         {
             Guid g1 = new(); // Noncompliant


### PR DESCRIPTION
Root cause: for `T x = new(..)`, the arguments where not detected.

See: #5703