### PR TITLE
Fix S2699 FP: When using NSubstitute Received with quantity

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldContainAssertion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldContainAssertion.cs
@@ -148,7 +148,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 ?.ApplicationSyntaxReference.GetSyntax() as AttributeSyntax;
 
             return factAttributeSyntax?.ArgumentList != null
-                   && factAttributeSyntax.ArgumentList.Arguments.Any(x => x.NameEquals.Name.Identifier.ValueText == "Skip");
+                 && factAttributeSyntax.ArgumentList.Arguments.Any(x => x.NameEquals.Name.Identifier.ValueText == "Skip");
         }
 
         private static bool IsAssertion(InvocationExpressionSyntax invocation) =>
@@ -159,7 +159,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 .Any();
 
         private static bool IsKnownAssertion(ISymbol methodSymbol) =>
-            (KnownAssertions.GetValueOrDefault(methodSymbol.Name) is { } types && types.Any(type => methodSymbol.ContainingType.ConstructedFrom.Is(type)))
+            (KnownAssertions.GetValueOrDefault(methodSymbol.Name) is { } types && types.Any(x => methodSymbol.ContainingType.ConstructedFrom.Is(x)))
             || methodSymbol.ContainingType.DerivesFromAny(KnownAssertionTypes);
 
         private static bool IsCustomAssertion(ISymbol methodSymbol) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldContainAssertion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldContainAssertion.cs
@@ -39,21 +39,21 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string CustomAssertionAttributeName = "AssertionMethodAttribute";
         private const int MaxInvocationDepth = 2; // Consider BFS instead of DFS if this gets increased
 
-        private static readonly Dictionary<string, KnownType> KnownAssertions = new Dictionary<string, KnownType>
+        private static readonly Dictionary<string, KnownType[]> KnownAssertions = new Dictionary<string, KnownType[]>
         {
-            {"DidNotReceive", KnownType.NSubstitute_SubstituteExtensions},
-            {"DidNotReceiveWithAnyArgs", KnownType.NSubstitute_SubstituteExtensions},
-            {"Received", KnownType.NSubstitute_SubstituteExtensions},
-            {"ReceivedWithAnyArgs", KnownType.NSubstitute_SubstituteExtensions},
-            {"InOrder", KnownType.NSubstitute_Received }
+            {"DidNotReceive", new[] {KnownType.NSubstitute_SubstituteExtensions}},
+            {"DidNotReceiveWithAnyArgs", new[] {KnownType.NSubstitute_SubstituteExtensions}},
+            {"Received", new[] {KnownType.NSubstitute_SubstituteExtensions, KnownType.NSubstitute_ReceivedExtensions_ReceivedExtensions}},
+            {"ReceivedWithAnyArgs", new[] {KnownType.NSubstitute_SubstituteExtensions, KnownType.NSubstitute_ReceivedExtensions_ReceivedExtensions}},
+            {"InOrder", new[] {KnownType.NSubstitute_Received}}
         };
 
         /// The assertions in the Shouldly library are supported by <see cref="UnitTestHelper.KnownAssertionMethodParts"/> (they all contain "Should")
         private static readonly ImmutableArray<KnownType> KnownAssertionTypes = ImmutableArray.Create(
-                KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_Assert,
-                KnownType.NFluent_Check,
-                KnownType.NUnit_Framework_Assert,
-                KnownType.Xunit_Assert);
+            KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_Assert,
+            KnownType.NFluent_Check,
+            KnownType.NUnit_Framework_Assert,
+            KnownType.Xunit_Assert);
 
         private static readonly ImmutableArray<KnownType> KnownAsertionExceptionTypes = ImmutableArray.Create(
             KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_AssertFailedException,
@@ -89,10 +89,10 @@ namespace SonarAnalyzer.Rules.CSharp
 
         // only xUnit allows local functions to be test methods.
         private static bool IsTestMethod(IMethodSymbol symbol, bool isLocalFunction) =>
-                isLocalFunction ? IsXunitTestMethod(symbol) : symbol.IsTestMethod();
+            isLocalFunction ? IsXunitTestMethod(symbol) : symbol.IsTestMethod();
 
         private static bool IsXunitTestMethod(IMethodSymbol methodSymbol) =>
-                methodSymbol.AnyAttributeDerivesFromAny(UnitTestHelper.KnownTestMethodAttributesOfxUnit);
+            methodSymbol.AnyAttributeDerivesFromAny(UnitTestHelper.KnownTestMethodAttributesOfxUnit);
 
         private static bool ContainsAssertion(SyntaxNode methodDeclaration, SemanticModel previousSemanticModel, ISet<IMethodSymbol> visitedSymbols, int level)
         {
@@ -101,6 +101,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 return false;
             }
+
             var descendantNodes = methodDeclaration.DescendantNodes();
             var invocations = descendantNodes.OfType<InvocationExpressionSyntax>().ToArray();
             if (invocations.Any(x => IsAssertion(x))
@@ -114,10 +115,12 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 return true;
             }
+
             if (level == MaxInvocationDepth)
             {
                 return false;
             }
+
             foreach (var symbol in invokedSymbols.Where(x => !visitedSymbols.Contains(x)))
             {
                 visitedSymbols.Add(symbol);
@@ -129,6 +132,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     }
                 }
             }
