### PR TITLE
bump s4net version to 5.7.2

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -22,7 +22,7 @@
   </organization>
 
   <properties>
-    <scannerMsbuild.version>5.7.1.49528</scannerMsbuild.version>
+    <scannerMsbuild.version>5.7.2.50892</scannerMsbuild.version>
     <surefire.argLine>-server</surefire.argLine>
     <maven.compiler.release>8</maven.compiler.release>
   </properties>

--- a/its/src/test/java/com/sonar/it/shared/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/shared/TestUtils.java
@@ -140,7 +140,7 @@ public class TestUtils {
   private static Build<ScannerForMSBuild> newScanner(Path projectDir) {
     // We need to set the fallback version to run from inside the IDE when the property isn't set
     return ScannerForMSBuild.create(projectDir.toFile())
-      .setScannerVersion(System.getProperty("scannerMsbuild.version", "5.7.1.49528"))
+      .setScannerVersion(System.getProperty("scannerMsbuild.version", "5.7.2.50892"))
 
       // In order to be able to run tests on Azure pipelines, the AGENT_BUILDDIRECTORY environment variable
       // needs to be set to the analyzed project directory.


### PR DESCRIPTION
as part of our release process: https://xtranet-sonarsource.atlassian.net/wiki/spaces/SSG/pages/1181769/Scanner+for+.NET+Release+Process

we want to be using the latest S4NET version in all our ITs