### PR TITLE
Simplify ObjectCreatedDropped rule add test coverage

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ObjectCreatedDropped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ObjectCreatedDropped.cs
@@ -25,31 +25,27 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.CSharp
+namespace SonarAnalyzer.Rules.CSharp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ObjectCreatedDropped : SonarDiagnosticAnalyzer
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class ObjectCreatedDropped : SonarDiagnosticAnalyzer
-    {
-        internal const string DiagnosticId = "S1848";
-        private const string MessageFormat = "Either remove this useless object instantiation of class '{0}' or use it.";
+    private const string DiagnosticId = "S1848";
+    private const string MessageFormat = "Either remove this useless object instantiation of class '{0}' or use it.";
 
-        private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+    private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-        protected override void Initialize(SonarAnalysisContext context)
-        {
-            context.RegisterSyntaxNodeActionInNonGenerated(
-                c =>
+    protected override void Initialize(SonarAnalysisContext context) =>
+        context.RegisterSyntaxNodeActionInNonGenerated(
+            c =>
+            {
+                if (c.Node is ObjectCreationExpressionSyntax creation
+                    && creation.Parent is ExpressionStatementSyntax)
                 {
-                    var objectCreation = (ObjectCreationExpressionSyntax)c.Node;
-                    if (objectCreation.Parent is ExpressionStatementSyntax parent)
-                    {
-                        c.ReportIssue(Diagnostic.Create(rule, objectCreation.GetLocation(), objectCreation.Type));
-                    }
-                },
-                SyntaxKind.ObjectCreationExpression);
-        }
-    }
+                    c.ReportIssue(Diagnostic.Create(Rule, creation.GetLocation(), creation.Type));
+                }
+            },
+            SyntaxKind.ObjectCreationExpression);
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ObjectCreatedDroppedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ObjectCreatedDroppedTest.cs
@@ -20,17 +20,19 @@
 
 using SonarAnalyzer.Rules.CSharp;
 
-namespace SonarAnalyzer.UnitTest.Rules
-{
-    [TestClass]
-    public class ObjectCreatedDroppedTest
-    {
-        [TestMethod]
-        public void ObjectCreatedDropped() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\ObjectCreatedDropped.cs", new ObjectCreatedDropped());
+namespace SonarAnalyzer.UnitTest.Rules;
 
-        [TestMethod]
-        public void ObjectCreatedDropped_InTest() =>
-            OldVerifier.VerifyNoIssueReportedInTest(@"TestCases\ObjectCreatedDropped.cs", new ObjectCreatedDropped());
-    }
+[TestClass]
+public class ObjectCreatedDroppedTest
+{
+    [TestMethod]
+    public void ObjectCreatedDropped() =>
+        new VerifierBuilder<ObjectCreatedDropped>().AddPaths("ObjectCreatedDropped.cs").Verify();
+
+    [TestMethod]
+    public void ObjectCreatedDropped_CSharp9() =>
+        new VerifierBuilder<ObjectCreatedDropped>()
+        .WithOptions(ParseOptionsHelper.FromCSharp9)
+        .AddPaths("ObjectCreatedDropped.CSharp9.cs")
+        .Verify();
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObjectCreatedDropped.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObjectCreatedDropped.CSharp9.cs
@@ -1,0 +1,12 @@
+﻿namespace S1848.ObjectCreatedDropped
+{
+    class Noncompliant
+    {
+        void CreatedOnly()
+        {
+            new SomeRecord(); // Noncompliant
+        }
+
+        record SomeRecord();
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObjectCreatedDropped.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObjectCreatedDropped.cs
@@ -35,7 +35,24 @@ namespace Tests.TestCases
 
             var xx = func();
 
+            new Guid(); // Noncompliant, struct
+
+            new SomeDisposable(); // Noncompliant
+
             return new object();
         }
+
+        void Disposing()
+        {
+            using (new SomeDisposable()) // Compliant
+            {
+
+            }
+        }
+
+    }
+    class SomeDisposable : IDisposable
+    {
+        public void Dispose() { }
     }
 }


### PR DESCRIPTION
While investing [RSPEC-1848](https://jira.sonarsource.com/browse/RSPEC-1848) for VB.NET, I found out, that it is no applicable to VB.NET, as the VB.NET compiler will raise a BC30035 error. As far as I know, I can not address that in the RSPEC myself.

While at it, I did some small clean-up on the rule, and added some test coverage. Worth being merged I think.

See: #5730