### PR TITLE
Clear exception after catch block in SE

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -83,11 +83,11 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         public ProgramState SetException(ExceptionState exception) =>
             this with { Exception = exception };
 
-        public ProgramState ResetException() =>
-            this with { Exception = null };
-
         public ProgramState SetException(ITypeSymbol exception) =>
             this with { Exception = new(exception) };
+
+        public ProgramState ResetException() =>
+            this with { Exception = null };
 
         public IEnumerable<ISymbol> SymbolsWith(SymbolicConstraint constraint) =>
             SymbolValue.Where(x => x.Value != null && x.Value.HasConstraint(constraint)).Select(x => x.Key);

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -83,6 +83,9 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         public ProgramState SetException(ExceptionState exception) =>
             this with { Exception = exception };
 
+        public ProgramState ResetException() =>
+            this with { Exception = null };
+
         public ProgramState SetException(ITypeSymbol exception) =>
             this with { Exception = new(exception) };
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -175,6 +175,10 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             {
                 state = state.RemoveCapture(capture);
             }
+            if (branch.Source.EnclosingRegion is { Kind: ControlFlowRegionKind.Catch or ControlFlowRegionKind.FilterAndHandler })
+            {
+                state = state.ResetException();
+            }
             var liveVariables = lva.LiveOut(branch.Source).ToHashSet();
             return state.RemoveSymbols(x => lva.IsLocal(x) && (x is ILocalSymbol or IParameterSymbol { RefKind: RefKind.None }) && !liveVariables.Contains(x))
                 .ResetOperations();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.Exception.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.Exception.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.SymbolicExecution.Roslyn;
+
+namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
+{
+    public partial class ProgramStateTest
+    {
+        [TestMethod]
+        public void SetException_IsImmutable()
+        {
+            var sut = ProgramState.Empty;
+            sut.Exception.Should().BeNull();
+
+            sut = sut.SetException(ExceptionState.UnknownException);
+            sut.Exception.Should().Be(ExceptionState.UnknownException);
+
+            ProgramState.Empty.Exception.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ResetException_IsImmutable()
+        {
+            var original = ProgramState.Empty.SetException(ExceptionState.UnknownException);
+            var other = original.ResetException();
+            other.Exception.Should().BeNull();
+            original.Exception.Should().Be(ExceptionState.UnknownException);
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
@@ -850,8 +850,7 @@ tag = ""End"";";
                 "BeforeTry",
                 "InTry",
                 "InCatch",
-                "End",
-                "End");     // FIXME: Should be removed
+                "End");
         }
 
         [TestMethod]
@@ -872,8 +871,7 @@ tag = ""End"";";
                 "BeforeTry",
                 "InTry",
                 "InCatch",
-                "End",
-                "End");     // FIXME: Should be removed
+                "End");
         }
 
         [TestMethod]
@@ -904,8 +902,7 @@ tag = ""End"";";
                 "End",
                 "InCatchArgumentNull",
                 "InCatchNotSupported",
-                "InCatchEverything",
-                "End"); // FIXME: Should be removed
+                "InCatchEverything");
         }
 
         [TestMethod]
@@ -931,9 +928,7 @@ tag = ""End"";";
                 "InTry",
                 "InFinally",    // Happy path
                 "InCatch",      // Exception thrown by Tag("InTry")
-                "End",
-                "InFinally",    // FIXME: With Exception after InCatch, should be removed
-                "End");         // FIXME: With Exception after InCatch, should be removed
+                "End");
         }
 
         [TestMethod]
@@ -966,9 +961,7 @@ tag = ""End"";";
                 "InInnerTry",
                 "End",
                 "AfterInnerTry",
-                "InInnerCatch",
-                "End",              // FIXME: Should be removed
-                "AfterInnerTry");   // FIXME: Should be removed
+                "InInnerCatch");
         }
 
         [TestMethod]
@@ -1001,8 +994,7 @@ tag = ""End"";";
                 "BeforeInnerTry",
                 "InInnerTry",
                 "AfterInnerTry",
-                "InInnerCatch",
-                "End"); // FIXME: Should be removed
+                "InInnerCatch");
         }
 
         [TestMethod]
