### PR TITLE
Implement S4060 - Avoid unsealed attributes - for VB.NET

### DIFF
--- a/analyzers/rspec/vbnet/S4060_vb.net.html
+++ b/analyzers/rspec/vbnet/S4060_vb.net.html
@@ -1,0 +1,30 @@
+<p>The .NET framework class library provides methods for retrieving custom attributes. Sealing the attribute eliminates the search through the
+inheritance hierarchy, and can improve performance.</p>
+<p>This rule raises an issue when a public type inherits from <code>System.Attribute</code>, is not abstract, and is not sealed.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+Public Class MyAttribute    ' Noncompliant
+    Inherits Attribute
+
+    Public ReadOnly Property Name As String
+
+    Public Sub New(Name As String)
+        Me.Name = Name
+    End Sub
+
+End Class
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+Public NotInheritable Class MyAttribute    ' Noncompliant
+    Inherits Attribute
+
+    Public ReadOnly Property Name As String
+
+    Public Sub New(Name As String)
+        Me.Name = Name
+    End Sub
+
+End Class
+</pre>
+

--- a/analyzers/rspec/vbnet/S4060_vb.net.html
+++ b/analyzers/rspec/vbnet/S4060_vb.net.html
@@ -16,7 +16,7 @@ End Class
 </pre>
 <h2>Compliant Solution</h2>
 <pre>
-Public NotInheritable Class MyAttribute    ' Noncompliant
+Public NotInheritable Class MyAttribute
     Inherits Attribute
 
     Public ReadOnly Property Name As String

--- a/analyzers/rspec/vbnet/S4060_vb.net.json
+++ b/analyzers/rspec/vbnet/S4060_vb.net.json
@@ -1,0 +1,17 @@
+{
+  "title": "Non-abstract attributes should be sealed",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "2min"
+  },
+  "tags": [
+    "performance"
+  ],
+  "defaultSeverity": "Minor",
+  "ruleSpecification": "RSPEC-4060",
+  "sqKey": "S4060",
+  "scope": "Main",
+  "quickfix": "unknown"
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxKindFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxKindFacade.cs
@@ -21,49 +21,49 @@
 using Microsoft.CodeAnalysis.CSharp;
 using StyleCop.Analyzers.Lightup;
 
