### PR TITLE
Add extension methods for tuple flattening and assignment target handling

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/AssignmentExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/AssignmentExpressionSyntaxExtensions.cs
@@ -42,6 +42,12 @@ namespace SonarAnalyzer.Extensions
                 var arguments = left.AllArguments();
                 return arguments.Select(x => (CSharpSyntaxNode)x.Expression).ToImmutableArray();
             }
+            if (DeclarationExpressionSyntaxWrapper.IsInstance(assignment.Left))
+            {
+                var left = (DeclarationExpressionSyntaxWrapper)assignment.Left;
+                var variables = left.Designation.AllVariables();
+                return variables.Select(x => x.SyntaxNode).ToImmutableArray();
+            }
 
             return ImmutableArray.Create<CSharpSyntaxNode>(assignment.Left);
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/AssignmentExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/AssignmentExpressionSyntaxExtensions.cs
@@ -39,17 +39,17 @@ namespace SonarAnalyzer.Extensions
             if (TupleExpressionSyntaxWrapper.IsInstance(assignment.Left))
             {
                 var left = (TupleExpressionSyntaxWrapper)assignment.Left;
-                var arguments = left.AllArguments();
-                return arguments.Select(x => (CSharpSyntaxNode)x.Expression).ToImmutableArray();
+                return left.AllArguments().Select(x => (CSharpSyntaxNode)x.Expression).ToImmutableArray();
             }
-            if (DeclarationExpressionSyntaxWrapper.IsInstance(assignment.Left))
+            else if (DeclarationExpressionSyntaxWrapper.IsInstance(assignment.Left))
             {
                 var left = (DeclarationExpressionSyntaxWrapper)assignment.Left;
-                var variables = left.Designation.AllVariables();
-                return variables.Select(x => x.SyntaxNode).ToImmutableArray();
+                return left.Designation.AllVariables().Select(x => x.SyntaxNode).ToImmutableArray();
             }
