### PR TITLE
Implement ExceptionCandidate

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 _ when ILocalReferenceOperationWrapper.IsInstance(operation) => ILocalReferenceOperationWrapper.FromOperation(operation).Local,
                 _ when IFieldReferenceOperationWrapper.IsInstance(operation)
                     && IFieldReferenceOperationWrapper.FromOperation(operation) is var fieldReference
-                    && IsStaticOrThis(fieldReference.Instance) => fieldReference.Field,
+                    && IsStaticOrThis(fieldReference) => fieldReference.Field,
                 _ => null
             };
 
@@ -53,9 +53,9 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         internal static IArgumentOperationWrapper ToArgument(this IOperation operation) =>
             IArgumentOperationWrapper.FromOperation(operation);
 
-        public static bool IsStaticOrThis(this IOperation operation) =>
-            operation == null // static fields
-            || operation.IsAnyKind(OperationKindEx.InstanceReference);
+        public static bool IsStaticOrThis(this IMemberReferenceOperationWrapper reference) =>
+            reference.Instance == null // static fields
+            || reference.Instance.IsAnyKind(OperationKindEx.InstanceReference);
 
         private static T? As<T>(this IOperation operation, OperationKind kind, Func<IOperation, T> fromOperation) where T : struct =>
             operation.Kind == kind ? fromOperation(operation) : null;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
@@ -53,11 +53,11 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         internal static IArgumentOperationWrapper ToArgument(this IOperation operation) =>
             IArgumentOperationWrapper.FromOperation(operation);
 
-        private static T? As<T>(this IOperation operation, OperationKind kind, Func<IOperation, T> fromOperation) where T : struct =>
-            operation.Kind == kind ? fromOperation(operation) : null;
-
-        private static bool IsStaticOrThis(IOperation operation) =>
+        public static bool IsStaticOrThis(this IOperation operation) =>
             operation == null // static fields
             || operation.IsAnyKind(OperationKindEx.InstanceReference);
+
+        private static T? As<T>(this IOperation operation, OperationKind kind, Func<IOperation, T> fromOperation) where T : struct =>
+            operation.Kind == kind ? fromOperation(operation) : null;
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -264,7 +264,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             operation.Instance.Kind switch
             {
                 OperationKindEx.ArrayElementReference => ExceptionState.UnknownException, // ToDo: be explicit regarding exception type
-                OperationKindEx.Conversion => operation.IsImplicit ? null : ExceptionState.UnknownException, // ToDo: be explicit regarding exception type
+                OperationKindEx.Conversion => ConversionExceptionCandidate(operation),
                 OperationKindEx.DynamicIndexerAccess => ExceptionState.UnknownException, // ToDo: be explicit regarding exception type
                 OperationKindEx.DynamicInvocation => ExceptionState.UnknownException, // ToDo: be explicit regarding exception type
                 OperationKindEx.DynamicMemberReference => ExceptionState.UnknownException, // ToDo: be explicit regarding exception type
@@ -273,13 +273,27 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 OperationKindEx.FieldReference => ExceptionCandidate(IMemberReferenceOperationWrapper.FromOperation(operation.Instance)),
                 OperationKindEx.Invocation => ExceptionState.UnknownException,
                 OperationKindEx.MethodReference => ExceptionCandidate(IMemberReferenceOperationWrapper.FromOperation(operation.Instance)),
-                OperationKindEx.ObjectCreation => operation.Instance.Type.DerivesFrom(KnownType.System_Exception) ? null : ExceptionState.UnknownException, // Filter out exception constructors assuming that usually they do not throw.
+                OperationKindEx.ObjectCreation => operation.Instance.Type.DerivesFrom(KnownType.System_Exception) ? null : ExceptionState.UnknownException, // Exception constructors shouldn't throw
                 OperationKindEx.PropertyReference => ExceptionCandidate(IMemberReferenceOperationWrapper.FromOperation(operation.Instance)),
                 _ => null
             };
 