@@ -1037,13 +1029,10 @@ tag = ""End"";";
                 "InOuterTry",
                 "BeforeInnerTry",
                 "InOuterCatch",
-                "BeforeInnerTry",   // FIXME: Should be removed
                 "InInnerTry",
                 "AfterInnerTry",
                 "InInnerCatch",
-                "InInnerTry",       // FIXME: Should be removed
-                "End",
-                "AfterInnerTry");   // FIXME: Should be removed
+                "End");
         }
 
         [TestMethod]
@@ -1069,9 +1058,7 @@ tag = ""End"";";
                 "InTry",
                 "InFinally",
                 "InCatch",
-                "End",
-                "InFinally",    // FIXME: Should be removed
-                "End");         // FIXME: Should be removed
+                "End");
         }
 
         [TestMethod]
@@ -1112,9 +1099,7 @@ tag = ""End"";";
                 "InCatchAll",
                 "InCatchAllWhen",
                 "End",
-                "InCatchArgumentWhen",
-                "InFinally",        // FIXME: SHould be removed
-                "End");             // FIXME: SHould be removed
+                "InCatchArgumentWhen");
         }
 
         [TestMethod]
@@ -1140,9 +1125,7 @@ tag = ""End"";";
                 "InTry",
                 "InFinally",
                 "InCatch",
-                "End",
-                "InFinally",    // FIXME: Should be removed
-                "End");         // FIXME: Should be removed
+                "End");
         }
 
         private static void ValidateHasOnlyUnknownExceptionAndSystemException(ValidatorTestCheck validator, string stateName) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
@@ -493,11 +493,10 @@ tag = ""AfterCatch"";";
                 "InTry",
                 "InCatch",          // With Exception thrown by Tag("InTry")
                 "InCatch",          // With Exception thrown by `throw`
-                "AfterCatch",
-                "AfterCatch");      // Should go away after https://github.com/SonarSource/sonar-dotnet/pull/5745 is done.
+                "AfterCatch");
 
             ValidateHasOnlyUnknownExceptionAndSystemException(validator, "InCatch");
-            ValidateHasOnlyUnknownExceptionAndSystemException(validator, "AfterCatch");
+            validator.TagStates("AfterCatch").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));  // ToDo: Use custom assertion
         }
 
         [TestMethod]
@@ -590,13 +589,12 @@ tag = ""AfterCatch"";";
                 "InFirstCatch",
                 "InSecondCatch",
                 "InThirdCatch",
-                "AfterCatch",
-                "AfterCatch");      // Should go away after https://github.com/SonarSource/sonar-dotnet/pull/5745 is done.
+                "AfterCatch");
 
             ValidateHasOnlyUnknownExceptionAndSystemException(validator, "InFirstCatch");
             ValidateHasOnlyUnknownExceptionAndSystemException(validator, "InSecondCatch");
             ValidateHasOnlyUnknownExceptionAndSystemException(validator, "InThirdCatch");
-            ValidateHasOnlyUnknownExceptionAndSystemException(validator, "AfterCatch");
+            validator.TagStates("AfterCatch").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));  // ToDo: Use custom assertion
         }
 
         [TestMethod]
@@ -656,13 +654,11 @@ tag = ""AfterFinally"";";
                 "InCatch",          // With Exception thrown by Tag("InTry")
                 "InCatch",          // With Exception thrown by `throw`
                 "InFinally",
-                "InFinally",        // Should go away after https://github.com/SonarSource/sonar-dotnet/pull/5745 is done.
-                "AfterFinally",
                 "AfterFinally");
 
             ValidateHasOnlyUnknownExceptionAndSystemException(validator, "InCatch");
-            ValidateHasOnlyUnknownExceptionAndSystemException(validator, "InFinally");
-            ValidateHasOnlyUnknownExceptionAndSystemException(validator, "AfterFinally");
+            validator.TagStates("InFinally").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));       // ToDo: Use custom assertion
+            validator.TagStates("AfterFinally").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));    // ToDo: Use custom assertion
         }
 
         [TestMethod]
@@ -730,13 +726,12 @@ tag = ""UnreachableAfterFinally"";";
                 "BeforeTry",
                 "InTry",
                 "InCatch",
-                "InFinally",
                 "InFinally");
 
             validator.TagStates("InCatch").Should().HaveCount(1)
                      .And.ContainSingle(x => HasUnknownException(x));
 
