### PR TITLE
ProgramState.ToString always ends with EOL

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -135,7 +135,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             && other.PreservedSymbols.SetEquals(PreservedSymbols);
 
         public override string ToString() =>
-            Equals(Empty) ? "Empty" : SerializeException() + SerializeSymbols() + SerializeOperations() + SerializeCaptures();
+            Equals(Empty) ? "Empty" + Environment.NewLine : SerializeException() + SerializeSymbols() + SerializeOperations() + SerializeCaptures();
 
         private string SerializeException() =>
             Exception is null ? null : $"Exception: {Exception}{Environment.NewLine}";

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ExplodedNodeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ExplodedNodeTest.cs
@@ -134,6 +134,11 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             var cfg = TestHelper.CompileCfgBodyCS("var a = true;");
             var state = ProgramState.Empty.SetSymbolValue(cfg.Blocks[1].Operations[0].Children.First().TrackedSymbol(), new());
 
+            new ExplodedNode(cfg.Blocks[0], ProgramState.Empty, null).ToString().Should().BeIgnoringLineEndings(
+@"Block #0, Branching
+Empty
+");
+
             new ExplodedNode(cfg.Blocks[1], state, null).ToString().Should().BeIgnoringLineEndings(
 @"Block #1, Operation #0, LocalReferenceOperation / VariableDeclaratorSyntax: a = true
 Symbols:

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
@@ -170,7 +170,9 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
 
         [TestMethod]
         public void ToString_Empty() =>
-            ProgramState.Empty.ToString().Should().Be("Empty");
+            ProgramState.Empty.ToString().Should().BeIgnoringLineEndings(
+@"Empty
+");
 
         [TestMethod]
         public void ToString_WithSymbols()
@@ -178,7 +180,9 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             var assignment = TestHelper.CompileCfgBodyCS("var a = true;").Blocks[1].Operations[0];
             var variableSymbol = assignment.Children.First().TrackedSymbol();
             var sut = ProgramState.Empty.SetSymbolValue(variableSymbol, null);
-            sut.ToString().Should().Be("Empty");
+            sut.ToString().Should().BeIgnoringLineEndings(
+@"Empty
+");
 
             sut = ProgramState.Empty.SetSymbolValue(variableSymbol, new());
             sut.ToString().Should().BeIgnoringLineEndings(
@@ -200,7 +204,9 @@ Sample.Main(): Second
         {
             var assignment = TestHelper.CompileCfgBodyCS("var a = true;").Blocks[1].Operations[0];
             var sut = ProgramState.Empty.SetOperationValue(assignment, null);
-            sut.ToString().Should().Be("Empty");
+            sut.ToString().Should().BeIgnoringLineEndings(
+@"Empty
+");
 
             sut = ProgramState.Empty.SetOperationValue(assignment, new());
             sut.ToString().Should().BeIgnoringLineEndings(


### PR DESCRIPTION
This helps a lot when debugging the SE flow:
```
Console.WriteLine(current);
```
Previously, empty program state did not have EOL at the end, while all non-empty states had. That made tracking of exploded nodes irregular and harder to follow.

This PR ensures that all results of `ToString()` of a `ProgramState` always ends with EOL. This change is not important for `ProgramState` itself, but for usages, mainly in `ExplodedNode.ToString()`