### PR TITLE
Add ExceptionState to ProgramState

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/HashCode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/HashCode.cs
@@ -38,34 +38,24 @@ namespace SonarAnalyzer.Helpers
             enumerable.Aggregate(0, (seed, x) => Combine(seed, x));
 
         public static int Combine<T1, T2>(T1 a, T2 b) =>
-            (int)Seed
-                .AddHash((uint)(a?.GetHashCode() ?? 0))
-                .AddHash((uint)(b?.GetHashCode() ?? 0));
+            (int)Seed.AddHash(a?.GetHashCode()).AddHash(b?.GetHashCode());
 
         public static int Combine<T1, T2, T3>(T1 a, T2 b, T3 c) =>
-            (int)Seed
-                .AddHash((uint)(a?.GetHashCode() ?? 0))
-                .AddHash((uint)(b?.GetHashCode() ?? 0))
-                .AddHash((uint)(c?.GetHashCode() ?? 0));
+            (int)Combine(a, b).AddHash(c?.GetHashCode());
 
         public static int Combine<T1, T2, T3, T4>(T1 a, T2 b, T3 c, T4 d) =>
-            (int)Seed
-                .AddHash((uint)(a?.GetHashCode() ?? 0))
-                .AddHash((uint)(b?.GetHashCode() ?? 0))
-                .AddHash((uint)(c?.GetHashCode() ?? 0))
-                .AddHash((uint)(d?.GetHashCode() ?? 0));
+            (int)Combine(a, b, c).AddHash(d?.GetHashCode());
 
         public static int Combine<T1, T2, T3, T4, T5>(T1 a, T2 b, T3 c, T4 d, T5 e) =>
-            (int)Seed
-                .AddHash((uint)(a?.GetHashCode() ?? 0))
-                .AddHash((uint)(b?.GetHashCode() ?? 0))
-                .AddHash((uint)(c?.GetHashCode() ?? 0))
-                .AddHash((uint)(d?.GetHashCode() ?? 0))
-                .AddHash((uint)(e?.GetHashCode() ?? 0));
+            (int)Combine(a, b, c, d).AddHash(e?.GetHashCode());
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static uint AddHash(this uint hash, uint value) =>
-            RotateLeft(hash + value * PreMultiplier) * PostMultiplier;
+        private static uint AddHash(this int hash, int? value) =>
+            ((uint)hash).AddHash(value);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint AddHash(this uint hash, int? value) =>
+            RotateLeft(hash + (uint)(value ?? 0) * PreMultiplier) * PostMultiplier;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static uint RotateLeft(uint value) =>

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/HashCode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/HashCode.cs
@@ -55,6 +55,14 @@ namespace SonarAnalyzer.Helpers
                 .AddHash((uint)(c?.GetHashCode() ?? 0))
                 .AddHash((uint)(d?.GetHashCode() ?? 0));
 
+        public static int Combine<T1, T2, T3, T4, T5>(T1 a, T2 b, T3 c, T4 d, T5 e) =>
+            (int)Seed
+                .AddHash((uint)(a?.GetHashCode() ?? 0))
+                .AddHash((uint)(b?.GetHashCode() ?? 0))
+                .AddHash((uint)(c?.GetHashCode() ?? 0))
+                .AddHash((uint)(d?.GetHashCode() ?? 0))
+                .AddHash((uint)(e?.GetHashCode() ?? 0));
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static uint AddHash(this uint hash, uint value) =>
             RotateLeft(hash + value * PreMultiplier) * PostMultiplier;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExceptionState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExceptionState.cs