-            ValidateHasOnlyNoExceptionAndUnknownException(validator, "InFinally");
+            validator.TagStates("InFinally").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));  // ToDo: Use custom assertion
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
@@ -846,11 +846,15 @@ catch
     tag = ""InCatch"";
 }
 tag = ""End"";";
-            SETestContext.CreateCS(code).Validator.ValidateTagOrder(
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTagOrder(
                 "BeforeTry",
                 "InTry",
                 "InCatch",
                 "End");
+
+            validator.TagStates("InCatch").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);   // ToDo: Use custom assertions
+            validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
         }
 
         [TestMethod]
@@ -867,11 +871,15 @@ catch (Exception)
     tag = ""InCatch"";
 }
 tag = ""End"";";
-            SETestContext.CreateCS(code).Validator.ValidateTagOrder(
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTagOrder(
                 "BeforeTry",
                 "InTry",
                 "InCatch",
                 "End");
+
+            validator.TagStates("InCatch").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);   // ToDo: Use custom assertions
+            validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
         }
 
         [TestMethod]
@@ -896,13 +904,19 @@ catch (Exception ex)
     tag = ""InCatchEverything"";
 }
 tag = ""End"";";
-            SETestContext.CreateCS(code).Validator.ValidateTagOrder(
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTagOrder(
                 "BeforeTry",
                 "InTry",
                 "End",
                 "InCatchArgumentNull",
                 "InCatchNotSupported",
                 "InCatchEverything");
+
+            validator.TagStates("InCatchArgumentNull").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);   // ToDo: Use custom assertions
+            validator.TagStates("InCatchNotSupported").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);
+            validator.TagStates("InCatchEverything").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);
+            validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
         }
 
         [TestMethod]
@@ -923,12 +937,17 @@ finally
     tag = ""InFinally"";
 }
 tag = ""End"";";
-            SETestContext.CreateCS(code).Validator.ValidateTagOrder(
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTagOrder(
                 "BeforeTry",
                 "InTry",
                 "InFinally",    // Happy path
                 "InCatch",      // Exception thrown by Tag("InTry")
                 "End");
+
+            validator.TagStates("InCatch").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);   // ToDo: Use custom assertions
+            validator.TagStates("InFinally").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
+            validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
         }
 
         [TestMethod]
@@ -954,7 +973,8 @@ catch (Exception ex)
     tag = ""InOuterCatch"";
 }
 tag = ""End"";";
-            SETestContext.CreateCS(code).Validator.ValidateTagOrder(
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTagOrder(
                 "BeforeOuterTry",
                 "BeforeInnerTry",
                 "InOuterCatch",
@@ -962,6 +982,11 @@ tag = ""End"";";
                 "End",
                 "AfterInnerTry",
                 "InInnerCatch");
+
+            validator.TagStates("InInnerCatch").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);   // ToDo: Use custom assertions
+            validator.TagStates("AfterInnerTry").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
+            validator.TagStates("InOuterCatch").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);
+            validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
         }
 
         [TestMethod]
@@ -987,7 +1012,8 @@ catch (Exception ex)
     tag = ""AfterInnerTry"";
 }
 tag = ""End"";";
-            SETestContext.CreateCS(code).Validator.ValidateTagOrder(
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTagOrder(
                 "BeforeOuterTry",
                 "InOuterTry",
                 "End",
@@ -995,6 +1021,12 @@ tag = ""End"";";
                 "InInnerTry",
                 "AfterInnerTry",
                 "InInnerCatch");
+
+            validator.TagStates("BeforeInnerTry").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);    // ToDo: Use custom assertions
+            validator.TagStates("InInnerTry").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);        // ToDo: This should have the original exception
+            validator.TagStates("InInnerCatch").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);
+            validator.TagStates("AfterInnerTry").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);     // ToDo: This should have the original exception
+            validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
         }
 
         [TestMethod]
@@ -1024,7 +1056,8 @@ finally
     tag = ""AfterInnerTry"";
 }
 tag = ""End"";";
