### PR TITLE
Remove RspecResources references - batch 4

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
@@ -22,6 +22,7 @@ using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers.Facade;
 
 namespace SonarAnalyzer.Helpers
@@ -50,6 +51,9 @@ namespace SonarAnalyzer.Helpers
 
         public DiagnosticDescriptor CreateDescriptor(string id, string messageFormat, bool? isEnabledByDefault = null, bool fadeOutCode = false) =>
             DescriptorFactory.Create(id, messageFormat, isEnabledByDefault, fadeOutCode);
+
+        public object FindConstantValue(SemanticModel model, SyntaxNode node) =>
+            node.FindConstantValue(model);
 
         public IMethodParameterLookup MethodParameterLookup(SyntaxNode invocation, IMethodSymbol methodSymbol) =>
             new CSharpMethodParameterLookup((InvocationExpressionSyntax)invocation, methodSymbol);

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -64,6 +64,12 @@ namespace SonarAnalyzer.Helpers.Facade
                 _ => throw InvalidOperation(node, nameof(ArgumentExpressions))
             };
 
+        public override SyntaxNode AssignmentLeft(SyntaxNode assignment) =>
+            Cast<AssignmentExpressionSyntax>(assignment).Left;
+
+        public override SyntaxNode AssignmentRight(SyntaxNode assignment) =>
+            Cast<AssignmentExpressionSyntax>(assignment).Right;
+
         public override SyntaxNode BinaryExpressionLeft(SyntaxNode binaryExpression) =>
             Cast<BinaryExpressionSyntax>(binaryExpression).Left;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxKindFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxKindFacade.cs
@@ -51,7 +51,9 @@ namespace SonarAnalyzer.Helpers.Facade
         public SyntaxKind[] MethodDeclarations => new[] { SyntaxKind.MethodDeclaration };
         public SyntaxKind[] ObjectCreationExpressions => new[] { SyntaxKind.ObjectCreationExpression, SyntaxKindEx.ImplicitObjectCreationExpression };
         public SyntaxKind Parameter => SyntaxKind.Parameter;
+        public SyntaxKind ParameterList => SyntaxKind.ParameterList;
         public SyntaxKind ReturnStatement => SyntaxKind.ReturnStatement;
