### PR TITLE
Fix false positive S2699: NUnit test method does not regonize named argument ExpectedResult

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
@@ -120,11 +120,12 @@ namespace SonarAnalyzer.Helpers
                     method.GetAttributes().Any(att => att.AttributeClass.Is(known)));
 
         private static bool IsAnyTestCaseAttributeWithExpectedResult(AttributeData a) =>
-            IsTestCaseAttributeWithExpectedResult(a)
+            IsTestAttributeWithExpectedResult(a)
             || a.AttributeClass.Is(KnownType.NUnit_Framework_TestCaseSourceAttribute);
 
-        private static bool IsTestCaseAttributeWithExpectedResult(AttributeData a) =>
-            a.AttributeClass.Is(KnownType.NUnit_Framework_TestCaseAttribute)
+        private static bool IsTestAttributeWithExpectedResult(AttributeData a) =>
+            (a.AttributeClass.Is(KnownType.NUnit_Framework_TestCaseAttribute)
+            || a.AttributeClass.Is(KnownType.NUnit_Framework_TestAttribute))
             && a.NamedArguments.Any(arg => arg.Key == "ExpectedResult");
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
@@ -124,8 +124,7 @@ namespace SonarAnalyzer.Helpers
             || a.AttributeClass.Is(KnownType.NUnit_Framework_TestCaseSourceAttribute);
 
         private static bool IsTestAttributeWithExpectedResult(AttributeData a) =>
-            (a.AttributeClass.Is(KnownType.NUnit_Framework_TestCaseAttribute)
-            || a.AttributeClass.Is(KnownType.NUnit_Framework_TestAttribute))
+a.AttributeClass.IsAny(KnownType.NUnit_Framework_TestCaseAttribute, KnownType.NUnit_Framework_TestAttribute)
             && a.NamedArguments.Any(arg => arg.Key == "ExpectedResult");
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
@@ -137,6 +137,12 @@
         public void Test17() // Don't raise on skipped test methods
         {
         }
+
+        [Test(ExpectedResult = 69)]
+        public int TestViaExpectedResult() // Compliant, assertion via expected result
+        {
+            return 69;
+        }
     }
 
     [TestFixture]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
@@ -138,10 +138,10 @@
         {
         }
 
-        [Test(ExpectedResult = 69)]
+        [Test(ExpectedResult = 42)]
         public int TestViaExpectedResult() // Compliant, assertion via expected result
         {
-            return 69;
+            return 42;
         }
     }
 


### PR DESCRIPTION
Named argument `ExpectedResult` was only taken into account for `[TestCase]`, not `[Test]`. Has been changed.

See: #5702