-            SETestContext.CreateCS(code).Validator.ValidateTagOrder(
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTagOrder(
                 "BeforeOuterTry",
                 "InOuterTry",
                 "BeforeInnerTry",
@@ -1033,6 +1066,12 @@ tag = ""End"";";
                 "AfterInnerTry",
                 "InInnerCatch",
                 "End");
+
+            validator.TagStates("InOuterCatch").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);    // ToDo: Use custom assertions
+            validator.TagStates("BeforeInnerTry").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
+            validator.TagStates("InInnerCatch").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);
+            validator.TagStates("AfterInnerTry").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
+            validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
         }
 
         [TestMethod]
@@ -1053,12 +1092,17 @@ finally
     tag = ""InFinally"";
 }
 tag = ""End"";";
-            SETestContext.CreateCS(code).Validator.ValidateTagOrder(
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTagOrder(
                 "BeforeTry",
                 "InTry",
                 "InFinally",
                 "InCatch",
                 "End");
+
+            validator.TagStates("InCatch").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);   // ToDo: Use custom assertions
+            validator.TagStates("InFinally").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
+            validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
         }
 
         [TestMethod]
@@ -1091,7 +1135,8 @@ finally
     tag = ""InFinally"";
 }
 tag = ""End"";";
-            SETestContext.CreateCS(code).Validator.ValidateTagOrder(
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTagOrder(
                 "BeforeTry",
                 "InTry",
                 "InFinally",
@@ -1100,6 +1145,13 @@ tag = ""End"";";
                 "InCatchAllWhen",
                 "End",
                 "InCatchArgumentWhen");
+
+            validator.TagStates("InCatchArgumentWhen").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);   // ToDo: Use custom assertions
+            validator.TagStates("InCatchArgument").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);
+            validator.TagStates("InCatchAllWhen").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);
+            validator.TagStates("InCatchAll").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);
+            validator.TagStates("InFinally").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
+            validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
         }
 
         [TestMethod]
@@ -1120,12 +1172,17 @@ finally
     tag = ""InFinally"";
 }
 tag = ""End"";";
-            SETestContext.CreateCS(code).Validator.ValidateTagOrder(
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTagOrder(
                 "BeforeTry",
                 "InTry",
                 "InFinally",
                 "InCatch",
                 "End");
+
+            validator.TagStates("InCatch").Should().HaveCount(1).And.ContainSingle(x => x.Exception != null);   // ToDo: Use custom assertions
+            validator.TagStates("InFinally").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
+            validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => x.Exception == null);
         }
 
         private static void ValidateHasOnlyUnknownExceptionAndSystemException(ValidatorTestCheck validator, string stateName) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Mutex.NetFx.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Mutex.NetFx.cs
@@ -61,7 +61,7 @@ public class MutexTest
         if (doesNotExist)
         {
             // The mutex does not exist, so create it.
-            m = new Mutex(true, mutexName, out mutexWasCreated, mutexSecurity);
+            m = new Mutex(true, mutexName, out mutexWasCreated, mutexSecurity); // Noncompliant FP, because the rule doesn't support out mutexWasCreated
             if (!mutexWasCreated)
             {
                 // unable to create the mutex
@@ -94,7 +94,7 @@ public class MutexTest
             // Enter the mutex, and hold it until the program exits.
             try
             {
-                m.WaitOne();    // Noncompliant FP, because the current implementation of the SE thinks that the locking operation itself can also lock and throw at the same time
+                m.WaitOne();
             }
             catch (UnauthorizedAccessException ex)
             {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Mutex.NetFx.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Mutex.NetFx.cs
@@ -61,7 +61,7 @@ public class MutexTest
         if (doesNotExist)
         {
             // The mutex does not exist, so create it.
-            m = new Mutex(true, mutexName, out mutexWasCreated, mutexSecurity); // Noncompliant FP, because the rule doesn't support out mutexWasCreated
+            m = new Mutex(true, mutexName, out mutexWasCreated, mutexSecurity); // Noncompliant FP, because the rule is not aware that the mutex didn't exist before and doesn't support out mutexWasCreated. Only awareness of both can fix it.
             if (!mutexWasCreated)
             {
                 // unable to create the mutex


### PR DESCRIPTION
Related to #5710 

`ProgramState.Exception` needs to be cleared at the end of `catch` block because it is handled. Whatever follows the `catch` block is happy path again.