### PR TITLE
Replace WalkUpParentheses with GetFirstNonParenthesizedParent

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -119,15 +119,6 @@ namespace SonarAnalyzer.Extensions
             return current;
         }
 
-        public static SyntaxNode WalkUpParentheses(this SyntaxNode node)
-        {
-            while (node is not null && node.IsKind(SyntaxKind.ParenthesizedExpression))
-            {
-                node = node.Parent;
-            }
-            return node;
-        }
-
         private static string GetUnknownType(SyntaxKind kind)
         {
 #if DEBUG

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsReuseClients.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsReuseClients.cs
@@ -88,7 +88,7 @@ namespace SonarAnalyzer.Rules.CSharp
             node.Ancestors().Any(x => x.IsAnyKind(SyntaxKind.FieldDeclaration, SyntaxKind.PropertyDeclaration));
 
         private static bool IsAssignedToStaticFieldOrProperty(SyntaxNodeAnalysisContext context) =>
-            context.Node.Parent.WalkUpParentheses() is AssignmentExpressionSyntax assignment
+            context.Node.Parent.GetFirstNonParenthesizedParent() is AssignmentExpressionSyntax assignment
                 && assignment.Left.GetIdentifier() is { } identifier
                 && context.SemanticModel.GetSymbolInfo(identifier, context.CancellationToken).Symbol is { IsStatic: true, Kind: SymbolKind.Field or SymbolKind.Property };
 


### PR DESCRIPTION
`WalkUpParentheses` and `GetFirstNonParenthesizedParent` do the same thing. No need to have both.