-        private static ExceptionState ExceptionCandidate(IMemberReferenceOperationWrapper wrapper) =>
-            wrapper.Instance.IsStaticOrThis() ? null : ExceptionState.UnknownException; // ToDo: be explicit regarding exception type
+        private static ExceptionState ConversionExceptionCandidate(IOperationWrapperSonar operation)
+        {
+            if (operation.IsImplicit)
+            {
+                return null;
+            }
+
+            var conversion = IConversionOperationWrapper.FromOperation(operation.Instance);
+            return conversion.Operand.Type.DerivesOrImplements(conversion.Type)
+                       ? null
+                       : ExceptionState.UnknownException;
+        }
+
+
+        private static ExceptionState ExceptionCandidate(IMemberReferenceOperationWrapper reference) =>
+            reference.IsStaticOrThis() ? null : ExceptionState.UnknownException; // ToDo: be explicit regarding exception type
 
         private static bool IsReachable(ExplodedNode node, ControlFlowBranch branch) =>
             node.Block.ConditionKind == ControlFlowConditionKind.None

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
@@ -549,10 +549,14 @@ tag = ""UnreachableAfterCatch"";";
             validator.ValidateTagOrder(
                 "BeforeTry",
                 "InTry",
-                "InCatch",          // With Exception thrown by Tag("InTry")
-                "InCatch");         // With Exception thrown by `throw`
+                "InCatch", // With Exception thrown by Tag("InTry")
+                "InCatch"); // With Exception thrown by `throw`
 
-            ValidateHasOnlyUnknownExceptionAndSystemException(validator, "InCatch");
+            validator.TagStates("InCatch").Should().HaveCount(2)
+                .And.ContainSingle(x => HasSystemException(x))
+                .And.ContainSingle(x => HasUnknownException(x));
+
+            validator.ValidateExitReachCount(1);
         }
 
         [TestMethod]
@@ -1172,6 +1176,7 @@ tag = ""End"";";
                 "InFinally",
                 "InCatchArgument",
                 "InCatchAll",
+                "InFinally", // ToDo: remove this, ex.ParamName cannot throw in this case
                 "InCatchAllWhen",
                 "End",
                 "InCatchArgumentWhen");
@@ -1180,7 +1185,9 @@ tag = ""End"";";
             validator.TagStates("InCatchArgument").Should().HaveCount(1).And.ContainSingle(x => HasUnknownException(x));
             validator.TagStates("InCatchAllWhen").Should().HaveCount(1).And.ContainSingle(x => HasUnknownException(x));
             validator.TagStates("InCatchAll").Should().HaveCount(1).And.ContainSingle(x => HasUnknownException(x));
-            validator.TagStates("InFinally").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));
+            validator.TagStates("InFinally").Should().HaveCount(2)
+                .And.ContainSingle(x => HasNoException(x))
+                .And.ContainSingle(x => HasUnknownException(x));
             validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));
         }
 
@@ -1351,9 +1358,12 @@ tag = ""AfterCatch"";";
                 "BeforeTry",
                 "InTry",
                 "InCatch",
+                "InCatch",
                 "AfterCatch");
 
-            validator.TagStates("InCatch").Should().HaveCount(1).And.ContainSingle(x => HasExceptionOfType(x, "NotImplementedException"));
+            validator.TagStates("InCatch").Should().HaveCount(2)
+                     .And.ContainSingle(x => HasExceptionOfType(x, "NotImplementedException"))
+                     .And.ContainSingle(x => HasUnknownException(x)); // ArrayReference can throw IndexOutOfBounds
             validator.TagStates("AfterCatch").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));
         }
 
@@ -1433,9 +1443,12 @@ tag = ""AfterCatch"";";
                 "BeforeTry",
                 "InTry",
                 "InCatch",
+                "InCatch",
                 "AfterCatch");
 
