### PR TITLE
Remove unsupported members from PropertyType

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Common/PropertyType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/PropertyType.cs
@@ -20,19 +20,18 @@
 
 namespace SonarAnalyzer.Common
 {
+    /// <summary>
+    /// sonar-plugin-api / RuleParamType also supports lists with single/multi selection.
+    /// We don't have a way how to annotate those on .NET side.
+    /// See sonar-plugin-api / RuleParamTypeTest.java for format an usages.
+    /// </summary>
     public enum PropertyType
     {
         String,
         Text,
-        Password,
         Boolean,
         Integer,
         Float,
-        SingleSelectList,
-        Metric,
-        License,
-        RegularExpression,
-        PropertySet,
-        UserLogin
+        RegularExpression,  // This will be translated to String by RuleParamType.parse() on the API side
     }
 }

--- a/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/Descriptors/RuleParameter.cs
+++ b/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/Descriptors/RuleParameter.cs
@@ -61,7 +61,24 @@ public class RuleParameter
     {
         Key = attribute.Key;
         Description = attribute.Description;
-        Type = attribute.Type.ToString();
+        Type = ToServerApi(attribute.Type);
         DefaultValue = attribute.DefaultValue;
     }
+
+    /// <summary>
+    /// sonar-plugin-api / RuleParamTypeTest.java contains other possibilities how to serialize enum values with single-select and multi-select:
+    /// SINGLE_SELECT_LIST,multiple=false,values="First,Second,Third"
+    /// SINGLE_SELECT_LIST,multiple=true,values="First,Second,Third"
+    /// </summary>
+    private static string ToServerApi(PropertyType type) =>
+        type switch
+        {
+            PropertyType.String => "STRING",
+            PropertyType.Text => "TEXT",
+            PropertyType.Boolean => "BOOLEAN",
+            PropertyType.Integer => "INTEGER",
+            PropertyType.Float => "FLOAT",
+            PropertyType.RegularExpression => "REGULAR_EXPRESSION",  // This will be translated to STRING by RuleParamType.parse() on the sonar-plugin-api side
+            _ => throw new UnexpectedValueException(nameof(type), type.ToString())
+        };
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleDetailTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleDetailTest.cs
@@ -30,12 +30,12 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void RuleParameter_Constructor_CopiesValues()
         {
-            var att = new RuleParameterAttribute("key", PropertyType.Password, "Description", "Secret");
+            var att = new RuleParameterAttribute("key", PropertyType.Boolean, "Description", "False");
             var sut = new RuleParameter(att);
             sut.Key.Should().Be("key");
             sut.Description.Should().Be("Description");
-            sut.Type.Should().Be("PASSWORD");
-            sut.DefaultValue.Should().Be("Secret");
+            sut.Type.Should().Be("BOOLEAN");
+            sut.DefaultValue.Should().Be("False");
         }
 
         [DataTestMethod]


### PR DESCRIPTION
Related to #5590 

Unused enum values serialized from .NET side are not supported by sonar-plugin-api on the server side.
