### PR TITLE
Support exception handling for finally regions in SE

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/Extensions/ControlFlowRegionExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Extensions/ControlFlowRegionExtensions.cs
@@ -46,5 +46,11 @@ namespace SonarAnalyzer.Extensions
             }
             return region;
         }
+
+        public static ControlFlowRegion EnclosingRegion(this ControlFlowRegion region, ControlFlowRegionKind kind) =>
+            region.EnclosingRegion.EnclosingRegionOrSelf(kind);
+
+        public static ControlFlowRegion NestedRegion(this ControlFlowRegion region, ControlFlowRegionKind kind) =>
+            region.NestedRegions.Single(x => x.Kind == kind);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CFG/LiveVariableAnalysis/RoslynLiveVariableAnalysis.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/LiveVariableAnalysis/RoslynLiveVariableAnalysis.cs
@@ -122,7 +122,7 @@ namespace SonarAnalyzer.CFG.LiveVariableAnalysis
 
         private IEnumerable<ControlFlowBranch> TryRegionSuccessors(ControlFlowRegion finallyRegion)
         {
-            var tryRegion = finallyRegion.EnclosingRegion.NestedRegions.Single(x => x.Kind == ControlFlowRegionKind.Try);
+            var tryRegion = finallyRegion.EnclosingRegion.NestedRegion(ControlFlowRegionKind.Try);
             return tryRegion.Blocks(Cfg).SelectMany(x => x.Successors).Where(x => x.FinallyRegions.Contains(finallyRegion));
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -116,16 +116,16 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                     ? FromFinally(new FinallyPoint(node.FinallyPoint, branch))
                     : CreateNode(branch.Destination, node.FinallyPoint);
             }
