### PR TITLE
Introduction of CSharpOnlyAnalyzer

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -76,6 +76,13 @@ namespace SonarAnalyzer.Helpers.Facade
         public override SyntaxToken? InvocationIdentifier(SyntaxNode invocation) =>
             invocation == null ? null : Cast<InvocationExpressionSyntax>(invocation).GetMethodCallIdentifier();
 
+        public override string Name(SyntaxNode node) =>
+            node switch
+            {
+                ObjectCreationExpressionSyntax x => x.Type.GetName(),
+                _ => string.Empty
+            };
+
         public override SyntaxNode NodeExpression(SyntaxNode node) =>
             node switch
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxKindFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxKindFacade.cs
@@ -43,6 +43,7 @@ namespace SonarAnalyzer.Helpers.Facade
         public SyntaxKind ConstructorDeclaration => SyntaxKind.ConstructorDeclaration;
         public SyntaxKind[] DefaultExpressions => new[] { SyntaxKind.DefaultExpression, SyntaxKindEx.DefaultLiteralExpression };
         public SyntaxKind EnumDeclaration => SyntaxKind.EnumDeclaration;
+        public SyntaxKind ExpressionStatement => SyntaxKind.ExpressionStatement;
         public SyntaxKind FieldDeclaration => SyntaxKind.FieldDeclaration;
         public SyntaxKind IdentifierName => SyntaxKind.IdentifierName;
         public SyntaxKind IdentifierToken => SyntaxKind.IdentifierToken;

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpOnlyAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpOnlyAnalyzer.cs
@@ -18,21 +18,16 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarAnalyzer.Rules.CSharp;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace SonarAnalyzer.UnitTest.Rules;
+namespace SonarAnalyzer.Helpers;
 
-[TestClass]
-public class ObjectCreatedDroppedTest
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public abstract class CSharpOnlyAnalyzer : SonarDiagnosticAnalyzer<SyntaxKind>
 {
-    [TestMethod]
-    public void ObjectCreatedDropped() =>
-        new VerifierBuilder<ObjectCreatedDropped>().AddPaths("ObjectCreatedDropped.cs").Verify();
+    protected sealed override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
-    [TestMethod]
-    public void ObjectCreatedDropped_CSharp9() =>
-        new VerifierBuilder<ObjectCreatedDropped>()
-        .WithOptions(ParseOptionsHelper.FromCSharp9)
-        .AddPaths("ObjectCreatedDropped.CSharp9.cs")
-        .Verify();
+    protected CSharpOnlyAnalyzer(string diagnosticId) : base(diagnosticId) { }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Facade/ISyntaxKindFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/ISyntaxKindFacade.cs
@@ -29,6 +29,7 @@ namespace SonarAnalyzer.Helpers.Facade
         abstract TSyntaxKind ConstructorDeclaration { get; }
         abstract TSyntaxKind[] DefaultExpressions { get; }
         abstract TSyntaxKind EnumDeclaration { get; }
+        abstract TSyntaxKind ExpressionStatement { get; }
         abstract TSyntaxKind FieldDeclaration { get; }
         abstract TSyntaxKind IdentifierName { get; }
         abstract TSyntaxKind IdentifierToken { get; }
@@ -41,5 +42,6 @@ namespace SonarAnalyzer.Helpers.Facade
         abstract TSyntaxKind SimpleMemberAccessExpression { get; }
         abstract TSyntaxKind StringLiteralExpression { get; }
         abstract TSyntaxKind[] TypeDeclaration { get; }
+        
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
@@ -41,6 +41,7 @@ namespace SonarAnalyzer.Helpers.Facade
         public abstract SyntaxNode BinaryExpressionRight(SyntaxNode binaryExpression);
         public abstract IEnumerable<SyntaxNode> EnumMembers(SyntaxNode @enum);
         public abstract SyntaxToken? InvocationIdentifier(SyntaxNode invocation);
+        public abstract string Name(SyntaxNode node);
         public abstract SyntaxNode NodeExpression(SyntaxNode node);
         public abstract SyntaxToken? NodeIdentifier(SyntaxNode node);
         public abstract SyntaxNode RemoveConditionalAcesss(SyntaxNode node);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
@@ -73,6 +73,13 @@ namespace SonarAnalyzer.Helpers.Facade
         public override SyntaxToken? InvocationIdentifier(SyntaxNode invocation) =>
             invocation == null ? null : Cast<InvocationExpressionSyntax>(invocation).GetMethodCallIdentifier();
 
+        public override string Name(SyntaxNode node) =>
+            node switch
+            {
+                ObjectCreationExpressionSyntax x => x.Type.GetName(),
+                _ => string.Empty
+            };
+
         public override SyntaxNode NodeExpression(SyntaxNode node) =>
             node switch
             {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxKindFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxKindFacade.cs
@@ -38,6 +38,7 @@ namespace SonarAnalyzer.Helpers.Facade
         public SyntaxKind ConstructorDeclaration => SyntaxKind.ConstructorBlock;
         public SyntaxKind[] DefaultExpressions => new[] { SyntaxKind.NothingLiteralExpression };
         public SyntaxKind EnumDeclaration => SyntaxKind.EnumStatement;
+        public SyntaxKind ExpressionStatement => SyntaxKind.ExpressionStatement;
         public SyntaxKind FieldDeclaration => SyntaxKind.FieldDeclaration;
         public SyntaxKind IdentifierName => SyntaxKind.IdentifierName;
         public SyntaxKind IdentifierToken => SyntaxKind.IdentifierToken;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObjectCreatedDropped.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObjectCreatedDropped.CSharp9.cs
@@ -1,0 +1,12 @@
+﻿namespace S1848.ObjectCreatedDropped
+{
+    class Noncompliant
+    {
+        void CreatedOnly()
+        {
+            new SomeRecord(); // Noncompliant
+        }
+
+        record SomeRecord();
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObjectCreatedDropped.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObjectCreatedDropped.cs
@@ -35,7 +35,24 @@ namespace Tests.TestCases
 
             var xx = func();
 
+            new Guid(); // Noncompliant, struct
+
+            new SomeDisposable(); // Noncompliant
+
             return new object();
         }
+
+        void Disposing()
+        {
+            using (new SomeDisposable()) // Compliant
+            {
+
+            }
+        }
+
+    }
+    class SomeDisposable : IDisposable
+    {
+        public void Dispose() { }
     }
 }


### PR DESCRIPTION
While investing [RSPEC-1848](https://jira.sonarsource.com/browse/RSPEC-1848) for VB.NET, I found out, that it is no applicable to VB.NET, as the VB.NET compiler will raise a `BC30035` error.

As I noticed in another PR, @martin-strecker-sonarsource also preferred to have access to the `ILanguageFacade` in C#-only rules, as they provide some useful abstractions. But more importantly, it helps to distinguish between rules that just happen not to be implemented for VB.NET yet, and those who apply to C# only because they deal with a language feature that is not applicable to the other. 