-            validator.TagStates("InCatch").Should().HaveCount(1).And.ContainSingle(x => HasExceptionOfType(x, "FileNotFoundException"));
+            validator.TagStates("InCatch").Should().HaveCount(2)
+                     .And.ContainSingle(x => HasExceptionOfType(x, "FileNotFoundException"))
+                     .And.ContainSingle(x => HasUnknownException(x)); // ObjectCreation can throw unknown exception
             validator.TagStates("AfterCatch").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
@@ -549,12 +549,10 @@ tag = ""UnreachableAfterCatch"";";
             validator.ValidateTagOrder(
                 "BeforeTry",
                 "InTry",
-                "InCatch", // With Exception thrown by Tag("InTry")
+                "InCatch",  // With Exception thrown by Tag("InTry")
                 "InCatch"); // With Exception thrown by `throw`
 
-            validator.TagStates("InCatch").Should().HaveCount(2)
-                .And.ContainSingle(x => HasSystemException(x))
-                .And.ContainSingle(x => HasUnknownException(x));
+            ValidateHasOnlyUnknownExceptionAndSystemException(validator, "InCatch");
 
             validator.ValidateExitReachCount(1);
         }
@@ -1176,7 +1174,7 @@ tag = ""End"";";
                 "InFinally",
                 "InCatchArgument",
                 "InCatchAll",
-                "InFinally", // ToDo: remove this, ex.ParamName cannot throw in this case
+                "InFinally", // ex.ParamName cannot throw in this case, will be solved by https://jira.sonarsource.com/browse/MMF-2401
                 "InCatchAllWhen",
                 "End",
                 "InCatchArgumentWhen");
@@ -1221,16 +1219,6 @@ tag = ""End"";";
             validator.TagStates("InFinally").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));
             validator.TagStates("End").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));
         }
-
-        private static void ValidateHasOnlyUnknownExceptionAndSystemException(ValidatorTestCheck validator, string stateName) =>
-            validator.TagStates(stateName).Should().HaveCount(2)
-                .And.ContainSingle(x => HasUnknownException(x))
-                .And.ContainSingle(x => HasSystemException(x));
-
-        private static void ValidateHasOnlyNoExceptionAndUnknownException(ValidatorTestCheck validator, string stateName) =>
-            validator.TagStates(stateName).Should().HaveCount(2)
-                .And.ContainSingle(x => HasNoException(x))
-                .And.ContainSingle(x => HasUnknownException(x));
 
         [TestMethod]
         public void Exception_FieldReference()
@@ -1443,12 +1431,9 @@ tag = ""AfterCatch"";";
                 "BeforeTry",
                 "InTry",
                 "InCatch",
-                "InCatch",
                 "AfterCatch");
 
-            validator.TagStates("InCatch").Should().HaveCount(2)
-                     .And.ContainSingle(x => HasExceptionOfType(x, "FileNotFoundException"))
-                     .And.ContainSingle(x => HasUnknownException(x)); // ObjectCreation can throw unknown exception
+            validator.TagStates("InCatch").Should().HaveCount(1).And.ContainSingle(x => HasExceptionOfType(x, "FileNotFoundException"));
             validator.TagStates("AfterCatch").Should().HaveCount(1).And.ContainSingle(x => HasNoException(x));
         }
 
@@ -1463,5 +1448,15 @@ tag = ""AfterCatch"";";
 
         private static bool HasExceptionOfType(ProgramState state, string typeName) =>
             state.Exception?.Type?.Name == typeName;
+
+        private static void ValidateHasOnlyUnknownExceptionAndSystemException(ValidatorTestCheck validator, string stateName) =>
+            validator.TagStates(stateName).Should().HaveCount(2)
+                     .And.ContainSingle(x => HasUnknownException(x))
+                     .And.ContainSingle(x => HasSystemException(x));
+
+        private static void ValidateHasOnlyNoExceptionAndUnknownException(ValidatorTestCheck validator, string stateName) =>
+            validator.TagStates(stateName).Should().HaveCount(2)
+                     .And.ContainSingle(x => HasNoException(x))
+                     .And.ContainSingle(x => HasUnknownException(x));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.cs
@@ -44,7 +44,8 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void Execute_SecondRun_Throws()
         {
-            var se = new RoslynSymbolicExecution(TestHelper.CompileCfgBodyCS(), new[] { new ValidatorTestCheck() });
+            var cfg = TestHelper.CompileCfgBodyCS();
+            var se = new RoslynSymbolicExecution(cfg, new[] { new ValidatorTestCheck(cfg) });
             se.Execute();
             se.Invoking(x => x.Execute()).Should().Throw<InvalidOperationException>().WithMessage("Engine can be executed only once.");
         }
