### PR TITLE
Remove RspecResources references - batch 2

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AllBranchesShouldNotHaveSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AllBranchesShouldNotHaveSameImplementation.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class AllBranchesShouldNotHaveSameImplementation : AllBranchesShouldNotHaveSameImplementationBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AnonymousDelegateEventUnsubscribe.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AnonymousDelegateEventUnsubscribe.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Unsubscribe with the same delegate that was used for the subscription.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ArgumentSpecifiedForCallerInfoParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ArgumentSpecifiedForCallerInfoParameter.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this argument from the method call; it hides the caller information.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> CallerInfoAttributesToReportOn =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AsyncAwaitIdentifier.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AsyncAwaitIdentifier.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static readonly ISet<string> AsyncOrAwait = new HashSet<string> { "async", "await" };
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidUnsealedAttributes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidUnsealedAttributes.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Seal this attribute or make it abstract.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BooleanCheckInverted.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BooleanCheckInverted.cs
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
             };
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BreakOutsideSwitch.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BreakOutsideSwitch.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor the code in order to remove this break statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CallerInformationParametersShouldBeLast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CallerInformationParametersShouldBeLast.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Move '{0}' to the end of the parameter list.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CastConcreteTypeToInterface.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CastConcreteTypeToInterface.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this cast and edit the interface to add the missing functionality.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CatchEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CatchEmpty.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Handle the exception or explain in a comment why it can be ignored.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CatchRethrow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CatchRethrow.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static readonly BlockSyntax ThrowBlock = SyntaxFactory.Block(SyntaxFactory.ThrowStatement());
 
         protected override DiagnosticDescriptor Rule { get; } =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         protected override bool ContainsOnlyThrow(CatchClauseSyntax currentCatch) =>
             CSharpEquivalenceChecker.AreEquivalent(currentCatch.Block, ThrowBlock);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeAbstract.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeAbstract.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageToConcreteImplementation = "a concrete type with a protected constructor";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithEqualityShouldImplementIEquatable.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithEqualityShouldImplementIEquatable.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string EqualsMethodName = nameof(object.Equals);
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "you are using LINQ to Entities.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ComparableInterfaceImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ComparableInterfaceImplementation.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                .ToArray();
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsShouldStartOnNewLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsShouldStartOnNewLine.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Move this 'if' to a new line or add the missing 'else'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConsoleLogging.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConsoleLogging.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this logging statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorArgumentValueShouldExist.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorArgumentValueShouldExist.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class ConstructorArgumentValueShouldExist : ConstructorArgumentValueShouldExistBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorOverridableCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorOverridableCall.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this call from a constructor to the overridable '{0}' method.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ControlCharacterInString.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ControlCharacterInString.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Replace the control character at position {0} by its escape sequence '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DebugAssertHasNoSideEffects.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DebugAssertHasNoSideEffects.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Expressions used in 'Debug.Assert' should not produce side effects.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ISet<string> sideEffectWords = new HashSet<string>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeclareEventHandlersCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeclareEventHandlersCorrectly.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const int DelegateEventHandlerArgCount = 2;
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DefaultSectionShouldBeFirstOrLast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DefaultSectionShouldBeFirstOrLast.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Move this 'default:' case to the beginning or end of this 'switch' statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DelegateSubtraction.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DelegateSubtraction.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Review this subtraction of a chain of delegates: it may not work as you expect.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableReturnedFromUsing.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableReturnedFromUsing.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove the 'using' statement; it will cause automatic disposal of {0}.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCatchNullReferenceException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCatchNullReferenceException.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Do not catch NullReferenceException; test for null instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCopyArraysInProperties.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCopyArraysInProperties.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor '{0}' into a method, properties should not copy collections.";
 
         private static readonly DiagnosticDescriptor s2365 =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(s2365);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotInstantiateSharedClasses.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotInstantiateSharedClasses.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class DoNotInstantiateSharedClasses : DoNotInstantiateSharedClassesBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotLockOnSharedResource.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotLockOnSharedResource.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class DoNotLockOnSharedResource : DoNotLockOnSharedResourceBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotMarkEnumsWithFlags.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotMarkEnumsWithFlags.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove the 'FlagsAttribute' from this enum.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotNestTernaryOperators.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotNestTernaryOperators.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Extract this nested ternary operation into an independent statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotThrowFromDestructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotThrowFromDestructors.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this 'throw' statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseCollectionInItsOwnMethodCalls.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseCollectionInItsOwnMethodCalls.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string UnexpectedBehaviorMessage = "This operation will probably result in an unexpected behavior.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ISet<string> trackedMethodNames = new HashSet<string> {"AddRange", "Concat", "Except",

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseLiteralBoolInAssertions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseLiteralBoolInAssertions.cs
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
             };
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseOutRefParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseOutRefParameters.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Consider refactoring this method in order to remove the need for this '{0}' modifier.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DontMixIncrementOrDecrementWithOtherOperators.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DontMixIncrementOrDecrementWithOtherOperators.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Extract this {0} operation into a dedicated statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ISet<SyntaxKind> arithmeticOperator =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DotNotOverloadOperatorEqual.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DotNotOverloadOperatorEqual.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
             );
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyNamespace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyNamespace.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this empty namespace.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumStorageNeedsToBeInt32.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumStorageNeedsToBeInt32.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Change this enum storage to 'Int32'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumerableSumInUnchecked.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumerableSumInUnchecked.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor this code to handle 'OverflowException'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumsShouldNotBeNamedReserved.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumsShouldNotBeNamedReserved.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove or rename this enum member.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Do not check floating point {0} with exact values, use a range instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EquatableClassShouldBeSealed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EquatableClassShouldBeSealed.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string EqualsMethodName = nameof(object.Equals);
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EventHandlerDelegateShouldHaveProperArguments.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EventHandlerDelegateShouldHaveProperArguments.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string NonNullSenderMessage = "Make the sender on this static event invocation null.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> EventHandlerTypes =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionRethrow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionRethrow.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Consider using 'throw;' to preserve the stack trace.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsNeedStandardConstructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsNeedStandardConstructors.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Implement the missing constructors for this exception.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBePublic.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBePublic.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make this exception 'public'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ImmutableArray<KnownType> baseExceptions =
             ImmutableArray.Create(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Throw this exception or remove this useless statement.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExtensionMethodShouldNotExtendObject.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExtensionMethodShouldNotExtendObject.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor this extension to extend a more concrete type.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShouldBeReadonly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShouldBeReadonly.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make '{0}' 'readonly'.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopIncrementSign.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopIncrementSign.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "'{0}' is {1}remented and will never reach 'stop condition'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotUseRandom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotUseRandom.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make sure that using this pseudorandom number generator is safe here.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager)
+            DescriptorFactory.Create(DiagnosticId, MessageFormat)
                 .WithNotConfigurable();
 
         public DoNotUseRandom()

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private readonly IChecker checker;
 
-        private static DiagnosticDescriptor Rule => DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static DiagnosticDescriptor Rule => DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverloadOptionalParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverloadOptionalParameter.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "This method signature overlaps the one defined on line {0}{1}, the default parameter value {2}.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideAddsParams.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideAddsParams.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "'params' should be removed from this override.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideChangedDefaultValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideChangedDefaultValue.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string MessageRemoveExplicit = "from this explicit interface implementation";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideNoParams.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideNoParams.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "'params' should not be removed from an override.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterMissingOptional.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterMissingOptional.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Add the 'Optional' attribute to this parameter.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodShouldBeNamedAccordingToSynchronicity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodShouldBeNamedAccordingToSynchronicity.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
             ImmutableArray.Create(KnownType.System_Collections_Generic_IAsyncEnumerable_T);
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MultilineBlocksWithoutBrace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MultilineBlocksWithoutBrace.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "This line will not be executed {0}; only the first line of this {2}-line block will be. The rest will execute {1}.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MultipleVariableDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MultipleVariableDeclaration.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         FieldDeclarationSyntax, LocalDeclarationStatementSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         public override SyntaxKind FieldDeclarationKind => SyntaxKind.FieldDeclaration;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MakeThisWrapperLessTrivialMessage = "Make this wrapper for native method '{0}' less trivial.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NonAsyncTaskShouldNotReturnNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NonAsyncTaskShouldNotReturnNull.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "'Task.CompletedTask' or 'Task.Delay(0)'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ISet<SyntaxKind> TrackedNullLiteralLocations =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NonFlagsEnumInBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NonFlagsEnumInBitwiseOperation.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string MessageChangeOrRemove = "Mark enum '{0}' with 'Flags' attribute or remove this bitwise operation.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NotAssignedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NotAssignedPrivateMember.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const Accessibility MaxAccessibility = Accessibility.Private;
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ISet<SyntaxKind> PreOrPostfixOpSyntaxKinds = new HashSet<SyntaxKind>
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const int NotFound = -1;
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OperatorOverloadsShouldHaveNamedAlternatives.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OperatorOverloadsShouldHaveNamedAlternatives.cs
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
         };
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OperatorsShouldBeOverloadedConsistently.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OperatorsShouldBeOverloadedConsistently.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Provide an implementation for: {0}.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         private static class MethodName

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameter.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class OptionalParameter : OptionalParameterBase<SyntaxKind, BaseMethodDeclarationSyntax, ParameterSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<SyntaxKind> kindsOfInterest = ImmutableArray.Create(SyntaxKind.MethodDeclaration, SyntaxKind.ConstructorDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameterNotPassedToBaseCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameterNotPassedToBaseCall.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class OptionalParameterNotPassedToBaseCall : OptionalParameterNotPassedToBaseCallBase<InvocationExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameterWithDefaultValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameterWithDefaultValue.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Use '[DefaultParameterValue]' instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalRefOutParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalRefOutParameter.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove the 'Optional' attribute, it cannot be used with '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OrderByRepeated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OrderByRepeated.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Use 'ThenBy' instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OverrideGetHashCodeOnOverridingEquals.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OverrideGetHashCodeOnOverridingEquals.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "This {0} overrides '{1}' and should therefore also override '{2}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PInvokesShouldNotBeVisible.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PInvokesShouldNotBeVisible.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make this 'P/Invoke' method private or internal.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterNamesShouldNotDuplicateMethodNames.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterNamesShouldNotDuplicateMethodNames.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Rename the parameter '{0}' so that it does not duplicate the method name.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterValidationInYieldShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterValidationInYieldShouldBeWrapped.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
            "handling the iterator.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class ParametersCorrectOrder : ParametersCorrectOrderBase<ArgumentSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PointersShouldBePrivate.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PointersShouldBePrivate.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make '{0}' 'private' or 'protected readonly'.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PreferJaggedArraysOverMultidimensional.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PreferJaggedArraysOverMultidimensional.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Change this multidimensional array to a jagged array.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertiesShouldBePreferred.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertiesShouldBePreferred.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Consider making method '{0}' a property.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyGetterWithThrow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyGetterWithThrow.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class PropertyGetterWithThrow : PropertyGetterWithThrowBase<SyntaxKind, AccessorDeclarationSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override SyntaxKind ThrowSyntaxKind => SyntaxKind.ThrowStatement;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicConstantField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicConstantField.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class PublicConstantField : PublicConstantFieldBase<SyntaxKind, FieldDeclarationSyntax, VariableDeclaratorSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         public override SyntaxKind FieldDeclarationKind => SyntaxKind.FieldDeclaration;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicMethodWithMultidimensionalArray.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicMethodWithMultidimensionalArray.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<SyntaxKind> kindsOfInterest = ImmutableArray.Create(SyntaxKind.MethodDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantCast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantCast.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this unnecessary cast to '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormatForPatterns = "Remove this unnecessary null check; it is already done by the pattern match.";
 
         private static readonly DiagnosticDescriptor RuleForIs =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly DiagnosticDescriptor RuleForPatternSyntax =
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormatForPatterns, RspecStrings.ResourceManager);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullableTypeComparison.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullableTypeComparison.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this redundant type comparison.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantParentheses.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantParentheses.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class RedundantParentheses : RedundantParenthesesBase<ParenthesizedExpressionSyntax, SyntaxKind>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantParenthesesObjectsCreation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantParenthesesObjectsCreation.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove these redundant parentheses.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantPropertyNamesInAnonymousClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantPropertyNamesInAnonymousClass.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove the redundant '{0} ='.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToCharArrayCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToCharArrayCall.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this redundant 'ToCharArray' call.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToStringCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToStringCall.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string MessageCompiler = ", the compiler will do it for you";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string EqualsName = nameof(Equals);
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualsOnValueType.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualsOnValueType.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string ReferenceEqualsName = "ReferenceEquals";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RequireAttributeUsageAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RequireAttributeUsageAttribute.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Specify AttributeUsage on '{0}'{1}.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Return an empty collection instead of null.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> CollectionTypes =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnValueIgnored.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnValueIgnored.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Use the return value of method '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RightCurlyBraceStartsLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RightCurlyBraceStartsLine.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Move this closing curly brace to the next line.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Secure this serialization constructor.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly AttributeComparer attributeComparer = new AttributeComparer();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ShiftDynamicNotInteger.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ShiftDynamicNotInteger.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class ShiftDynamicNotInteger : ShiftDynamicNotIntegerBase<ExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SingleStatementPerLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SingleStatementPerLine.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class SingleStatementPerLine : SingleStatementPerLineBase<StatementSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override bool StatementShouldBeExcluded(StatementSyntax statement)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyIFormatProviderOrCultureInfo.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyIFormatProviderOrCultureInfo.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Use the overload that takes a 'CultureInfo' or 'IFormatProvider' parameter.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> formatAndCultureType =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyStringComparison.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyStringComparison.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "'StringComparison' as a parameter.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> stringComparisonType = ImmutableArray.Create(KnownType.System_StringComparison);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SqlKeywordsDelimitedBySpace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SqlKeywordsDelimitedBySpace.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Add a space before '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldWrittenFromInstanceConstructor.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldWrittenFromInstanceConstructor.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this assignment of '{0}' or initialize it statically.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override bool IsValidCodeBlockContext(SyntaxNode node, ISymbol owningSymbol) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldWrittenFromInstanceMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldWrittenFromInstanceMember.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormatRemoveSet = "Remove this set, which updates a 'static' field from an instance {0}.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override bool IsValidCodeBlockContext(SyntaxNode node, ISymbol owningSymbol) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticSealedClassProtectedMembers.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticSealedClassProtectedMembers.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this 'protected' modifier.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StreamReadStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StreamReadStatement.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "Check the return value of the '{0}' call to see how many bytes were read.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringConcatenationInLoop.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringConcatenationInLoop.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         : StringConcatenationInLoopBase<SyntaxKind, AssignmentExpressionSyntax, BinaryExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override bool IsExpressionConcatenation(BinaryExpressionSyntax addExpression) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOffsetMethods.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOffsetMethods.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Replace '{0}' with the overload that accepts an offset parameter.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string MessageChangeCompareTo = "Use 'CompareOrdinal' or 'Compare' with the locale specified instead of 'CompareTo'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOrIntegralTypesForIndexers.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOrIntegralTypesForIndexers.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
             .ToImmutableArray();
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SuppressFinalizeUseless.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SuppressFinalizeUseless.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this useless call to 'GC.SuppressFinalize'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchCaseFallsThroughToDefault.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchCaseFallsThroughToDefault.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this empty 'case' clause.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchDefaultClauseEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchDefaultClauseEmpty.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this empty 'default' clause.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class SwitchSectionShouldNotHaveTooManyStatements : SwitchSectionShouldNotHaveTooManyStatementsBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchShouldNotBeNested.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchShouldNotBeNested.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor the code to eliminate this nested 'switch'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchWithoutDefault.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchWithoutDefault.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public class SwitchWithoutDefault : SwitchWithoutDefaultBase<SyntaxKind>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<SyntaxKind> kindsOfInterest = ImmutableArray.Create(SyntaxKind.SwitchStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4158";
         private const string MessageFormat = "Remove this call, the collection is known to be empty here.";
 
-        internal static readonly DiagnosticDescriptor S4158 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S4158 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ImmutableArray<KnownType> TrackedCollectionTypes =
             ImmutableArray.Create(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyNullableValueAccess.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyNullableValueAccess.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string ValueLiteral = "Value";
         private const string HasValueLiteral = "HasValue";
 
-        internal static readonly DiagnosticDescriptor S3655 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S3655 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S3655);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/HashesShouldHaveUnpredictableSalt.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/HashesShouldHaveUnpredictableSalt.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
         private const string MakeSaltUnpredictableMessage = "Make this salt unpredictable.";
         private const string MakeThisSaltLongerMessage = "Make this salt at least 16 bytes.";
 
-        internal static readonly DiagnosticDescriptor S2053 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S2053 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S2053);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InitializationVectorShouldBeRandom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InitializationVectorShouldBeRandom.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
         internal const string DiagnosticId = "S3329";
         private const string MessageFormat = "Use a dynamically-generated, random IV.";
 