-namespace SonarAnalyzer.Helpers.Facade
+namespace SonarAnalyzer.Helpers.Facade;
+
+internal sealed class CSharpSyntaxKindFacade : ISyntaxKindFacade<SyntaxKind>
 {
-    internal sealed class CSharpSyntaxKindFacade : ISyntaxKindFacade<SyntaxKind>
+    public SyntaxKind Attribute => SyntaxKind.Attribute;
+    public SyntaxKind[] ClassAndRecordDeclaration => new[]
     {
-        public SyntaxKind Attribute => SyntaxKind.Attribute;
-        public SyntaxKind[] ClassAndRecordDeclaration => new[]
-        {
-            SyntaxKind.ClassDeclaration,
-            SyntaxKindEx.RecordClassDeclaration,
-        };
-        public SyntaxKind[] ComparisonKinds => new[]
-        {
-            SyntaxKind.GreaterThanExpression,
-            SyntaxKind.GreaterThanOrEqualExpression,
-            SyntaxKind.LessThanExpression,
-            SyntaxKind.LessThanOrEqualExpression,
-            SyntaxKind.EqualsExpression,
-            SyntaxKind.NotEqualsExpression,
-        };
-        public SyntaxKind ConstructorDeclaration => SyntaxKind.ConstructorDeclaration;
-        public SyntaxKind[] DefaultExpressions => new[] { SyntaxKind.DefaultExpression, SyntaxKindEx.DefaultLiteralExpression };
-        public SyntaxKind EnumDeclaration => SyntaxKind.EnumDeclaration;
-        public SyntaxKind FieldDeclaration => SyntaxKind.FieldDeclaration;
-        public SyntaxKind IdentifierName => SyntaxKind.IdentifierName;
-        public SyntaxKind IdentifierToken => SyntaxKind.IdentifierToken;
-        public SyntaxKind InvocationExpression => SyntaxKind.InvocationExpression;
-        public SyntaxKind InterpolatedStringExpression => SyntaxKind.InterpolatedStringExpression;
-        public SyntaxKind[] MethodDeclarations => new[] { SyntaxKind.MethodDeclaration };
-        public SyntaxKind[] ObjectCreationExpressions => new[] { SyntaxKind.ObjectCreationExpression, SyntaxKindEx.ImplicitObjectCreationExpression };
-        public SyntaxKind Parameter => SyntaxKind.Parameter;
-        public SyntaxKind ParameterList => SyntaxKind.ParameterList;
-        public SyntaxKind ReturnStatement => SyntaxKind.ReturnStatement;
-        public SyntaxKind SimpleAssignment => SyntaxKind.SimpleAssignmentExpression;
-        public SyntaxKind SimpleMemberAccessExpression => SyntaxKind.SimpleMemberAccessExpression;
-        public SyntaxKind StringLiteralExpression => SyntaxKind.StringLiteralExpression;
-        public SyntaxKind[] TypeDeclaration => new[]
-        {
-            SyntaxKind.ClassDeclaration,
-            SyntaxKind.StructDeclaration,
-            SyntaxKind.InterfaceDeclaration,
-            SyntaxKind.EnumDeclaration,
-            SyntaxKindEx.RecordClassDeclaration,
-            SyntaxKindEx.RecordStructDeclaration,
-        };
-    }
+        SyntaxKind.ClassDeclaration,
+        SyntaxKindEx.RecordClassDeclaration,
+    };
+    public SyntaxKind ClassDeclaration => SyntaxKind.ClassDeclaration;
+    public SyntaxKind[] ComparisonKinds => new[]
+    {
+        SyntaxKind.GreaterThanExpression,
+        SyntaxKind.GreaterThanOrEqualExpression,
+        SyntaxKind.LessThanExpression,
+        SyntaxKind.LessThanOrEqualExpression,
+        SyntaxKind.EqualsExpression,
+        SyntaxKind.NotEqualsExpression,
+    };
+    public SyntaxKind ConstructorDeclaration => SyntaxKind.ConstructorDeclaration;
+    public SyntaxKind[] DefaultExpressions => new[] { SyntaxKind.DefaultExpression, SyntaxKindEx.DefaultLiteralExpression };
+    public SyntaxKind EnumDeclaration => SyntaxKind.EnumDeclaration;
+    public SyntaxKind FieldDeclaration => SyntaxKind.FieldDeclaration;
+    public SyntaxKind IdentifierName => SyntaxKind.IdentifierName;
+    public SyntaxKind IdentifierToken => SyntaxKind.IdentifierToken;
+    public SyntaxKind InvocationExpression => SyntaxKind.InvocationExpression;
+    public SyntaxKind InterpolatedStringExpression => SyntaxKind.InterpolatedStringExpression;
+    public SyntaxKind[] MethodDeclarations => new[] { SyntaxKind.MethodDeclaration };
+    public SyntaxKind[] ObjectCreationExpressions => new[] { SyntaxKind.ObjectCreationExpression, SyntaxKindEx.ImplicitObjectCreationExpression };
+    public SyntaxKind Parameter => SyntaxKind.Parameter;
+    public SyntaxKind ParameterList => SyntaxKind.ParameterList;
+    public SyntaxKind ReturnStatement => SyntaxKind.ReturnStatement;
+    public SyntaxKind SimpleAssignment => SyntaxKind.SimpleAssignmentExpression;
+    public SyntaxKind SimpleMemberAccessExpression => SyntaxKind.SimpleMemberAccessExpression;
+    public SyntaxKind StringLiteralExpression => SyntaxKind.StringLiteralExpression;
+    public SyntaxKind[] TypeDeclaration => new[]
+    {
+        SyntaxKind.ClassDeclaration,
+        SyntaxKind.StructDeclaration,
+        SyntaxKind.InterfaceDeclaration,
+        SyntaxKind.EnumDeclaration,
+        SyntaxKindEx.RecordClassDeclaration,
+        SyntaxKindEx.RecordStructDeclaration,
+    };
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidUnsealedAttributes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidUnsealedAttributes.cs
@@ -18,44 +18,15 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.CSharp
+namespace SonarAnalyzer.Rules.CSharp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class AvoidUnsealedAttributes : AvoidUnsealedAttributesBase<SyntaxKind>
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class AvoidUnsealedAttributes : SonarDiagnosticAnalyzer
-    {
-        internal const string DiagnosticId = "S4060";
-        private const string MessageFormat = "Seal this attribute or make it abstract.";
-
-        private static readonly DiagnosticDescriptor rule =
-            DescriptorFactory.Create(DiagnosticId, MessageFormat);
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
-
-        protected override void Initialize(SonarAnalysisContext context)
-        {
-            context.RegisterSyntaxNodeActionInNonGenerated(
-                c =>
-                {
-                    var classDeclaration = (ClassDeclarationSyntax)c.Node;
-                    var classSymbol = c.SemanticModel.GetDeclaredSymbol(classDeclaration);
-
-                    if (!classDeclaration.Identifier.IsMissing &&
-                        classSymbol != null &&
-                        classSymbol.DerivesFrom(KnownType.System_Attribute) &&
-                        classSymbol.IsPubliclyAccessible() &&
-                        !classSymbol.IsAbstract &&
-                        !classSymbol.IsSealed)
-                    {
-                        c.ReportIssue(Diagnostic.Create(rule, classDeclaration.Identifier.GetLocation()));
-                    }
-                },
-                SyntaxKind.ClassDeclaration);
-        }
-    }
+    protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 }