+        public SyntaxKind SimpleAssignment => SyntaxKind.SimpleAssignmentExpression;
         public SyntaxKind SimpleMemberAccessExpression => SyntaxKind.SimpleMemberAccessExpression;
         public SyntaxKind StringLiteralExpression => SyntaxKind.StringLiteralExpression;
         public SyntaxKind[] TypeDeclaration => new[]

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AllBranchesShouldNotHaveSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AllBranchesShouldNotHaveSameImplementation.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class AllBranchesShouldNotHaveSameImplementation : AllBranchesShouldNotHaveSameImplementationBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AnonymousDelegateEventUnsubscribe.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AnonymousDelegateEventUnsubscribe.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Unsubscribe with the same delegate that was used for the subscription.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ArgumentSpecifiedForCallerInfoParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ArgumentSpecifiedForCallerInfoParameter.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this argument from the method call; it hides the caller information.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> CallerInfoAttributesToReportOn =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ArrayCovariance.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ArrayCovariance.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2330";
         private const string MessageFormat = "Refactor the code to not rely on potentially unsafe array conversions.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AssertionArgsShouldBePassedInCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AssertionArgsShouldBePassedInCorrectOrder.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S3415";
         private const string MessageFormat = "Make sure these 2 arguments are in the correct order: expected value, actual value.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         private static readonly IDictionary<string, ImmutableArray<KnownType>> MethodsWithType = new Dictionary<string, ImmutableArray<KnownType>>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AssignmentInsideSubExpression.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AssignmentInsideSubExpression.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S1121";
         private const string MessageFormat = "Extract the assignment of '{0}' from this expression.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ISet<SyntaxKind> AllowedParentExpressionKinds = new HashSet<SyntaxKind>
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AsyncAwaitIdentifier.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AsyncAwaitIdentifier.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static readonly ISet<string> AsyncOrAwait = new HashSet<string> { "async", "await" };
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AsyncVoidMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AsyncVoidMethod.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Return 'Task' instead.";
         private const string MsTestV1AssemblyName = "Microsoft.VisualStudio.QualityTools.UnitTestFramework";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ImmutableArray<KnownType> AllowedAsyncVoidMsTestAttributes =
             ImmutableArray.Create(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveClassCoupling.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveClassCoupling.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Split this {0} into smaller and more specialized ones to reduce its dependencies on other types from {1} to the maximum authorized {2} or less.";
         private const int ThresholdDefaultValue = 30;
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager, isEnabledByDefault: false);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat, isEnabledByDefault: false);
         private static readonly ImmutableArray<KnownType> IgnoredTypes =
             ImmutableArray.Create(
                 KnownType.Void,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveInheritance.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveInheritance.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "This {0} has {1} parents which is greater than {2} authorized.";
         private const string FilteredClassesDefaultValue = "";
         private const int MaximumDepthDefaultValue = 5;
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager, false);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat, false);
         private string filteredClasses = FilteredClassesDefaultValue;
         private ICollection<Regex> filters = new List<Regex>();
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidUnsealedAttributes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidUnsealedAttributes.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Seal this attribute or make it abstract.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BinaryOperationWithIdenticalExpressions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BinaryOperationWithIdenticalExpressions.cs
@@ -32,10 +32,9 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class BinaryOperationWithIdenticalExpressions : BinaryOperationWithIdenticalExpressionsBase
     {
-        internal static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, "{0}", RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, "{0}");
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         private static readonly SyntaxKind[] SyntaxKindsToCheckBinary =
         {
@@ -89,7 +88,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 var message = string.Format(EqualsMessage, operands.Item2);
 
-                context.ReportIssue(Diagnostic.Create(rule, operands.Item1.GetLocation(),
+                context.ReportIssue(Diagnostic.Create(Rule, operands.Item1.GetLocation(),
                     additionalLocations: new[] { operands.Item2.GetLocation() },
                     messageArgs: message));
             }
@@ -131,7 +130,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 var message = string.Format(OperatorMessageFormat, operatorToken);
 
-                context.ReportIssue(Diagnostic.Create(rule, right.GetLocation(),
+                context.ReportIssue(Diagnostic.Create(Rule, right.GetLocation(),
                     additionalLocations: new[] { left.GetLocation() },
                     messageArgs: message));
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BooleanCheckInverted.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BooleanCheckInverted.cs
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
             };
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BreakOutsideSwitch.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BreakOutsideSwitch.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor the code in order to remove this break statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CallToAsyncMethodShouldNotBeBlocking.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CallToAsyncMethodShouldNotBeBlocking.cs
@@ -39,8 +39,8 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string SleepName = "Sleep";
         private const string AzureFunctionSuffix = @" Do not perform blocking operations in Azure Functions.";
 
-        private static readonly DiagnosticDescriptor RuleS4462 = DiagnosticDescriptorBuilder.GetDescriptor("S4462", MessageFormat, RspecStrings.ResourceManager);
-        private static readonly DiagnosticDescriptor RuleS6422 = DiagnosticDescriptorBuilder.GetDescriptor("S6422", MessageFormat + AzureFunctionSuffix, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor RuleS4462 = DescriptorFactory.Create("S4462", MessageFormat);
+        private static readonly DiagnosticDescriptor RuleS6422 = DescriptorFactory.Create("S6422", MessageFormat + AzureFunctionSuffix);
 
         private static readonly Dictionary<string, ImmutableArray<KnownType>> InvalidMemberAccess = new()
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CallerInformationParametersShouldBeLast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CallerInformationParametersShouldBeLast.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Move '{0}' to the end of the parameter list.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CastConcreteTypeToInterface.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CastConcreteTypeToInterface.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this cast and edit the interface to add the missing functionality.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CastShouldNotBeDuplicated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CastShouldNotBeDuplicated.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string RemoveRedundantCastAnotherVariableMessage = "Remove this cast and use the appropriate variable.";
         private const string RemoveRedundantCastMessage = "Remove this redundant cast.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CatchEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CatchEmpty.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Handle the exception or explain in a comment why it can be ignored.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CatchRethrow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CatchRethrow.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static readonly BlockSyntax ThrowBlock = SyntaxFactory.Block(SyntaxFactory.ThrowStatement());
 
         protected override DiagnosticDescriptor Rule { get; } =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         protected override bool ContainsOnlyThrow(CatchClauseSyntax currentCatch) =>
             CSharpEquivalenceChecker.AreEquivalent(currentCatch.Block, ThrowBlock);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CbdeHandlerRule.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CbdeHandlerRule.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
         private const string S3949DiagnosticId = "S3949";
         private const string S3949MessageFormat = "{0}";
-        private static readonly DiagnosticDescriptor RuleS3949 = DiagnosticDescriptorBuilder.GetDescriptor(S3949DiagnosticId, S3949MessageFormat, RspecStrings.ResourceManager, fadeOutCode: true);
+        private static readonly DiagnosticDescriptor RuleS3949 = DescriptorFactory.Create(S3949DiagnosticId, S3949MessageFormat, fadeOutCode: true);
         private readonly ImmutableDictionary<string, DiagnosticDescriptor> ruleIdToDiagDescriptor = ImmutableDictionary<string, DiagnosticDescriptor>.Empty.Add("S3949", RuleS3949);
         private readonly bool unitTest;
         private readonly Action<string> onCbdeExecution;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CheckArgumentException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CheckArgumentException.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string ConstructorParametersInverted = "ArgumentException constructor arguments have been inverted.";
         private const string InvalidParameterName = "The parameter name '{0}' is not declared in the argument list.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassAndMethodName.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassAndMethodName.cs
@@ -43,11 +43,8 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormatNonUnderscore = "consider using '{0}'";
         private const string MessageFormatUnderscore = "trim underscores from the name";
 
-        private static readonly DiagnosticDescriptor MethodNameRule =
-            DiagnosticDescriptorBuilder.GetDescriptor(MethodNameDiagnosticId, MessageFormat, RspecStrings.ResourceManager);
-
-        private static readonly DiagnosticDescriptor TypeNameRule =
-            DiagnosticDescriptorBuilder.GetDescriptor(TypeNameDiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor MethodNameRule = DescriptorFactory.Create(MethodNameDiagnosticId, MessageFormat);
+        private static readonly DiagnosticDescriptor TypeNameRule = DescriptorFactory.Create(TypeNameDiagnosticId, MessageFormat);
 
         private static readonly Dictionary<SyntaxKind, string> TypeKindNameMapping = new()
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeAbstract.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeAbstract.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageToConcreteImplementation = "a concrete type with a protected constructor";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithEqualityShouldImplementIEquatable.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithEqualityShouldImplementIEquatable.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string EqualsMethodName = nameof(object.Equals);
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithOnlyStaticMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithOnlyStaticMember.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormatConstructor = "Hide this public constructor by making it '{0}'.";
         private const string MessageFormatStaticClass = "Add a '{0}' constructor or the 'static' keyword to the class declaration.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly ISet<Accessibility> ProblematicConstructorAccessibility = new HashSet<Accessibility>
         {
             Accessibility.Public,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsCatchExceptions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsCatchExceptions.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S6421";
         private const string MessageFormat = "Wrap Azure Function body in try/catch block.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsLogFailures.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsLogFailures.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
             6, // None
         };
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsReuseClients.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsReuseClients.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S6420";
         private const string MessageFormat = "Reuse client instances rather than creating new ones with each function invocation.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly KnownType[] ReusableClients =
             {
                 KnownType.System_Net_Http_HttpClient,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsStateless.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsStateless.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S6419";
         private const string MessageFormat = "Do not modify a static state from Azure Function.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/DurableEntityInterfaceRestrictions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/DurableEntityInterfaceRestrictions.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string SignalEntityAsyncName = "SignalEntityAsync";
         private const string CreateEntityProxyName = "CreateEntityProxy";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionPropertiesShouldBeReadOnly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionPropertiesShouldBeReadOnly.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
             Accessibility.Internal,
         };
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "you are using LINQ to Entities.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionsShouldImplementGenericInterface.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionsShouldImplementGenericInterface.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3909";
         private const string MessageFormat = "Refactor this collection to implement '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly Dictionary<KnownType, string> NonGenericToGenericMapping = new()
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentKeyword.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentKeyword.cs
@@ -27,16 +27,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class CommentKeyword : CommentKeywordBase
     {
-        internal static readonly DiagnosticDescriptor TODO_Descriptor =
-            DiagnosticDescriptorBuilder.GetDescriptor(TodoDiagnosticId, TodoMessageFormat, RspecStrings.ResourceManager);
-        protected override DiagnosticDescriptor TodoDiagnostic { get; } = TODO_Descriptor;
-
-        internal static readonly DiagnosticDescriptor FIXME_Descriptor =
-            DiagnosticDescriptorBuilder.GetDescriptor(FixMeDiagnosticId, FixMeMessageFormat, RspecStrings.ResourceManager);
-        protected override DiagnosticDescriptor FixMeDiagnostic { get; } = FIXME_Descriptor;
-
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer
-            => CSharpGeneratedCodeRecognizer.Instance;
+        protected override ILanguageFacade Language => CSharpFacade.Instance;
 
         protected override bool IsComment(SyntaxTrivia trivia) => trivia.IsComment();
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentedOutCode.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentedOutCode.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static readonly string[] CodePartsWithRelationalOperator = { "for(", "if(", "while(" };
         private static readonly string[] RelationalOperators = { "<", ">", "<=", ">=", "==", "!=" };
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ComparableInterfaceImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ComparableInterfaceImplementation.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                .ToArray();
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CompareNaN.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CompareNaN.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2688";
         private const string MessageFormat = "Use {0}.IsNaN() instead.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly Dictionary<KnownType, string> KnownTypeAliasMap = new()
         {
             { KnownType.System_Byte, "byte" },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalSimplification.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalSimplification.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string CoalesceOp = "??";
         private const string TernaryOp = "?:";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly DiagnosticDescriptor RuleMultipleNegation = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageMultipleNegation, RspecStrings.ResourceManager);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule, RuleMultipleNegation);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalSimplification.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalSimplification.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string TernaryOp = "?:";
 
         private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
-        private static readonly DiagnosticDescriptor RuleMultipleNegation = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageMultipleNegation, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor RuleMultipleNegation = DescriptorFactory.Create(DiagnosticId, MessageMultipleNegation);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule, RuleMultipleNegation);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameImplementation.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class ConditionalStructureSameImplementation : ConditionalStructureSameImplementationBase
     {
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsShouldStartOnNewLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsShouldStartOnNewLine.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Move this 'if' to a new line or add the missing 'else'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S2760";
         private const string MessageFormat = "This condition was just checked on line {0}.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConsoleLogging.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConsoleLogging.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this logging statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorArgumentValueShouldExist.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorArgumentValueShouldExist.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class ConstructorArgumentValueShouldExist : ConstructorArgumentValueShouldExistBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorOverridableCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorOverridableCall.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this call from a constructor to the overridable '{0}' method.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConsumeValueTaskCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConsumeValueTaskCorrectly.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         // 'Result' and '.GetAwaiter().GetResult()' should be consumed inside an 'if (valueTask.IsCompletedSuccessfully)'
         private const string ConsumeOnlyIfCompletedMessage = "Refactor this 'ValueTask' usage to consume the result only if the operation has completed successfully.";
 
-        private static readonly DiagnosticDescriptor rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ImmutableArray<KnownType> ValueTaskTypes =
             new[] {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ControlCharacterInString.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ControlCharacterInString.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Replace the control character at position {0} by its escape sequence '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CryptographicKeyShouldNotBeTooShort.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CryptographicKeyShouldNotBeTooShort.cs
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 KnownType.System_Security_Cryptography_ECDiffieHellman,
                 KnownType.System_Security_Cryptography_ECDsa);
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S1854";
         private const string MessageFormat = "Remove this useless assignment to local variable '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly string[] AllowedNumericValues = new[] { "-1", "0", "1" };
         private static readonly string[] AllowedStringValues = new[] { string.Empty };
         private readonly bool useSonarCfg;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DebugAssertHasNoSideEffects.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DebugAssertHasNoSideEffects.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Expressions used in 'Debug.Assert' should not produce side effects.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ISet<string> sideEffectWords = new HashSet<string>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeclareEventHandlersCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeclareEventHandlersCorrectly.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const int DelegateEventHandlerArgCount = 2;
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DefaultSectionShouldBeFirstOrLast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DefaultSectionShouldBeFirstOrLast.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Move this 'default:' case to the beginning or end of this 'switch' statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DelegateSubtraction.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DelegateSubtraction.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Review this subtraction of a chain of delegates: it may not work as you expect.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableMemberInNonDisposableClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableMemberInNonDisposableClass.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2931";
         private const string MessageFormat = "Implement 'IDisposable' in this class and use the 'Dispose' method to call 'Dispose' on {0}.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableNotDisposed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableNotDisposed.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2930";
         private const string MessageFormat = "Dispose '{0}' when it is no longer needed.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ImmutableArray<KnownType> TrackedTypes =
             ImmutableArray.Create(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableReturnedFromUsing.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableReturnedFromUsing.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove the 'using' statement; it will cause automatic disposal of {0}.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableTypesNeedFinalizers.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableTypesNeedFinalizers.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4002";
         private const string MessageFormat = "Implement a finalizer that calls your 'Dispose' method.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly ImmutableArray<KnownType> NativeHandles = ImmutableArray.Create(
             KnownType.System_IntPtr,
             KnownType.System_UIntPtr,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeFromDispose.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeFromDispose.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DisposeMethodName = nameof(IDisposable.Dispose);
         private const string DisposeMethodExplicitName = "System.IDisposable.Dispose";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeNotImplementingDispose.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeNotImplementingDispose.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Either implement 'IDisposable.Dispose', or totally rename this method to prevent confusion.";
         private const string DisposeMethodName = "Dispose";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCatchNullReferenceException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCatchNullReferenceException.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Do not catch NullReferenceException; test for null instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCatchSystemException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCatchSystemException.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2221";
         private const string MessageFormat = "Catch a list of specific exception subtype or use exception filters instead.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCopyArraysInProperties.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCopyArraysInProperties.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor '{0}' into a method, properties should not copy collections.";
 
         private static readonly DiagnosticDescriptor s2365 =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(s2365);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotDecreaseMemberVisibility.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotDecreaseMemberVisibility.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4015";
         private const string MessageFormat = "This member hides '{0}'. Make it non-private or seal the class.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotExposeListT.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotExposeListT.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3956";
         private const string MessageFormat = "Refactor this {0} to use a generic collection designed for inheritance.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotHideBaseClassMethods.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotHideBaseClassMethods.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4019";
         private const string MessageFormat = "Remove or rename that method because it hides '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotInstantiateSharedClasses.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotInstantiateSharedClasses.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class DoNotInstantiateSharedClasses : DoNotInstantiateSharedClassesBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotLockOnSharedResource.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotLockOnSharedResource.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class DoNotLockOnSharedResource : DoNotLockOnSharedResourceBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotMarkEnumsWithFlags.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotMarkEnumsWithFlags.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove the 'FlagsAttribute' from this enum.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotNestTernaryOperators.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotNestTernaryOperators.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Extract this nested ternary operation into an independent statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotNestTypesInArguments.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotNestTypesInArguments.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4017";
         private const string MessageFormat = "Refactor this method to remove the nested type argument.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotShiftByZeroOrIntSize.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotShiftByZeroOrIntSize.cs
@@ -34,17 +34,15 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class DoNotShiftByZeroOrIntSize : SonarDiagnosticAnalyzer
     {
-        internal const string DiagnosticId = "S2183";
-
-        private const string MessageFormat_UseLargerTypeOrPromote
-            = "Either promote shift target to a larger integer type or shift by {0} instead.";
+        private const string DiagnosticId = "S2183";
+        private const string MessageFormat_UseLargerTypeOrPromote = "Either promote shift target to a larger integer type or shift by {0} instead.";
         private const string MessageFormat_ShiftTooLarge = "Correct this shift; shift by {0} instead.";
         private const string MessageFormat_RightShiftTooLarge = "Correct this shift; '{0}' is larger than the type size.";
         private const string MessageFormat_UselessShift = "Remove this useless shift by {0}.";
 
-        private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, "{0}", RspecStrings.ResourceManager);
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, "{0}");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         private static ImmutableDictionary<KnownType, int> mapKnownTypesToIntegerBitSize
             = new Dictionary<KnownType, int>
@@ -234,7 +232,7 @@ namespace SonarAnalyzer.Rules.CSharp
             public ShiftInstance(string description, bool isLieralZero, SyntaxNode node)
                 : this(node)
             {
-                Diagnostic = Diagnostic.Create(rule, node.GetLocation(), description);
+                Diagnostic = Diagnostic.Create(Rule, node.GetLocation(), description);
                 IsLiteralZero = isLieralZero;
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotTestThisWithIsOperator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotTestThisWithIsOperator.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3060";
         private const string MessageFormat = "Offload the code that's conditional on this type test to the appropriate subclass and remove the condition.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotThrowFromDestructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotThrowFromDestructors.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this 'throw' statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseCollectionInItsOwnMethodCalls.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseCollectionInItsOwnMethodCalls.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string UnexpectedBehaviorMessage = "This operation will probably result in an unexpected behavior.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ISet<string> trackedMethodNames = new HashSet<string> {"AddRange", "Concat", "Except",

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseLiteralBoolInAssertions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseLiteralBoolInAssertions.cs
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
             };
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseOutRefParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseOutRefParameters.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Consider refactoring this method in order to remove the need for this '{0}' modifier.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotWriteToStandardOutput.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotWriteToStandardOutput.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S106";
         private const string MessageFormat = "Remove this logging statement.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DontMixIncrementOrDecrementWithOtherOperators.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DontMixIncrementOrDecrementWithOtherOperators.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Extract this {0} operation into a dedicated statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ISet<SyntaxKind> arithmeticOperator =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DotNotOverloadOperatorEqual.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DotNotOverloadOperatorEqual.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
             );
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyMethod.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class EmptyMethod : EmptyMethodBase<SyntaxKind>
     {
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = CSharpGeneratedCodeRecognizer.Instance;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyNamespace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyNamespace.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this empty namespace.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyStatement.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S1116";
         private const string MessageFormat = "Remove this empty statement.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumStorageNeedsToBeInt32.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumStorageNeedsToBeInt32.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Change this enum storage to 'Int32'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumerableSumInUnchecked.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumerableSumInUnchecked.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor this code to handle 'OverflowException'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumsShouldNotBeNamedReserved.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumsShouldNotBeNamedReserved.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove or rename this enum member.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Do not check floating point {0} with exact values, use a range instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnModulus.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnModulus.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static readonly CSharpExpressionNumericConverter ExpressionNumericConverter = new();
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EquatableClassShouldBeSealed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EquatableClassShouldBeSealed.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string EqualsMethodName = nameof(object.Equals);
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EventHandlerDelegateShouldHaveProperArguments.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EventHandlerDelegateShouldHaveProperArguments.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string NonNullSenderMessage = "Make the sender on this static event invocation null.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> EventHandlerTypes =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionRethrow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionRethrow.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Consider using 'throw;' to preserve the stack trace.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionShouldNotBeThrownFromUnexpectedMethods.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionShouldNotBeThrownFromUnexpectedMethods.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3877";
         private const string MessageFormat = "Remove this 'throw' {0}.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ImmutableArray<KnownType> DefaultAllowedExceptions = ImmutableArray.Create(KnownType.System_NotImplementedException);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsNeedStandardConstructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsNeedStandardConstructors.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Implement the missing constructors for this exception.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBePublic.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBePublic.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make this exception 'public'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ImmutableArray<KnownType> baseExceptions =
             ImmutableArray.Create(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Throw this exception or remove this useless statement.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExtensionMethodShouldBeInSeparateNamespace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExtensionMethodShouldBeInSeparateNamespace.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4226";
         private const string MessageFormat = "Either move this extension to another namespace or move the method inside the class itself.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExtensionMethodShouldNotExtendObject.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExtensionMethodShouldNotExtendObject.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor this extension to extend a more concrete type.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShadowsParentField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShadowsParentField.cs
@@ -28,9 +28,9 @@ using SonarAnalyzer.Helpers;
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class FieldShadowsParentField : FieldShadowsParentFieldBase<VariableDeclaratorSyntax>
+    public sealed class FieldShadowsParentField : FieldShadowsParentFieldBase<SyntaxKind, VariableDeclaratorSyntax>
     {
-        public FieldShadowsParentField() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
@@ -45,8 +45,5 @@ namespace SonarAnalyzer.Rules.CSharp
                     }
                 },
                 SyntaxKind.FieldDeclaration);
-
-        protected override SyntaxToken GetIdentifier(VariableDeclaratorSyntax declarator) =>
-            declarator.Identifier;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShouldBeReadonly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShouldBeReadonly.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make '{0}' 'readonly'.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldsShouldBeEncapsulatedInProperties.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldsShouldBeEncapsulatedInProperties.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S1104";
         private const string MessageFormat = "Make this field 'private' and encapsulate it in a 'public' property.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FileLines.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FileLines.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class FileLines : FileLinesBase
     {
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager, false);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat, false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FileShouldEndWithEmptyNewLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FileShouldEndWithEmptyNewLine.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S113";
         private const string MessageFormat = "Add a new line at the end of the file '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FinalizerShouldNotBeEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FinalizerShouldNotBeEmpty.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3880";
         private const string MessageFormat = "Remove this empty finalizer.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopConditionAlwaysFalse.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopConditionAlwaysFalse.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKind.NotEqualsExpression
         };
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopCounterChanged.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopCounterChanged.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S127";
         private const string MessageFormat = "Do not update the loop counter '{0}' within the loop body.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopCounterCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopCounterCondition.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormatNotEmpty = "This loop's stop condition tests {0} but the incrementer updates {1}.";
         private const string MessageFormatEmpty = "This loop's stop incrementer updates {0} but the stop condition doesn't test any variables.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopIncrementSign.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopIncrementSign.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "'{0}' is {1}remented and will never reach 'stop condition'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForeachLoopExplicitConversion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForeachLoopExplicitConversion.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S3217";
         private const string MessageFormat = "Either change the type of '{0}' to '{1}' or iterate on a generic collection of type '{2}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FrameworkTypeNaming.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FrameworkTypeNaming.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make this class name end with '{0}'.";
         private const int SelfAndBaseTypesCount = 2;
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionComplexity.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "The Cyclomatic Complexity of this {2} is {1} which is greater than {0} authorized.";
         private const int DefaultValueMaximum = 10;
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager, isEnabledByDefault: false);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat, isEnabledByDefault: false);
 
         [RuleParameter("maximumFunctionComplexityThreshold", PropertyType.Integer, "The maximum authorized complexity.", DefaultValueMaximum)]
         public int Maximum { get; set; } = DefaultValueMaximum;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericReadonlyFieldPropertyAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericReadonlyFieldPropertyAssignment.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S2934";
         private const string MessageFormat = "Restrict '{0}' to be a reference type or remove this assignment of '{1}'; it is useless if '{0}' is a value type.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterEmptinessChecking.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterEmptinessChecking.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S2955";
         private const string MessageFormat = "Use a comparison to 'default({0})' instead or add a constraint to '{0}' so that it can't be a value type.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterInOut.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterInOut.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3246";
         private const string MessageFormat = "Add the '{0}' keyword to parameter '{1}' to make it '{2}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterUnused.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2326";
         private const string MessageFormat = "'{0}' is not used in the {1}.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly SyntaxKind[] MethodModifiersToSkip =
         {
             SyntaxKind.AbstractKeyword,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParametersRequired.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParametersRequired.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4018";
         private const string MessageFormat = "Refactor this method to have parameters matching all the type parameters.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeEqualsOverride.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeEqualsOverride.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3249";
         private const string MessageFormat = "Remove this 'base' call to 'object.{0}', which is directly based on the object reference.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly ISet<string> MethodNames = new HashSet<string> { "GetHashCode", EqualsName };
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeMutable.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeMutable.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string IssueMessage = "Refactor 'GetHashCode' to not reference mutable fields.";
         private const string SecondaryMessageFormat = "Remove this use of '{0}' or make it 'readonly'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, IssueMessage, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, IssueMessage);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeMutableCodeFix.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeMutableCodeFix.cs
@@ -37,13 +37,8 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class GetHashCodeMutableCodeFix : SonarCodeFix
     {
         internal const string Title = "Make field 'readonly'";
-        public override ImmutableArray<string> FixableDiagnosticIds
-        {
-            get
-            {
-                return ImmutableArray.Create(GetHashCodeMutable.DiagnosticId);
-            }
-        }
+
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(GetHashCodeMutable.DiagnosticId);
 
         protected  override async Task RegisterCodeFixesAsync(SyntaxNode root, CodeFixContext context)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetTypeWithIsAssignableFrom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetTypeWithIsAssignableFrom.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageIsInstanceOfType = "the 'IsInstanceOfType()' method";
         private const string MessageNullCheck = "a 'null' check";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GotoStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GotoStatement.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class GotoStatement : GotoStatementBase<SyntaxKind>
     {
-        public GotoStatement() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
         protected override SyntaxKind[] GotoSyntaxKinds => new[]
         {
@@ -36,9 +36,6 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKind.GotoCaseStatement,
             SyntaxKind.GotoDefaultStatement
         };
-
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>
-           CSharpGeneratedCodeRecognizer.Instance;
 
         protected override string GoToLabel => "goto";
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GuardConditionOnEqualsOverride.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GuardConditionOnEqualsOverride.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3397";
         private const string MessageFormat = "Change this guard condition to call 'object.ReferenceEquals'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string TelnetKey = "telnet";
         private const string EnableSslName = "EnableSsl";
 
-        private static readonly DiagnosticDescriptor DefaultRule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager).WithNotConfigurable();
+        private static readonly DiagnosticDescriptor DefaultRule = DescriptorFactory.Create(DiagnosticId, MessageFormat).WithNotConfigurable();
         private static readonly DiagnosticDescriptor EnableSslRule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, EnableSslMessage, RspecStrings.ResourceManager).WithNotConfigurable();
 
         private readonly Dictionary<string, string> recommendedProtocols = new Dictionary<string, string>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string EnableSslName = "EnableSsl";
 
         private static readonly DiagnosticDescriptor DefaultRule = DescriptorFactory.Create(DiagnosticId, MessageFormat).WithNotConfigurable();
-        private static readonly DiagnosticDescriptor EnableSslRule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, EnableSslMessage, RspecStrings.ResourceManager).WithNotConfigurable();
+        private static readonly DiagnosticDescriptor EnableSslRule = DescriptorFactory.Create(DiagnosticId, EnableSslMessage).WithNotConfigurable();
 
         private readonly Dictionary<string, string> recommendedProtocols = new Dictionary<string, string>
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make sure disabling CSRF protection is safe here.";
         private const SyntaxKind ImplicitObjectCreationExpression = (SyntaxKind)8659;
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager).WithNotConfigurable();
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat).WithNotConfigurable();
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingRequestValidation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingRequestValidation.cs
@@ -21,14 +21,17 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class DisablingRequestValidation : DisablingRequestValidationBase
     {
+        protected override ILanguageFacade Language => CSharpFacade.Instance;
+
         public DisablingRequestValidation() : this(AnalyzerConfiguration.Hotspot) { }
 
-        public DisablingRequestValidation(IAnalyzerConfiguration analyzerConfiguration) : base(RspecStrings.ResourceManager, analyzerConfiguration) { }
+        public DisablingRequestValidation(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration) { }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotUseRandom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotUseRandom.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make sure that using this pseudorandom number generator is safe here.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager)
+            DescriptorFactory.Create(DiagnosticId, MessageFormat)
                 .WithNotConfigurable();
 
         public DoNotUseRandom()

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/HardcodedIpAddress.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/HardcodedIpAddress.cs
@@ -30,19 +30,12 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class HardcodedIpAddress : HardcodedIpAddressBase<SyntaxKind, LiteralExpressionSyntax>
     {
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = CSharpGeneratedCodeRecognizer.Instance;
-
+        protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
         protected override SyntaxKind SyntaxKind { get; } = SyntaxKind.StringLiteralExpression;
 
-        public HardcodedIpAddress()
-            : this(AnalyzerConfiguration.Hotspot)
-        {
-        }
+        public HardcodedIpAddress() : this(AnalyzerConfiguration.Hotspot) { }
 
-        public HardcodedIpAddress(IAnalyzerConfiguration analyzerConfiguration)
-            : base(analyzerConfiguration, RspecStrings.ResourceManager)
-        {
-        }
+        public HardcodedIpAddress(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration) { }
 
         protected override string GetValueText(LiteralExpressionSyntax literalExpression) =>
             literalExpression.Token.ValueText;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/InsecureDeserialization.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/InsecureDeserialization.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S5766";
         private const string MessageFormat = "Make sure not performing data validation after deserialization is safe here.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager).WithNotConfigurable();
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat).WithNotConfigurable();
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/HttpPostControllerActionShouldValidateInput.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/HttpPostControllerActionShouldValidateInput.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4564";
         private const string MessageFormat = "Enable input validation for this HttpPost method.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/IfCollapsible.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/IfCollapsible.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class IfCollapsible : IfCollapsibleBase
     {
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementIDisposableCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementIDisposableCorrectly.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKind.AbstractKeyword
         };
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementISerializableCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementISerializableCorrectly.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3925";
         private const string MessageFormat = "Update this implementation of 'ISerializable' to conform to the recommended serialization pattern.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementSerializationMethodsCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementSerializationMethodsCorrectly.cs
