### PR TITLE
Serialize rule metadata to Json

### DIFF
--- a/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/Descriptors/Rule.cs
+++ b/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/Descriptors/Rule.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace SonarAnalyzer.RuleDescriptorGenerator;
+
+[ExcludeFromCodeCoverage]
+public class Rule   // ToDo: Use records after changing target framework
+{
+    public string Id { get; }
+    public RuleParameter[] Parameters { get; }
+
+    public Rule(string id, RuleParameter[] parameters)
+    {
+        Id = id;
+        Parameters = parameters;
+    }
+}

--- a/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/Descriptors/RuleParameter.cs
+++ b/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/Descriptors/RuleParameter.cs
@@ -19,31 +19,49 @@
  */
 
 using System.Diagnostics.CodeAnalysis;
+#if NETCOREAPP  // ToDo: Remove conditional compilation after change of target framework
+using System.Text.Json.Serialization;
+#endif
 using System.Xml;
 using System.Xml.Serialization;
+using SonarAnalyzer.Common;
 
-namespace SonarAnalyzer.RuleDescriptorGenerator
+namespace SonarAnalyzer.RuleDescriptorGenerator;
+
+[ExcludeFromCodeCoverage]
+public class RuleParameter
 {
-    [ExcludeFromCodeCoverage]
-    public class RuleParameter
+    // ToDo: Remove XML annotations
+    [XmlElement("key")]
+    public string Key { get; set; }
+
+    [XmlIgnore]
+    public string Description { get; set; }
+
+    // ToDo: Remove XML-only property
+#if NETCOREAPP
+    [JsonIgnore]
+#endif
+    [XmlElement("description")]
+    public XmlCDataSection DescriptionCDataSection
     {
-        [XmlElement("key")]
-        public string Key { get; set; }
+        get => new XmlDocument().CreateCDataSection(Description);
+        set => Description = value == null ? "" : value.Value;
+    }
 
-        [XmlIgnore]
-        public string Description { get; set; }
+    [XmlElement("type")]
+    public string Type { get; set; }
 
-        [XmlElement("description")]
-        public XmlCDataSection DescriptionCDataSection
-        {
-            get => new XmlDocument().CreateCDataSection(Description);
-            set => Description = value == null ? "" : value.Value;
-        }
+    [XmlElement("defaultValue")]
+    public string DefaultValue { get; set; }
 
-        [XmlElement("type")]
-        public string Type { get; set; }
+    public RuleParameter() { }
 
-        [XmlElement("defaultValue")]
-        public string DefaultValue { get; set; }
+    public RuleParameter(RuleParameterAttribute attribute)
+    {
+        Key = attribute.Key;
+        Description = attribute.Description;
+        Type = attribute.Type.ToString();
+        DefaultValue = attribute.DefaultValue;
     }
 }

--- a/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/Program.cs
+++ b/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/Program.cs
@@ -22,9 +22,14 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
+#if NETCOREAPP      // ToDo: Remove conditional compilation everywhere after change of target framework
+using System.Text.Json;
+#endif
 using System.Xml;
 using System.Xml.Serialization;
+using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Utilities;
 
@@ -47,8 +52,18 @@ namespace SonarAnalyzer.RuleDescriptorGenerator
                 Directory.CreateDirectory(args[0]);
                 SerializeObjectToFile(Path.Combine(args[0], "rules.xml"), root);
             }
+#if NETCOREAPP
+            else if (args.Length == 2)
+            {
+                var analyzers = LoadAnalyzerTypes(args[0]);
+                var rules = LoadRules(analyzers);
+                var json = JsonSerializer.Serialize(rules, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+                File.WriteAllText(args[1], json);
+            }
+#endif
             else
             {
+                // ToDo: Will be outdated after removing rules.xml
                 Console.WriteLine("[AnalyzerLanguage: 'cs' for C#, 'vbnet' for VB.Net]");
                 Console.WriteLine("All files will be created by the application");
             }
@@ -67,10 +82,40 @@ namespace SonarAnalyzer.RuleDescriptorGenerator
             using (var writer = XmlWriter.Create(stream, settings))
             {
                 var serializer = new XmlSerializer(objectToSerialize.GetType());
-                serializer.Serialize(writer, objectToSerialize, new XmlSerializerNamespaces(new[] {XmlQualifiedName.Empty}));
+                serializer.Serialize(writer, objectToSerialize, new XmlSerializerNamespaces(new[] { XmlQualifiedName.Empty }));
                 var ruleXml = Encoding.UTF8.GetString(stream.ToArray());
                 File.WriteAllText(filePath, ruleXml);
             }
         }
+
+#if NETCOREAPP
+
+        private static Type[] LoadAnalyzerTypes(string path) =>
+            Assembly.LoadFrom(path)  // We don't need 'Load', we have full control over the environment. It would make local build too complicated.
+                .ExportedTypes
+                .Where(x => !x.IsAbstract && typeof(DiagnosticAnalyzer).IsAssignableFrom(x))
+                .ToArray();
+
+        private static Rule[] LoadRules(Type[] analyzers) =>
+            analyzers
+                .Select(x => new { Type = x, Parameters = RuleParameters(x) })
+                .SelectMany(x => UniqueIds(x.Type).Select(id => new { Id = id, x.Parameters }))
+                .GroupBy(x => x.Id)     // Same id can be in multiple classes (see InvalidCastToInterface)
+                .Select(x => new Rule(x.Key, x.SelectMany(x => x.Parameters).ToArray()))
+                .ToArray();
+
+        private static RuleParameter[] RuleParameters(Type analyzer) =>
+            analyzer.GetProperties()
+                .Select(x => x.GetCustomAttributes<RuleParameterAttribute>().SingleOrDefault())
+                .Where(x => x != null)
+                .Select(x => new RuleParameter(x))
+                .ToArray();
+
+        // One class can have the same ruleId multiple times, see S3240
+        private static string[] UniqueIds(Type analyzer) =>
+            ((DiagnosticAnalyzer)Activator.CreateInstance(analyzer)).SupportedDiagnostics.Select(x => x.Id).Distinct().ToArray();
+
+#endif
+
     }
 }


### PR DESCRIPTION
Prerequisite for #5590 

The project state is rather ugly, as most of it will be eventually removed and target framework will be updated to `net6`. For this stage, we need to preserve both functionalities.

Reflection is used intentionally so we can get rid of the dependency on the analyzer DLLs.