--- a/analyzers/src/SonarAnalyzer.Common/Facade/ISyntaxKindFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/ISyntaxKindFacade.cs
@@ -18,30 +18,30 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Helpers.Facade
+namespace SonarAnalyzer.Helpers.Facade;
+
+public interface ISyntaxKindFacade<out TSyntaxKind>
+    where TSyntaxKind : struct
 {
-    public interface ISyntaxKindFacade<out TSyntaxKind>
-        where TSyntaxKind : struct
-    {
-        abstract TSyntaxKind Attribute { get; }
-        abstract TSyntaxKind[] ClassAndRecordDeclaration { get; }
-        abstract TSyntaxKind[] ComparisonKinds { get; }
-        abstract TSyntaxKind ConstructorDeclaration { get; }
-        abstract TSyntaxKind[] DefaultExpressions { get; }
-        abstract TSyntaxKind EnumDeclaration { get; }
-        abstract TSyntaxKind FieldDeclaration { get; }
-        abstract TSyntaxKind IdentifierName { get; }
-        abstract TSyntaxKind IdentifierToken { get; }
-        abstract TSyntaxKind InvocationExpression { get; }
-        abstract TSyntaxKind InterpolatedStringExpression { get; }
-        abstract TSyntaxKind[] MethodDeclarations { get; }
-        abstract TSyntaxKind[] ObjectCreationExpressions { get; }
-        abstract TSyntaxKind Parameter { get; }
-        abstract TSyntaxKind ParameterList { get; }
-        abstract TSyntaxKind ReturnStatement { get; }
-        abstract TSyntaxKind SimpleAssignment { get; }
-        abstract TSyntaxKind SimpleMemberAccessExpression { get; }
-        abstract TSyntaxKind StringLiteralExpression { get; }
-        abstract TSyntaxKind[] TypeDeclaration { get; }
-    }
+    abstract TSyntaxKind Attribute { get; }
+    abstract TSyntaxKind[] ClassAndRecordDeclaration { get; }
+    abstract TSyntaxKind ClassDeclaration { get; }
+    abstract TSyntaxKind[] ComparisonKinds { get; }
+    abstract TSyntaxKind ConstructorDeclaration { get; }
+    abstract TSyntaxKind[] DefaultExpressions { get; }
+    abstract TSyntaxKind EnumDeclaration { get; }
+    abstract TSyntaxKind FieldDeclaration { get; }
+    abstract TSyntaxKind IdentifierName { get; }
+    abstract TSyntaxKind IdentifierToken { get; }
+    abstract TSyntaxKind InvocationExpression { get; }
+    abstract TSyntaxKind InterpolatedStringExpression { get; }
+    abstract TSyntaxKind[] MethodDeclarations { get; }
+    abstract TSyntaxKind[] ObjectCreationExpressions { get; }
+    abstract TSyntaxKind Parameter { get; }
+    abstract TSyntaxKind ParameterList { get; }
+    abstract TSyntaxKind ReturnStatement { get; }
+    abstract TSyntaxKind SimpleAssignment { get; }
+    abstract TSyntaxKind SimpleMemberAccessExpression { get; }
+    abstract TSyntaxKind StringLiteralExpression { get; }
+    abstract TSyntaxKind[] TypeDeclaration { get; }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AvoidUnsealedAttributesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AvoidUnsealedAttributesBase.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules;
+
+public abstract class AvoidUnsealedAttributesBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
+    where TSyntaxKind : struct
+{
+    private const string DiagnosticId = "S4060";
+
+    protected override string MessageFormat => "Seal this attribute or make it abstract.";
+
+    protected AvoidUnsealedAttributesBase() : base(DiagnosticId) { }
+
+    protected sealed override void Initialize(SonarAnalysisContext context)
+        => context.RegisterSyntaxNodeActionInNonGenerated(
+            Language.GeneratedCodeRecognizer,
+            c =>
+            {
+                if (Language.Syntax.NodeIdentifier(c.Node) is { } identifier
+                    && !identifier.IsMissing
+                    && c.SemanticModel.GetDeclaredSymbol(c.Node) is INamedTypeSymbol { IsAbstract: false, IsSealed: false } symbol
+                    && symbol.DerivesFrom(KnownType.System_Attribute)
+                    && symbol.IsPubliclyAccessible())
+                {
+                    c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation()));
+                }
+            },
+            Language.SyntaxKind.ClassAndRecordDeclaration);
+}

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AvoidUnsealedAttributesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AvoidUnsealedAttributesBase.cs
@@ -37,8 +37,7 @@ public abstract class AvoidUnsealedAttributesBase<TSyntaxKind> : SonarDiagnostic
             Language.GeneratedCodeRecognizer,
             c =>
             {
-                if (Language.Syntax.NodeIdentifier(c.Node) is { } identifier
-                    && !identifier.IsMissing
+                if (Language.Syntax.NodeIdentifier(c.Node) is { IsMissing: false } identifier
                     && c.SemanticModel.GetDeclaredSymbol(c.Node) is INamedTypeSymbol { IsAbstract: false, IsSealed: false } symbol
                     && symbol.DerivesFrom(KnownType.System_Attribute)
                     && symbol.IsPubliclyAccessible())

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AvoidUnsealedAttributesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AvoidUnsealedAttributesBase.cs
@@ -32,8 +32,8 @@ public abstract class AvoidUnsealedAttributesBase<TSyntaxKind> : SonarDiagnostic
 
     protected AvoidUnsealedAttributesBase() : base(DiagnosticId) { }
 
-    protected sealed override void Initialize(SonarAnalysisContext context)
-        => context.RegisterSyntaxNodeActionInNonGenerated(
+    protected sealed override void Initialize(SonarAnalysisContext context) =>
+        context.RegisterSyntaxNodeActionInNonGenerated(
             Language.GeneratedCodeRecognizer,
             c =>
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AvoidUnsealedAttributesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AvoidUnsealedAttributesBase.cs
@@ -46,5 +46,5 @@ public abstract class AvoidUnsealedAttributesBase<TSyntaxKind> : SonarDiagnostic
                     c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation()));
                 }
             },