@@ -35,12 +35,8 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string ProblemStatic = "non-static";
         private const string ProblemReturnVoidText = "return 'void'";
 
-        public ImplementSerializationMethodsCorrectly() : base(RspecStrings.ResourceManager) { }
-
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
-
+        protected override ILanguageFacade Language => CSharpFacade.Instance;
         protected override string MethodStaticMessage => ProblemStatic;
-
         protected override string MethodReturnTypeShouldBeVoidMessage => ProblemReturnVoidText;
 
         protected override Location GetIdentifierLocation(IMethodSymbol methodSymbol) =>
@@ -59,7 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                 foreach (var attribute in attributes)
                 {
-                    c.ReportIssue(Diagnostic.Create(AttributeOnLocalFunctionRule, attribute.GetLocation()));
+                    c.ReportIssue(Diagnostic.Create(attributeOnLocalFunctionRule, attribute.GetLocation()));
                 }
             },
             SyntaxKindEx.LocalFunctionStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/IndentSingleLineFollowingConditional.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/IndentSingleLineFollowingConditional.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3973";
         private const string MessageFormat = "Use curly braces or indentation to denote the code conditionally executed by this '{0}'";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private readonly IChecker checker;
 
-        private static DiagnosticDescriptor Rule => DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static DiagnosticDescriptor Rule => DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InheritedCollidingInterfaceMembers.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InheritedCollidingInterfaceMembers.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const int MaxMemberDisplayCount = 2;
         private const int MinBaseListTypes = 2;
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InitializeStaticFieldsInline.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InitializeStaticFieldsInline.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S3963";
         private const string MessageFormat = "Initialize all 'static fields' inline and remove the 'static constructor'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfaceMethodsShouldBeCallableByChildTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfaceMethodsShouldBeCallableByChildTypes.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make '{0}' sealed, change to a non-explicit declaration or provide a " +
             "new method exposing the functionality of '{1}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfacesShouldNotBeEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfacesShouldNotBeEmpty.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4023";
         private const string MessageFormat = "Remove this interface or add members to it.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3220";
         private const string MessageFormat = "Review this call, which partially matches an overload without 'params'. The partial match is '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/IssueSuppression.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/IssueSuppression.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S1309";
         private const string MessageFormat = "Do not suppress issues.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LineLength.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LineLength.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class LineLength : LineLengthBase
     {
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager, false);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat, false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LiteralSuffixUpperCase.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LiteralSuffixUpperCase.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S818";
         private const string MessageFormat = "Upper case this literal suffix.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LiteralsShouldNotBePassedAsLocalizedParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LiteralsShouldNotBePassedAsLocalizedParameters.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4055";
         private const string MessageFormat = "Replace this string literal with a string retrieved through an instance of the 'ResourceManager' class.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LoopsAndLinq.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LoopsAndLinq.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string WhereMessageFormat = @"Loops should be simplified with ""LINQ"" expressions";
         private const string SelectMessageFormat = "Loop should be simplified by calling Select({0} => {0}.{1}))";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LossOfFractionInDivision.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LossOfFractionInDivision.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2184";
         private const string MessageFormat = "Cast one of the operands of this division to '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MagicNumberShouldNotBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MagicNumberShouldNotBeUsed.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S109";
         private const string MessageFormat = "Assign this magic number '{0}' to a well-named (variable|constant), and use the (variable|constant) instead.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         private static readonly ISet<string> NotConsideredAsMagicNumbers = new HashSet<string> { "-1", "0", "1" };

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithAssemblyVersionAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithAssemblyVersionAttribute.cs
@@ -20,12 +20,13 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class MarkAssemblyWithAssemblyVersionAttribute : MarkAssemblyWithAssemblyVersionAttributeBase
     {
-        public MarkAssemblyWithAssemblyVersionAttribute() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => CSharpFacade.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithClsCompliantAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithClsCompliantAttribute.cs
@@ -20,12 +20,13 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class MarkAssemblyWithClsCompliantAttribute : MarkAssemblyWithClsCompliantAttributeBase
     {
-        public MarkAssemblyWithClsCompliantAttribute() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => CSharpFacade.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithComVisibleAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithComVisibleAttribute.cs
@@ -20,12 +20,13 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class MarkAssemblyWithComVisibleAttribute : MarkAssemblyWithComVisibleAttributeBase
     {
-        public MarkAssemblyWithComVisibleAttribute() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => CSharpFacade.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithNeutralResourcesLanguageAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithNeutralResourcesLanguageAttribute.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Provide a 'System.Resources.NeutralResourcesLanguageAttribute' attribute for assembly '{0}'.";
         private const string StronglyTypedResourceBuilder = "System.Resources.Tools.StronglyTypedResourceBuilder";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializedToDefault.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializedToDefault.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static readonly CSharpExpressionNumericConverter ExpressionNumericConverter = new CSharpExpressionNumericConverter();
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializerRedundant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializerRedundant.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private readonly bool useSonarCfg;
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, "{0}", RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, "{0}");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberOverrideCallsBaseMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberOverrideCallsBaseMember.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S1185";
         private const string MessageFormat = "Remove this {1} '{0}' to simply inherit its behavior.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly string[] IgnoredMethodNames = { "Equals", "GetHashCode" };
         private static readonly string[] IgnoredRecordMethodNames = { "ToString", "PrintMembers" };

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShadowsOuterStaticMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShadowsOuterStaticMember.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3218";
         private const string MessageFormat = "Rename this {0} to not shadow the outer class' member with the same name.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldBeStatic.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldBeStatic.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2325";
         private const string MessageFormat = "Make '{0}' a static {1}.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         private static readonly ImmutableHashSet<string> MethodNameWhitelist =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldNotHaveConflictingTransparencyAttributes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldNotHaveConflictingTransparencyAttributes.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4211";
         private const string MessageFormat = "Change or remove this attribute to be consistent with its container.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
         protected override bool EnableConcurrentExecution => false;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverloadOptionalParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverloadOptionalParameter.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "This method signature overlaps the one defined on line {0}{1}, the default parameter value {2}.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideAddsParams.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideAddsParams.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "'params' should be removed from this override.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideChangedDefaultValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideChangedDefaultValue.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string MessageRemoveExplicit = "from this explicit interface implementation";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideNoParams.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideNoParams.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "'params' should not be removed from an override.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterMissingOptional.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterMissingOptional.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Add the 'Optional' attribute to this parameter.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageDead = "parameter '{0}', whose value is ignored in the method";
         private const string MessageFormat = "Remove this {0}.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private readonly bool useSonarCfg;
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodShouldBeNamedAccordingToSynchronicity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodShouldBeNamedAccordingToSynchronicity.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
             ImmutableArray.Create(KnownType.System_Collections_Generic_IAsyncEnumerable_T);
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodShouldNotOnlyReturnConstant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodShouldNotOnlyReturnConstant.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3400";
         private const string MessageFormat = "Remove this method and declare a constant for this value.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveTooManyLines.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveTooManyLines.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string LocalFunctionMessageFormat = "{0} local function has {1} lines, which is greater than the {2} lines authorized.";
 
         private static readonly DiagnosticDescriptor DefaultRule = DescriptorFactory.Create(DiagnosticId, MessageFormat, false);
-        private static readonly DiagnosticDescriptor LocalFunctionRule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, LocalFunctionMessageFormat, RspecStrings.ResourceManager, false);
+        private static readonly DiagnosticDescriptor LocalFunctionRule = DescriptorFactory.Create(DiagnosticId, LocalFunctionMessageFormat, false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(DefaultRule, LocalFunctionRule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveTooManyLines.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveTooManyLines.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
         private const string LocalFunctionMessageFormat = "{0} local function has {1} lines, which is greater than the {2} lines authorized.";
 
-        private static readonly DiagnosticDescriptor DefaultRule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager, false);
+        private static readonly DiagnosticDescriptor DefaultRule = DescriptorFactory.Create(DiagnosticId, MessageFormat, false);
         private static readonly DiagnosticDescriptor LocalFunctionRule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, LocalFunctionMessageFormat, RspecStrings.ResourceManager, false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(DefaultRule, LocalFunctionRule);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldUseBaseTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldUseBaseTypes.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3242";
         private const string MessageFormat = "Consider using more general type '{0}' instead of '{1}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MultilineBlocksWithoutBrace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MultilineBlocksWithoutBrace.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "This line will not be executed {0}; only the first line of this {2}-line block will be. The rest will execute {1}.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MultipleVariableDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MultipleVariableDeclaration.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         FieldDeclarationSyntax, LocalDeclarationStatementSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         public override SyntaxKind FieldDeclarationKind => SyntaxKind.FieldDeclaration;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MutableFieldsShouldNotBe.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MutableFieldsShouldNotBe.cs
@@ -24,7 +24,6 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
 using StyleCop.Analyzers.Lightup;
@@ -56,7 +55,7 @@ namespace SonarAnalyzer.Rules
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected MutableFieldsShouldNotBe(string diagnosticId, string messageFormat) =>
-             rule = DiagnosticDescriptorBuilder.GetDescriptor(diagnosticId, messageFormat, RspecStrings.ResourceManager);
+             rule = DescriptorFactory.Create(diagnosticId, messageFormat);
 
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(c =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MakeThisWrapperLessTrivialMessage = "Make this wrapper for native method '{0}' less trivial.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NestedCodeBlock.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NestedCodeBlock.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S1199";
         private const string MessageFormat = "Extract this nested code block into a separate method.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NoExceptionsInFinally.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NoExceptionsInFinally.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class NoExceptionsInFinally : NoExceptionsInFinallyBase
     {
-        public NoExceptionsInFinally() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => CSharpFacade.Instance;
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NoExceptionsInFinally.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NoExceptionsInFinally.cs
@@ -27,9 +27,9 @@ using SonarAnalyzer.Helpers;
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class NoExceptionsInFinally : NoExceptionsInFinallyBase
+    public sealed class NoExceptionsInFinally : NoExceptionsInFinallyBase<SyntaxKind>
     {
-        protected override ILanguageFacade Language => CSharpFacade.Instance;
+        protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NonAsyncTaskShouldNotReturnNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NonAsyncTaskShouldNotReturnNull.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "'Task.CompletedTask' or 'Task.Delay(0)'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ISet<SyntaxKind> TrackedNullLiteralLocations =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NonDerivedPrivateClassesShouldBeSealed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NonDerivedPrivateClassesShouldBeSealed.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3260";
         private const string MessageFormat = "Private classes or records which are not derived in the current assembly should be marked as 'sealed'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NonFlagsEnumInBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NonFlagsEnumInBitwiseOperation.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string MessageChangeOrRemove = "Mark enum '{0}' with 'Flags' attribute or remove this bitwise operation.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NotAssignedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NotAssignedPrivateMember.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const Accessibility MaxAccessibility = Accessibility.Private;
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ISet<SyntaxKind> PreOrPostfixOpSyntaxKinds = new HashSet<SyntaxKind>
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const int NotFound = -1;
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ObsoleteAttributesNeedExplanation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ObsoleteAttributesNeedExplanation.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S1123";
         private const string MessageFormat = "Add an explanation.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OperatorOverloadsShouldHaveNamedAlternatives.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OperatorOverloadsShouldHaveNamedAlternatives.cs
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
         };
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OperatorsShouldBeOverloadedConsistently.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OperatorsShouldBeOverloadedConsistently.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Provide an implementation for: {0}.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         private static class MethodName

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameter.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class OptionalParameter : OptionalParameterBase<SyntaxKind, BaseMethodDeclarationSyntax, ParameterSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<SyntaxKind> kindsOfInterest = ImmutableArray.Create(SyntaxKind.MethodDeclaration, SyntaxKind.ConstructorDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameterNotPassedToBaseCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameterNotPassedToBaseCall.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class OptionalParameterNotPassedToBaseCall : OptionalParameterNotPassedToBaseCallBase<InvocationExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameterWithDefaultValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameterWithDefaultValue.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Use '[DefaultParameterValue]' instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalRefOutParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalRefOutParameter.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove the 'Optional' attribute, it cannot be used with '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OrderByRepeated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OrderByRepeated.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Use 'ThenBy' instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OverrideGetHashCodeOnOverridingEquals.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OverrideGetHashCodeOnOverridingEquals.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "This {0} overrides '{1}' and should therefore also override '{2}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PInvokesShouldNotBeVisible.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PInvokesShouldNotBeVisible.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make this 'P/Invoke' method private or internal.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterAssignedTo.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterAssignedTo.cs
@@ -30,31 +30,26 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class ParameterAssignedTo : ParameterAssignedToBase<SyntaxKind, AssignmentExpressionSyntax, IdentifierNameSyntax>
     {
+        protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
-        public ParameterAssignedTo() : base(RspecStrings.ResourceManager) { }
+        protected override SyntaxNode AssignmentLeft(AssignmentExpressionSyntax assignment) =>
+            assignment.Left;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
-
-        protected override SyntaxKind SyntaxKindOfInterest => SyntaxKind.SimpleAssignmentExpression;
-
-        protected override SyntaxNode AssignmentLeft(AssignmentExpressionSyntax assignment) => assignment.Left;
-
-        protected override SyntaxNode AssignmentRight(AssignmentExpressionSyntax assignment) => assignment.Right;
+        protected override SyntaxNode AssignmentRight(AssignmentExpressionSyntax assignment) =>
+            assignment.Right;
 
         protected override bool IsAssignmentToCatchVariable(ISymbol symbol, SyntaxNode node)
         {
-            if (!(symbol is ILocalSymbol localSymbol))
+            if (symbol is not ILocalSymbol localSymbol)
             {
                 return false;
             }
 
-            var result = localSymbol.DeclaringSyntaxReferences
+            return localSymbol.DeclaringSyntaxReferences
                 .Select(declaringSyntaxReference => declaringSyntaxReference.GetSyntax())
                 .Any(syntaxNode =>
                     syntaxNode.Parent is CatchClauseSyntax &&
                     ((CatchClauseSyntax)syntaxNode.Parent).Declaration == syntaxNode);
-
-            return result;
         }
 
         protected override bool IsAssignmentToParameter(ISymbol symbol)
@@ -63,7 +58,5 @@ namespace SonarAnalyzer.Rules.CSharp
             var result = parameterSymbol?.RefKind == RefKind.None;
             return result;
         }
-
-
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterAssignedTo.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterAssignedTo.cs
@@ -28,35 +28,12 @@ using SonarAnalyzer.Helpers;
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class ParameterAssignedTo : ParameterAssignedToBase<SyntaxKind, AssignmentExpressionSyntax, IdentifierNameSyntax>
+    public sealed class ParameterAssignedTo : ParameterAssignedToBase<SyntaxKind, IdentifierNameSyntax>
     {
         protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
-        protected override SyntaxNode AssignmentLeft(AssignmentExpressionSyntax assignment) =>
-            assignment.Left;
-
-        protected override SyntaxNode AssignmentRight(AssignmentExpressionSyntax assignment) =>
-            assignment.Right;
-
-        protected override bool IsAssignmentToCatchVariable(ISymbol symbol, SyntaxNode node)
-        {
-            if (symbol is not ILocalSymbol localSymbol)
-            {
-                return false;
-            }
-
-            return localSymbol.DeclaringSyntaxReferences
-                .Select(declaringSyntaxReference => declaringSyntaxReference.GetSyntax())
-                .Any(syntaxNode =>
-                    syntaxNode.Parent is CatchClauseSyntax &&
-                    ((CatchClauseSyntax)syntaxNode.Parent).Declaration == syntaxNode);
-        }
-
-        protected override bool IsAssignmentToParameter(ISymbol symbol)
-        {
-            var parameterSymbol = symbol as IParameterSymbol;
-            var result = parameterSymbol?.RefKind == RefKind.None;
-            return result;
-        }
+        protected override bool IsAssignmentToCatchVariable(ISymbol symbol, SyntaxNode node) =>
+            symbol is ILocalSymbol localSymbol
+            && localSymbol.DeclaringSyntaxReferences.Select(x => x.GetSyntax()).Any(x => x.Parent is CatchClauseSyntax catchClause && catchClause.Declaration == x);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterNamesShouldNotDuplicateMethodNames.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterNamesShouldNotDuplicateMethodNames.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Rename the parameter '{0}' so that it does not duplicate the method name.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterValidationInAsyncShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterValidationInAsyncShouldBeWrapped.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4457";
         private const string MessageFormat = "Split this method into two, one handling parameters check and the other handling the asynchronous code.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterValidationInYieldShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterValidationInYieldShouldBeWrapped.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
            "handling the iterator.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class ParametersCorrectOrder : ParametersCorrectOrderBase<ArgumentSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PartCreationPolicyShouldBeUsedWithExportAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PartCreationPolicyShouldBeUsedWithExportAttribute.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class PartCreationPolicyShouldBeUsedWithExportAttribute
         : PartCreationPolicyShouldBeUsedWithExportAttributeBase<AttributeSyntax, TypeDeclarationSyntax>
     {
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PartialMethodNoImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PartialMethodNoImplementation.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Supply an implementation for {0} partial method{1}.";
         private const string MessageAdditional = ", otherwise this call will be ignored";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PointersShouldBePrivate.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PointersShouldBePrivate.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make '{0}' 'private' or 'protected readonly'.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PreferJaggedArraysOverMultidimensional.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PreferJaggedArraysOverMultidimensional.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Change this multidimensional array to a jagged array.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PrivateFieldUsedAsLocalVariable.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PrivateFieldUsedAsLocalVariable.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S1450";
         private const string MessageFormat = "Remove the field '{0}' and declare it as a local variable in the relevant methods.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertiesAccessCorrectField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertiesAccessCorrectField.cs
@@ -31,9 +31,9 @@ using StyleCop.Analyzers.Lightup;
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class PropertiesAccessCorrectField : PropertiesAccessCorrectFieldBase
+    public sealed class PropertiesAccessCorrectField : PropertiesAccessCorrectFieldBase<SyntaxKind>
     {
-        protected override ILanguageFacade Language => CSharpFacade.Instance;
+        protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
         protected override IEnumerable<FieldData> FindFieldAssignments(IPropertySymbol property, Compilation compilation)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertiesAccessCorrectField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertiesAccessCorrectField.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class PropertiesAccessCorrectField : PropertiesAccessCorrectFieldBase
     {
-        public PropertiesAccessCorrectField() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => CSharpFacade.Instance;
 
         protected override IEnumerable<FieldData> FindFieldAssignments(IPropertySymbol property, Compilation compilation)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertiesShouldBePreferred.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertiesShouldBePreferred.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Consider making method '{0}' a property.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyGetterWithThrow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyGetterWithThrow.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class PropertyGetterWithThrow : PropertyGetterWithThrowBase<SyntaxKind, AccessorDeclarationSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override SyntaxKind ThrowSyntaxKind => SyntaxKind.ThrowStatement;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyNamesShouldNotMatchGetMethods.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyNamesShouldNotMatchGetMethods.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4059";
         private const string MessageFormat = "Change either the name of property '{0}' or the name of method '{1}' to make them distinguishable.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyToAutoProperty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyToAutoProperty.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2292";
         private const string MessageFormat = "Make this an auto-implemented property and remove its backing field.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicConstantField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicConstantField.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class PublicConstantField : PublicConstantFieldBase<SyntaxKind, FieldDeclarationSyntax, VariableDeclaratorSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         public override SyntaxKind FieldDeclarationKind => SyntaxKind.FieldDeclaration;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicMethodWithMultidimensionalArray.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicMethodWithMultidimensionalArray.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<SyntaxKind> kindsOfInterest = ImmutableArray.Create(SyntaxKind.MethodDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundancyInConstructorDestructorDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundancyInConstructorDestructorDeclaration.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S3253";
         private const string MessageFormat = "Remove this redundant {0}.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantArgument.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantArgument.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S3254";
         private const string MessageFormat = "Remove this default value assigned to parameter '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantCast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantCast.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this unnecessary cast to '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S3440";
         private const string MessageFormat = "Remove this useless conditional.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantDeclaration.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules.CSharp
         }
 
         private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
-        private static readonly DiagnosticDescriptor DiscardRule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, UseDiscardMessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor DiscardRule = DescriptorFactory.Create(DiagnosticId, UseDiscardMessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule, DiscardRule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantDeclaration.cs
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Rules.CSharp
             DelegateParameterList
         }
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly DiagnosticDescriptor DiscardRule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, UseDiscardMessageFormat, RspecStrings.ResourceManager);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule, DiscardRule);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageAlreadyImplements = "'{0}' implements '{1}' so '{1}' can be removed from the inheritance list.";
         private const string MessageFormat = "{0}";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3626";
         private const string MessageFormat = "Remove this redundant jump.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantModifier.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantModifier.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S2333";
         private const string MessageFormat = "'{0}' is {1} in this context.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ISet<SyntaxKind> UnsafeConstructKinds = new HashSet<SyntaxKind>
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
@@ -35,10 +35,8 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this unnecessary null check; 'is' returns false for nulls.";
         private const string MessageFormatForPatterns = "Remove this unnecessary null check; it is already done by the pattern match.";
 
-        private static readonly DiagnosticDescriptor RuleForIs =
-            DescriptorFactory.Create(DiagnosticId, MessageFormat);
-        private static readonly DiagnosticDescriptor RuleForPatternSyntax =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormatForPatterns, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor RuleForIs = DescriptorFactory.Create(DiagnosticId, MessageFormat);
+        private static readonly DiagnosticDescriptor RuleForPatternSyntax = DescriptorFactory.Create(DiagnosticId, MessageFormatForPatterns);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(RuleForIs, RuleForPatternSyntax);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormatForPatterns = "Remove this unnecessary null check; it is already done by the pattern match.";
 
         private static readonly DiagnosticDescriptor RuleForIs =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly DiagnosticDescriptor RuleForPatternSyntax =
             DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormatForPatterns, RspecStrings.ResourceManager);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullableTypeComparison.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullableTypeComparison.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this redundant type comparison.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantParentheses.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantParentheses.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class RedundantParentheses : RedundantParenthesesBase<ParenthesizedExpressionSyntax, SyntaxKind>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantParenthesesObjectsCreation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantParenthesesObjectsCreation.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove these redundant parentheses.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantPropertyNamesInAnonymousClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantPropertyNamesInAnonymousClass.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove the redundant '{0} ='.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToCharArrayCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToCharArrayCall.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this redundant 'ToCharArray' call.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToStringCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToStringCall.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string MessageCompiler = ", the compiler will do it for you";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string EqualsName = nameof(Equals);
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualsOnValueType.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualsOnValueType.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string ReferenceEqualsName = "ReferenceEquals";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RequireAttributeUsageAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RequireAttributeUsageAttribute.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Specify AttributeUsage on '{0}'{1}.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Return an empty collection instead of null.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> CollectionTypes =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnValueIgnored.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnValueIgnored.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Use the return value of method '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReversedOperators.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReversedOperators.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class ReversedOperators : ReversedOperatorsBase<PrefixUnaryExpressionSyntax>
     {
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RightCurlyBraceStartsLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RightCurlyBraceStartsLine.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Move this closing curly brace to the next line.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SelfAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SelfAssignment.cs
@@ -28,9 +28,9 @@ using StyleCop.Analyzers.Lightup;
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class SelfAssignment : SelfAssignmentBase
+    public sealed class SelfAssignment : SelfAssignmentBase<SyntaxKind>
     {
-        protected override ILanguageFacade Language => CSharpFacade.Instance;
+        protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
         protected override void Initialize(SonarAnalysisContext context)
         {
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (CSharpEquivalenceChecker.AreEquivalent(expression.Left, expression.Right))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation()));
+                        c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
                     }
                 },
                 SyntaxKind.SimpleAssignmentExpression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SelfAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SelfAssignment.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class SelfAssignment : SelfAssignmentBase
     {
-        public SelfAssignment() : base(RspecStrings.ResourceManager) {}
+        protected override ILanguageFacade Language => CSharpFacade.Instance;
 
         protected override void Initialize(SonarAnalysisContext context)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Secure this serialization constructor.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly AttributeComparer attributeComparer = new AttributeComparer();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SetLocaleForDataTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SetLocaleForDataTypes.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4057";
         private const string MessageFormat = "Set the locale for this '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly ImmutableArray<KnownType> CheckedTypes = ImmutableArray.Create(
             KnownType.System_Data_DataTable,
             KnownType.System_Data_DataSet);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ShiftDynamicNotInteger.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ShiftDynamicNotInteger.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class ShiftDynamicNotInteger : ShiftDynamicNotIntegerBase<ExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SillyBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SillyBitwiseOperation.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class SillyBitwiseOperation : SillyBitwiseOperationBase
     {
-        public SillyBitwiseOperation() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => CSharpFacade.Instance;
 
         protected override void Initialize(SonarAnalysisContext context)
         {
@@ -53,11 +53,6 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ExclusiveOrAssignmentExpression);
         }
 
-        protected override object FindConstant(SemanticModel semanticModel, SyntaxNode node) =>
-            IsFieldOrProperty(semanticModel, node, out var symbol) && !IsInSystemNamespace(symbol)
-                ? null
-                : node.FindConstantValue(semanticModel);
-
         private void CheckAssignment(SyntaxNodeAnalysisContext context, int constValueToLookFor)
         {
             var assignment = (AssignmentExpressionSyntax)context.Node;
@@ -76,14 +71,5 @@ namespace SonarAnalyzer.Rules.CSharp
             var binary = (BinaryExpressionSyntax)context.Node;
             CheckBinary(context, binary.Left, binary.OperatorToken, binary.Right, constValueToLookFor);
         }
-
-        private static bool IsFieldOrProperty(SemanticModel semanticModel, SyntaxNode node, out ISymbol symbol)
-        {
-            symbol = semanticModel.GetSymbolInfo(node).Symbol;
-            return symbol is {Kind: SymbolKind.Field or SymbolKind.Property};
-        }
-
-        private static bool IsInSystemNamespace(ISymbol symbol) =>
-            symbol.ContainingNamespace.Name == "System";
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SillyBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SillyBitwiseOperation.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SingleStatementPerLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SingleStatementPerLine.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class SingleStatementPerLine : SingleStatementPerLineBase<StatementSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override bool StatementShouldBeExcluded(StatementSyntax statement)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyIFormatProviderOrCultureInfo.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyIFormatProviderOrCultureInfo.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Use the overload that takes a 'CultureInfo' or 'IFormatProvider' parameter.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> formatAndCultureType =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyStringComparison.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyStringComparison.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "'StringComparison' as a parameter.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> stringComparisonType = ImmutableArray.Create(KnownType.System_StringComparison);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SqlKeywordsDelimitedBySpace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SqlKeywordsDelimitedBySpace.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Add a space before '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInGenericClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInGenericClass.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2743";
         private const string MessageFormat = "A static field in a generic type is not shared among instances of different close constructed types.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInitializerOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInitializerOrder.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3263";
         private const string MessageFormat = "Move this field's initializer into a static constructor.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly SyntaxKind[] EnclosingTypes =
         {
             SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldVisible.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldVisible.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2223";
         private const string MessageFormat = "Change the visibility of '{0}' or make it 'const' or 'readonly'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldWrittenFromInstanceConstructor.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldWrittenFromInstanceConstructor.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this assignment of '{0}' or initialize it statically.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override bool IsValidCodeBlockContext(SyntaxNode node, ISymbol owningSymbol) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldWrittenFromInstanceMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldWrittenFromInstanceMember.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormatRemoveSet = "Remove this set, which updates a 'static' field from an instance {0}.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override bool IsValidCodeBlockContext(SyntaxNode node, ISymbol owningSymbol) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticSealedClassProtectedMembers.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticSealedClassProtectedMembers.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this 'protected' modifier.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StreamReadStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StreamReadStatement.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "Check the return value of the '{0}' call to see how many bytes were read.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringConcatenationInLoop.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringConcatenationInLoop.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         : StringConcatenationInLoopBase<SyntaxKind, AssignmentExpressionSyntax, BinaryExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override bool IsExpressionConcatenation(BinaryExpressionSyntax addExpression) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringFormatValidator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringFormatValidator.cs
@@ -42,8 +42,8 @@ namespace SonarAnalyzer.Rules.CSharp
         // This is the value as defined in .Net Framework
         private const int MaxValueForArgumentIndexAndAlignment = 1_000_000;
 
-        private static readonly DiagnosticDescriptor BugRule = DiagnosticDescriptorBuilder.GetDescriptor(BugDiagnosticId, MessageFormat, RspecStrings.ResourceManager);
-        private static readonly DiagnosticDescriptor CodeSmellRule = DiagnosticDescriptorBuilder.GetDescriptor(CodeSmellDiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor BugRule = DescriptorFactory.Create(BugDiagnosticId, MessageFormat);
+        private static readonly DiagnosticDescriptor CodeSmellRule = DescriptorFactory.Create(CodeSmellDiagnosticId, MessageFormat);
 
         private static readonly HashSet<MemberDescriptor> HandledFormatMethods = new HashSet<MemberDescriptor>
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOffsetMethods.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOffsetMethods.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Replace '{0}' with the overload that accepts an offset parameter.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string MessageChangeCompareTo = "Use 'CompareOrdinal' or 'Compare' with the locale specified instead of 'CompareTo'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOrIntegralTypesForIndexers.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOrIntegralTypesForIndexers.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
             .ToImmutableArray();
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SuppressFinalizeUseless.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SuppressFinalizeUseless.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this useless call to 'GC.SuppressFinalize'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchCaseFallsThroughToDefault.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchCaseFallsThroughToDefault.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this empty 'case' clause.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchCasesMinimumThree.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchCasesMinimumThree.cs
@@ -46,8 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private const string SingleReturnValueSwitchExpressionMessage = "Remove this 'switch' expression to increase readability.";
 
-        private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, "{0}", RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor rule = DescriptorFactory.Create(DiagnosticId, "{0}");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchDefaultClauseEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchDefaultClauseEmpty.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this empty 'default' clause.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class SwitchSectionShouldNotHaveTooManyStatements : SwitchSectionShouldNotHaveTooManyStatementsBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchShouldNotBeNested.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchShouldNotBeNested.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor the code to eliminate this nested 'switch'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchWithoutDefault.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchWithoutDefault.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public class SwitchWithoutDefault : SwitchWithoutDefaultBase<SyntaxKind>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<SyntaxKind> kindsOfInterest = ImmutableArray.Create(SyntaxKind.SwitchStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ConditionEvaluatesToConstant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ConditionEvaluatesToConstant.cs
@@ -37,16 +37,16 @@ namespace SonarAnalyzer.Rules.CSharp
 {
     internal sealed class ConditionEvaluatesToConstant : ISymbolicExecutionAnalyzer
     {
-        internal const string S2583DiagnosticId = "S2583"; // Bug
+        private const string S2583DiagnosticId = "S2583"; // Bug
         private const string S2583MessageFormatBool = "Change this condition so that it does not always evaluate to '{0}'; some subsequent code is never executed.";
         private const string S2583MessageNotNull = "Change this expression which always evaluates to 'not null'; some subsequent code is never executed.";
 
-        internal const string S2589DiagnosticId = "S2589"; // Code smell
+        private const string S2589DiagnosticId = "S2589"; // Code smell
         private const string S2589MessageFormatBool = "Change this condition so that it does not always evaluate to '{0}'.";
         private const string S2589MessageNull = "Change this expression which always evaluates to 'null'.";
 
-        internal static readonly DiagnosticDescriptor S2583 = DiagnosticDescriptorBuilder.GetDescriptor(S2583DiagnosticId, "{0}", RspecStrings.ResourceManager);
-        internal static readonly DiagnosticDescriptor S2589 = DiagnosticDescriptorBuilder.GetDescriptor(S2589DiagnosticId, "{0}", RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S2583 = DescriptorFactory.Create(S2583DiagnosticId, "{0}");
+        internal static readonly DiagnosticDescriptor S2589 = DescriptorFactory.Create(S2589DiagnosticId, "{0}");
 
         private static readonly ISet<SyntaxKind> OmittedSyntaxKinds = new HashSet<SyntaxKind>
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4158";
         private const string MessageFormat = "Remove this call, the collection is known to be empty here.";
 
-        internal static readonly DiagnosticDescriptor S4158 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S4158 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ImmutableArray<KnownType> TrackedCollectionTypes =
             ImmutableArray.Create(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyNullableValueAccess.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/EmptyNullableValueAccess.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string ValueLiteral = "Value";
         private const string HasValueLiteral = "HasValue";
 
-        internal static readonly DiagnosticDescriptor S3655 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S3655 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S3655);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/HashesShouldHaveUnpredictableSalt.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/HashesShouldHaveUnpredictableSalt.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
         private const string MakeSaltUnpredictableMessage = "Make this salt unpredictable.";
         private const string MakeThisSaltLongerMessage = "Make this salt at least 16 bytes.";
 
-        internal static readonly DiagnosticDescriptor S2053 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S2053 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S2053);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InitializationVectorShouldBeRandom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InitializationVectorShouldBeRandom.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.SymbolicExecution
         internal const string DiagnosticId = "S3329";
         private const string MessageFormat = "Use a dynamically-generated, random IV.";
 
-        internal static readonly DiagnosticDescriptor S3329 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S3329 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(S3329);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InvalidCastToInterfaceSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/InvalidCastToInterfaceSymbolicExecution.cs
@@ -34,10 +34,10 @@ namespace SonarAnalyzer.Rules.CSharp
 {
     internal sealed class InvalidCastToInterfaceSymbolicExecution : ISymbolicExecutionAnalyzer
     {
-        internal const string DiagnosticId = "S1944";
+        private const string DiagnosticId = "S1944";
         private const string MessageDefinite = "Nullable is known to be empty, this cast throws an exception.";
 
-        internal static readonly DiagnosticDescriptor S1944 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, "{0}", RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S1944 = DescriptorFactory.Create(DiagnosticId, "{0}");
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics  { get; } = ImmutableArray.Create(S1944);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/NullPointerDereference.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/NullPointerDereference.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S2259";
         private const string MessageFormat = "'{0}' is null on at least one execution path.";
 
-        internal static readonly DiagnosticDescriptor S2259 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S2259 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S2259);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnce.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnce.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S3966";
         private const string MessageFormat = "Refactor this code to make sure '{0}' is disposed only once.";
 
-        internal static readonly DiagnosticDescriptor S3966 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S3966 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S3966);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string Constructor = "constructor to avoid using members of parameter '{0}' because it could be null";
         private const string Method = "method to add validation of parameter '{0}' before using it";
 
-        public static readonly DiagnosticDescriptor S3900 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        public static readonly DiagnosticDescriptor S3900 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(S3900);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/RestrictDeserializedTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/RestrictDeserializedTypes.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string RestrictTypesMessage = "Restrict types of objects allowed to be deserialized.";
         private const string VerifyMacMessage = "Serialized data signature (MAC) should be verified.";
 
-        internal static readonly DiagnosticDescriptor S5773 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        internal static readonly DiagnosticDescriptor S5773 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(S5773);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TabCharacter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TabCharacter.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Replace all tab characters in this file by sequences of white-spaces.";
 
         internal static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TaskConfigureAwait.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TaskConfigureAwait.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3216";
         private const string MessageFormat = "Add '.ConfigureAwait(false)' to this call to allow execution to continue in any thread.";
 
-        private static readonly DiagnosticDescriptor rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestClassShouldHaveTestMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestClassShouldHaveTestMethod.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_AssemblyCleanupAttribute);
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldContainAssertion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldContainAssertion.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
             KnownType.Xunit_Sdk_AssertException,
             KnownType.Xunit_Sdk_XunitException);
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
@@ -99,7 +99,7 @@ namespace SonarAnalyzer.Rules.CSharp
         };
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldNotBeIgnored.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldNotBeIgnored.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S1607";
         private const string MessageFormat = "Either remove this 'Ignore' attribute or add an explanation about why this test is ignored.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         private static readonly ImmutableArray<KnownType> TrackedTestIdentifierAttributes =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThisShouldNotBeExposedFromConstructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThisShouldNotBeExposedFromConstructors.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make sure the use of 'this' doesn't expose partially-constructed instances of this class in multi-threaded environments.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadStaticNonStaticField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadStaticNonStaticField.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove the 'ThreadStatic' attribute from this definition.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadStaticWithInitializer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadStaticWithInitializer.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove this initialization of '{0}' or make it lazy.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThrowReservedExceptions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThrowReservedExceptions.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class ThrowReservedExceptions : ThrowReservedExceptionsBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ToStringNoNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ToStringNoNull.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Return empty string instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyGenericParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyGenericParameters.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const int DefaultMaxNumberOfGenericParametersInClass = 2;
         private const int DefaultMaxNumberOfGenericParametersInMethod = 3;
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager, isEnabledByDefault: false);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat, isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyLabelsInSwitch.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyLabelsInSwitch.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public class TooManyLabelsInSwitch : TooManyLabelsInSwitchBase<SyntaxKind, SwitchStatementSyntax>
     {
         protected override DiagnosticDescriptor Rule { get; } =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         private const string MessageFormat = "Consider reworking this 'switch' to reduce the number of 'case's" +

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyParameters.cs
@@ -32,8 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class TooManyParameters : TooManyParametersBase<SyntaxKind, ParameterListSyntax>
     {
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = CSharpGeneratedCodeRecognizer.Instance;
-        protected override SyntaxKind[] SyntaxKinds { get; } = new[] { SyntaxKind.ParameterList };
+        protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
         private static readonly ImmutableDictionary<SyntaxKind, string> NodeToDeclarationName = new Dictionary<SyntaxKind, string>
         {
@@ -46,11 +45,11 @@ namespace SonarAnalyzer.Rules.CSharp
             { SyntaxKindEx.LocalFunctionStatement, "Local function" }
         }.ToImmutableDictionary();
 
-        public TooManyParameters() : base(RspecStrings.ResourceManager) { }
+        protected override string UserFriendlyNameForNode(SyntaxNode node) =>
+            NodeToDeclarationName[node.Kind()];
 
-        protected override string UserFriendlyNameForNode(SyntaxNode node) => NodeToDeclarationName[node.Kind()];
-
-        protected override int CountParameters(ParameterListSyntax parameterList) => parameterList.Parameters.Count;
+        protected override int CountParameters(ParameterListSyntax parameterList) =>
+            parameterList.Parameters.Count;
 
         protected override bool CanBeChanged(SyntaxNode node, SemanticModel semanticModel) =>
             NodeToDeclarationName.ContainsKey(node.Kind()) && VerifyCanBeChangedBySymbol(node, semanticModel);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Implement this method or throw 'NotSupportedException' instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TryStatementsWithIdenticalCatchShouldBeMerged.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TryStatementsWithIdenticalCatchShouldBeMerged.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Combine this 'try' with the one starting on line {0}.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeExaminationOnSystemType.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeExaminationOnSystemType.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageIsInstanceOfType = "Pass an argument that is not a 'System.Type' or consider using 'IsAssignableFrom'.";
         private const string MessageIsInstanceOfTypeWithGetType = "Consider removing the 'GetType' call, it's suspicious in an 'IsInstanceOfType' call.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeMemberVisibility.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeMemberVisibility.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3059";
         private const string MessageFormat = "Types should not have members with visibility set higher than the type's visibility";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly SyntaxKind[] TypeKinds =
         {
             SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S4041";
         private const string MessageFormat = "Change the name of type '{0}' to be different from an existing framework namespace.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         // Based on https://msdn.microsoft.com/en-us/library/gg145045%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypesShouldNotExtendOutdatedBaseTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypesShouldNotExtendOutdatedBaseTypes.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor this type not to derive from an outdated type '{0}'.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         private static readonly ImmutableArray<KnownType> OutdatedTypes =
             ImmutableArray.Create(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnaryPrefixOperatorRepeated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnaryPrefixOperatorRepeated.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
         UnaryPrefixOperatorRepeatedBase<SyntaxKind, PrefixUnaryExpressionSyntax>
     {
         protected override DiagnosticDescriptor Rule { get; } =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         protected override ISet<SyntaxKind> SyntaxKinds { get; } = new HashSet<SyntaxKind>
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3353";
         private const string MessageFormat = "Add the 'const' modifier to '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         private enum DeclarationType

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove the unused event '{0}' or invoke it.";
 
         private static readonly Accessibility MaxAccessibility = Accessibility.Public;
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         private static readonly ISet<SyntaxKind> EventSyntax = new HashSet<SyntaxKind>
         {
             SyntaxKind.EventFieldDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryUsings.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryUsings.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal const string DiagnosticId = "S1128";
         private const string MessageFormat = "Remove this unnecessary 'using'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -43,8 +43,8 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string S4487DiagnosticId = "S4487";
         private const string S4487MessageFormat = "Remove this unread {0} field '{1}' or refactor the code to use its value.";
 
-        private static readonly DiagnosticDescriptor RuleS1144 = DiagnosticDescriptorBuilder.GetDescriptor(S1144DiagnosticId, S1144MessageFormat, RspecStrings.ResourceManager, fadeOutCode: true);
-        private static readonly DiagnosticDescriptor RuleS4487 = DiagnosticDescriptorBuilder.GetDescriptor(S4487DiagnosticId, S4487MessageFormat, RspecStrings.ResourceManager, fadeOutCode: true);
+        private static readonly DiagnosticDescriptor RuleS1144 = DescriptorFactory.Create(S1144DiagnosticId, S1144MessageFormat, fadeOutCode: true);
+        private static readonly DiagnosticDescriptor RuleS4487 = DescriptorFactory.Create(S4487DiagnosticId, S4487MessageFormat, fadeOutCode: true);
         private static readonly ImmutableArray<KnownType> IgnoredTypes =
             ImmutableArray.Create(
                 KnownType.UnityEditor_AssetModificationProcessor,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3241";
         private const string MessageFormat = "Change return type to 'void'; not a single caller uses the returned value.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UriShouldNotBeHardcoded.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UriShouldNotBeHardcoded.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKind, BinaryExpressionSyntax, ArgumentSyntax, VariableDeclaratorSyntax>
     {
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
         protected override SyntaxKind StringLiteralSyntaxKind { get; } = SyntaxKind.StringLiteralExpression;
         protected override SyntaxKind[] StringConcatenateExpressions { get; } = { SyntaxKind.AddExpression };

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseConstantsWhereAppropriate.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseConstantsWhereAppropriate.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Replace this 'static readonly' declaration with 'const'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> RelevantTypes =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseCurlyBraces.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseCurlyBraces.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Add curly braces around the nested statement(s) in this '{0}' block.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericEventHandlerInstances.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericEventHandlerInstances.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Refactor this delegate to use 'System.EventHandler<TEventArgs>'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private static readonly ImmutableArray<KnownType> allowedTypes =

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericWithRefParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericWithRefParameters.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make this method generic and replace the 'object' parameter with a type parameter.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseNumericLiteralSeparator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseNumericLiteralSeparator.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const int DecimalMinimumDigits = 6;
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseParamsForVariableArguments.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseParamsForVariableArguments.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Use the 'params' keyword instead of '__arglist'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseShortCircuitingOperator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseShortCircuitingOperator.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     public sealed class UseShortCircuitingOperator : UseShortCircuitingOperatorBase<SyntaxKind, BinaryExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override string GetSuggestedOpName(BinaryExpressionSyntax node) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringIsNullOrEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringIsNullOrEmpty.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
             "Use 'string.IsNullOrEmpty()' instead of comparing to empty string.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
@@ -45,11 +45,11 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormatRuleS3997 = "Refactor this method so it invokes the overload accepting a 'System.Uri' parameter.";
         private const string MessageFormatRuleS4005 = "Call the overload that takes a 'System.Uri' as an argument instead.";
 
-        private static readonly DiagnosticDescriptor RuleS3994 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticIdRuleS3994, MessageFormatRuleS3994, RspecStrings.ResourceManager);
-        private static readonly DiagnosticDescriptor RuleS3995 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticIdRuleS3995, MessageFormatRuleS3995, RspecStrings.ResourceManager);
-        private static readonly DiagnosticDescriptor RuleS3996 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticIdRuleS3996, MessageFormatRuleS3996, RspecStrings.ResourceManager);
-        private static readonly DiagnosticDescriptor RuleS3997 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticIdRuleS3997, MessageFormatRuleS3997, RspecStrings.ResourceManager);
-        private static readonly DiagnosticDescriptor RuleS4005 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticIdRuleS4005, MessageFormatRuleS4005, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor RuleS3994 = DescriptorFactory.Create(DiagnosticIdRuleS3994, MessageFormatRuleS3994);
+        private static readonly DiagnosticDescriptor RuleS3995 = DescriptorFactory.Create(DiagnosticIdRuleS3995, MessageFormatRuleS3995);
+        private static readonly DiagnosticDescriptor RuleS3996 = DescriptorFactory.Create(DiagnosticIdRuleS3996, MessageFormatRuleS3996);
+        private static readonly DiagnosticDescriptor RuleS3997 = DescriptorFactory.Create(DiagnosticIdRuleS3997, MessageFormatRuleS3997);
+        private static readonly DiagnosticDescriptor RuleS4005 = DescriptorFactory.Create(DiagnosticIdRuleS4005, MessageFormatRuleS4005);
         private static readonly ISet<string> UrlNameVariants = new HashSet<string> { "URI", "URL", "URN" };
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(RuleS3994, RuleS3995, RuleS3996, RuleS3997, RuleS4005);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseValueParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseValueParameter.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3237";
         private const string MessageFormat = "Use the 'value' parameter in this {0} accessor declaration.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseWhileLoopInstead.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseWhileLoopInstead.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Replace this 'for' loop with a 'while' loop.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ValueTypeShouldImplementIEquatable.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ValueTypeShouldImplementIEquatable.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S3898";
         private const string MessageFormat = "Implement 'IEquatable<T>' in value type '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ValuesUselesslyIncremented.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ValuesUselesslyIncremented.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2123";
         private const string MessageFormat = "Remove this {0} or correct the code not to waste it.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S1117";
         private const string MessageFormat = "Rename '{0}' which hides the {1} with the same name.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableUnused.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class VariableUnused : VariableUnusedBase
     {
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VirtualEventField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VirtualEventField.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         internal const string DiagnosticId = "S2290";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfMissingContractAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfMissingContractAttribute.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageOperation = "the methods of this {0}";
         private const string MessageService = " this {0}";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfNonVoidOneWay.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfNonVoidOneWay.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class WcfNonVoidOneWay : WcfNonVoidOneWayBase<MethodDeclarationSyntax, SyntaxKind>
     {
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string SecondaryMessageFormat = "This value enables external entities in XML parsing.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/LocksReleasedAllPaths.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/LocksReleasedAllPaths.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.CSharp
 {
     public class LocksReleasedAllPaths : LocksReleasedAllPathsBase
     {
-        public static readonly DiagnosticDescriptor S2222 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        public static readonly DiagnosticDescriptor S2222 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         protected override DiagnosticDescriptor Rule => S2222;
 

--- a/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/SonarDiagnosticAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/SonarDiagnosticAnalyzer.cs
@@ -60,10 +60,9 @@ namespace SonarAnalyzer.Helpers
         protected abstract string MessageFormat { get; }
         protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected DiagnosticDescriptor Rule { get; }
+        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         protected SonarDiagnosticAnalyzer(string diagnosticId) =>
            Rule = Language.CreateDescriptor(diagnosticId, MessageFormat);
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Facade/ILanguageFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/ILanguageFacade.cs
@@ -33,6 +33,7 @@ namespace SonarAnalyzer.Helpers
         IExpressionNumericConverter ExpressionNumericConverter { get; }
 
         DiagnosticDescriptor CreateDescriptor(string id, string messageFormat, bool? isEnabledByDefault = null, bool fadeOutCode = false);
+        object FindConstantValue(SemanticModel model, SyntaxNode node);
         IMethodParameterLookup MethodParameterLookup(SyntaxNode invocation, IMethodSymbol methodSymbol);
     }
 

--- a/analyzers/src/SonarAnalyzer.Common/Facade/ISyntaxKindFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/ISyntaxKindFacade.cs
@@ -37,7 +37,9 @@ namespace SonarAnalyzer.Helpers.Facade
         abstract TSyntaxKind[] MethodDeclarations { get; }
         abstract TSyntaxKind[] ObjectCreationExpressions { get; }
         abstract TSyntaxKind Parameter { get; }
+        abstract TSyntaxKind ParameterList { get; }
         abstract TSyntaxKind ReturnStatement { get; }
+        abstract TSyntaxKind SimpleAssignment { get; }
         abstract TSyntaxKind SimpleMemberAccessExpression { get; }
         abstract TSyntaxKind StringLiteralExpression { get; }
         abstract TSyntaxKind[] TypeDeclaration { get; }

--- a/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
@@ -37,6 +37,8 @@ namespace SonarAnalyzer.Helpers.Facade
         public abstract bool IsAnyKind(SyntaxNode node, params TSyntaxKind[] syntaxKinds);
 
         public abstract IEnumerable<SyntaxNode> ArgumentExpressions(SyntaxNode node);
+        public abstract SyntaxNode AssignmentLeft(SyntaxNode assignment);
+        public abstract SyntaxNode AssignmentRight(SyntaxNode assignment);
         public abstract SyntaxNode BinaryExpressionLeft(SyntaxNode binaryExpression);
         public abstract SyntaxNode BinaryExpressionRight(SyntaxNode binaryExpression);
         public abstract IEnumerable<SyntaxNode> EnumMembers(SyntaxNode @enum);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CommentKeywordBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CommentKeywordBase.cs
@@ -75,7 +75,6 @@ namespace SonarAnalyzer.Rules
                     }
                 });
 
-
         private static IEnumerable<Location> GetKeywordLocations(SyntaxTree tree, SyntaxTrivia comment, string word)
         {
             var text = comment.ToString();

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CommentKeywordBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CommentKeywordBase.cs
@@ -34,25 +34,28 @@ namespace SonarAnalyzer.Rules
         protected const string TodoDiagnosticId = "S1135";
         protected const string TodoMessageFormat = "Complete the task associated to this '" + TodoKeyword + "' comment.";
 
-        private const string FixMeKeyword = "FIXME";
-        protected const string FixMeDiagnosticId = "S1134";
-        protected const string FixMeMessageFormat = "Take the required action to fix the issue indicated by this '" + FixMeKeyword + "' comment.";
+        private const string FixmeKeyword = "FIXME";
+        protected const string FixmeDiagnosticId = "S1134";
+        protected const string FixmeMessageFormat = "Take the required action to fix the issue indicated by this '" + FixmeKeyword + "' comment.";
 
-        protected abstract DiagnosticDescriptor TodoDiagnostic { get; }
-        protected abstract DiagnosticDescriptor FixMeDiagnostic { get; }
-        protected abstract GeneratedCodeRecognizer GeneratedCodeRecognizer { get; }
+        private readonly DiagnosticDescriptor todoRule;
+        private readonly DiagnosticDescriptor fixmeRule;
+
+        protected abstract ILanguageFacade Language { get; }
 
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
 
         protected CommentKeywordBase()
         {
-            SupportedDiagnostics = ImmutableArray.Create(TodoDiagnostic, FixMeDiagnostic);
+            todoRule = Language.CreateDescriptor(TodoDiagnosticId, TodoMessageFormat);
+            fixmeRule = Language.CreateDescriptor(FixmeDiagnosticId, FixmeMessageFormat);
+            SupportedDiagnostics = ImmutableArray.Create(todoRule, fixmeRule);
         }
 
         protected sealed override void Initialize(SonarAnalysisContext context)
         {
             context.RegisterSyntaxTreeActionInNonGenerated(
-                GeneratedCodeRecognizer,
+                Language.GeneratedCodeRecognizer,
                 c =>
                 {
                     var comments = c.Tree.GetRoot().DescendantTrivia()
@@ -62,12 +65,12 @@ namespace SonarAnalyzer.Rules
                     {
                         foreach (var location in GetKeywordLocations(c.Tree, comment, TodoKeyword))
                         {
-                            c.ReportIssue(Diagnostic.Create(TodoDiagnostic, location));
+                            c.ReportIssue(Diagnostic.Create(todoRule, location));
                         }
 
-                        foreach (var location in GetKeywordLocations(c.Tree, comment, FixMeKeyword))
+                        foreach (var location in GetKeywordLocations(c.Tree, comment, FixmeKeyword))
                         {
-                            c.ReportIssue(Diagnostic.Create(FixMeDiagnostic, location));
+                            c.ReportIssue(Diagnostic.Create(fixmeRule, location));
                         }
                     }
                 });

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CommentKeywordBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CommentKeywordBase.cs
@@ -30,30 +30,30 @@ namespace SonarAnalyzer.Rules
 {
     public abstract class CommentKeywordBase : SonarDiagnosticAnalyzer
     {
-        private const string TodoKeyword = "TODO";
-        protected const string TodoDiagnosticId = "S1135";
-        protected const string TodoMessageFormat = "Complete the task associated to this '" + TodoKeyword + "' comment.";
+        private const string ToDoKeyword = "TODO";
+        protected const string ToDoDiagnosticId = "S1135";
+        protected const string ToDoMessageFormat = "Complete the task associated to this '" + ToDoKeyword + "' comment.";
 
-        private const string FixmeKeyword = "FIXME";
-        protected const string FixmeDiagnosticId = "S1134";
-        protected const string FixmeMessageFormat = "Take the required action to fix the issue indicated by this '" + FixmeKeyword + "' comment.";
+        private const string FixMeKeyword = "FIXME";
+        protected const string FixMeDiagnosticId = "S1134";
+        protected const string FixMeMessageFormat = "Take the required action to fix the issue indicated by this '" + FixMeKeyword + "' comment.";
 
-        private readonly DiagnosticDescriptor todoRule;
-        private readonly DiagnosticDescriptor fixmeRule;
+        private readonly DiagnosticDescriptor toDoRule;
+        private readonly DiagnosticDescriptor fixMeRule;
 
         protected abstract ILanguageFacade Language { get; }
+        protected abstract bool IsComment(SyntaxTrivia trivia);
 
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
 
         protected CommentKeywordBase()
         {
-            todoRule = Language.CreateDescriptor(TodoDiagnosticId, TodoMessageFormat);
-            fixmeRule = Language.CreateDescriptor(FixmeDiagnosticId, FixmeMessageFormat);
-            SupportedDiagnostics = ImmutableArray.Create(todoRule, fixmeRule);
+            toDoRule = Language.CreateDescriptor(ToDoDiagnosticId, ToDoMessageFormat);
+            fixMeRule = Language.CreateDescriptor(FixMeDiagnosticId, FixMeMessageFormat);
+            SupportedDiagnostics = ImmutableArray.Create(toDoRule, fixMeRule);
         }
 
-        protected sealed override void Initialize(SonarAnalysisContext context)
-        {
+        protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxTreeActionInNonGenerated(
                 Language.GeneratedCodeRecognizer,
                 c =>
@@ -63,20 +63,18 @@ namespace SonarAnalyzer.Rules
 
                     foreach (var comment in comments)
                     {
-                        foreach (var location in GetKeywordLocations(c.Tree, comment, TodoKeyword))
+                        foreach (var location in GetKeywordLocations(c.Tree, comment, ToDoKeyword))
                         {
-                            c.ReportIssue(Diagnostic.Create(todoRule, location));
+                            c.ReportIssue(Diagnostic.Create(toDoRule, location));
                         }
 
-                        foreach (var location in GetKeywordLocations(c.Tree, comment, FixmeKeyword))
+                        foreach (var location in GetKeywordLocations(c.Tree, comment, FixMeKeyword))
                         {
-                            c.ReportIssue(Diagnostic.Create(fixmeRule, location));
+                            c.ReportIssue(Diagnostic.Create(fixMeRule, location));
                         }
                     }
                 });
-        }
 
-        protected abstract bool IsComment(SyntaxTrivia trivia);
 
         private static IEnumerable<Location> GetKeywordLocations(SyntaxTree tree, SyntaxTrivia comment, string word)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/GotoStatementBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/GotoStatementBase.cs
@@ -18,33 +18,27 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class GotoStatementBase<TSyntaxKind> : SonarDiagnosticAnalyzer
+    public abstract class GotoStatementBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
     {
         private const string DiagnosticId = "S907";
-        internal const string MessageFormat = "Remove this use of '{0}'.";
 
-        private readonly DiagnosticDescriptor rule;
+        protected override string MessageFormat => $"Remove this use of '{GoToLabel}'.";
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
-
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract TSyntaxKind[] GotoSyntaxKinds { get; }
         protected abstract string GoToLabel { get; }
 
-        protected GotoStatementBase() =>
-            rule = Language.CreateDescriptor(DiagnosticId, string.Format(MessageFormat, GoToLabel));
+        protected GotoStatementBase() : base(DiagnosticId) { }
 
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(
                 Language.GeneratedCodeRecognizer,
-                c => c.ReportIssue(Diagnostic.Create(rule, c.Node.GetFirstToken().GetLocation())),
+                c => c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetFirstToken().GetLocation())),
                 GotoSyntaxKinds);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DisablingRequestValidationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DisablingRequestValidationBase.cs
@@ -40,10 +40,12 @@ namespace SonarAnalyzer.Rules
 
         private readonly DiagnosticDescriptor rule;
 
+        protected abstract ILanguageFacade Language { get; }
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
-        protected DisablingRequestValidationBase(System.Resources.ResourceManager rspecResources, IAnalyzerConfiguration configuration) : base(configuration) =>
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, rspecResources).WithNotConfigurable();
+        protected DisablingRequestValidationBase(IAnalyzerConfiguration configuration) : base(configuration) =>
+            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat).WithNotConfigurable();
 
         protected override void Initialize(SonarAnalysisContext context)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/HardcodedIpAddressBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/HardcodedIpAddressBase.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules
 
         private readonly DiagnosticDescriptor rule;
 
-        protected abstract GeneratedCodeRecognizer GeneratedCodeRecognizer { get; }
+        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract TSyntaxKind SyntaxKind { get; }
 
         protected abstract string GetAssignedVariableName(TLiteralExpression stringLiteral);
@@ -56,13 +56,11 @@ namespace SonarAnalyzer.Rules
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
-        protected HardcodedIpAddressBase(IAnalyzerConfiguration analyzerConfiguration, System.Resources.ResourceManager rspecResources) : base(analyzerConfiguration)
-        {
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, rspecResources).WithNotConfigurable();
-        }
+        protected HardcodedIpAddressBase(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration) =>
+            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat).WithNotConfigurable();
 
         protected override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterSyntaxNodeActionInNonGenerated(GeneratedCodeRecognizer, CheckForHardcodedIpAddresses, SyntaxKind);
+            context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, CheckForHardcodedIpAddresses, SyntaxKind);
 
         private void CheckForHardcodedIpAddresses(SyntaxNodeAnalysisContext context)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MarkAssemblyWithAssemblyVersionAttributeBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MarkAssemblyWithAssemblyVersionAttributeBase.cs
@@ -29,7 +29,6 @@ namespace SonarAnalyzer.Rules
 
         private protected override KnownType AttributeToFind => KnownType.System_Reflection_AssemblyVersionAttribute;
 
-        protected MarkAssemblyWithAssemblyVersionAttributeBase(System.Resources.ResourceManager rspecResources)
-            : base(DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, rspecResources)) { }
+        protected MarkAssemblyWithAssemblyVersionAttributeBase() : base(DiagnosticId, MessageFormat) { }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MarkAssemblyWithAttributeBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MarkAssemblyWithAttributeBase.cs
@@ -28,14 +28,15 @@ namespace SonarAnalyzer.Rules
     {
         private readonly DiagnosticDescriptor rule;
 
+        protected abstract ILanguageFacade Language { get; }
         private protected abstract KnownType AttributeToFind { get; }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override bool EnableConcurrentExecution => false;
 
-        protected MarkAssemblyWithAttributeBase(DiagnosticDescriptor rule) =>
-            this.rule = rule;
+        protected MarkAssemblyWithAttributeBase(string diagnosticId, string messageFormat) =>
+            rule = Language.CreateDescriptor(diagnosticId, messageFormat);
 
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterCompilationStartAction(c =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MarkAssemblyWithClsCompliantAttributeBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MarkAssemblyWithClsCompliantAttributeBase.cs
@@ -29,7 +29,6 @@ namespace SonarAnalyzer.Rules
 
         private protected override KnownType AttributeToFind => KnownType.System_CLSCompliantAttribute;
 
-        protected MarkAssemblyWithClsCompliantAttributeBase(System.Resources.ResourceManager rspecResources)
-            : base(DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, rspecResources)) { }
+        protected MarkAssemblyWithClsCompliantAttributeBase() : base(DiagnosticId, MessageFormat) { }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MarkAssemblyWithComVisibleAttributeBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MarkAssemblyWithComVisibleAttributeBase.cs
@@ -24,12 +24,11 @@ namespace SonarAnalyzer.Rules
 {
     public abstract class MarkAssemblyWithComVisibleAttributeBase : MarkAssemblyWithAttributeBase
     {
-        protected const string DiagnosticId = "S3992";
+        private const string DiagnosticId = "S3992";
         private const string MessageFormat = "Provide a 'ComVisible' attribute for assembly '{0}'.";
 
         private protected override KnownType AttributeToFind => KnownType.System_Runtime_InteropServices_ComVisibleAttribute;
 
-        public MarkAssemblyWithComVisibleAttributeBase(System.Resources.ResourceManager rspecResources)
-            : base(DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, rspecResources)) { }
+        protected MarkAssemblyWithComVisibleAttributeBase() : base(DiagnosticId, MessageFormat) { }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/NoExceptionsInFinallyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/NoExceptionsInFinallyBase.cs
@@ -29,11 +29,13 @@ namespace SonarAnalyzer.Rules
         protected const string DiagnosticId = "S1163";
         private const string MessageFormat = "Refactor this code to not throw exceptions in finally blocks.";
 
+        protected abstract ILanguageFacade Language { get; }
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         protected DiagnosticDescriptor Rule { get; }
 
-        protected NoExceptionsInFinallyBase(System.Resources.ResourceManager rspecResources) =>
-            Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, rspecResources);
+        protected NoExceptionsInFinallyBase() =>
+            Rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/NoExceptionsInFinallyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/NoExceptionsInFinallyBase.cs
@@ -18,24 +18,17 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class NoExceptionsInFinallyBase : SonarDiagnosticAnalyzer
+    public abstract class NoExceptionsInFinallyBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
+        where TSyntaxKind : struct
     {
         protected const string DiagnosticId = "S1163";
-        private const string MessageFormat = "Refactor this code to not throw exceptions in finally blocks.";
 
-        protected abstract ILanguageFacade Language { get; }
+        protected override string MessageFormat => "Refactor this code to not throw exceptions in finally blocks.";
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
-
-        protected DiagnosticDescriptor Rule { get; }
-
-        protected NoExceptionsInFinallyBase() =>
-            Rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
+        protected NoExceptionsInFinallyBase() : base(DiagnosticId) { }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParameterAssignedToBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParameterAssignedToBase.cs
@@ -20,29 +20,23 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class ParameterAssignedToBase<TSyntaxKind, TIdentifierNameSyntax> : SonarDiagnosticAnalyzer
+    public abstract class ParameterAssignedToBase<TSyntaxKind, TIdentifierNameSyntax> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
         where TIdentifierNameSyntax : SyntaxNode
     {
         private const string DiagnosticId = "S1226";
-        private const string MessageFormat = "Introduce a new variable instead of reusing the parameter '{0}'.";
 
-        private readonly DiagnosticDescriptor rule;
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
-
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract bool IsAssignmentToCatchVariable(ISymbol symbol, SyntaxNode node);
 
-        protected ParameterAssignedToBase() =>
-            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
+        protected override string MessageFormat => "Introduce a new variable instead of reusing the parameter '{0}'.";
+
+        protected ParameterAssignedToBase() : base(DiagnosticId) { }
 
         protected sealed override void Initialize(SonarAnalysisContext context)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertiesAccessCorrectFieldBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertiesAccessCorrectFieldBase.cs
@@ -29,28 +29,24 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class PropertiesAccessCorrectFieldBase : SonarDiagnosticAnalyzer
+    public abstract class PropertiesAccessCorrectFieldBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
+        where TSyntaxKind : struct
     {
         private const string DiagnosticId = "S4275";
-        private const string MessageFormat = "Refactor this {0} so that it actually refers to the field '{1}'.";
 
-        private readonly DiagnosticDescriptor rule;
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        protected override string MessageFormat => "Refactor this {0} so that it actually refers to the field '{1}'.";
 
         /**
          * Assignments can be done either
          * - directly via an assignment
          * - indirectly, when passed as 'out' or 'ref' parameter
          */
-        protected abstract ILanguageFacade Language { get; }
         protected abstract IEnumerable<FieldData> FindFieldAssignments(IPropertySymbol property, Compilation compilation);
         protected abstract IEnumerable<FieldData> FindFieldReads(IPropertySymbol property, Compilation compilation);
         protected abstract bool ImplementsExplicitGetterOrSetter(IPropertySymbol property);
         protected abstract bool ShouldIgnoreAccessor(IMethodSymbol accessorMethod, Compilation compilation);
 
-        protected PropertiesAccessCorrectFieldBase() =>
-            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
+        protected PropertiesAccessCorrectFieldBase() : base(DiagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             // We want to check the fields read and assigned in all properties in this class
@@ -135,7 +131,7 @@ namespace SonarAnalyzer.Rules
                 if (locationAndAccessorType.Item1 != null)
                 {
                     context.ReportIssue(Diagnostic.Create(
-                        rule,
+                        Rule,
                         locationAndAccessorType.Item1,
                         locationAndAccessorType.Item2,
                         expectedField.Name));

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertiesAccessCorrectFieldBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertiesAccessCorrectFieldBase.cs
@@ -35,6 +35,7 @@ namespace SonarAnalyzer.Rules
         private const string MessageFormat = "Refactor this {0} so that it actually refers to the field '{1}'.";
 
         private readonly DiagnosticDescriptor rule;
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         /**
@@ -42,15 +43,14 @@ namespace SonarAnalyzer.Rules
          * - directly via an assignment
          * - indirectly, when passed as 'out' or 'ref' parameter
          */
+        protected abstract ILanguageFacade Language { get; }
         protected abstract IEnumerable<FieldData> FindFieldAssignments(IPropertySymbol property, Compilation compilation);
         protected abstract IEnumerable<FieldData> FindFieldReads(IPropertySymbol property, Compilation compilation);
         protected abstract bool ImplementsExplicitGetterOrSetter(IPropertySymbol property);
         protected abstract bool ShouldIgnoreAccessor(IMethodSymbol accessorMethod, Compilation compilation);
 
-        protected PropertiesAccessCorrectFieldBase(System.Resources.ResourceManager rspecResources)
-        {
-            rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, rspecResources);
-        }
+        protected PropertiesAccessCorrectFieldBase() =>
+            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
 
         protected override void Initialize(SonarAnalysisContext context) =>
             // We want to check the fields read and assigned in all properties in this class

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SelfAssignmentBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SelfAssignmentBase.cs
@@ -18,25 +18,17 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class SelfAssignmentBase : SonarDiagnosticAnalyzer
+    public abstract class SelfAssignmentBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
+        where TSyntaxKind : struct
     {
         private const string DiagnosticId = "S1656";
-        private const string MessageFormat = "Remove or correct this useless self-assignment.";
 
-        protected abstract ILanguageFacade Language { get; }
+        protected override string MessageFormat => "Remove or correct this useless self-assignment.";
 
-        protected readonly DiagnosticDescriptor rule;
-
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
-
-        protected SelfAssignmentBase() =>
-             rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
-
+        protected SelfAssignmentBase() : base(DiagnosticId) { }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SelfAssignmentBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SelfAssignmentBase.cs
@@ -26,16 +26,17 @@ namespace SonarAnalyzer.Rules
 {
     public abstract class SelfAssignmentBase : SonarDiagnosticAnalyzer
     {
-        internal const string DiagnosticId = "S1656";
-        internal const string MessageFormat = "Remove or correct this useless self-assignment.";
+        private const string DiagnosticId = "S1656";
+        private const string MessageFormat = "Remove or correct this useless self-assignment.";
 
-        internal readonly DiagnosticDescriptor rule;
+        protected abstract ILanguageFacade Language { get; }
+
+        protected readonly DiagnosticDescriptor rule;
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
-        protected SelfAssignmentBase(System.Resources.ResourceManager rspecResources)
-        {
-             this.rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, rspecResources);
-        }
+        protected SelfAssignmentBase() =>
+             rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
 
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicFacade.cs
@@ -22,6 +22,7 @@ using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers.Facade;
 
 namespace SonarAnalyzer.Helpers
@@ -50,6 +51,9 @@ namespace SonarAnalyzer.Helpers
 
         public DiagnosticDescriptor CreateDescriptor(string id, string messageFormat, bool? isEnabledByDefault = null, bool fadeOutCode = false) =>
             DescriptorFactory.Create(id, messageFormat, isEnabledByDefault, fadeOutCode);
+
+        public object FindConstantValue(SemanticModel model, SyntaxNode node) =>
+            node.FindConstantValue(model);
 
         public IMethodParameterLookup MethodParameterLookup(SyntaxNode invocation, IMethodSymbol methodSymbol) =>
             new VisualBasicMethodParameterLookup((InvocationExpressionSyntax)invocation, methodSymbol);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
@@ -61,6 +61,12 @@ namespace SonarAnalyzer.Helpers.Facade
                 _ => throw InvalidOperation(node, nameof(ArgumentExpressions))
             };
 
+        public override SyntaxNode AssignmentLeft(SyntaxNode assignment) =>
+            Cast<AssignmentStatementSyntax>(assignment).Left;
+
+        public override SyntaxNode AssignmentRight(SyntaxNode assignment) =>
+            Cast<AssignmentStatementSyntax>(assignment).Right;
+
         public override SyntaxNode BinaryExpressionLeft(SyntaxNode binaryExpression) =>
             Cast<BinaryExpressionSyntax>(binaryExpression).Left;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxKindFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxKindFacade.cs
@@ -46,7 +46,9 @@ namespace SonarAnalyzer.Helpers.Facade
         public SyntaxKind[] MethodDeclarations => new[] { SyntaxKind.FunctionStatement, SyntaxKind.SubStatement };
         public SyntaxKind[] ObjectCreationExpressions => new[] { SyntaxKind.ObjectCreationExpression };
         public SyntaxKind Parameter => SyntaxKind.Parameter;
+        public SyntaxKind ParameterList => SyntaxKind.ParameterList;
         public SyntaxKind ReturnStatement => SyntaxKind.ReturnStatement;
+        public SyntaxKind SimpleAssignment => SyntaxKind.SimpleAssignmentStatement;
         public SyntaxKind SimpleMemberAccessExpression => SyntaxKind.SimpleMemberAccessExpression;
         public SyntaxKind StringLiteralExpression => SyntaxKind.StringLiteralExpression;
         public SyntaxKind[] TypeDeclaration => new[] { SyntaxKind.ClassBlock, SyntaxKind.StructureBlock, SyntaxKind.InterfaceBlock, SyntaxKind.EnumBlock };

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/AllBranchesShouldNotHaveSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/AllBranchesShouldNotHaveSameImplementation.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class AllBranchesShouldNotHaveSameImplementation : AllBranchesShouldNotHaveSameImplementationBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayDesignatorOnVariable.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayDesignatorOnVariable.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Move the array designator from the variable to the type.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayInitializationMultipleStatements.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayInitializationMultipleStatements.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Refactor this code to use the '... = {}' syntax.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BinaryOperationWithIdenticalExpressions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BinaryOperationWithIdenticalExpressions.cs
@@ -30,10 +30,9 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class BinaryOperationWithIdenticalExpressions : BinaryOperationWithIdenticalExpressionsBase
     {
-        private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, "{0}", RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, "{0}");
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         private static readonly SyntaxKind[] SyntaxKindsToCheckBinary =
         {
@@ -78,7 +77,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             if (VisualBasicEquivalenceChecker.AreEquivalent(left.RemoveParentheses(), right.RemoveParentheses()))
             {
                 var message = string.Format(OperatorMessageFormat, operatorToken);
-                context.ReportIssue(Diagnostic.Create(rule, context.Node.GetLocation(), message));
+                context.ReportIssue(Diagnostic.Create(Rule, context.Node.GetLocation(), message));
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanCheckInverted.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanCheckInverted.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             };
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CatchRethrow.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CatchRethrow.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private static readonly SyntaxList<StatementSyntax> ThrowBlock = new SyntaxList<StatementSyntax>().Add(SyntaxFactory.ThrowStatement());
 
         protected override DiagnosticDescriptor Rule { get; } =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         protected override bool ContainsOnlyThrow(CatchBlockSyntax currentCatch) =>
             VisualBasicEquivalenceChecker.AreEquivalent(currentCatch.Statements, ThrowBlock);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CommentKeyword.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CommentKeyword.cs
@@ -27,16 +27,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class CommentKeyword : CommentKeywordBase
     {
-        internal static readonly DiagnosticDescriptor TODO_Descriptor =
-            DiagnosticDescriptorBuilder.GetDescriptor(TodoDiagnosticId, TodoMessageFormat, RspecStrings.ResourceManager);
-        protected override DiagnosticDescriptor TodoDiagnostic { get; } = TODO_Descriptor;
-
-        internal static readonly DiagnosticDescriptor FIXME_Descriptor =
-            DiagnosticDescriptorBuilder.GetDescriptor(FixMeDiagnosticId, FixMeMessageFormat, RspecStrings.ResourceManager);
-        protected override DiagnosticDescriptor FixMeDiagnostic { get; } = FIXME_Descriptor;
-
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer
-            => VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
 
         protected override bool IsComment(SyntaxTrivia trivia) => trivia.IsComment();
     }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CommentLineEnd.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CommentLineEnd.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Move this trailing comment on the previous empty line.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         private const string DefaultPattern = @"^'\s*\S+\s*$";

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameImplementation.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class ConditionalStructureSameImplementation : ConditionalStructureSameImplementationBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConstructorArgumentValueShouldExist.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConstructorArgumentValueShouldExist.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class ConstructorArgumentValueShouldExist : ConstructorArgumentValueShouldExistBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotInstantiateSharedClasses.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotInstantiateSharedClasses.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class DoNotInstantiateSharedClasses : DoNotInstantiateSharedClassesBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotLockOnSharedResource.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotLockOnSharedResource.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class DoNotLockOnSharedResource : DoNotLockOnSharedResourceBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotNestTernaryOperators.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotNestTernaryOperators.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     {
         private const string MessageFormat = "Extract this nested If operator into independent If...Then...Else statements.";
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotThrowFromDestructors.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotThrowFromDestructors.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this 'Throw' statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotUseByVal.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotUseByVal.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this redundant 'ByVal' modifier.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotUseIif.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotUseIif.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string IIfOperatorName = "IIf";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyMethod.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyMethod.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class EmptyMethod : EmptyMethodBase<SyntaxKind>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = VisualBasicGeneratedCodeRecognizer.Instance;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EndStatementUsage.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EndStatementUsage.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this call to 'End' or ensure it is really required.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EventNameContainsBeforeOrAfter.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EventNameContainsBeforeOrAfter.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this event to remove the '{0}' {1}.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExitStatementUsage.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExitStatementUsage.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this 'Exit' statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FieldShadowsParentField.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FieldShadowsParentField.cs
@@ -28,9 +28,9 @@ using SonarAnalyzer.Helpers;
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class FieldShadowsParentField : FieldShadowsParentFieldBase<ModifiedIdentifierSyntax>
+    public sealed class FieldShadowsParentField : FieldShadowsParentFieldBase<SyntaxKind, ModifiedIdentifierSyntax>
     {
-        public FieldShadowsParentField() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
@@ -45,8 +45,5 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     }
                 },
                 SyntaxKind.FieldDeclaration);
-
-        protected override SyntaxToken GetIdentifier(ModifiedIdentifierSyntax declarator) =>
-            declarator.Identifier;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FileLines.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FileLines.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class FileLines : FileLinesBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FunctionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FunctionComplexity.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class FunctionComplexity : FunctionComplexityBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/GotoStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/GotoStatement.cs
@@ -28,9 +28,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class GotoStatement : GotoStatementBase<SyntaxKind>
     {
-        public GotoStatement() : base(RspecStrings.ResourceManager) { }
-
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
+        protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
         protected override SyntaxKind[] GotoSyntaxKinds => new[] { SyntaxKind.GoToStatement };
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DisablingRequestValidation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DisablingRequestValidation.cs
@@ -21,14 +21,17 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class DisablingRequestValidation : DisablingRequestValidationBase
     {
+        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
+
         public DisablingRequestValidation() : this(AnalyzerConfiguration.Hotspot) { }
 
-        public DisablingRequestValidation(IAnalyzerConfiguration analyzerConfiguration) : base(RspecStrings.ResourceManager, analyzerConfiguration) { }
+        public DisablingRequestValidation(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration) { }
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/HardcodedIpAddress.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/HardcodedIpAddress.cs
@@ -30,19 +30,12 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class HardcodedIpAddress : HardcodedIpAddressBase<SyntaxKind, LiteralExpressionSyntax>
     {
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = VisualBasicGeneratedCodeRecognizer.Instance;
-
+        protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
         protected override SyntaxKind SyntaxKind { get; } = SyntaxKind.StringLiteralExpression;
 
-        public HardcodedIpAddress()
-            : this(AnalyzerConfiguration.Hotspot)
-        {
-        }
+        public HardcodedIpAddress() : this(AnalyzerConfiguration.Hotspot) { }
 
-        public HardcodedIpAddress(IAnalyzerConfiguration analyzerConfiguration)
-            : base(analyzerConfiguration, RspecStrings.ResourceManager)
-        {
-        }
+        public HardcodedIpAddress(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration) { }
 
         protected override string GetValueText(LiteralExpressionSyntax literalExpression) =>
             literalExpression.Token.ValueText;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IfCollapsible.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IfCollapsible.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class IfCollapsible : IfCollapsibleBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ImplementSerializationMethodsCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ImplementSerializationMethodsCorrectly.cs
@@ -32,12 +32,8 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string ProblemStatic = "non-shared";
         private const string ProblemReturnVoidText = "a 'Sub' not a 'Function'";
 
-        public ImplementSerializationMethodsCorrectly() : base(RspecStrings.ResourceManager) { }
-
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
-
+        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
         protected override string MethodStaticMessage => ProblemStatic;
-
         protected override string MethodReturnTypeShouldBeVoidMessage => ProblemReturnVoidText;
 
         protected override Location GetIdentifierLocation(IMethodSymbol methodSymbol) =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IndexedPropertyWithMultipleParameters.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IndexedPropertyWithMultipleParameters.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "This indexed property has {0} parameters, use methods instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LineContinuation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LineContinuation.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Reformat the code to remove this use of the line continuation character.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LineLength.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LineLength.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class LineLength : LineLengthBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MarkAssemblyWithAssemblyVersionAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MarkAssemblyWithAssemblyVersionAttribute.cs
@@ -20,12 +20,13 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class MarkAssemblyWithAssemblyVersionAttribute : MarkAssemblyWithAssemblyVersionAttributeBase
     {
-        public MarkAssemblyWithAssemblyVersionAttribute() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MarkAssemblyWithClsCompliantAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MarkAssemblyWithClsCompliantAttribute.cs
@@ -20,12 +20,13 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class MarkAssemblyWithClsCompliantAttribute : MarkAssemblyWithClsCompliantAttributeBase
     {
-        public MarkAssemblyWithClsCompliantAttribute() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MarkAssemblyWithComVisibleAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MarkAssemblyWithComVisibleAttribute.cs
@@ -20,12 +20,13 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class MarkAssemblyWithComVisibleAttribute : MarkAssemblyWithComVisibleAttributeBase
     {
-        public MarkAssemblyWithComVisibleAttribute() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodParameterUnused.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     {
         private const string MessageFormat = "Remove this unused procedure parameter '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodsShouldNotHaveTooManyLines.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodsShouldNotHaveTooManyLines.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         : MethodsShouldNotHaveTooManyLinesBase<SyntaxKind, MethodBlockBaseSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MultipleVariableDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MultipleVariableDeclaration.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         FieldDeclarationSyntax, LocalDeclarationStatementSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ClassName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ClassName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this class to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EnumerationValueName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EnumerationValueName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventHandlerName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventHandlerName.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         private const string DefaultPattern = "^(([a-z][a-z0-9]*)?" + NamingHelper.PascalCasingInternalPattern + "_)?" + NamingHelper.PascalCasingInternalPattern + "$";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager, isEnabledByDefault: false);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat, isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this event to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/FunctionName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/FunctionName.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename {0} '{1}' to match the regular expression: '{2}'.";
 
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager, isEnabledByDefault: false);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat, isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/IndexedPropertyName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/IndexedPropertyName.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this property to 'Item'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/InterfaceName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/InterfaceName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this interface to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this local variable to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/NamespaceName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/NamespaceName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this namespace to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ParameterName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this parameter to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PrivateConstantFieldName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PrivateConstantFieldName.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PrivateFieldName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PrivateFieldName.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PrivateSharedReadonlyFieldName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PrivateSharedReadonlyFieldName.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PropertyName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PropertyName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename this property to match the regular expression: '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PublicConstantFieldName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PublicConstantFieldName.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PublicFieldName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PublicFieldName.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PublicSharedReadonlyFieldName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PublicSharedReadonlyFieldName.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/TypeParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/TypeParameterName.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NegatedIsExpression.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NegatedIsExpression.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Replace this use of 'Not...Is...' with 'IsNot'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NoExceptionsInFinally.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NoExceptionsInFinally.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class NoExceptionsInFinally : NoExceptionsInFinallyBase
     {
-        public NoExceptionsInFinally() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NoExceptionsInFinally.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NoExceptionsInFinally.cs
@@ -27,9 +27,9 @@ using SonarAnalyzer.Helpers;
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class NoExceptionsInFinally : NoExceptionsInFinallyBase
+    public sealed class NoExceptionsInFinally : NoExceptionsInFinallyBase<SyntaxKind>
     {
-        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
+        protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NonAsyncTaskShouldNotReturnNull.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NonAsyncTaskShouldNotReturnNull.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             "'Task.FromResult(Of T)(Nothing)', 'Task.CompletedTask' or 'Task.Delay(0)'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OnErrorStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OnErrorStatement.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this use of 'OnError'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionExplicitOn.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionExplicitOn.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string StatementMessage = "Change this to 'Option Explicit On'.";
         private const string AssemblyMessageFormat = "Configure 'Option Explicit On' for assembly '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionStrictOn.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionStrictOn.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string StatementMessage = "Change this to 'Option Strict On'.";
         private const string AssemblyMessageFormat = "Configure 'Option Strict On' for assembly '{0}'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameter.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameter.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class OptionalParameter : OptionalParameterBase<SyntaxKind, MethodBaseSyntax, ParameterSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameterNotPassedToBaseCall.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameterNotPassedToBaseCall.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class OptionalParameterNotPassedToBaseCall : OptionalParameterNotPassedToBaseCallBase<InvocationExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override DiagnosticDescriptor Rule => rule;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParameterAssignedTo.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParameterAssignedTo.cs
@@ -30,16 +30,13 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class ParameterAssignedTo : ParameterAssignedToBase<SyntaxKind, AssignmentStatementSyntax, IdentifierNameSyntax>
     {
+        protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
-        public ParameterAssignedTo() : base(RspecStrings.ResourceManager) { }
+        protected override SyntaxNode AssignmentLeft(AssignmentStatementSyntax assignment) =>
+            assignment.Left;
 
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
-
-        protected override SyntaxKind SyntaxKindOfInterest => SyntaxKind.SimpleAssignmentStatement;
-
-        protected override SyntaxNode AssignmentLeft(AssignmentStatementSyntax assignment) => assignment.Left;
-
-        protected override SyntaxNode AssignmentRight(AssignmentStatementSyntax assignment) => assignment.Right;
+        protected override SyntaxNode AssignmentRight(AssignmentStatementSyntax assignment) =>
+            assignment.Right;
 
         protected override bool IsAssignmentToCatchVariable(ISymbol symbol, SyntaxNode node)
         {
@@ -68,7 +65,5 @@ namespace SonarAnalyzer.Rules.VisualBasic
             var parameterSymbol = symbol as IParameterSymbol;
             return parameterSymbol?.RefKind == RefKind.None;
         }
-
-
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class ParametersCorrectOrder : ParametersCorrectOrderBase<ArgumentSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PartCreationPolicyShouldBeUsedWithExportAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PartCreationPolicyShouldBeUsedWithExportAttribute.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         : PartCreationPolicyShouldBeUsedWithExportAttributeBase<AttributeSyntax, ClassStatementSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertiesAccessCorrectField.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertiesAccessCorrectField.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class PropertiesAccessCorrectField : PropertiesAccessCorrectFieldBase
     {
-        public PropertiesAccessCorrectField() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
 
         protected override IEnumerable<FieldData> FindFieldAssignments(IPropertySymbol property, Compilation compilation)
         {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertiesAccessCorrectField.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertiesAccessCorrectField.cs
@@ -30,9 +30,9 @@ using SonarAnalyzer.Helpers;
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class PropertiesAccessCorrectField : PropertiesAccessCorrectFieldBase
+    public sealed class PropertiesAccessCorrectField : PropertiesAccessCorrectFieldBase<SyntaxKind>
     {
-        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
+        protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
         protected override IEnumerable<FieldData> FindFieldAssignments(IPropertySymbol property, Compilation compilation)
         {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyGetterWithThrow.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyGetterWithThrow.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class PropertyGetterWithThrow : PropertyGetterWithThrowBase<SyntaxKind, AccessorBlockSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyWithArrayType.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyWithArrayType.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         internal const string DiagnosticId = "S2365";
         private const string MessageFormat = "Refactor '{0}' into a method, properties should not be based on arrays.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicConstantField.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicConstantField.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class PublicConstantField : PublicConstantFieldBase<SyntaxKind, FieldDeclarationSyntax, ModifiedIdentifierSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicMethodWithMultidimensionalArray.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicMethodWithMultidimensionalArray.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class PublicMethodWithMultidimensionalArray : PublicMethodWithMultidimensionalArrayBase<SyntaxKind, MethodStatementSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantExitSelect.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantExitSelect.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this redundant use of 'Exit Select'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantNullCheck.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantNullCheck.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Remove this unnecessary null check; 'TypeOf ... Is' returns false for nulls.";
 
         private static readonly DiagnosticDescriptor rule =
-           DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+           DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantParentheses.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantParentheses.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class RedundantParentheses : RedundantParenthesesBase<ParenthesizedExpressionSyntax, SyntaxKind>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ReversedOperators.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ReversedOperators.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class ReversedOperators : ReversedOperatorsBase<UnaryExpressionSyntax>
     {
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SelfAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SelfAssignment.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class SelfAssignment : SelfAssignmentBase
     {
-        public SelfAssignment() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
 
         protected override void Initialize(SonarAnalysisContext context)
         {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SelfAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SelfAssignment.cs
@@ -27,9 +27,9 @@ using SonarAnalyzer.Helpers;
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class SelfAssignment : SelfAssignmentBase
+    public sealed class SelfAssignment : SelfAssignmentBase<SyntaxKind>
     {
-        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
+        protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
         protected override void Initialize(SonarAnalysisContext context)
         {
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var expression = (AssignmentStatementSyntax) c.Node;
                     if (VisualBasicEquivalenceChecker.AreEquivalent(expression.Left, expression.Right))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation()));
+                        c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
                     }
                 },
                 SyntaxKind.SimpleAssignmentStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ShiftDynamicNotInteger.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ShiftDynamicNotInteger.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class ShiftDynamicNotInteger : ShiftDynamicNotIntegerBase<ExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SillyBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SillyBitwiseOperation.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class SillyBitwiseOperation : SillyBitwiseOperationBase
     {
-        public SillyBitwiseOperation() : base(RspecStrings.ResourceManager) { }
+        protected override ILanguageFacade Language => VisualBasicFacade.Instance;
 
         protected override void Initialize(SonarAnalysisContext context)
         {
@@ -43,9 +43,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 SyntaxKind.OrExpression,
                 SyntaxKind.ExclusiveOrExpression);
         }
-
-        protected override object FindConstant(SemanticModel semanticModel, SyntaxNode node) =>
-            node.FindConstantValue(semanticModel);
 
         private void CheckBinary(SyntaxNodeAnalysisContext context, int constValueToLookFor)
         {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SillyBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SillyBitwiseOperation.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
-using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.VisualBasic

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SimpleDoLoop.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SimpleDoLoop.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Use a structured loop instead.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SingleStatementPerLine.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SingleStatementPerLine.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class SingleStatementPerLine : SingleStatementPerLineBase<StatementSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringConcatenationInLoop.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringConcatenationInLoop.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         : StringConcatenationInLoopBase<SyntaxKind, AssignmentStatementSyntax, BinaryExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringConcatenationWithPlus.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringConcatenationWithPlus.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         internal const string DiagnosticId = "S1645";
         private const string MessageFormat = "Switch this use of the '+' operator to the '&'.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchCasesMinimumThree.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchCasesMinimumThree.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     {
         private const string MessageFormat = "Replace this 'Select' statement with 'If' statements to increase readability.";
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class SwitchSectionShouldNotHaveTooManyStatements : SwitchSectionShouldNotHaveTooManyStatementsBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchShouldNotBeNested.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchShouldNotBeNested.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Refactor the code to eliminate this nested 'Select Case'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchWithoutDefault.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchWithoutDefault.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class SwitchWithoutDefault : SwitchWithoutDefaultBase<SyntaxKind>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TabCharacter.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TabCharacter.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Replace all tab characters in this file by sequences of white-spaces.";
 
         internal static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ThrowReservedExceptions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ThrowReservedExceptions.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class ThrowReservedExceptions : ThrowReservedExceptionsBase
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TooManyLabelsInSwitch.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TooManyLabelsInSwitch.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class TooManyLabelsInSwitch : TooManyLabelsInSwitchBase<SyntaxKind, SelectStatementSyntax>
     {
         protected override DiagnosticDescriptor Rule { get; } =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
 
         private const string MessageFormat = "Consider reworking this 'Select Case' to reduce the number of 'Case's" +

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TooManyParameters.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/TooManyParameters.cs
@@ -32,8 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class TooManyParameters : TooManyParametersBase<SyntaxKind, ParameterListSyntax>
     {
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } = VisualBasicGeneratedCodeRecognizer.Instance;
-        protected override SyntaxKind[] SyntaxKinds { get; } = new SyntaxKind[] { SyntaxKind.ParameterList };
+        protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
         private static readonly ImmutableDictionary<SyntaxKind, string> NodeToDeclarationName = new Dictionary<SyntaxKind, string>
         {
@@ -54,11 +53,11 @@ namespace SonarAnalyzer.Rules.VisualBasic
             SyntaxKind.SubLambdaHeader
         };
 
-        public TooManyParameters() : base(RspecStrings.ResourceManager) { }
+        protected override string UserFriendlyNameForNode(SyntaxNode node) =>
+            NodeToDeclarationName[node.Kind()];
 
-        protected override string UserFriendlyNameForNode(SyntaxNode node) => NodeToDeclarationName[node.Kind()];
-
-        protected override int CountParameters(ParameterListSyntax parameterList) => parameterList.Parameters.Count;
+        protected override int CountParameters(ParameterListSyntax parameterList) =>
+            parameterList.Parameters.Count;
 
         protected override bool CanBeChanged(SyntaxNode node, SemanticModel semanticModel) =>
             node.IsAnyKind(LambdaHeaders)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnaryPrefixOperatorRepeated.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnaryPrefixOperatorRepeated.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         };
 
         protected override DiagnosticDescriptor Rule { get; } =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer { get; } =
             VisualBasicGeneratedCodeRecognizer.Instance;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnsignedTypesUsage.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnsignedTypesUsage.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Change this unsigned type to '{0}'.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UriShouldNotBeHardcoded.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UriShouldNotBeHardcoded.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             SyntaxKind, BinaryExpressionSyntax, ArgumentSyntax, VariableDeclaratorSyntax>
     {
         private static readonly DiagnosticDescriptor Rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
         protected override SyntaxKind StringLiteralSyntaxKind => SyntaxKind.StringLiteralExpression;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseReturnStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseReturnStatement.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string UseReturnStatementMessage = "Use a 'Return' statement; assigning returned values to function names is obsolete.";
         private const string DontUseImplicitMessage = "Do not make use of the implicit return value.";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperator.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperator.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class UseShortCircuitingOperator : UseShortCircuitingOperatorBase<SyntaxKind, BinaryExpressionSyntax>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private const string MessageFormat = "Wrap this and the following {0} statement{2} that use '{1}' in a 'With' statement.";
 
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager,
+            DescriptorFactory.Create(DiagnosticId, MessageFormat,
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/VariableUnused.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/VariableUnused.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class VariableUnused : VariableUnusedBase
     {
-        private static readonly DiagnosticDescriptor rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        private static readonly DiagnosticDescriptor rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/WcfNonVoidOneWay.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/WcfNonVoidOneWay.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class WcfNonVoidOneWay : WcfNonVoidOneWayBase<MethodStatementSyntax, SyntaxKind>
     {
         private static readonly DiagnosticDescriptor rule =
-            DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
         protected override GeneratedCodeRecognizer GeneratedCodeRecognizer =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/LocksReleasedAllPaths.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/LocksReleasedAllPaths.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.VisualBasic
 {
     public class LocksReleasedAllPaths : LocksReleasedAllPathsBase
     {
-        public static readonly DiagnosticDescriptor S2222 = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+        public static readonly DiagnosticDescriptor S2222 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         protected override DiagnosticDescriptor Rule => S2222;
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SillyBitwiseOperation.Fixed.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SillyBitwiseOperation.Fixed.vb
@@ -196,3 +196,26 @@ Public Class Repro_4399
     End Sub
 
 End Class
+
+Public Class LocalFields
+
+    Private Start As Integer = 0
+
+    Public Property [End] As Integer = 0
+
+    Public Sub UpdateStart(Val As Integer)
+        Start = Val
+    End Sub
+
+    Public Overrides Function GetHashCode() As Integer
+        Dim Value1 = Method() ^ [End]
+        Dim Value2 = Start ^ [End]
+        Dim Value3 = [End] ^ Start
+        Return Method() ^ Start
+    End Function
+
+    Private Function Method() As Integer
+        Return 42
+    End Function
+
+End Class

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SillyBitwiseOperation.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SillyBitwiseOperation.vb
@@ -198,3 +198,26 @@ Public Class Repro_4399
     End Sub
 
 End Class
+
+Public Class LocalFields
+
+    Private Start As Integer = 0
+
+    Public Property [End] As Integer = 0
+
+    Public Sub UpdateStart(Val As Integer)
+        Start = Val
+    End Sub
+
+    Public Overrides Function GetHashCode() As Integer
+        Dim Value1 = Method() ^ [End]
+        Dim Value2 = Start ^ [End]
+        Dim Value3 = [End] ^ Start
+        Return Method() ^ Start
+    End Function
+
+    Private Function Method() As Integer
+        Return 42
+    End Function
+
+End Class


### PR DESCRIPTION
#5644 follow up

Calls from common base classes:
* Add `ILanguageFacade` or `ILanguageFacade<TSyntaxKind>` based on rule needs
* Remove abstract members that can be done through the facade
* Jump into a rabbit hole around `SillyBitwiseOperation`
  * Align C# and VB version of the rule around fields and properties
  * Add UTs fro VB version - copy/pasted/translated from C#
  * Improve performance by not asking for the symbol twice - once in the old `IsFieldOrProperty`, second time in `IsEnum`