### PR TITLE
Move RSPEC related UTs to RuleCatalog

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Common/RuleDescriptor.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/RuleDescriptor.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Common
 {
-    public record RuleDescriptor(string Id, string Title, string Type, string DefaultSeverity, SourceScope Scope, bool SonarWay, string Description)
+    public record RuleDescriptor(string Id, string Title, string Type, string DefaultSeverity, string Status, SourceScope Scope, bool SonarWay, string Description)
     {
         public string Category =>
             $"{DefaultSeverity} {ReadableType}";

--- a/analyzers/src/SonarAnalyzer.SourceGenerators/RuleCatalogGenerator.cs
+++ b/analyzers/src/SonarAnalyzer.SourceGenerators/RuleCatalogGenerator.cs
@@ -72,6 +72,7 @@ namespace SonarAnalyzer.SourceGenerators
                     Encode(json.Value<string>("title")),
                     Encode(json.Value<string>("type")),
                     Encode(json.Value<string>("defaultSeverity")),
+                    Encode(json.Value<string>("status")),
                     $"SourceScope.{json.Value<string>("scope")}",
                     sonarWay.Contains(id).ToString().ToLower(),
                     Encode(FirstParagraphText(id, html))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticDescriptorBuilderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticDescriptorBuilderTest.cs
@@ -174,7 +174,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
         [TestMethod]
         public void Create_UnexpectedType_Throws()
         {
-            var rule = new RuleDescriptor("Sxxxx", string.Empty, "Lorem Ipsum", string.Empty, SourceScope.Main, true, string.Empty);
+            var rule = new RuleDescriptor("Sxxxx", string.Empty, "Lorem Ipsum", string.Empty, string.Empty, SourceScope.Main, true, string.Empty);
             var f = () => DiagnosticDescriptorBuilder.Create(AnalyzerLanguage.CSharp, rule, string.Empty, null, false);
             f.Should().Throw<UnexpectedValueException>().WithMessage("Unexpected Type value: Lorem Ipsum");
         }
@@ -190,12 +190,12 @@ namespace SonarAnalyzer.UnitTest.Helpers
         [DataRow("Whatever Xxx", "BUG", "Whatever Xxx Bug")]
         public void Create_ComputesCategory(string severity, string type, string expected)
         {
-            var rule = new RuleDescriptor("Sxxxx", string.Empty, type, severity, SourceScope.Main, true, string.Empty);
+            var rule = new RuleDescriptor("Sxxxx", string.Empty, type, severity, string.Empty, SourceScope.Main, true, string.Empty);
             DiagnosticDescriptorBuilder.Create(AnalyzerLanguage.CSharp, rule, "Sxxxx Message", null, false).Category.Should().Be(expected);
         }
 
         private static RuleDescriptor CreateRuleDescriptor(SourceScope scope, bool sonarWay) =>
-            new("Sxxxx", "Sxxxx Title", "BUG", "Major", scope, sonarWay, "Sxxxx Description");
+            new("Sxxxx", "Sxxxx Title", "BUG", "Major", string.Empty, scope, sonarWay, "Sxxxx Description");
 
         private static ResourceManager CreateMockedResourceManager(string diagnosticId, bool isActivatedByDefault)
         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/RuleCatalogTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/RuleCatalogTest.cs
@@ -86,6 +86,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
             rule.Title.Should().Be("Lines should not be too long");
             rule.Type.Should().Be("CODE_SMELL");
             rule.DefaultSeverity.Should().Be("Major");
+            rule.Status.Should().Be("ready");
             rule.Scope.Should().Be(SourceScope.All);
             rule.SonarWay.Should().BeFalse();
             rule.Description.Should().Be("Having to scroll horizontally makes it harder to get a quick overview and understanding of any piece of code.");

--- a/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeTest.cs
@@ -20,7 +20,7 @@
 
 extern alias csharp;
 extern alias vbnet;
-using System.Resources;
+using SonarAnalyzer.Common;
 
 namespace SonarAnalyzer.UnitTest.PackagingTests
 {
@@ -33,21 +33,21 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
 
         [TestMethod]
         public void DetectRuleTypeChanges_CS() =>
-            DetectTypeChanges(csharp::SonarAnalyzer.RspecStrings.ResourceManager, RuleTypeMappingCS.Rules, nameof(RuleTypeMappingCS));
+            DetectTypeChanges(csharp::SonarAnalyzer.RuleCatalog.Rules, RuleTypeMappingCS.Rules, nameof(RuleTypeMappingCS));
 
         [TestMethod]
         public void DetectRuleTypeChanges_VB() =>
-            DetectTypeChanges(vbnet::SonarAnalyzer.RspecStrings.ResourceManager, RuleTypeMappingVB.Rules, nameof(RuleTypeMappingVB));
+            DetectTypeChanges(vbnet::SonarAnalyzer.RuleCatalog.Rules, RuleTypeMappingVB.Rules, nameof(RuleTypeMappingVB));
 
         [AssertionMethod]
-        private static void DetectTypeChanges(ResourceManager resourceManager, IImmutableDictionary<string, string> expectedTypes, string expectedTypesName)
+        private static void DetectTypeChanges(Dictionary<string, RuleDescriptor> rules, IImmutableDictionary<string, string> expectedTypes, string expectedTypesName)
         {
             var items = Enumerable.Range(1, 10000)
                                   .Select(x => "S" + x)
                                   .Select(x => new
                                   {
                                       RuleId = x,
-                                      ActualType = resourceManager.GetString($"{x}_Type"),
+                                      ActualType = rules.ContainsKey(x) ? rules[x].Type : null,
                                       ExpectedType = expectedTypes.GetValueOrDefault(x)
                                   })
                                   .Where(x => x.ActualType != x.ExpectedType)


### PR DESCRIPTION
Cleanup after #5590

This is a prerequisite for removing resx files. We need to move remaining assertions from ResourceManager to RuleCatalog.
