### PR TITLE
Rule S4225: Extension method should not extend on object - for VB.NET

### DIFF
--- a/analyzers/rspec/vbnet/S4225_vb.net.html
+++ b/analyzers/rspec/vbnet/S4225_vb.net.html
@@ -1,0 +1,14 @@
+<p>Creating an extension method that extends <code>Object</code> is not recommended because it makes the method available on <em>every</em> type.
+Extensions should be applied at the most specialized level possible, and that is very unlikely to be <code>Object</code>.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+Imports System.Runtime.CompilerServices
+
+Module MyExtensions
+    &lt;Extension&gt;
+    Sub Function(obj As Object) ' Noncompliant
+		' ...
+    End Function
+End Module
+</pre>
+

--- a/analyzers/rspec/vbnet/S4225_vb.net.json
+++ b/analyzers/rspec/vbnet/S4225_vb.net.json
@@ -1,0 +1,15 @@
+{
+  "title": "Extension methods should not extend \"Object\"",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "15min"
+  },
+  "tags": [],
+  "defaultSeverity": "Minor",
+  "ruleSpecification": "RSPEC-4225",
+  "sqKey": "S4225",
+  "scope": "All",
+  "quickfix": "unknown"
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExtensionMethodShouldNotExtendObject.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExtensionMethodShouldNotExtendObject.cs
@@ -32,6 +32,6 @@ public sealed class ExtensionMethodShouldNotExtendObject : ExtensionMethodShould
 {
     protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
-    protected override bool IsExtensionMethod(MethodDeclarationSyntax declaration) =>
+    protected override bool IsExtensionMethod(MethodDeclarationSyntax declaration, SemanticModel semanticModel) =>
         declaration.IsExtensionMethod();
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExtensionMethodShouldNotExtendObject.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExtensionMethodShouldNotExtendObject.cs
@@ -28,10 +28,10 @@ using SonarAnalyzer.Helpers;
 namespace SonarAnalyzer.Rules.CSharp;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class ExtensionMethodShouldNotExtendObject : ExtensionMethodShouldNotExtendObjectBase<SyntaxKind>
+public sealed class ExtensionMethodShouldNotExtendObject : ExtensionMethodShouldNotExtendObjectBase<SyntaxKind, MethodDeclarationSyntax>
 {
     protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
-    protected override bool IsExtensionMethod(SyntaxNode methodDeclaration) =>
-        ((MethodDeclarationSyntax)methodDeclaration).IsExtensionMethod();
+    protected override bool IsExtensionMethod(MethodDeclarationSyntax declaration) =>
+        declaration.IsExtensionMethod();
 }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -336,6 +336,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_Reflection_Module = new("System.Reflection.Module");
         internal static readonly KnownType System_Reflection_ParameterInfo = new("System.Reflection.ParameterInfo");
         internal static readonly KnownType System_Resources_NeutralResourcesLanguageAttribute = new("System.Resources.NeutralResourcesLanguageAttribute");
+        internal static readonly KnownType System_Runtime_CompilerServices_ExtensionAttribute = new("System.Runtime.CompilerServices.ExtensionAttribute");
         internal static readonly KnownType System_Runtime_CompilerServices_CallerFilePathAttribute = new("System.Runtime.CompilerServices.CallerFilePathAttribute");
         internal static readonly KnownType System_Runtime_CompilerServices_CallerLineNumberAttribute = new("System.Runtime.CompilerServices.CallerLineNumberAttribute");
         internal static readonly KnownType System_Runtime_CompilerServices_CallerMemberNameAttribute = new("System.Runtime.CompilerServices.CallerMemberNameAttribute");

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ExtensionMethodShouldNotExtendObjectBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ExtensionMethodShouldNotExtendObjectBase.cs
@@ -23,12 +23,15 @@ using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules;
 
-public abstract class ExtensionMethodShouldNotExtendObjectBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
+public abstract class ExtensionMethodShouldNotExtendObjectBase<TSyntaxKind, TMethodDeclaration> : SonarDiagnosticAnalyzer<TSyntaxKind>
     where TSyntaxKind : struct
+    where TMethodDeclaration : SyntaxNode
 {
     private const string DiagnosticId = "S4225";
 
     protected override string MessageFormat => "Refactor this extension to extend a more concrete type.";
+
+    protected abstract bool IsExtensionMethod(TMethodDeclaration declaration);
 
     protected ExtensionMethodShouldNotExtendObjectBase() : base(DiagnosticId) { }
 
@@ -37,7 +40,7 @@ public abstract class ExtensionMethodShouldNotExtendObjectBase<TSyntaxKind> : So
             Language.GeneratedCodeRecognizer,
             c =>
             {
-                if (IsExtensionMethod(c.Node)
+                if (IsExtensionMethod((TMethodDeclaration)c.Node)
                     && c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol method
                     && method.IsExtensionMethod
                     && method.Parameters.Length > 0
@@ -47,6 +50,4 @@ public abstract class ExtensionMethodShouldNotExtendObjectBase<TSyntaxKind> : So
                 }
             },
             Language.SyntaxKind.MethodDeclarations);
-
-    protected abstract bool IsExtensionMethod(SyntaxNode methodDeclaration);
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ExtensionMethodShouldNotExtendObjectBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ExtensionMethodShouldNotExtendObjectBase.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules;
+
+public abstract class ExtensionMethodShouldNotExtendObjectBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
+    where TSyntaxKind : struct
+{
+    private const string DiagnosticId = "S4225";
+
+    protected override string MessageFormat => "Refactor this extension to extend a more concrete type.";
+
+    protected ExtensionMethodShouldNotExtendObjectBase() : base(DiagnosticId) { }
+
+    protected override void Initialize(SonarAnalysisContext context) =>
+        context.RegisterSyntaxNodeActionInNonGenerated(
+            Language.GeneratedCodeRecognizer,
+            c =>
+            {
+                if (IsExtensionMethod(c.Node)
+                    && c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol method
+                    && method.IsExtensionMethod
+                    && method.Parameters.Length > 0
+                    && method.Parameters[0].Type.Is(KnownType.System_Object))
+                {
+                    c.ReportIssue(Diagnostic.Create(Rule, Language.Syntax.NodeIdentifier(c.Node).Value.GetLocation()));
+                }
+            },
+            Language.SyntaxKind.MethodDeclarations);
+
+    protected abstract bool IsExtensionMethod(SyntaxNode methodDeclaration);
+}

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ExtensionMethodShouldNotExtendObjectBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ExtensionMethodShouldNotExtendObjectBase.cs
@@ -31,7 +31,7 @@ public abstract class ExtensionMethodShouldNotExtendObjectBase<TSyntaxKind, TMet
 
     protected override string MessageFormat => "Refactor this extension to extend a more concrete type.";
 
-    protected abstract bool IsExtensionMethod(TMethodDeclaration declaration);
+    protected abstract bool IsExtensionMethod(TMethodDeclaration declaration, SemanticModel semanticModel);
 
     protected ExtensionMethodShouldNotExtendObjectBase() : base(DiagnosticId) { }
 
@@ -40,7 +40,7 @@ public abstract class ExtensionMethodShouldNotExtendObjectBase<TSyntaxKind, TMet
             Language.GeneratedCodeRecognizer,
             c =>
             {
-                if (IsExtensionMethod((TMethodDeclaration)c.Node)
+                if (IsExtensionMethod((TMethodDeclaration)c.Node, c.SemanticModel)
                     && c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol method
                     && method.IsExtensionMethod
                     && method.Parameters.Length > 0

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/AttributeSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/AttributeSyntaxExtensions.cs
@@ -19,6 +19,7 @@
  */
 
 using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
 
@@ -26,10 +27,14 @@ namespace SonarAnalyzer.Extensions;
 
 internal static class AttributeSyntaxExtensions
 {
-    public static bool IsExtension(this AttributeSyntax attribute)
-    {
-        var name = attribute.GetName();
-        return name.Equals("Extension", StringComparison.InvariantCultureIgnoreCase)
-            || name.Equals("ExtensionAttribute", StringComparison.InvariantCultureIgnoreCase);
-    }
+    private const int AttributeLength = 9;
+
+    public static bool IsKnownType(this AttributeSyntax attribute, KnownType knownType, SemanticModel semanticModel) =>
+        attribute.Name.GetName().Contains(GetShortNameWithoutAttributeSuffix(knownType))
+        && SymbolHelper.IsKnownType(attribute, knownType, semanticModel);
+
+    private static string GetShortNameWithoutAttributeSuffix(KnownType knownType) =>
+        knownType.TypeName == nameof(Attribute) || !knownType.TypeName.EndsWith(nameof(Attribute))
+            ? knownType.TypeName
+            : knownType.TypeName.Remove(knownType.TypeName.Length - AttributeLength);
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/AttributeSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/AttributeSyntaxExtensions.cs
@@ -19,22 +19,17 @@
  */
 
 using System;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Extensions;
 
 internal static class AttributeSyntaxExtensions
 {
-    private const int AttributeLength = 9;
-
-    public static bool IsKnownType(this AttributeSyntax attribute, KnownType knownType, SemanticModel semanticModel) =>
-        attribute.Name.GetName().Contains(GetShortNameWithoutAttributeSuffix(knownType))
-        && SymbolHelper.IsKnownType(attribute, knownType, semanticModel);
-
-    private static string GetShortNameWithoutAttributeSuffix(KnownType knownType) =>
-        knownType.TypeName == nameof(Attribute) || !knownType.TypeName.EndsWith(nameof(Attribute))
-            ? knownType.TypeName
-            : knownType.TypeName.Remove(knownType.TypeName.Length - AttributeLength);
+    public static bool IsExtension(this AttributeSyntax attribute)
+    {
+        var name = attribute.GetName();
+        return name.Equals("Extension", StringComparison.InvariantCultureIgnoreCase)
+            || name.Equals("ExtensionAttribute", StringComparison.InvariantCultureIgnoreCase);
+    }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
@@ -187,9 +187,7 @@ namespace SonarAnalyzer.Helpers
             };
 
         public static string GetName(this SyntaxNode expression) =>
-            expression is AttributeSyntax x
-            ? x.Name.GetText().ToString()
-            : expression.GetIdentifier()?.ValueText ?? string.Empty;
+            expression.GetIdentifier()?.ValueText ?? string.Empty;
 
         public static bool NameIs(this ExpressionSyntax expression, string name) =>
             expression.GetName().Equals(name, StringComparison.InvariantCultureIgnoreCase);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
@@ -187,7 +187,9 @@ namespace SonarAnalyzer.Helpers
             };
 
         public static string GetName(this SyntaxNode expression) =>
-            expression.GetIdentifier()?.ValueText ?? string.Empty;
+            expression is AttributeSyntax x
+            ? x.Name.GetText().ToString()
+            : expression.GetIdentifier()?.ValueText ?? string.Empty;
 
         public static bool NameIs(this ExpressionSyntax expression, string name) =>
             expression.GetName().Equals(name, StringComparison.InvariantCultureIgnoreCase);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExtensionMethodShouldNotExtendObject.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExtensionMethodShouldNotExtendObject.cs
@@ -35,7 +35,5 @@ public sealed class ExtensionMethodShouldNotExtendObject : ExtensionMethodShould
 
     protected override bool IsExtensionMethod(MethodStatementSyntax declaration, SemanticModel semanticModel) =>
         declaration.Parent.Parent is ModuleBlockSyntax
-        && declaration.AttributeLists
-            .SelectMany(x => x.Attributes)
-            .Any(x => x.IsKnownType(KnownType.System_Runtime_CompilerServices_ExtensionAttribute, semanticModel));
+        && declaration.AttributeLists.SelectMany(x => x.Attributes).Any(x => x.IsKnownType(KnownType.System_Runtime_CompilerServices_ExtensionAttribute, semanticModel));
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExtensionMethodShouldNotExtendObject.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExtensionMethodShouldNotExtendObject.cs
@@ -23,6 +23,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.VisualBasic;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExtensionMethodShouldNotExtendObject.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExtensionMethodShouldNotExtendObject.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
@@ -32,5 +33,15 @@ public sealed class ExtensionMethodShouldNotExtendObject : ExtensionMethodShould
     protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
     protected override bool IsExtensionMethod(SyntaxNode methodDeclaration) =>
-        methodDeclaration.Parent?.Parent is ModuleBlockSyntax;
+        methodDeclaration.Parent.Parent is ModuleBlockSyntax
+        && ((MethodStatementSyntax)methodDeclaration).AttributeLists
+            .SelectMany(x => x.Attributes)
+            .Any(IsExtension);
+
+    private bool IsExtension(AttributeSyntax attribute)
+    {
+        var name = attribute.GetName();
+        return name.Equals("Extension", Language.NameComparison)
+            || name.Equals("ExtensionAttribute", Language.NameComparison);
+    }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExtensionMethodShouldNotExtendObject.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExtensionMethodShouldNotExtendObject.cs
@@ -18,24 +18,19 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using CS = SonarAnalyzer.Rules.CSharp;
-using VB = SonarAnalyzer.Rules.VisualBasic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.UnitTest.Rules
+namespace SonarAnalyzer.Rules.VisualBasic;
+
+[DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+public sealed class ExtensionMethodShouldNotExtendObject : ExtensionMethodShouldNotExtendObjectBase<SyntaxKind>
 {
-    [TestClass]
-    public class ExtensionMethodShouldNotExtendObjectTest
-    {
-        [TestMethod]
-        public void ExtensionMethodShouldNotExtendObject_CS() =>
-            new VerifierBuilder<CS.ExtensionMethodShouldNotExtendObject>()
-            .AddPaths("ExtensionMethodShouldNotExtendObject.cs")
-            .Verify();
+    protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
-        [TestMethod]
-        public void ExtensionMethodShouldNotExtendObject_VB() =>
-            new VerifierBuilder<VB.ExtensionMethodShouldNotExtendObject>()
-            .AddPaths("ExtensionMethodShouldNotExtendObject.vb")
-            .Verify();
-    }
+    protected override bool IsExtensionMethod(SyntaxNode methodDeclaration) =>
+        methodDeclaration.Parent?.Parent is ModuleBlockSyntax;
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExtensionMethodShouldNotExtendObject.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExtensionMethodShouldNotExtendObject.cs
@@ -23,25 +23,19 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.VisualBasic;
 
 [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-public sealed class ExtensionMethodShouldNotExtendObject : ExtensionMethodShouldNotExtendObjectBase<SyntaxKind>
+public sealed class ExtensionMethodShouldNotExtendObject : ExtensionMethodShouldNotExtendObjectBase<SyntaxKind, MethodStatementSyntax>
 {
     protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
-    protected override bool IsExtensionMethod(SyntaxNode methodDeclaration) =>
-        methodDeclaration.Parent.Parent is ModuleBlockSyntax
-        && ((MethodStatementSyntax)methodDeclaration).AttributeLists
+    protected override bool IsExtensionMethod(MethodStatementSyntax declaration) =>
+        declaration.Parent.Parent is ModuleBlockSyntax
+        && declaration.AttributeLists
             .SelectMany(x => x.Attributes)
-            .Any(IsExtension);
-
-    private bool IsExtension(AttributeSyntax attribute)
-    {
-        var name = attribute.GetName();
-        return name.Equals("Extension", Language.NameComparison)
-            || name.Equals("ExtensionAttribute", Language.NameComparison);
-    }
+            .Any(x => x.IsExtension());
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExtensionMethodShouldNotExtendObject.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExtensionMethodShouldNotExtendObject.cs
@@ -37,11 +37,4 @@ public sealed class ExtensionMethodShouldNotExtendObject : ExtensionMethodShould
         && declaration.AttributeLists
             .SelectMany(x => x.Attributes)
             .Any(x => x.IsKnownType(KnownType.System_Runtime_CompilerServices_ExtensionAttribute, semanticModel));
-
-    private bool IsExtension(AttributeSyntax attribute)
-    {
-        var name = attribute.GetName();
-        return name.Equals("Extension", Language.NameComparison)
-            || name.Equals("ExtensionAttribute", Language.NameComparison);
-    }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeMappingVB.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeMappingVB.cs
@@ -4149,7 +4149,7 @@ internal static class RuleTypeMappingVB
         // ["S4222"],
         // ["S4223"],
         // ["S4224"],
-        // ["S4225"],
+        ["S4225"] = "CODE_SMELL",
         // ["S4226"],
         // ["S4227"],
         // ["S4228"],

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExtensionMethodShouldNotExtendObjectTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExtensionMethodShouldNotExtendObjectTest.cs
@@ -21,21 +21,20 @@
 using CS = SonarAnalyzer.Rules.CSharp;
 using VB = SonarAnalyzer.Rules.VisualBasic;
 
-namespace SonarAnalyzer.UnitTest.Rules
-{
-    [TestClass]
-    public class ExtensionMethodShouldNotExtendObjectTest
-    {
-        [TestMethod]
-        public void ExtensionMethodShouldNotExtendObject_CS() =>
-            new VerifierBuilder<CS.ExtensionMethodShouldNotExtendObject>()
-            .AddPaths("ExtensionMethodShouldNotExtendObject.cs")
-            .Verify();
+namespace SonarAnalyzer.UnitTest.Rules;
 
-        [TestMethod]
-        public void ExtensionMethodShouldNotExtendObject_VB() =>
-            new VerifierBuilder<VB.ExtensionMethodShouldNotExtendObject>()
-            .AddPaths("ExtensionMethodShouldNotExtendObject.vb")
-            .Verify();
-    }
+[TestClass]
+public class ExtensionMethodShouldNotExtendObjectTest
+{
+    [TestMethod]
+    public void ExtensionMethodShouldNotExtendObject_CS() =>
+        new VerifierBuilder<CS.ExtensionMethodShouldNotExtendObject>()
+        .AddPaths("ExtensionMethodShouldNotExtendObject.cs")
+        .Verify();
+
+    [TestMethod]
+    public void ExtensionMethodShouldNotExtendObject_VB() =>
+        new VerifierBuilder<VB.ExtensionMethodShouldNotExtendObject>()
+        .AddPaths("ExtensionMethodShouldNotExtendObject.vb")
+        .Verify();
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.cs
@@ -1,17 +1,19 @@
 ﻿using System;
 
-namespace Tests.Diagnostics
+namespace S4225.ExtensionMethodShouldNotExtendObject
 {
-    static class Program
+    static class Compliant
     {
-        static void Foo(this object obj) // Noncompliant {{Refactor this extension to extend a more concrete type.}}
-//                  ^^^
+        static void Extends(this int i) { }
+        static System.Collections.Generic.IEnumerable<int> GetBaz() { return new[] { 0 }; }
+        static void NotAnExtension(object o) { }
+    }
+
+    static class NonCompliant
+    {
+        static void ExtendsObject(this object obj) // Noncompliant {{Refactor this extension to extend a more concrete type.}}
+        //          ^^^^^^^^^^^^^
         {
         }
-
-        static void Bar(this int i) { }
-        static System.Collections.Generic.IEnumerable<int> GetBaz() { return new[] { 0 }; }
-
-        static void NotAnExtensionMethod(object o) { }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.cs
@@ -1,19 +1,23 @@
 ﻿using System;
 
-namespace S4225.ExtensionMethodShouldNotExtendObject
+static class Compliant
 {
-    static class Compliant
+    static void ExtendsValueType(this int i) { }
+    static int ExtendsWithArguments(this int i, int n)
     {
-        static void Extends(this int i) { }
-        static System.Collections.Generic.IEnumerable<int> GetBaz() { return new[] { 0 }; }
-        static void NotAnExtension(object o) { }
+        return i + n;
+    }
+    static void ExtendsReferenceType(this Exception i) { }
+
+    static void NotAnExtension(object o) { }
+}
+
+static class NonCompliant
+{
+    static void ExtendsObject(this object obj) // Noncompliant {{Refactor this extension to extend a more concrete type.}}
+    //          ^^^^^^^^^^^^^
+    {
     }
 
-    static class NonCompliant
-    {
-        static void ExtendsObject(this object obj) // Noncompliant {{Refactor this extension to extend a more concrete type.}}
-        //          ^^^^^^^^^^^^^
-        {
-        }
-    }
+    static void ExtendsWithArguments(this object obj, int other) { } // Noncompliant
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.vb
@@ -1,0 +1,35 @@
+﻿Imports System.Runtime.CompilerServices
+
+Namespace S4225.ExtensionMethodShouldNotExtendObject
+
+    Module Compliant
+        <Extension>
+        Sub Extends(i As Integer)
+        End Sub
+        
+        <Extension>
+        Function Extends(i As Integer, n As Integer) as Integer
+            Return i + n
+        End Function
+
+        Sub NotAnExtension(obj As Object)
+        End Sub
+        
+        Function NotAnExtension(obj As Object, other as Object) as Object
+            return other
+        End Function
+    End Module
+
+    Module Noncompliant
+        <Extension>
+        Sub ExtendsObject(obj As Object) ' Noncompliant {{Refactor this extension to extend a more concrete type.}}
+'           ^^^^^^^^^^^^^
+        End Sub
+        
+        <Extension>
+        Function ExtendsObject(obj As Object, other as Object) as Object ' Noncompliant
+            Return other
+        End Function
+    End Module
+
+End Namespace

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.vb
@@ -37,4 +37,13 @@ Module Noncompliant
     Sub ExtendsWithLongName(obj As Object) ' Noncompliant
     End Sub
 
+    <Extension>
+    <DebuggerStepThrough>
+    Public Sub MultipleAttributes(obj As Object) ' Noncompliant
+    End Sub
+
+    <Extension, DebuggerStepThrough>
+    Public Sub MultipleConbinedAttributes(obj As Object) ' Noncompliant
+    End Sub
+
 End Module

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.vb
@@ -46,4 +46,20 @@ Module Noncompliant
     Public Sub MultipleConbinedAttributes(obj As Object) ' Noncompliant
     End Sub
 
+    <System.Runtime.CompilerServices.ExtensionAttribute>
+    Public Sub FullName(Arg As Object)          ' Noncompliant
+    End Sub
+
+    <Runtime.CompilerServices.ExtensionAttribute>
+    Public Sub ImplicitSystem(Arg As Object)    ' Noncompliant
+    End Sub
+
+    <System.Runtime.CompilerServices.Extension>
+    Public Sub ImplicitAttribute(Arg As Object) ' Noncompliant
+    End Sub
+
+    <Runtime.CompilerServices.Extension>
+    Public Sub ImplicitSystemAndAttribute(Arg As Object)    ' Noncompliant
+    End Sub
+
 End Module

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.vb
@@ -30,6 +30,11 @@ Namespace S4225.ExtensionMethodShouldNotExtendObject
         Function ExtendsObject(obj As Object, other as Object) as Object ' Noncompliant
             Return other
         End Function
+		
+		<ExtensionAttribute>
+        Sub ExtendsWithLongName(obj As Object) ' Noncompliant
+        End Sub
+		
     End Module
 
 End Namespace

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExtensionMethodShouldNotExtendObject.vb
@@ -1,40 +1,40 @@
 ﻿Imports System.Runtime.CompilerServices
 
-Namespace S4225.ExtensionMethodShouldNotExtendObject
+Module Compliant
+    <Extension>
+    Sub ExtendsValueType(i As Integer)
+    End Sub
 
-    Module Compliant
-        <Extension>
-        Sub Extends(i As Integer)
-        End Sub
-        
-        <Extension>
-        Function Extends(i As Integer, n As Integer) as Integer
-            Return i + n
-        End Function
+    <Extension>
+    Function ExtendsWithArguments(i As Integer, n As Integer) As Integer
+        Return i + n
+    End Function
 
-        Sub NotAnExtension(obj As Object)
-        End Sub
-        
-        Function NotAnExtension(obj As Object, other as Object) as Object
-            return other
-        End Function
-    End Module
+    <Extension>
+    Sub ExtendsReferenceType(obj As Exception)
+    End Sub
 
-    Module Noncompliant
-        <Extension>
-        Sub ExtendsObject(obj As Object) ' Noncompliant {{Refactor this extension to extend a more concrete type.}}
-'           ^^^^^^^^^^^^^
-        End Sub
-        
-        <Extension>
-        Function ExtendsObject(obj As Object, other as Object) as Object ' Noncompliant
-            Return other
-        End Function
-		
-		<ExtensionAttribute>
-        Sub ExtendsWithLongName(obj As Object) ' Noncompliant
-        End Sub
-		
-    End Module
+    Sub NotAnExtension(obj As Object)
+    End Sub
 
-End Namespace
+    Function NotAnExtension(obj As Object, other As Object) As Object
+        Return other
+    End Function
+End Module
+
+Module Noncompliant
+    <Extension>
+    Sub ExtendsObject(obj As Object) ' Noncompliant {{Refactor this extension to extend a more concrete type.}}
+'       ^^^^^^^^^^^^^
+    End Sub
+
+    <Extension>
+    Function ExtendsObject(obj As Object, other As Object) As Object ' Noncompliant
+        Return other
+    End Function
+
+    <ExtensionAttribute>
+    Sub ExtendsWithLongName(obj As Object) ' Noncompliant
+    End Sub
+
+End Module


### PR DESCRIPTION
Fixes #5823

Originally implemented via #763. [Documentation update](https://github.com/SonarSource/rspec/pull/1063) pending.