@@ -173,7 +174,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         {
             const string code = @"
 var first = boolParameter ? true : false;
-Tag(""BeforeLastUse""); 
+Tag(""BeforeLastUse"");
 bool second = first;
 if(boolParameter)
     boolParameter.ToString();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/SETestContext.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/SETestContext.cs
@@ -51,16 +51,21 @@ namespace SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution
 using System;
 using System.Collections.Generic;
 
-public class Sample
+public unsafe class Sample
 {{
     public static int StaticField;
     public static int StaticProperty {{ get; set; }}
+    public static event EventHandler StaticEvent;
+    public event EventHandler Event;
     public int Property {{ get; set; }}
     public NotImplementedException PropertyException {{ get; set; }}
     private int field;
-    private NotImplementedException  fieldException;
+    private NotImplementedException fieldException;
 
     private bool Condition => Environment.ProcessorCount == 42;  // Something that cannot have constraint
+
+    public Sample(){{ }}
+    public Sample(int i){{ }}
 
     public void Main(bool boolParameter{additionalParameters})
     {{
@@ -70,6 +75,21 @@ public class Sample
     public NotImplementedException CreateException() => new NotImplementedException();
 
     private void Tag(string name, object arg = null) {{ }}
+}}
+
+public class Person
+{{
+    public static string StaticProperty {{ get; set; }}
+
+    public string firstName;
+
+    public event EventHandler Event;
+
+    public string LastName {{ get; set; }}
+
+    public string GetName() => null;
+
+    public static void StaticMethod() {{ }}
 }}";
             return new(code, AnalyzerLanguage.CSharp, additionalChecks, localFunctionName);
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/SETestContext.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/SETestContext.cs
@@ -26,12 +26,13 @@ namespace SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution
 {
     internal class SETestContext
     {
-        public readonly ValidatorTestCheck Validator = new();
+        public readonly ValidatorTestCheck Validator;
 
         public SETestContext(string code, AnalyzerLanguage language, SymbolicCheck[] additionalChecks, string localFunctionName = null)
         {
             const string Separator = "----------";
             var cfg = TestHelper.CompileCfg(code, language, false, localFunctionName);
+            Validator = new ValidatorTestCheck(cfg);
             var se = new RoslynSymbolicExecution(cfg, additionalChecks.Concat(new[] { Validator }).ToArray());
             Console.WriteLine(Separator);
             Console.Write(CfgSerializer.Serialize(cfg));
@@ -77,19 +78,17 @@ public unsafe class Sample
     private void Tag(string name, object arg = null) {{ }}
 }}
 
-public class Person
+public class Person : PersonBase
 {{
     public static string StaticProperty {{ get; set; }}
-
-    public string firstName;
-
+    public string Field;
     public event EventHandler Event;
-
-    public string LastName {{ get; set; }}
-
-    public string GetName() => null;
-
+    public string Method() => null;
     public static void StaticMethod() {{ }}
+}}
+
+public class PersonBase
+{{
 }}";
             return new(code, AnalyzerLanguage.CSharp, additionalChecks, localFunctionName);
         }


### PR DESCRIPTION
Related to #5710

Remaining tasks after this PR:
- [IEndOperation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.operations.iendoperation?view=roslyn-dotnet-4.2.0) (`'End' statement cannot be used in class library projects.`)
- use specific exceptions instead of the unknown where possible (e.g. NullReferenceException for member reference)
- update testing infrastructure to run tests on C# 8 and add handling for indexes and ranges
- exception constructors should not throw