+
             return false;
         }
 
@@ -144,7 +148,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 ?.ApplicationSyntaxReference.GetSyntax() as AttributeSyntax;
 
             return factAttributeSyntax?.ArgumentList != null
-                && factAttributeSyntax.ArgumentList.Arguments.Any(x => x.NameEquals.Name.Identifier.ValueText == "Skip");
+                   && factAttributeSyntax.ArgumentList.Arguments.Any(x => x.NameEquals.Name.Identifier.ValueText == "Skip");
         }
 
         private static bool IsAssertion(InvocationExpressionSyntax invocation) =>
@@ -155,7 +159,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 .Any();
 
         private static bool IsKnownAssertion(ISymbol methodSymbol) =>
-            (KnownAssertions.GetValueOrDefault(methodSymbol.Name) is { } type && methodSymbol.ContainingType.ConstructedFrom.Is(type))
+            (KnownAssertions.GetValueOrDefault(methodSymbol.Name) is { } types && types.Any(type => methodSymbol.ContainingType.ConstructedFrom.Is(type)))
             || methodSymbol.ContainingType.DerivesFromAny(KnownAssertionTypes);
 
         private static bool IsCustomAssertion(ISymbol methodSymbol) =>

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -482,6 +482,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType Void = new("System.Void");
         internal static readonly KnownType NSubstitute_SubstituteExtensions = new("NSubstitute.SubstituteExtensions");
         internal static readonly KnownType NSubstitute_Received = new("NSubstitute.Received");
+        internal static readonly KnownType NSubstitute_ReceivedExtensions_ReceivedExtensions = new("NSubstitute.ReceivedExtensions.ReceivedExtensions");
         internal static readonly ImmutableArray<KnownType> SystemActionVariants =
             ImmutableArray.Create<KnownType>(
                 new("System.Action"),

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.NUnit.cs
@@ -7,6 +7,7 @@
     using FluentAssertions;
     using NFluent;
     using NSubstitute;
+    using NSubstitute.ReceivedExtensions;
     using NUnit.Framework;
     using Shouldly;
 
@@ -512,6 +513,24 @@
         public void ReceivedWithAnyArgs()
         {
             calculator.ReceivedWithAnyArgs().Add(0, 0);
+        }
+
+        [TestCase]
+        public void ReceivedWithQuantity()
+        {
+            calculator.Received(Quantity.AtLeastOne()).Add(1, 2);
+        }
+
+        [TestCase]
+        public void ReceivedExpressionWithQuantity() => calculator.Received(Quantity.AtLeastOne()).Add(1, 2);
+
+        [TestCase]
+        public void ReceivedNameSpaceWithQuantity() => NSubstitute.ReceivedExtensions.ReceivedExtensions.Received(calculator, Quantity.AtLeastOne()).Add(1, 2);
+
+        [TestCase]
+        public void ReceivedWithAnyArgsWithQuantity()
+        {
+            calculator.ReceivedWithAnyArgs(Quantity.AtLeastOne()).Add(0, 0);
         }
 
         [TestCase]


### PR DESCRIPTION
Fixes #5826 

KnownAssertions changed to dictionary of <string, KnownTypes[]> in favor "Received" and "ReceivedWithAnyArgs" is used by multiple types