-        internal static readonly DiagnosticDescriptor S3329 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S3329 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(S3329);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/NullPointerDereference.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/NullPointerDereference.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S2259";
         private const string MessageFormat = "'{0}' is null on at least one execution path.";
 
-        internal static readonly DiagnosticDescriptor S2259 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S2259 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S2259);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnce.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnce.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S3966";
         private const string MessageFormat = "Refactor this code to make sure '{0}' is disposed only once.";
 
-        internal static readonly DiagnosticDescriptor S3966 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S3966 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S3966);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string Constructor = "constructor to avoid using members of parameter '{0}' because it could be null";
         private const string Method = "method to add validation of parameter '{0}' before using it";
 
-        public static readonly DiagnosticDescriptor S3900 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        public static readonly DiagnosticDescriptor S3900 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(S3900);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/RestrictDeserializedTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/RestrictDeserializedTypes.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string RestrictTypesMessage = "Restrict types of objects allowed to be deserialized.";
         private const string VerifyMacMessage = "Serialized data signature (MAC) should be verified.";
 
-        internal static readonly DiagnosticDescriptor S5773 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S5773 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(S5773);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TabCharacter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TabCharacter.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Replace all tab characters in this file by sequences of white-spaces.";
 
         internal static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestClassShouldHaveTestMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestClassShouldHaveTestMethod.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_AssemblyCleanupAttribute);
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
@@ -99,7 +99,7 @@ namespace SonarAnalyzer.Rules.CSharp
         };
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThisShouldNotBeExposedFromConstructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThisShouldNotBeExposedFromConstructors.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make sure the use of 'this' doesn't expose partially-constructed instances of this class in multi-threaded environments.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadStaticNonStaticField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadStaticNonStaticField.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove the 'ThreadStatic' attribute from this definition.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadStaticWithInitializer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadStaticWithInitializer.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this initialization of '{0}' or make it lazy.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThrowReservedExceptions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThrowReservedExceptions.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class ThrowReservedExceptions : ThrowReservedExceptionsBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ToStringNoNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ToStringNoNull.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Return empty string instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyLabelsInSwitch.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyLabelsInSwitch.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public class TooManyLabelsInSwitch : TooManyLabelsInSwitchBase<SyntaxKind, SwitchStatementSyntax>
     {
         protected override DiagnosticDescriptor Rule { get; } =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         private const string MessageFormat = "Consider reworking this 'switch' to reduce the number of 'case's" +

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Implement this method or throw 'NotSupportedException' instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TryStatementsWithIdenticalCatchShouldBeMerged.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TryStatementsWithIdenticalCatchShouldBeMerged.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Combine this 'try' with the one starting on line {0}.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypesShouldNotExtendOutdatedBaseTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypesShouldNotExtendOutdatedBaseTypes.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor this type not to derive from an outdated type '{0}'.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ImmutableArray<KnownType> OutdatedTypes =
             ImmutableArray.Create(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnaryPrefixOperatorRepeated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnaryPrefixOperatorRepeated.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
         UnaryPrefixOperatorRepeatedBase<SyntaxKind, PrefixUnaryExpressionSyntax>
     {
         protected override DiagnosticDescriptor Rule { get; } =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         protected override ISet<SyntaxKind> SyntaxKinds { get; } = new HashSet<SyntaxKind>
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UriShouldNotBeHardcoded.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UriShouldNotBeHardcoded.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKind, BinaryExpressionSyntax, ArgumentSyntax, VariableDeclaratorSyntax>
     {
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
         protected override SyntaxKind StringLiteralSyntaxKind { get; } = SyntaxKind.StringLiteralExpression;
         protected override SyntaxKind[] StringConcatenateExpressions { get; } = { SyntaxKind.AddExpression };

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseConstantsWhereAppropriate.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseConstantsWhereAppropriate.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Replace this 'static readonly' declaration with 'const'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> RelevantTypes =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseCurlyBraces.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseCurlyBraces.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Add curly braces around the nested statement(s) in this '{0}' block.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericEventHandlerInstances.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericEventHandlerInstances.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor this delegate to use 'System.EventHandler<TEventArgs>'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> allowedTypes =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericWithRefParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericWithRefParameters.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make this method generic and replace the 'object' parameter with a type parameter.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseNumericLiteralSeparator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseNumericLiteralSeparator.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const int DecimalMinimumDigits = 6;
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseParamsForVariableArguments.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseParamsForVariableArguments.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Use the 'params' keyword instead of '__arglist'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseShortCircuitingOperator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseShortCircuitingOperator.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class UseShortCircuitingOperator : UseShortCircuitingOperatorBase<SyntaxKind, BinaryExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override string GetSuggestedOpName(BinaryExpressionSyntax node) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringIsNullOrEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringIsNullOrEmpty.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "Use 'string.IsNullOrEmpty()' instead of comparing to empty string.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseWhileLoopInstead.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseWhileLoopInstead.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Replace this 'for' loop with a 'while' loop.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string SecondaryMessageFormat = "This value enables external entities in XML parsing.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/LocksReleasedAllPaths.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/LocksReleasedAllPaths.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.CSharp
 {
     public class LocksReleasedAllPaths : LocksReleasedAllPathsBase
     {
-        public static readonly DiagnosticDescriptor S2222 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        public static readonly DiagnosticDescriptor S2222 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         protected override DiagnosticDescriptor Rule => S2222;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/AllBranchesShouldNotHaveSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/AllBranchesShouldNotHaveSameImplementation.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class AllBranchesShouldNotHaveSameImplementation : AllBranchesShouldNotHaveSameImplementationBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayDesignatorOnVariable.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayDesignatorOnVariable.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Move the array designator from the variable to the type.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayInitializationMultipleStatements.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayInitializationMultipleStatements.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Refactor this code to use the '... = {}' syntax.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanCheckInverted.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanCheckInverted.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             };
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CatchRethrow.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CatchRethrow.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private static readonly SyntaxList<StatementSyntax> ThrowBlock = new SyntaxList<StatementSyntax>().Add(SyntaxFactory.ThrowStatement());
 
         protected override DiagnosticDescriptor Rule { get; } =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         protected override bool ContainsOnlyThrow(CatchBlockSyntax currentCatch) =>
             VisualBasicEquivalenceChecker.AreEquivalent(currentCatch.Statements, ThrowBlock);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CommentLineEnd.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CommentLineEnd.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Move this trailing comment on the previous empty line.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private const string DefaultPattern = @"^'\s*\S+\s*$";

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameImplementation.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class ConditionalStructureSameImplementation : ConditionalStructureSameImplementationBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConstructorArgumentValueShouldExist.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConstructorArgumentValueShouldExist.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class ConstructorArgumentValueShouldExist : ConstructorArgumentValueShouldExistBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotInstantiateSharedClasses.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotInstantiateSharedClasses.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class DoNotInstantiateSharedClasses : DoNotInstantiateSharedClassesBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotLockOnSharedResource.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotLockOnSharedResource.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class DoNotLockOnSharedResource : DoNotLockOnSharedResourceBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotNestTernaryOperators.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotNestTernaryOperators.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     {
         private const string MessageFormat = "Extract this nested If operator into independent If...Then...Else statements.";
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotThrowFromDestructors.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotThrowFromDestructors.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this 'Throw' statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotUseByVal.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotUseByVal.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this redundant 'ByVal' modifier.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotUseIif.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotUseIif.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string IIfOperatorName = "IIf";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyMethod.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyMethod.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class EmptyMethod : EmptyMethodBase<SyntaxKind>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = VisualBasicGeneratedCodeRecognizer.Instance;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EndStatementUsage.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EndStatementUsage.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this call to 'End' or ensure it is really required.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EventNameContainsBeforeOrAfter.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EventNameContainsBeforeOrAfter.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this event to remove the '{0}' {1}.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExitStatementUsage.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExitStatementUsage.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this 'Exit' statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FileLines.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FileLines.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class FileLines : FileLinesBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FunctionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FunctionComplexity.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class FunctionComplexity : FunctionComplexityBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IfCollapsible.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IfCollapsible.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class IfCollapsible : IfCollapsibleBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IndexedPropertyWithMultipleParameters.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IndexedPropertyWithMultipleParameters.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "This indexed property has {0} parameters, use methods instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LineContinuation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LineContinuation.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Reformat the code to remove this use of the line continuation character.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LineLength.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LineLength.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class LineLength : LineLengthBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodsShouldNotHaveTooManyLines.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodsShouldNotHaveTooManyLines.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         : MethodsShouldNotHaveTooManyLinesBase<SyntaxKind, MethodBlockBaseSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MultipleVariableDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MultipleVariableDeclaration.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         FieldDeclarationSyntax, LocalDeclarationStatementSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ClassName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ClassName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this class to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EnumerationValueName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EnumerationValueName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this event to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/FunctionName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/FunctionName.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename {0} '{1}' to match the regular expression: '{2}'.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager, isEnabledByDefault: false);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat, isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/IndexedPropertyName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/IndexedPropertyName.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this property to 'Item'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/InterfaceName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/InterfaceName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this interface to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this local variable to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/NamespaceName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/NamespaceName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this namespace to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ParameterName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this parameter to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PrivateConstantFieldName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PrivateConstantFieldName.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PrivateFieldName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PrivateFieldName.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PrivateSharedReadonlyFieldName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PrivateSharedReadonlyFieldName.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PropertyName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PropertyName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this property to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PublicConstantFieldName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PublicConstantFieldName.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PublicFieldName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PublicFieldName.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PublicSharedReadonlyFieldName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PublicSharedReadonlyFieldName.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/TypeParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/TypeParameterName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NegatedIsExpression.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NegatedIsExpression.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Replace this use of 'Not...Is...' with 'IsNot'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NonAsyncTaskShouldNotReturnNull.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NonAsyncTaskShouldNotReturnNull.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             "'Task.FromResult(Of T)(Nothing)', 'Task.CompletedTask' or 'Task.Delay(0)'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OnErrorStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OnErrorStatement.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this use of 'OnError'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameter.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameter.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class OptionalParameter : OptionalParameterBase<SyntaxKind, MethodBaseSyntax, ParameterSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameterNotPassedToBaseCall.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameterNotPassedToBaseCall.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class OptionalParameterNotPassedToBaseCall : OptionalParameterNotPassedToBaseCallBase<InvocationExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override DiagnosticDescriptor Rule => rule;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class ParametersCorrectOrder : ParametersCorrectOrderBase<ArgumentSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PartCreationPolicyShouldBeUsedWithExportAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PartCreationPolicyShouldBeUsedWithExportAttribute.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         : PartCreationPolicyShouldBeUsedWithExportAttributeBase<AttributeSyntax, ClassStatementSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyGetterWithThrow.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyGetterWithThrow.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class PropertyGetterWithThrow : PropertyGetterWithThrowBase<SyntaxKind, AccessorBlockSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicConstantField.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicConstantField.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class PublicConstantField : PublicConstantFieldBase<SyntaxKind, FieldDeclarationSyntax, ModifiedIdentifierSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicMethodWithMultidimensionalArray.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicMethodWithMultidimensionalArray.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class PublicMethodWithMultidimensionalArray : PublicMethodWithMultidimensionalArrayBase<SyntaxKind, MethodStatementSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantExitSelect.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantExitSelect.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this redundant use of 'Exit Select'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantNullCheck.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantNullCheck.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this unnecessary null check; 'TypeOf ... Is' returns false for nulls.";
 
         private static readonly DiagnosticDescriptor rule =
-           DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+           DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantParentheses.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantParentheses.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class RedundantParentheses : RedundantParenthesesBase<ParenthesizedExpressionSyntax, SyntaxKind>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ShiftDynamicNotInteger.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ShiftDynamicNotInteger.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class ShiftDynamicNotInteger : ShiftDynamicNotIntegerBase<ExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SimpleDoLoop.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SimpleDoLoop.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Use a structured loop instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SingleStatementPerLine.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SingleStatementPerLine.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class SingleStatementPerLine : SingleStatementPerLineBase<StatementSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringConcatenationInLoop.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringConcatenationInLoop.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         : StringConcatenationInLoopBase<SyntaxKind, AssignmentStatementSyntax, BinaryExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchCasesMinimumThree.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchCasesMinimumThree.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     {
         private const string MessageFormat = "Replace this 'Select' statement with 'If' statements to increase readability.";
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class SwitchSectionShouldNotHaveTooManyStatements : SwitchSectionShouldNotHaveTooManyStatementsBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchShouldNotBeNested.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchShouldNotBeNested.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Refactor the code to eliminate this nested 'Select Case'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchWithoutDefault.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchWithoutDefault.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class SwitchWithoutDefault : SwitchWithoutDefaultBase<SyntaxKind>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TabCharacter.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TabCharacter.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Replace all tab characters in this file by sequences of white-spaces.";
 
         internal static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ThrowReservedExceptions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ThrowReservedExceptions.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class ThrowReservedExceptions : ThrowReservedExceptionsBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TooManyLabelsInSwitch.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TooManyLabelsInSwitch.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class TooManyLabelsInSwitch : TooManyLabelsInSwitchBase<SyntaxKind, SelectStatementSyntax>
     {
         protected override DiagnosticDescriptor Rule { get; } =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         private const string MessageFormat = "Consider reworking this 'Select Case' to reduce the number of 'Case's" +

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnaryPrefixOperatorRepeated.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnaryPrefixOperatorRepeated.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         };
 
         protected override DiagnosticDescriptor Rule { get; } =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } =
             VisualBasicGeneratedCodeRecognizer.Instance;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnsignedTypesUsage.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnsignedTypesUsage.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Change this unsigned type to '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UriShouldNotBeHardcoded.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UriShouldNotBeHardcoded.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             SyntaxKind, BinaryExpressionSyntax, ArgumentSyntax, VariableDeclaratorSyntax>
     {
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
         protected override SyntaxKind StringLiteralSyntaxKind => SyntaxKind.StringLiteralExpression;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperator.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperator.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class UseShortCircuitingOperator : UseShortCircuitingOperatorBase<SyntaxKind, BinaryExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Wrap this and the following {0} statement{2} that use '{1}' in a 'With' statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/WcfNonVoidOneWay.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/WcfNonVoidOneWay.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class WcfNonVoidOneWay : WcfNonVoidOneWayBase<MethodStatementSyntax, SyntaxKind>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/LocksReleasedAllPaths.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/LocksReleasedAllPaths.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.VisualBasic
 {
     public class LocksReleasedAllPaths : LocksReleasedAllPathsBase
     {
-        public static readonly DiagnosticDescriptor S2222 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        public static readonly DiagnosticDescriptor S2222 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         protected override DiagnosticDescriptor Rule => S2222;
 


### PR DESCRIPTION
#5644 follow up

Batch replace for
```
DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager
DescriptorFactory.Create(DiagnosticId, MessageFormat
```

I'm intentionally not fixing the formatting to keep the review regular and simple. It will be cleaned as we code.