-
-            return ImmutableArray.Create<CSharpSyntaxNode>(assignment.Left);
+            else
+            {
+                return ImmutableArray.Create<CSharpSyntaxNode>(assignment.Left);
+            }
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/AssignmentExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/AssignmentExpressionSyntaxExtensions.cs
@@ -36,19 +36,20 @@ namespace SonarAnalyzer.Extensions
         /// <returns>The left side of the assignment. If it is a tuple, the flattened tuple elements are returned.</returns>
         public static ImmutableArray<CSharpSyntaxNode> AssignmentTargets(this AssignmentExpressionSyntax assignment)
         {
-            if (TupleExpressionSyntaxWrapper.IsInstance(assignment.Left))
+            var left = assignment.Left;
+            if (TupleExpressionSyntaxWrapper.IsInstance(left))
             {
-                var left = (TupleExpressionSyntaxWrapper)assignment.Left;
-                return left.AllArguments().Select(x => (CSharpSyntaxNode)x.Expression).ToImmutableArray();
+                var tuple = (TupleExpressionSyntaxWrapper)left;
+                return tuple.AllArguments().Select(x => (CSharpSyntaxNode)x.Expression).ToImmutableArray();
             }
-            else if (DeclarationExpressionSyntaxWrapper.IsInstance(assignment.Left))
+            else if (DeclarationExpressionSyntaxWrapper.IsInstance(left))
             {
-                var left = (DeclarationExpressionSyntaxWrapper)assignment.Left;
-                return left.Designation.AllVariables().Select(x => x.SyntaxNode).ToImmutableArray();
+                var declaration = (DeclarationExpressionSyntaxWrapper)left;
+                return declaration.Designation.AllVariables().Select(x => x.SyntaxNode).ToImmutableArray();
             }
             else
             {
-                return ImmutableArray.Create<CSharpSyntaxNode>(assignment.Left);
+                return ImmutableArray.Create<CSharpSyntaxNode>(left);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/AssignmentExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/AssignmentExpressionSyntaxExtensions.cs
@@ -30,11 +30,11 @@ namespace SonarAnalyzer.Extensions
     {
         /// <summary>
         /// Returns a list of nodes, that represent the target (left side) of an assignment. In case of tuple deconstructions, this can be more than one target.
-        /// Nested tuple elements are expanded so for <c>(a, (b, c))</c> the list <c>[a, b, c]</c> is returned.
+        /// Nested tuple elements are flattened so for <c>(a, (b, c))</c> the list <c>[a, b, c]</c> is returned.
         /// </summary>
-        /// <param name="assignment">The assignment expression</param>
-        /// <returns>The left side of the assignment. If it is a tuple, the tuple flattened elements are returned.</returns>
-        public static ImmutableArray<CSharpSyntaxNode> AssignmentTargets(AssignmentExpressionSyntax assignment)
+        /// <param name="assignment">The assignment expression.</param>
+        /// <returns>The left side of the assignment. If it is a tuple, the flattened tuple elements are returned.</returns>
+        public static ImmutableArray<CSharpSyntaxNode> AssignmentTargets(this AssignmentExpressionSyntax assignment)
         {
             if (TupleExpressionSyntaxWrapper.IsInstance(assignment.Left))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/AssignmentExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/AssignmentExpressionSyntaxExtensions.cs
@@ -28,6 +28,12 @@ namespace SonarAnalyzer.Extensions
 {
     public static class AssignmentExpressionSyntaxExtensions
     {
+        /// <summary>
+        /// Returns a list of nodes, that represent the target (left side) of an assignment. In case of tuple deconstructions, this can be more than one target.
+        /// Nested tuple elements are expanded so for <c>(a, (b, c))</c> the list <c>[a, b, c]</c> is returned.
+        /// </summary>
+        /// <param name="assignment">The assignment expression</param>
+        /// <returns>The left side of the assignment. If it is a tuple, the tuple flattened elements are returned.</returns>
         public static ImmutableArray<CSharpSyntaxNode> AssignmentTargets(AssignmentExpressionSyntax assignment)
         {
             if (TupleExpressionSyntaxWrapper.IsInstance(assignment.Left))

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/AssignmentExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/AssignmentExpressionSyntaxExtensions.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using StyleCop.Analyzers.Lightup;
+
+namespace SonarAnalyzer.Extensions
+{
+    public static class AssignmentExpressionSyntaxExtensions
+    {
+        public static ImmutableArray<CSharpSyntaxNode> AssignmentTargets(AssignmentExpressionSyntax assignment)
+        {
+            if (TupleExpressionSyntaxWrapper.IsInstance(assignment.Left))
+            {
+                var left = (TupleExpressionSyntaxWrapper)assignment.Left;
+                var arguments = left.AllArguments();
+                return arguments.Select(x => (CSharpSyntaxNode)x.Expression).ToImmutableArray();
+            }
+
+            return ImmutableArray.Create<CSharpSyntaxNode>(assignment.Left);
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/TupleExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/TupleExpressionSyntaxExtensions.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using StyleCop.Analyzers.Lightup;
+
+namespace SonarAnalyzer.Extensions
+{
+    public static class TupleExpressionSyntaxExtensions
+    {
+        /// <summary>
+        /// Gets all flattened arguments of a tuple. For a nested tuple like <c>(1, (2, 3))</c>, the arguments are flattened to <c>[1, 2, 3]</c>.
+        /// </summary>
+        /// <param name="tupleExpression">The tuple to flatten.</param>
+        /// <returns>An <see cref="ImmutableArray"/> of the flattened tuple arguments.</returns>
+        public static ImmutableArray<ArgumentSyntax> AllArguments(this TupleExpressionSyntaxWrapper tupleExpression)
+        {
+            var builder = ImmutableArray.CreateBuilder<ArgumentSyntax>(initialCapacity: tupleExpression.Arguments.Count);
+            Recurse(builder, tupleExpression.Arguments);
+            return builder.ToImmutableArray();
+
+            static void Recurse(ImmutableArray<ArgumentSyntax>.Builder builder, SeparatedSyntaxList<ArgumentSyntax> arguments)
+            {
+                foreach (var argument in arguments)
+                {
+                    if (TupleExpressionSyntaxWrapper.IsInstance(argument.Expression))
+                    {
+                        Recurse(builder, ((TupleExpressionSyntaxWrapper)argument.Expression).Arguments);
+                    }
+                    else
+                    {
+                        builder.Add(argument);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/TupleExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/TupleExpressionSyntaxExtensions.cs
@@ -40,16 +40,16 @@ namespace SonarAnalyzer.Extensions
         public static ImmutableArray<ArgumentSyntax> AllArguments(this TupleExpressionSyntaxWrapper tupleExpression)
         {
             var builder = ImmutableArray.CreateBuilder<ArgumentSyntax>(initialCapacity: tupleExpression.Arguments.Count);
-            Recurse(builder, tupleExpression.Arguments);
+            CollectTupleElements(builder, tupleExpression.Arguments);
             return builder.ToImmutableArray();
 
-            static void Recurse(ImmutableArray<ArgumentSyntax>.Builder builder, SeparatedSyntaxList<ArgumentSyntax> arguments)
+            static void CollectTupleElements(ImmutableArray<ArgumentSyntax>.Builder builder, SeparatedSyntaxList<ArgumentSyntax> arguments)
             {
                 foreach (var argument in arguments)
                 {
                     if (TupleExpressionSyntaxWrapper.IsInstance(argument.Expression))
                     {
-                        Recurse(builder, ((TupleExpressionSyntaxWrapper)argument.Expression).Arguments);
+                        CollectTupleElements(builder, ((TupleExpressionSyntaxWrapper)argument.Expression).Arguments);
                     }
                     else
                     {

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/TupleExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/TupleExpressionSyntaxExtensions.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Extensions
         /// <returns>An <see cref="ImmutableArray"/> of the flattened tuple arguments.</returns>
         public static ImmutableArray<ArgumentSyntax> AllArguments(this TupleExpressionSyntaxWrapper tupleExpression)
         {
-            var builder = ImmutableArray.CreateBuilder<ArgumentSyntax>(initialCapacity: tupleExpression.Arguments.Count);
+            var builder = ImmutableArray.CreateBuilder<ArgumentSyntax>(tupleExpression.Arguments.Count);
             CollectTupleElements(builder, tupleExpression.Arguments);
             return builder.ToImmutableArray();
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/TupleExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/TupleExpressionSyntaxExtensions.cs
@@ -18,12 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using StyleCop.Analyzers.Lightup;

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/VariableDesignationSyntaxWrapperExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/VariableDesignationSyntaxWrapperExtensions.cs
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Extensions
                 {
                     builder.Add((SingleVariableDesignationSyntaxWrapper)variableDesignation);
                 }
-                // DiscardDesignationSyntaxWrapper.IsInstance(variableDesignation) are excluded
+                // DiscardDesignationSyntaxWrapper.IsInstance(variableDesignation) is ignored
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/VariableDesignationSyntaxWrapperExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/VariableDesignationSyntaxWrapperExtensions.cs
@@ -26,8 +26,9 @@ namespace SonarAnalyzer.Extensions
     public static class VariableDesignationSyntaxWrapperExtensions
     {
         /// <summary>
-        /// Returns all <see cref="SingleVariableDesignationSyntaxWrapper"/> of the designation. Nested designations are flattened. For a designation like <c>(a, (b, c))</c>
-        /// the method returns <c>[a, b, c]</c>. Only identifiers are included in the result and discards are ignored.
+        /// Returns all <see cref="SingleVariableDesignationSyntaxWrapper"/> of the designation. Nested designations are flattened and
+        /// only identifiers are included in the result (discards are skipped). For a designation like <c>(a, (_, b))</c>
+        /// the method returns <c>[a, b]</c>.
         /// </summary>
         /// <param name="variableDesignation">The designation to return the variables for.</param>
         /// <returns>A list of <see cref="SingleVariableDesignationSyntaxWrapper"/> that contain all flattened variables of the designation.</returns>
@@ -51,7 +52,7 @@ namespace SonarAnalyzer.Extensions
                 {
                     builder.Add((SingleVariableDesignationSyntaxWrapper)variableDesignation);
                 }
-                // DiscardDesignationSyntaxWrapper.IsInstance(variableDesignation) is ignored
+                // DiscardDesignationSyntaxWrapper is skipped
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/VariableDesignationSyntaxWrapperExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/VariableDesignationSyntaxWrapperExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Immutable;
+using StyleCop.Analyzers.Lightup;
+
+namespace SonarAnalyzer.Extensions
+{
+    public static class VariableDesignationSyntaxWrapperExtensions
+    {
+        /// <summary>
+        /// Returns all <see cref="SingleVariableDesignationSyntaxWrapper"/> of the designation. Nested designations are flattened. For a designation like <c>(a, (b, c))</c>
+        /// the method returns <c>[a, b, c]</c>. Only identifiers are included in the result and discards are ignored.
+        /// </summary>
+        /// <param name="variableDesignation">The designation to return the variables for.</param>
+        /// <returns>A list of <see cref="SingleVariableDesignationSyntaxWrapper"/> that contain all flattened variables of the designation.</returns>
+        public static ImmutableArray<SingleVariableDesignationSyntaxWrapper> AllVariables(this VariableDesignationSyntaxWrapper variableDesignation)
+        {
+            var builder = ImmutableArray.CreateBuilder<SingleVariableDesignationSyntaxWrapper>();
+            CollectVariables(builder, variableDesignation);
+            return builder.ToImmutableArray();
+
+            static void CollectVariables(ImmutableArray<SingleVariableDesignationSyntaxWrapper>.Builder builder, VariableDesignationSyntaxWrapper variableDesignation)
+            {
+                if (ParenthesizedVariableDesignationSyntaxWrapper.IsInstance(variableDesignation))
+                {
+                    var parenthesized = (ParenthesizedVariableDesignationSyntaxWrapper)variableDesignation;
+                    foreach (var variable in parenthesized.Variables)
+                    {
+                        CollectVariables(builder, variable);
+                    }
+                }
+                else if (SingleVariableDesignationSyntaxWrapper.IsInstance(variableDesignation))
+                {
+                    builder.Add((SingleVariableDesignationSyntaxWrapper)variableDesignation);
+                }
+                // DiscardDesignationSyntaxWrapper.IsInstance(variableDesignation) are excluded
+            }
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/VariableDesignationSyntaxWrapperExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/VariableDesignationSyntaxWrapperExtensions.cs
@@ -1,4 +1,24 @@
-﻿using System.Collections.Immutable;
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Immutable;
 using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.Extensions

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AssignmentExpressionSyntaxExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AssignmentExpressionSyntaxExtensionsTests.cs
@@ -33,11 +33,14 @@ namespace SonarAnalyzer.UnitTest.Extensions
         // Deconstruction into tuple
         [DataRow("(var a, var b) = (1, 2);", "var a,var b")]
         [DataRow("(var a, _) = (1, 2);", "var a,_")]
+        [DataRow("(var _, _) = (1, 2);", "var _,_")]
+        [DataRow("(_, _) = (1, 2);", "_,_")]
         [DataRow("(var a, (var b, var c), var d) = (1, (2, 3), 4);", "var a,var b,var c,var d")]
         [DataRow("int b; (var a, (b, var c), _) = (1, (2, 3), 4);", "var a,b,var c,_")]
         // Deconstruction into declaration expression designation
         [DataRow("var (a, b) = (1, 2);", "a,b")]
         [DataRow("var (a, _) = (1, 2);", "a")]
+        [DataRow("var (_, _) = (1, 2);", "")]
         public void AssignmentExpressionSyntaxExtensions_AssignmentTargets_DeconstructTargets(string assignment, string expectedTargets)
         {
             var syntaxTree = CSharpSyntaxTree.ParseText(WrapInMethod(assignment));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AssignmentExpressionSyntaxExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AssignmentExpressionSyntaxExtensionsTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SonarAnalyzer.Extensions;
+
+namespace SonarAnalyzer.UnitTest.Extensions
+{
+    [TestClass]
+    public class AssignmentExpressionSyntaxExtensionsTests
+    {
+        [DataTestMethod]
+        [DataRow("(var x, var y) = (1, 2)", "var x,var y")]
+        public void AssignmentExpressionSyntaxExtensions_AssignmentTargets_DeconstructTargets(string assignment, string expectedTargets)
+        {
+            var syntaxTree = CSharpSyntaxTree.ParseText(WrapInMethod(assignment));
+            var assignmentExpression = syntaxTree.GetRoot().DescendantNodesAndSelf().OfType<AssignmentExpressionSyntax>().First();
+            var allTargets = assignmentExpression.AssignmentTargets();
+            var allTargetsAsString = string.Join(",", allTargets.Select(x => x.ToString()));
+            allTargetsAsString.Should().Be(expectedTargets);
+
+        }
+
+        private static string WrapInMethod(string code) =>
+$@"
+public class C
+{{
+    public int M()
+    {{
+        var t = {code};
+        return 0;
+    }}
+}}
+";
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AssignmentExpressionSyntaxExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AssignmentExpressionSyntaxExtensionsTests.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
 $@"
 public class C
 {{
-    public int M()
+    public void M()
     {{
         {code}
     }}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AssignmentExpressionSyntaxExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AssignmentExpressionSyntaxExtensionsTests.cs
@@ -18,11 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SonarAnalyzer.Extensions;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AssignmentExpressionSyntaxExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AssignmentExpressionSyntaxExtensionsTests.cs
@@ -28,13 +28,14 @@ namespace SonarAnalyzer.UnitTest.Extensions
     public class AssignmentExpressionSyntaxExtensionsTests
     {
         [DataTestMethod]
+        // Normal assignment
         [DataRow("int a; a = 1;", "a")]
-
+        // Deconstruction into tuple
         [DataRow("(var a, var b) = (1, 2);", "var a,var b")]
         [DataRow("(var a, _) = (1, 2);", "var a,_")]
         [DataRow("(var a, (var b, var c), var d) = (1, (2, 3), 4);", "var a,var b,var c,var d")]
         [DataRow("int b; (var a, (b, var c), _) = (1, (2, 3), 4);", "var a,b,var c,_")]
-
+        // Deconstruction into declaration expression designation
         [DataRow("var (a, b) = (1, 2);", "a,b")]
         [DataRow("var (a, _) = (1, 2);", "a")]
         public void AssignmentExpressionSyntaxExtensions_AssignmentTargets_DeconstructTargets(string assignment, string expectedTargets)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AssignmentExpressionSyntaxExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AssignmentExpressionSyntaxExtensionsTests.cs
@@ -1,4 +1,24 @@
-﻿using System;
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,7 +33,15 @@ namespace SonarAnalyzer.UnitTest.Extensions
     public class AssignmentExpressionSyntaxExtensionsTests
     {
         [DataTestMethod]
-        [DataRow("(var x, var y) = (1, 2)", "var x,var y")]
+        [DataRow("int a; a = 1;", "a")]
+
+        [DataRow("(var a, var b) = (1, 2);", "var a,var b")]
+        [DataRow("(var a, _) = (1, 2);", "var a,_")]
+        [DataRow("(var a, (var b, var c), var d) = (1, (2, 3), 4);", "var a,var b,var c,var d")]
+        [DataRow("int b; (var a, (b, var c), _) = (1, (2, 3), 4);", "var a,b,var c,_")]
+
+        [DataRow("var (a, b) = (1, 2);", "a,b")]
+        [DataRow("var (a, _) = (1, 2);", "a")]
         public void AssignmentExpressionSyntaxExtensions_AssignmentTargets_DeconstructTargets(string assignment, string expectedTargets)
         {
             var syntaxTree = CSharpSyntaxTree.ParseText(WrapInMethod(assignment));
@@ -21,7 +49,6 @@ namespace SonarAnalyzer.UnitTest.Extensions
             var allTargets = assignmentExpression.AssignmentTargets();
             var allTargetsAsString = string.Join(",", allTargets.Select(x => x.ToString()));
             allTargetsAsString.Should().Be(expectedTargets);
-
         }
 
         private static string WrapInMethod(string code) =>
@@ -30,8 +57,7 @@ public class C
 {{
     public int M()
     {{
-        var t = {code};
-        return 0;
+        {code}
     }}
 }}
 ";

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/TupleExpressionSyntaxExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/TupleExpressionSyntaxExtensionsTests.cs
@@ -1,0 +1,57 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis.CSharp;
+using SonarAnalyzer.Extensions;
+using StyleCop.Analyzers.Lightup;
+
+namespace SonarAnalyzer.UnitTest.Extensions
+{
+    [TestClass]
+    public class TupleExpressionSyntaxExtensionsTests
+    {
+        [DataTestMethod]
+        [DataRow("(1, 2)", "1,2")]
+        [DataRow("(1, (2, 3))", "1,2,3")]
+        [DataRow("(1, (2, 3), 4)", "1,2,3,4")]
+        [DataRow("(1, (2, 3), 4, M())", "1,2,3,4,M()")]
+        [DataRow("(1, (2, 3, (4, 5, 6), 7), 8, M())", "1,2,3,4,5,6,7,8,M()")]
+        public void T(string tuple, string expectedArguments)
+        {
+            var syntaxTree = CSharpSyntaxTree.ParseText(WrapInMethod(tuple));
+            var tupleExpression = (TupleExpressionSyntaxWrapper)syntaxTree.GetRoot().DescendantNodesAndSelf().First(x => TupleExpressionSyntaxWrapper.IsInstance(x));
+            var allArguments = tupleExpression.AllArguments();
+            var allArgumentsAsString = string.Join(",", allArguments.Select(x => x.ToString()));
+            allArgumentsAsString.Should().Be(expectedArguments);
+        }
+
+        private static string WrapInMethod(string code) =>
+$@"
+public class C
+{{
+    public int M()
+    {{
+        var t = {code};
+        return 0;
+    }}
+}}
+";
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/TupleExpressionSyntaxExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/TupleExpressionSyntaxExtensionsTests.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
         [DataRow("(1, (2, 3), 4)", "1,2,3,4")]
         [DataRow("(1, (2, 3), 4, M())", "1,2,3,4,M()")]
         [DataRow("(1, (2, 3, (4, 5, 6), 7), 8, M())", "1,2,3,4,5,6,7,8,M()")]
-        public void T(string tuple, string expectedArguments)
+        public void TupleExpressionSyntaxExtensions_FlatteningTests(string tuple, string expectedArguments)
         {
             var syntaxTree = CSharpSyntaxTree.ParseText(WrapInMethod(tuple));
             var tupleExpression = (TupleExpressionSyntaxWrapper)syntaxTree.GetRoot().DescendantNodesAndSelf().First(x => TupleExpressionSyntaxWrapper.IsInstance(x));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/VariableDesignationSyntaxWrapperTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/VariableDesignationSyntaxWrapperTests.cs
@@ -18,11 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using SonarAnalyzer.Extensions;
 using StyleCop.Analyzers.Lightup;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/VariableDesignationSyntaxWrapperTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/VariableDesignationSyntaxWrapperTests.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
 $@"
 public class C
 {{
-    public int M()
+    public void M()
     {{
         {code}
     }}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/VariableDesignationSyntaxWrapperTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/VariableDesignationSyntaxWrapperTests.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using SonarAnalyzer.Extensions;
+using StyleCop.Analyzers.Lightup;
+
+namespace SonarAnalyzer.UnitTest.Extensions
+{
+    [TestClass]
+    public class VariableDesignationSyntaxWrapperTests
+    {
+        [DataTestMethod]
+        [DataRow("var (a, b) = (1, 2);", "a,b")]
+        [DataRow("var (a, _) = (1, 2);", "a")]
+        [DataRow("var (a, (b, c), d) = (1, (2, 3), 4);", "a,b,c,d")]
+        [DataRow("_ = (1, 2) is var (a, b);", "a,b")]
+        [DataRow("_ = (1, 2) switch { var (a, b) => true };", "a,b")]
+        public void VariableDesignationSyntaxWrapper_DifferentDesignations(string designation, string expectedVariables)
+        {
+            var syntaxTree = CSharpSyntaxTree.ParseText(WrapInMethod(designation));
+            var variableDesignation = (VariableDesignationSyntaxWrapper)syntaxTree.GetRoot().DescendantNodesAndSelf().First(VariableDesignationSyntaxWrapper.IsInstance);
+            var allVariables = variableDesignation.AllVariables();
+            var allVariablesAsString = string.Join(",", allVariables.Select(x => x.SyntaxNode.ToString()));
+            allVariablesAsString.Should().Be(expectedVariables);
+        }
+
+        private static string WrapInMethod(string code) =>
+$@"
+public class C
+{{
+    public int M()
+    {{
+        {code}
+    }}
+}}
+";
+    }
+}


### PR DESCRIPTION
This PR will conflict with #5756 as both add the same file(s).

* [x] Add tests for AssignmentTargets
* [x] Support `var (x,y)= ..;` and `(var x, var y) = ..;`