+            else if (branch.Source.EnclosingRegion.Kind == ControlFlowRegionKind.Finally && node.FinallyPoint is not null)
+            {
+                return FromFinally(node.FinallyPoint.CreateNext());     // Redirect from finally back to the original place (or outer finally on the same branch)
+            }
             else if (branch.Source.EnclosingRegion.Kind == ControlFlowRegionKind.Finally && node.State.Exception is not null)
             {
                 var currentTryAndFinally = branch.Source.EnclosingRegion.EnclosingRegion;
                 return currentTryAndFinally.EnclosingRegion(ControlFlowRegionKind.TryAndFinally) is { } outerTryAndFinally
                     ? CreateNode(cfg.Blocks[outerTryAndFinally.NestedRegion(ControlFlowRegionKind.Finally).FirstBlockOrdinal], null)
                     : new(cfg.ExitBlock, node.State, null);
-            }
-            else if (branch.Source.EnclosingRegion.Kind == ControlFlowRegionKind.Finally && node.FinallyPoint is not null)
-            {
-                return FromFinally(node.FinallyPoint.CreateNext());     // Redirect from finally back to the original place (or outer finally on the same branch)
             }
             else
             {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -49,7 +49,7 @@ Tag(""End"", value);";
         [TestMethod]
         public void Loops_InstructionVisitedMaxTwice_ForEach()
         {
-            var code = @"
+            const string code = @"
 var value = 42;
 foreach (var i in items)
 {{

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -27,7 +27,6 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
     {
         [DataTestMethod]
         [DataRow("for (var i = 0; i < items.Length; i++)")]
-        [DataRow("foreach (var i in items)")]
         [DataRow("while (value > 0)")]
         [DataRow("while (Condition)")]
         public void Loops_InstructionVisitedMaxTwice(string loop)
@@ -43,6 +42,24 @@ Tag(""End"", value);";
             var validator = SETestContext.CreateCS(code, ", int[] items", new AddConstraintOnInvocationCheck(), new PreserveTestCheck("value")).Validator;
             validator.ValidateExitReachCount(2);
             validator.TagValues("End").Should().HaveCount(2)
+                .And.ContainSingle(x => x == null)
+                .And.ContainSingle(x => x != null && x.HasConstraint(TestConstraint.First) && !x.HasConstraint(BoolConstraint.True));
+        }
+
+        [TestMethod]
+        public void Loops_InstructionVisitedMaxTwice_ForEach()
+        {
+            var code = @"
+var value = 42;
+foreach (var i in items)
+{{
+    value.ToString(); // Add another constraint to 'value'
+    value--;
+}}
+Tag(""End"", value);";
+            var validator = SETestContext.CreateCS(code, ", int[] items", new AddConstraintOnInvocationCheck(), new PreserveTestCheck("value")).Validator;
+            validator.ValidateExitReachCount(4);                // foreach produces implicit TryFinally region where it can throw and changes the flow
+            validator.TagValues("End").Should().HaveCount(2)    // These Exception flows do not reach the Tag("End") line
                 .And.ContainSingle(x => x == null)
                 .And.ContainSingle(x => x != null && x.HasConstraint(TestConstraint.First) && !x.HasConstraint(BoolConstraint.True));
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using SonarAnalyzer.SymbolicExecution.Constraints;
 using SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution;
 
 namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
@@ -71,7 +72,8 @@ finally
     Tag(""InOuterFinally"");
 }
 Tag(""AfterOuterFinally"");";
-            SETestContext.CreateCS(code).Validator.ValidateTagOrder(
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTagOrder(
                 "BeforeOuterTry",
                 "InOuterTry",
                 "InInnerTry",
@@ -80,6 +82,16 @@ Tag(""AfterOuterFinally"");";
                 "InInnerFinally",
                 "InOuterFinally",
                 "AfterOuterFinally");
+
+            validator.TagStates("InInnerFinally").Should().HaveCount(2)
+                .And.ContainSingle(x => x.Exception == null)
+                .And.ContainSingle(x => x.Exception != null);
+            validator.TagStates("InOuterFinally").Should().HaveCount(2)
+                .And.ContainSingle(x => x.Exception == null)
+                .And.ContainSingle(x => x.Exception != null);
+            validator.TagStates("AfterOuterFinally").Should().HaveCount(1)  // Not visited by flows with Exception
+                .And.ContainSingle(x => x.Exception == null);
+            validator.ValidateExitReachCount(2);
         }
 
         [TestMethod]
@@ -107,16 +119,66 @@ finally
     Tag(""InOuterFinally"");
 }
 Tag(""AfterOuterFinally"");";
-            SETestContext.CreateCS(code).Validator.ValidateTagOrder(
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTagOrder(
                 "BeforeOuterTry",
                 "InOuterTry",
                 "InInnerTry",
                 "InOuterFinally",       // With Exception thrown by Tag("InOuterTry")
                 "InInnerFinally",       // With Exception thrown by Tag("InInnerTry")
                 "InInnerFinally",
-                "AfterInnerFinally",
+                "AfterInnerFinally",    // Only once, because exception run from Tag("InInnerTry") continues directlyto outer finally
                 "InOuterFinally",
                 "AfterOuterFinally");
+
+            validator.TagStates("InInnerFinally").Should().HaveCount(2)
+                .And.ContainSingle(x => x.Exception == null)
+                .And.ContainSingle(x => x.Exception != null);
+            validator.TagStates("AfterInnerFinally").Should().HaveCount(1)  // Not visited by flows with Exception
+                .And.ContainSingle(x => x.Exception == null);
+            validator.TagStates("InOuterFinally").Should().HaveCount(2)
+                .And.ContainSingle(x => x.Exception == null)
+                .And.ContainSingle(x => x.Exception != null);
+            validator.TagStates("AfterOuterFinally").Should().HaveCount(1)  // Not visited by flows with Exception
+                .And.ContainSingle(x => x.Exception == null);
+            validator.ValidateExitReachCount(2);
+        }
+
+        [TestMethod]
+        public void Finally_Nested_InstructionAfterFinally_NoThrowsInFinally()
+        {
+            const string code = @"
+var value = false;
+try
+{
+    try
+    {
+        Tag(""InInnerTry"");    // This can throw
+    }
+    finally
+    {
+        var something = true;   // Operation that cannot throw
+    }
+    value = true;
+}
+finally
+{
+    Tag(""InOuterFinally"", value);
+}
+Tag(""AfterOuterFinally"", value);";
+            var validator = SETestContext.CreateCS(code, new PreserveTestCheck("value")).Validator;
+            validator.ValidateTagOrder(
+                "InInnerTry",
+                "InOuterFinally",       // With Exception thrown by Tag("InInnerTry")
+                "InOuterFinally",
+                "AfterOuterFinally");
+
+            validator.TagStates("InOuterFinally").Should().HaveCount(2)
+                .And.ContainSingle(x => x.Exception == null && x.SymbolsWith(BoolConstraint.True).Any(symbol => symbol.Name == "value"))
+                .And.ContainSingle(x => x.Exception != null && x.SymbolsWith(BoolConstraint.False).Any(symbol => symbol.Name == "value"));
+            validator.TagStates("AfterOuterFinally").Should().HaveCount(1)  // Not visited by flow with Exception
+                .And.ContainSingle(x => x.Exception == null && x.SymbolsWith(BoolConstraint.True).Any(symbol => symbol.Name == "value"));
+            validator.ValidateExitReachCount(2);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.TryCatch.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.TryCatch.cs
@@ -232,6 +232,28 @@ namespace Monitor_TryCatch
             }
         }
 
+        public void Finally_Nested_ReleasedInWrongFinally()
+        {
+            Monitor.Enter(obj);     // Noncompliant
+            try
+            {
+                Console.WriteLine("Can throw");
+                try
+                {
+                    Console.WriteLine("Can also throw");
+                }
+                finally
+                {
+                    Monitor.Exit(obj);  // Wrong place
+                }
+            }
+            finally
+            {
+                Console.WriteLine("Lock should be released here");
+            }
+        }
+
+
         public void Finally_Foreach(int[] values)
         {
             Monitor.Enter(obj);     // Compliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.TryCatch.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.TryCatch.cs
@@ -197,5 +197,56 @@ namespace Monitor_TryCatch
                 Monitor.Exit(obj);
             }
         }
+
+        public void Finally_Simple()
+        {
+            Monitor.Enter(obj);     // Compliant
+            try
+            {
+                Console.WriteLine("CanThrow");
+            }
+            finally
+            {
+                Monitor.Exit(obj);
+            }
+        }
+
+        public void Finally_Nested()
+        {
+            Monitor.Enter(obj);     // Compliant
+            try
+            {
+                Console.WriteLine("Can throw");
+                try
+                {
+                    Console.WriteLine("Can also throw");
+                }
+                finally
+                {
+                    Console.WriteLine("Can also throw from finally when disposing something");
+                }
+            }
+            finally
+            {
+                Monitor.Exit(obj);
+            }
+        }
+
+        public void Finally_Foreach(int[] values)
+        {
+            Monitor.Enter(obj);     // Compliant
+            try
+            {
+                Console.WriteLine("CanThrow");
+                foreach(var value in values)    // Produces implicit try/finally
+                {
+                    Console.WriteLine(value);   // Can throw
+                }
+            }
+            finally
+            {
+                Monitor.Exit(obj);
+            }
+        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.SpinLock.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.SpinLock.cs
@@ -106,7 +106,7 @@ namespace SpinLock_Type
             bool lockTaken = false;
             try
             {
-                spinLock.TryEnter(ref lockTaken);
+                spinLock.TryEnter(ref lockTaken);   // Compliant
                 foreach (var arg in args)
                 {
                 }
@@ -126,7 +126,7 @@ namespace SpinLock_Type
             bool lockTaken = false;
             try
             {
-                spinLock.TryEnter(ref lockTaken);
+                spinLock.TryEnter(ref lockTaken);   // Compliant
                 try
                 {
                     Console.Write("X");


### PR DESCRIPTION
Related to #5710 

```C#
try
{
  try
  {
    CanThrow()
  }
  finally
  {
    // This is processed in happy-path and exception-path
    // Happy-path continues to DoSomething
    // Exception-path continues to outer finally
  }
  DoSomething() // This is process only in happy-path
}
finally
{
    // This is processed in happy-path and exception-path
    // Happy-path continues to DoSomethingElse
    // Exception-path reaches exit
}
DoSomethingElse() // This is process only in happy-path
```