### PR TITLE
Preserve exception in nested catch in SE

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -133,11 +133,11 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         public bool Equals(ProgramState other) =>
             // VisitCount is not compared, two ProgramState are equal if their current state is equal. No matter was historical path led to it.
             other is not null
-            && other.Exceptions.SequenceEqual(Exceptions)
             && other.OperationValue.DictionaryEquals(OperationValue)
             && other.SymbolValue.DictionaryEquals(SymbolValue)
             && other.CaptureOperation.DictionaryEquals(CaptureOperation)
-            && other.PreservedSymbols.SetEquals(PreservedSymbols);
+            && other.PreservedSymbols.SetEquals(PreservedSymbols)
+            && other.Exceptions.SequenceEqual(Exceptions);
 
         public override string ToString() =>
             Equals(Empty) ? "Empty" + Environment.NewLine : SerializeExceptions() + SerializeSymbols() + SerializeOperations() + SerializeCaptures();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.Exception.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.Exception.cs
@@ -19,30 +19,70 @@
  */
 
 using SonarAnalyzer.SymbolicExecution.Roslyn;
+using SonarAnalyzer.UnitTest.Helpers;
 
 namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
 {
     public partial class ProgramStateTest
     {
         [TestMethod]
-        public void SetException_IsImmutable()
+        public void PushException_IsImmutable()
         {
             var sut = ProgramState.Empty;
             sut.Exception.Should().BeNull();
 
-            sut = sut.SetException(ExceptionState.UnknownException);
+            sut = sut.PushException(ExceptionState.UnknownException);
             sut.Exception.Should().Be(ExceptionState.UnknownException);
 
             ProgramState.Empty.Exception.Should().BeNull();
         }
 
         [TestMethod]
-        public void ResetException_IsImmutable()
+        public void SetException_RemovesAllPrevious()
         {
-            var original = ProgramState.Empty.SetException(ExceptionState.UnknownException);
-            var other = original.ResetException();
+            var sut = ProgramState.Empty.PushException(ExceptionState.UnknownException).PushException(ExceptionState.UnknownException).PushException(ExceptionState.UnknownException);
+            sut.ToString().Should().BeIgnoringLineEndings(
+@"Exception: Unknown
+Exception: Unknown
+Exception: Unknown
+");
+            sut = sut.SetException(ExceptionState.UnknownException);
+            sut.ToString().Should().BeIgnoringLineEndings(
+@"Exception: Unknown
+");
+        }
+
+        [TestMethod]
+        public void PopException_IsImmutable()
+        {
+            var original = ProgramState.Empty.PushException(ExceptionState.UnknownException);
+            var other = original.PopException();
             other.Exception.Should().BeNull();
             original.Exception.Should().Be(ExceptionState.UnknownException);
+        }
+
+        [TestMethod]
+        public void PopException_RemovesInCorrectOrder()
+        {
+            var compilation = TestHelper.CompileCS(string.Empty).Model.Compilation;
+            var sut = ProgramState.Empty
+                .PushException(new(compilation.GetTypeByMetadataName("System.NotImplementedException")))
+                .PushException(new(compilation.GetTypeByMetadataName("System.ArgumentNullException")))
+                .PushException(new(compilation.GetTypeByMetadataName("System.FormatException")));
+
+            sut.Exception.Should().NotBeNull();
+            sut.Exception.Type.Name.Should().Be("FormatException");
+
+            sut = sut.PopException();
+            sut.Exception.Should().NotBeNull();
+            sut.Exception.Type.Name.Should().Be("ArgumentNullException");
+
+            sut = sut.PopException();
+            sut.Exception.Should().NotBeNull();
+            sut.Exception.Type.Name.Should().Be("NotImplementedException");
+
+            sut = sut.PopException();
+            sut.Exception.Should().BeNull();
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.Exception.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.Exception.cs
@@ -38,6 +38,18 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
+        public void SetException_IsImmutable()
+        {
+            var sut = ProgramState.Empty;
+            sut.Exception.Should().BeNull();
+
+            sut = sut.SetException(ExceptionState.UnknownException);
+            sut.Exception.Should().Be(ExceptionState.UnknownException);
+
+            ProgramState.Empty.Exception.Should().BeNull();
+        }
+
+        [TestMethod]
         public void SetException_RemovesAllPrevious()
         {
             var sut = ProgramState.Empty.PushException(ExceptionState.UnknownException).PushException(ExceptionState.UnknownException).PushException(ExceptionState.UnknownException);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
@@ -1050,15 +1050,12 @@ tag = ""End"";";
                 "BeforeInnerTry",
                 "InInnerTry",
                 "AfterInnerTry",
-                "InInnerCatch",
-                "AfterInnerTry");   // ToDo: This should not be here, it is now visited on happy-path (with exOuter) and with empty state from catch exInner
+                "InInnerCatch");
 
             validator.TagStates("BeforeInnerTry").Should().HaveCount(1).And.ContainSingle(x => HasUnknownException(x));
             validator.TagStates("InInnerTry").Should().HaveCount(1).And.ContainSingle(x => HasUnknownException(x));
             validator.TagStates("InInnerCatch").Should().HaveCount(1).And.ContainSingle(x => HasUnknownException(x));
-            validator.TagStates("AfterInnerTry").Should().HaveCount(2)
-                .And.ContainSingle(x => HasUnknownException(x))
-                .And.ContainSingle(x => HasNoException(x));     // ToDo: This should not be here, same reason as above in AfterInnerTry
+            validator.TagStates("AfterInnerTry").Should().HaveCount(1).And.ContainSingle(x => HasUnknownException(x));
             validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));
         }
 


### PR DESCRIPTION
Related to #5710, follow up of #5745

```
try
{
    CanThrow_First(); // Do not preserve previous exception, like in Finally for example
}
catch
{
    try
    {
        CanThrow_Second(); // Do not clear information about CanThrow_First(), add info about CanThrow_Second
    }
    catch
    {
    }   // Here, only CanThrow_Second is cleared. Returning CanThrow_First to the throne
} // Here, CanThrow_First is cleared as before
```