-            Language.SyntaxKind.ClassAndRecordDeclaration);
+            Language.SyntaxKind.ClassDeclaration);
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxKindFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxKindFacade.cs
@@ -20,37 +20,37 @@
 
 using Microsoft.CodeAnalysis.VisualBasic;
 
-namespace SonarAnalyzer.Helpers.Facade
+namespace SonarAnalyzer.Helpers.Facade;
+
+internal sealed class VisualBasicSyntaxKindFacade : ISyntaxKindFacade<SyntaxKind>
 {
-    internal sealed class VisualBasicSyntaxKindFacade : ISyntaxKindFacade<SyntaxKind>
+    public SyntaxKind Attribute => SyntaxKind.Attribute;
+    public SyntaxKind[] ClassAndRecordDeclaration => new[] { SyntaxKind.ClassBlock };
+    public SyntaxKind ClassDeclaration => SyntaxKind.ClassBlock;
+    public SyntaxKind[] ComparisonKinds => new[]
     {
-        public SyntaxKind Attribute => SyntaxKind.Attribute;
-        public SyntaxKind[] ClassAndRecordDeclaration => new[] { SyntaxKind.ClassBlock };
-        public SyntaxKind[] ComparisonKinds => new[]
-        {
-            SyntaxKind.GreaterThanExpression,
-            SyntaxKind.GreaterThanOrEqualExpression,
-            SyntaxKind.LessThanExpression,
-            SyntaxKind.LessThanOrEqualExpression,
-            SyntaxKind.EqualsExpression,
-            SyntaxKind.NotEqualsExpression,
-        };
-        public SyntaxKind ConstructorDeclaration => SyntaxKind.ConstructorBlock;
-        public SyntaxKind[] DefaultExpressions => new[] { SyntaxKind.NothingLiteralExpression };
-        public SyntaxKind EnumDeclaration => SyntaxKind.EnumStatement;
-        public SyntaxKind FieldDeclaration => SyntaxKind.FieldDeclaration;
-        public SyntaxKind IdentifierName => SyntaxKind.IdentifierName;
-        public SyntaxKind IdentifierToken => SyntaxKind.IdentifierToken;
-        public SyntaxKind InvocationExpression => SyntaxKind.InvocationExpression;
-        public SyntaxKind InterpolatedStringExpression => SyntaxKind.InterpolatedStringExpression;
-        public SyntaxKind[] MethodDeclarations => new[] { SyntaxKind.FunctionStatement, SyntaxKind.SubStatement };
-        public SyntaxKind[] ObjectCreationExpressions => new[] { SyntaxKind.ObjectCreationExpression };
-        public SyntaxKind Parameter => SyntaxKind.Parameter;
-        public SyntaxKind ParameterList => SyntaxKind.ParameterList;
-        public SyntaxKind ReturnStatement => SyntaxKind.ReturnStatement;
-        public SyntaxKind SimpleAssignment => SyntaxKind.SimpleAssignmentStatement;
-        public SyntaxKind SimpleMemberAccessExpression => SyntaxKind.SimpleMemberAccessExpression;
-        public SyntaxKind StringLiteralExpression => SyntaxKind.StringLiteralExpression;
-        public SyntaxKind[] TypeDeclaration => new[] { SyntaxKind.ClassBlock, SyntaxKind.StructureBlock, SyntaxKind.InterfaceBlock, SyntaxKind.EnumBlock };
-    }
+        SyntaxKind.GreaterThanExpression,
+        SyntaxKind.GreaterThanOrEqualExpression,
+        SyntaxKind.LessThanExpression,
+        SyntaxKind.LessThanOrEqualExpression,
+        SyntaxKind.EqualsExpression,
+        SyntaxKind.NotEqualsExpression,
+    };
+    public SyntaxKind ConstructorDeclaration => SyntaxKind.ConstructorBlock;
+    public SyntaxKind[] DefaultExpressions => new[] { SyntaxKind.NothingLiteralExpression };
+    public SyntaxKind EnumDeclaration => SyntaxKind.EnumStatement;
+    public SyntaxKind FieldDeclaration => SyntaxKind.FieldDeclaration;
+    public SyntaxKind IdentifierName => SyntaxKind.IdentifierName;
+    public SyntaxKind IdentifierToken => SyntaxKind.IdentifierToken;
+    public SyntaxKind InvocationExpression => SyntaxKind.InvocationExpression;
+    public SyntaxKind InterpolatedStringExpression => SyntaxKind.InterpolatedStringExpression;
+    public SyntaxKind[] MethodDeclarations => new[] { SyntaxKind.FunctionStatement, SyntaxKind.SubStatement };
+    public SyntaxKind[] ObjectCreationExpressions => new[] { SyntaxKind.ObjectCreationExpression };
+    public SyntaxKind Parameter => SyntaxKind.Parameter;
+    public SyntaxKind ParameterList => SyntaxKind.ParameterList;
+    public SyntaxKind ReturnStatement => SyntaxKind.ReturnStatement;
+    public SyntaxKind SimpleAssignment => SyntaxKind.SimpleAssignmentStatement;
+    public SyntaxKind SimpleMemberAccessExpression => SyntaxKind.SimpleMemberAccessExpression;
+    public SyntaxKind StringLiteralExpression => SyntaxKind.StringLiteralExpression;
+    public SyntaxKind[] TypeDeclaration => new[] { SyntaxKind.ClassBlock, SyntaxKind.StructureBlock, SyntaxKind.InterfaceBlock, SyntaxKind.EnumBlock };
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
@@ -168,6 +168,7 @@ namespace SonarAnalyzer.Helpers
         public static SyntaxToken? GetIdentifier(this SyntaxNode node) =>
             node?.RemoveParentheses() switch
             {
+                ClassBlockSyntax x => x.ClassStatement.Identifier,
                 ClassStatementSyntax x => x.Identifier,
                 IdentifierNameSyntax x => x.Identifier,
                 MemberAccessExpressionSyntax x => x.Name.Identifier,

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/AvoidUnsealedAttributes.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/AvoidUnsealedAttributes.cs
@@ -18,19 +18,15 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using CS = SonarAnalyzer.Rules.CSharp;
-using VB = SonarAnalyzer.Rules.VisualBasic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.VisualBasic;
+using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.UnitTest.Rules;
+namespace SonarAnalyzer.Rules.VisualBasic;
 
-[TestClass]
-public class AvoidUnsealedAttributesTest
+[DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+public sealed class AvoidUnsealedAttributes : AvoidUnsealedAttributesBase<SyntaxKind>
 {
-    [TestMethod]
-    public void AvoidUnsealedAttributes_CS() =>
-        new VerifierBuilder<CS.AvoidUnsealedAttributes>().AddPaths("AvoidUnsealedAttributes.cs").Verify();
-
-    [TestMethod]
-    public void AvoidUnsealedAttributes_VB() =>
-        new VerifierBuilder<VB.AvoidUnsealedAttributes>().AddPaths("AvoidUnsealedAttributes.vb").Verify();
+    protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeMappingVB.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeMappingVB.cs
@@ -3984,7 +3984,7 @@ internal static class RuleTypeMappingVB
         // ["S4057"],
         // ["S4058"],
         // ["S4059"],
-        // ["S4060"],
+        ["S4060"] = "CODE_SMELL",
         // ["S4061"],
         // ["S4062"],
         // ["S4063"],

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AvoidUnsealedAttributesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AvoidUnsealedAttributesTest.cs
@@ -20,14 +20,12 @@
 
 using SonarAnalyzer.Rules.CSharp;
 
-namespace SonarAnalyzer.UnitTest.Rules
+namespace SonarAnalyzer.UnitTest.Rules;
+
+[TestClass]
+public class AvoidUnsealedAttributesTest
 {
-    [TestClass]
-    public class AvoidUnsealedAttributesTest
-    {
-        [TestMethod]
-        public void AvoidUnsealedAttributes() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\AvoidUnsealedAttributes.cs",
-                new AvoidUnsealedAttributes());
-    }
+    [TestMethod]
+    public void AvoidUnsealedAttributes() =>
+        new VerifierBuilder<AvoidUnsealedAttributes>().AddPaths("AvoidUnsealedAttributes.cs").Verify();
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.cs
@@ -1,35 +1,21 @@
 ﻿using System;
 
-namespace Tests.Diagnostics
+public class MyAttribute : Attribute { } // Noncompliant {{Seal this attribute or make it abstract.}}
+//           ^^^^^^^^^^^
+
+public class MyOtherAttribute : Attribute { } // Noncompliant
+
+public sealed class Bar : Attribute // Compliant - sealed
+{ }
+
+public abstract class FooBar : Attribute { } // Compliant - abstract
+
+public sealed class Attr : Attribute
 {
-    public class MyAttribute : Attribute // Noncompliant {{Seal this attribute or make it abstract.}}
-//               ^^^^^^^^^^^
+    private class InnerAttr : Attribute // Compliant - private
     {
+        public class InnerInnerAttr : Attribute { } // Compliant - effective accessibility is private
     }
 
-    public class MyOtherAttribute : Attribute // Noncompliant
-    {
-    }
-
-
-    public sealed class Bar : Attribute // Compliant - sealed
-    { }
-
-    public abstract class FooBar : Attribute // Compliant - abstract
-    {
-    }
-
-    public sealed class Attr : Attribute
-    {
-        private class InnerAttr : Attribute // Compliant - private
-        {
-            public class InnerInnerAttr : Attribute // Compliant - effective accessibility is private
-            {
-            }
-        }
-
-        protected class InnerAttr2 : Attribute // Noncompliant
-        {
-        }
-    }
+    protected class InnerAttr2 : Attribute { } // Noncompliant
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.cs
@@ -5,10 +5,12 @@ public class MyAttribute : Attribute { } // Noncompliant {{Seal this attribute o
 
 public class MyOtherAttribute : Attribute { } // Noncompliant
 
-public sealed class Bar : Attribute // Compliant - sealed
-{ }
+public sealed class Bar : Attribute { } // Compliant - sealed
+
 
 public abstract class FooBar : Attribute { } // Compliant - abstract
+
+public class NotAnAttribute { } // Compliant - not an attribute
 
 public sealed class Attr : Attribute
 {
@@ -19,3 +21,5 @@ public sealed class Attr : Attribute
 
     protected class InnerAttr2 : Attribute { } // Noncompliant
 }
+
+public class { }    // Error CS1001  Identifier expected

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.vb
@@ -1,0 +1,31 @@
+﻿
+Namespace AvoidUnsealedAttributes
+
+    Public Class PublicAttribute ' Noncompliant {{Seal this attribute or make it abstract.}}
+        Inherits Attribute
+        '        ^^^^^^^^^^^^^^^ @-1
+    End Class
+
+    Public NotInheritable Class SealedAttribute
+        Inherits Attribute ' Compliant
+    End Class
+
+    Public MustInherit Class AbstractAttribute
+        Inherits Attribute ' Compliant
+    End Class
+
+    Public Class Container
+
+        Protected Class ProtectedAttribute ' Noncompliant
+            Inherits Attribute
+        End Class
+
+        Private Class PrivateAttribute ' Compliant
+            Inherits Attribute
+
+            Public Class SubClassAttribute ' Compliant - effective accessibility is private
+                Inherits Attribute
+            End Class
+        End Class
+    End Class
+End Namespace

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.vb
@@ -12,6 +12,9 @@ Public MustInherit Class AbstractAttribute
     Inherits Attribute ' Compliant
 End Class
 
+Public Class NotAnAttribute ' Compliant - not an attribute
+End Class
+
 Public Class Container
 
     Protected Class ProtectedAttribute ' Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AvoidUnsealedAttributes.vb
@@ -1,31 +1,27 @@
-﻿
-Namespace AvoidUnsealedAttributes
+﻿Public Class PublicAttribute ' Noncompliant {{Seal this attribute or make it abstract.}}
+    Inherits Attribute
+    '        ^^^^^^^^^^^^^^^ @-1
+End Class
 
-    Public Class PublicAttribute ' Noncompliant {{Seal this attribute or make it abstract.}}
+Public NotInheritable Class SealedAttribute
+    Inherits Attribute ' Compliant
+End Class
+
+Public MustInherit Class AbstractAttribute
+    Inherits Attribute ' Compliant
+End Class
+
+Public Class Container
+
+    Protected Class ProtectedAttribute ' Noncompliant
         Inherits Attribute
-        '        ^^^^^^^^^^^^^^^ @-1
     End Class
 
-    Public NotInheritable Class SealedAttribute
-        Inherits Attribute ' Compliant
-    End Class
+    Private Class PrivateAttribute ' Compliant
+        Inherits Attribute
 
-    Public MustInherit Class AbstractAttribute
-        Inherits Attribute ' Compliant
-    End Class
-
-    Public Class Container
-
-        Protected Class ProtectedAttribute ' Noncompliant
+        Public Class SubClassAttribute ' Compliant - effective accessibility is private
             Inherits Attribute
         End Class
-
-        Private Class PrivateAttribute ' Compliant
-            Inherits Attribute
-
-            Public Class SubClassAttribute ' Compliant - effective accessibility is private
-                Inherits Attribute
-            End Class
-        End Class
     End Class
-End Namespace
+End Class


### PR DESCRIPTION
See #501

# Description

The .NET framework class library provides methods for retrieving custom attributes. Sealing the attribute eliminates the search through the inheritance hierarchy, and can improve performance.

This rule raises an issue when a public type inherits from System.Attribute, is not abstract, and is not sealed.
## Noncompliant Code Example

``` VB
Namespace MyLibrary 

    <AttributeUsage(AttributeTargets.Class)>
    Public Class MyAttribute ' Noncompliant
        Inherits Attribute 
    
        Public Sub New(name as String) 
            Value = val
        End Sub
        
        Public Readonly Property Value as String
    End Class
End Namespace
```

## Compliant Solution

``` VB
Namespace MyLibrary 

    <AttributeUsage(AttributeTargets.Class)>
    Public MustInherit Class MyAttribute ' Noncompliant
        Inherits Attribute 
    
        Public Sub New(val as String) 
            Value = val 
        End Sub
        
        Public Readonly Property Value as String
    End Class
End Namespace
```