@@ -23,7 +23,7 @@ using Microsoft.CodeAnalysis;
 
 namespace SonarAnalyzer.SymbolicExecution.Roslyn
 {
-    public sealed record ExceptionState : IEquatable<ExceptionState>
+    public sealed record ExceptionState
     {
         public static readonly ExceptionState UnknownException = new();
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExceptionState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExceptionState.cs
@@ -18,25 +18,23 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.UnitTest.Helpers
-{
-    [TestClass]
-    public class HashCodeTest
-    {
-        [DataTestMethod]
-        [DataRow(null)]
-        [DataRow("Lorem Ipsum")]
-        public void Combine_ProducesDifferentResults(string input)
-        {
-            var hash2 = SonarAnalyzer.Helpers.HashCode.Combine(input, input);
-            var hash3 = SonarAnalyzer.Helpers.HashCode.Combine(input, input, input);
-            var hash4 = SonarAnalyzer.Helpers.HashCode.Combine(input, input, input, input);
-            var hash5 = SonarAnalyzer.Helpers.HashCode.Combine(input, input, input, input, input);
+using System;
+using Microsoft.CodeAnalysis;
 
-            hash2.Should().NotBe(0);
-            hash3.Should().NotBe(0).And.NotBe(hash2);
-            hash4.Should().NotBe(0).And.NotBe(hash2).And.NotBe(hash3);
-            hash5.Should().NotBe(0).And.NotBe(hash2).And.NotBe(hash3).And.NotBe(hash4);
-        }
+namespace SonarAnalyzer.SymbolicExecution.Roslyn
+{
+    public sealed record ExceptionState : IEquatable<ExceptionState>
+    {
+        public static readonly ExceptionState UnknownException = new();
+
+        public ITypeSymbol Type { get; }
+
+        public ExceptionState(ITypeSymbol type) =>
+            Type = type ?? throw new ArgumentNullException(nameof(type));
+
+        private ExceptionState() { }
+
+        public override string ToString() =>
+            Type is null ? "Unknown" : Type.Name;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ExceptionStateTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ExceptionStateTest.cs
@@ -1,0 +1,74 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.SymbolicExecution.Roslyn;
+
+namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
+{
+    [TestClass]
+    public partial class ExceptionStateTest
+    {
+        [TestMethod]
+        public void Constructor_Null_Throws() =>
+            ((Func<ExceptionState>)(() => new ExceptionState(null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("type");
+
+        [TestMethod]
+        public void ToString_Unknown() =>
+            ExceptionState.UnknownException.ToString().Should().Be("Unknown");
+
+        [DataTestMethod]
+        [DataRow("System.Exception", "Exception")]
+        [DataRow("System.ArgumentNullException", "ArgumentNullException")]
+        [DataRow("System.IO.IOException", "IOException")]
+        public void ToString_Known(string typeName, string expected) =>
+            new ExceptionState(TestHelper.CompileCS(string.Empty).Model.Compilation.GetTypeByMetadataName(typeName)).ToString().Should().Be(expected);
+
+        [TestMethod]
+        public void Equals_ReturnsTrueForEquivalent()
+        {
+            var compilation = TestHelper.CompileCS(string.Empty).Model.Compilation;
+            var first = new ExceptionState(compilation.GetTypeByMetadataName("System.Exception"));
+            var same = new ExceptionState(compilation.GetTypeByMetadataName("System.Exception"));
+            var second = new ExceptionState(compilation.GetTypeByMetadataName("System.ArgumentNullException"));
+
+            first.Equals(first).Should().BeTrue();
+            first.Equals(same).Should().BeTrue();
+            first.Equals(null).Should().BeFalse();
+            first.Equals(second).Should().BeFalse();
+            first.Equals(ExceptionState.UnknownException).Should().BeFalse();
+
+            ExceptionState.UnknownException.Equals(ExceptionState.UnknownException).Should().BeTrue();
+            ExceptionState.UnknownException.Equals(first).Should().BeFalse();
+            ExceptionState.UnknownException.Equals(null).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void GetHashCode_ReturnsSameForEquivalent()
+        {
+            var compilation = TestHelper.CompileCS(string.Empty).Model.Compilation;
+            var first = new ExceptionState(compilation.GetTypeByMetadataName("System.Exception"));
+            var same = new ExceptionState(compilation.GetTypeByMetadataName("System.Exception"));
+            var second = new ExceptionState(compilation.GetTypeByMetadataName("System.ArgumentNullException"));
+
+            first.GetHashCode().Should().Be(same.GetHashCode()).And.NotBe(second.GetHashCode());
+            ExceptionState.UnknownException.GetHashCode().Should().NotBe(first.GetHashCode());
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ExceptionStateTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ExceptionStateTest.cs
@@ -23,7 +23,7 @@ using SonarAnalyzer.SymbolicExecution.Roslyn;
 namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
 {
     [TestClass]
-    public partial class ExceptionStateTest
+    public class ExceptionStateTest
     {
         [TestMethod]
         public void Constructor_Null_Throws() =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
@@ -34,8 +34,11 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         {
             var reusedValue = new SymbolicValue().WithConstraint(TestConstraint.First);
             var anotherValue = new SymbolicValue().WithConstraint(TestConstraint.Second);
-            var operations = TestHelper.CompileCfgBodyCS("var x = 42; var y = 42;").Blocks[1].Operations.ToExecutionOrder().ToArray();
+            var cfg = TestHelper.CompileCfgBodyCS("var x = 42; var y = 42;");
+            var operations = cfg.Blocks[1].Operations.ToExecutionOrder().ToArray();
             var symbols = operations.Select(x => x.Instance.TrackedSymbol()).Where(x => x is not null).ToArray();
+            var exceptionType = cfg.OriginalOperation.SemanticModel.Compilation.GetTypeByMetadataName("System.Exception");
+
             var empty = ProgramState.Empty;
             var withOperationOrig = empty.SetOperationValue(operations[0], reusedValue);
             var withOperationSame = empty.SetOperationValue(operations[0], reusedValue);
@@ -49,6 +52,9 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             var withPreservedSymbolOrig = empty.Preserve(symbols[0]);
             var withPreservedSymbolSame = empty.Preserve(symbols[0]);
             var withPreservedSymbolDiff = empty.Preserve(symbols[1]);
+            var withExceptionOrig = empty.SetException(exceptionType);
+            var withExceptionSame = empty.SetException(exceptionType);
+            var withExceptionDiff = empty.SetException(ExceptionState.UnknownException);
             var mixedOrig = withOperationOrig.SetSymbolValue(symbols[0], reusedValue);
             var mixedSame = withOperationSame.SetSymbolValue(symbols[0], reusedValue);
             var mixedDiff = withOperationDiff.SetSymbolValue(symbols[0], anotherValue);
@@ -66,6 +72,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             withOperationOrig.Equals(withSymbolDiff).Should().BeFalse();
             withOperationOrig.Equals(withCaptureDiff).Should().BeFalse();
             withOperationOrig.Equals(withPreservedSymbolDiff).Should().BeFalse();
+            withOperationOrig.Equals(withExceptionDiff).Should().BeFalse();
 
             withSymbolOrig.Equals(withSymbolOrig).Should().BeTrue();
             withSymbolOrig.Equals(withSymbolSame).Should().BeTrue();
@@ -74,6 +81,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             withSymbolOrig.Equals(withOperationDiff).Should().BeFalse();
             withSymbolOrig.Equals(withCaptureDiff).Should().BeFalse();
             withSymbolOrig.Equals(withPreservedSymbolDiff).Should().BeFalse();
+            withSymbolOrig.Equals(withExceptionDiff).Should().BeFalse();
 
             withCaptureOrig.Equals(withCaptureOrig).Should().BeTrue();
             withCaptureOrig.Equals(withCaptureSame).Should().BeTrue();
@@ -81,12 +89,22 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             withCaptureOrig.Equals(empty).Should().BeFalse();
             withCaptureOrig.Equals(withOperationDiff).Should().BeFalse();
             withCaptureOrig.Equals(withSymbolDiff).Should().BeFalse();
+
             withPreservedSymbolOrig.Equals(withPreservedSymbolOrig).Should().BeTrue();
             withPreservedSymbolOrig.Equals(withPreservedSymbolSame).Should().BeTrue();
             withPreservedSymbolOrig.Equals(withPreservedSymbolDiff).Should().BeFalse();
             withPreservedSymbolOrig.Equals(empty).Should().BeFalse();
             withPreservedSymbolOrig.Equals(withOperationDiff).Should().BeFalse();
             withPreservedSymbolOrig.Equals(withSymbolDiff).Should().BeFalse();
+            withPreservedSymbolOrig.Equals(withExceptionDiff).Should().BeFalse();
+
+            withExceptionOrig.Equals(withExceptionOrig).Should().BeTrue();
+            withExceptionOrig.Equals(withExceptionSame).Should().BeTrue();
+            withExceptionOrig.Equals(withExceptionDiff).Should().BeFalse();
+            withExceptionOrig.Equals(empty).Should().BeFalse();
+            withExceptionOrig.Equals(withOperationDiff).Should().BeFalse();
+            withExceptionOrig.Equals(withSymbolDiff).Should().BeFalse();
+            withExceptionOrig.Equals(withExceptionDiff).Should().BeFalse();
 
             mixedOrig.Equals(mixedOrig).Should().BeTrue();
             mixedOrig.Equals(mixedSame).Should().BeTrue();
@@ -99,8 +117,11 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         {
             var reusedValue = new SymbolicValue().WithConstraint(TestConstraint.First);
             var anotherValue = new SymbolicValue().WithConstraint(TestConstraint.Second);
-            var operations = TestHelper.CompileCfgBodyCS("var x = 42; var y = 42;").Blocks[1].Operations.ToExecutionOrder().ToArray();
+            var cfg = TestHelper.CompileCfgBodyCS("var x = 42; var y = 42;");
+            var operations = cfg.Blocks[1].Operations.ToExecutionOrder().ToArray();
             var symbols = operations.Select(x => x.Instance.TrackedSymbol()).Where(x => x is not null).ToArray();
+            var exceptionType = cfg.OriginalOperation.SemanticModel.Compilation.GetTypeByMetadataName("System.Exception");
+
             var empty = ProgramState.Empty;
             var withOperationOrig = empty.SetOperationValue(operations[0], reusedValue);
             var withOperationSame = empty.SetOperationValue(operations[0], reusedValue);
@@ -114,6 +135,9 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             var withPreservedSymbolOrig = empty.Preserve(symbols[0]);
             var withPreservedSymbolSame = empty.Preserve(symbols[0]);
             var withPreservedSymbolDiff = empty.Preserve(symbols[1]);
+            var withExceptionOrig = empty.SetException(exceptionType);
+            var withExceptionSame = empty.SetException(exceptionType);
+            var withExceptionDiff = empty.SetException(ExceptionState.UnknownException);
             var mixedOrig = withOperationOrig.SetSymbolValue(symbols[0], reusedValue);
             var mixedSame = withOperationSame.SetSymbolValue(symbols[0], reusedValue);
             var mixedDiff = withOperationDiff.SetSymbolValue(symbols[0], anotherValue);
@@ -135,6 +159,10 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             withPreservedSymbolOrig.GetHashCode().Should().Be(withPreservedSymbolSame.GetHashCode());
             withPreservedSymbolOrig.GetHashCode().Should().NotBe(withPreservedSymbolDiff.GetHashCode());
             withPreservedSymbolOrig.GetHashCode().Should().NotBe(mixedSame.GetHashCode());
+
+            withExceptionOrig.GetHashCode().Should().Be(withExceptionSame.GetHashCode());
+            withExceptionOrig.GetHashCode().Should().NotBe(withExceptionDiff.GetHashCode());
+            withExceptionOrig.GetHashCode().Should().NotBe(mixedSame.GetHashCode());
 
             mixedOrig.GetHashCode().Should().Be(mixedSame.GetHashCode());
             mixedOrig.GetHashCode().Should().NotBe(mixedDiff.GetHashCode());
@@ -205,6 +233,15 @@ SimpleAssignmentOperation / VariableDeclaratorSyntax: a = true: No constraints
         }
 
         [TestMethod]
+        public void ToString_Exception()
+        {
+            var sut = ProgramState.Empty.SetException(ExceptionState.UnknownException);
+            sut.ToString().Should().BeIgnoringLineEndings(
+@"Exception: Unknown
+");
+        }
+
+        [TestMethod]
         public void ToString_WithAll()
         {
             var assignment = TestHelper.CompileCfgBodyCS("var a = true;").Blocks[1].Operations[0];
@@ -216,10 +253,12 @@ SimpleAssignmentOperation / VariableDeclaratorSyntax: a = true: No constraints
                 .SetOperationValue(assignment, new())
                 .SetOperationValue(assignment.Children.First(), valueWithConstraint).Preserve(variableSymbol)
                 .SetCapture(new CaptureId(0), assignment)
-                .SetCapture(new CaptureId(1), assignment.Children.First());
+                .SetCapture(new CaptureId(1), assignment.Children.First())
+                .SetException(ExceptionState.UnknownException);
 
             sut.ToString().Should().BeIgnoringLineEndings(
-@"Symbols:
+@"Exception: Unknown
+Symbols:
 a: No constraints
 Sample.Main(): First
 Operations:


### PR DESCRIPTION
Related to #5710, prerequisite for #5718

We need to track what kind of exception are we dealing with.

We will need this to know that we're on an exception-thrown path for nested scenario.
```C#
try{
  try{
     throw new Exception(); // Persist state, that we're in an exception
  } finally {
    // After this, we need to skip DoSomething()
  }
  DoSomething();
} finally {
    // And continue with this
}
```