### PR TITLE
Use file scoped namespaces in rspec template

### DIFF
--- a/scripts/rspec/rspec-templates/Rule.Base.cs
+++ b/scripts/rspec/rspec-templates/Rule.Base.cs
@@ -23,21 +23,14 @@ using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules
+namespace SonarAnalyzer.Rules;
+
+public abstract class $DiagnosticClassName$Base<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
+    where TSyntaxKind : struct
 {
-    public abstract class $DiagnosticClassName$Base<TSyntaxKind> : SonarDiagnosticAnalyzer
-        where TSyntaxKind : struct
-    {
-        protected const string DiagnosticId = "$DiagnosticId$";
-        private const string MessageFormat = "";
+    private const string DiagnosticId = "$DiagnosticId$";
 
-        protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
+    protected override string MessageFormat => "FIXME";
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
-
-        protected DiagnosticDescriptor Rule { get; }
-
-        protected $DiagnosticClassName$Base() =>
-            Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, Language.RspecResources);
-    }
+    protected $DiagnosticClassName$Base() : base(DiagnosticId) { }
 }

--- a/scripts/rspec/rspec-templates/Rule.CS.cs
+++ b/scripts/rspec/rspec-templates/Rule.CS.cs
@@ -27,27 +27,26 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.CSharp
+namespace SonarAnalyzer.Rules.CSharp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class $DiagnosticClassName$ : SonarDiagnosticAnalyzer
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class $DiagnosticClassName$ : SonarDiagnosticAnalyzer
-    {
-        private const string DiagnosticId = "$DiagnosticId$";
-        private const string MessageFormat = "";
+    private const string DiagnosticId = "$DiagnosticId$";
+    private const string MessageFormat = "FIXME";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+    private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        protected override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterSyntaxNodeActionInNonGenerated(c =>
+    protected override void Initialize(SonarAnalysisContext context) =>
+        context.RegisterSyntaxNodeActionInNonGenerated(c =>
+            {
+                var node = c.Node;
+                if (true)
                 {
-                    var node = c.Node;
-                    if (true)
-                    {
-                        c.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
-                    }
-                },
-                SyntaxKind.InvocationExpression);
-    }
+                    c.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
+                }
+            },
+            SyntaxKind.InvocationExpression);
 }

--- a/scripts/rspec/rspec-templates/Rule.VB.cs
+++ b/scripts/rspec/rspec-templates/Rule.VB.cs
@@ -27,27 +27,26 @@ using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.VisualBasic
+namespace SonarAnalyzer.Rules.VisualBasic;
+
+[DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+public sealed class $DiagnosticClassName$ : SonarDiagnosticAnalyzer
 {
-    [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class $DiagnosticClassName$ : SonarDiagnosticAnalyzer
-    {
-        private const string DiagnosticId = "$DiagnosticId$";
-        private const string MessageFormat = "";
+    private const string DiagnosticId = "$DiagnosticId$";
+    private const string MessageFormat = "FIXME";
 
-        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);
+    private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);;
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        protected override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterSyntaxNodeActionInNonGenerated(c =>
+    protected override void Initialize(SonarAnalysisContext context) =>
+        context.RegisterSyntaxNodeActionInNonGenerated(c =>
+            {
+                var node = c.Node;
+                if (true)
                 {
-                    var node = c.Node;
-                    if (true)
-                    {
-                        c.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
-                    }
-                },
-                SyntaxKind.InvocationExpression);
-    }
+                    c.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
+                }
+            },
+            SyntaxKind.InvocationExpression);
 }

--- a/scripts/rspec/rspec-templates/Test.CS.cs
+++ b/scripts/rspec/rspec-templates/Test.CS.cs
@@ -20,15 +20,14 @@
 
 using SonarAnalyzer.Rules.CSharp;
 
-namespace SonarAnalyzer.UnitTest.Rules
-{
-    [TestClass]
-    public class $DiagnosticClassName$Test
-    {
-        private readonly VerifierBuilder builder = new VerifierBuilder<$DiagnosticClassName$>();
+namespace SonarAnalyzer.UnitTest.Rules;
 
-        [TestMethod]
-        public void $DiagnosticClassName$_CS() =>
-            builder.AddPaths("$DiagnosticClassName$.cs").Verify();
-    }
+[TestClass]
+public class $DiagnosticClassName$Test
+{
+    private readonly VerifierBuilder builder = new VerifierBuilder<$DiagnosticClassName$>();
+
+    [TestMethod]
+    public void $DiagnosticClassName$_CS() =>
+        builder.AddPaths("$DiagnosticClassName$.cs").Verify();
 }

--- a/scripts/rspec/rspec-templates/Test.VB.cs
+++ b/scripts/rspec/rspec-templates/Test.VB.cs
@@ -20,15 +20,14 @@
 
 using SonarAnalyzer.Rules.VisualBasic;
 
-namespace SonarAnalyzer.UnitTest.Rules
-{
-    [TestClass]
-    public class $DiagnosticClassName$Test
-    {
-        private readonly VerifierBuilder builder = new VerifierBuilder<$DiagnosticClassName$>();
+namespace SonarAnalyzer.UnitTest.Rules;
 
-        [TestMethod]
-        public void $DiagnosticClassName$_VB() =>
-            builder.AddPaths("$DiagnosticClassName$.vb").Verify();
-    }
+[TestClass]
+public class $DiagnosticClassName$Test
+{
+    private readonly VerifierBuilder builder = new VerifierBuilder<$DiagnosticClassName$>();
+
+    [TestMethod]
+    public void $DiagnosticClassName$_VB() =>
+        builder.AddPaths("$DiagnosticClassName$.vb").Verify();
 }

--- a/scripts/rspec/rspec-templates/TestMethod.VB.cs
+++ b/scripts/rspec/rspec-templates/TestMethod.VB.cs
@@ -1,5 +1,5 @@
-﻿        private readonly VerifierBuilder builderVB = new VerifierBuilder<VB.$DiagnosticClassName$>();    // FIXME: Move this up
+﻿    private readonly VerifierBuilder builderVB = new VerifierBuilder<VB.$DiagnosticClassName$>();    // FIXME: Move this up
 
-        [TestMethod]
-        public void $DiagnosticClassName$_VB() =>
-            builderVB.AddPaths("$DiagnosticClassName$.vb").Verify();
+    [TestMethod]
+    public void $DiagnosticClassName$_VB() =>
+        builderVB.AddPaths("$DiagnosticClassName$.vb").Verify();

--- a/scripts/rspec/rspec.ps1
+++ b/scripts/rspec/rspec.ps1
@@ -173,29 +173,28 @@ function GenerateBaseClassIfSecondLanguage()
         $existingCSClassText = Get-Content -Path "${csRulesFolder}\\${csClassName}.cs" -Raw
         $existingVBClassText = Get-Content -Path "${vbRulesFolder}\\${vbClassName}.cs" -Raw
 
-        $oldCsClass ="    public sealed class ${csClassName} : SonarDiagnosticAnalyzer"
-        $newCsClass ="    public sealed class ${csClassName} : ${className}Base<SyntaxKind>"
-        $oldVbClass ="    public sealed class ${vbClassName} : SonarDiagnosticAnalyzer"
-        $newVbClass ="    public sealed class ${vbClassName} : ${className}Base<SyntaxKind>"
+        $oldCsClass ="public sealed class ${csClassName} : SonarDiagnosticAnalyzer"
+        $newCsClass ="public sealed class ${csClassName} : ${className}Base<SyntaxKind>"
+        $oldVbClass ="public sealed class ${vbClassName} : SonarDiagnosticAnalyzer"
+        $newVbClass ="public sealed class ${vbClassName} : ${className}Base<SyntaxKind>"
         $existingCSClassText = ReplaceTextInString -oldText $oldCsClass -newText $newCsClass -modifiableString $existingCSClassText
         $existingVBClassText = ReplaceTextInString -oldText $oldVbClass -newText $newVbClass -modifiableString $existingVBClassText
 
-        $diagnosticIdToken = "        private const string DiagnosticId = ""${ruleKey}"";"
+        $diagnosticIdToken = "    private const string DiagnosticId = ""${ruleKey}"";"
         $existingCSClassText = RemoveText -textToRemove $diagnosticIdToken -modifiableString $existingCSClassText
         $existingVBClassText = RemoveText -textToRemove $diagnosticIdToken -modifiableString $existingVBClassText
 
-        $messageFormatToken = "       private const string MessageFormat = """";"
+        $messageFormatToken = "   private const string MessageFormat = ""FIXME"";"
         $existingCSClassText = RemoveText -textToRemove $messageFormatToken -modifiableString $existingCSClassText
         $existingVBClassText = RemoveText -textToRemove $messageFormatToken -modifiableString $existingVBClassText
 
-        $ruleToken = "        private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetDescriptor(DiagnosticId, MessageFormat, RspecStrings.ResourceManager);"
+        $ruleToken = "    private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);"
         $existingCSClassText = RemoveText -textToRemove $ruleToken -modifiableString $existingCSClassText
         $existingVBClassText = RemoveText -textToRemove $ruleToken -modifiableString $existingVBClassText
 
-        $supportedDiagToken = "        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);"
-        $csLanguageFacadeToken = "        protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;"
-        $vbLanguageFacadeToken = "        protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;"
-
+        $supportedDiagToken = "    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);"
+        $csLanguageFacadeToken = "    protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;"
+        $vbLanguageFacadeToken = "    protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;"
         $existingCSClassText = ReplaceTextInString -oldText $supportedDiagToken -newText $csLanguageFacadeToken -modifiableString $existingCSClassText
         $existingVBClassText = ReplaceTextInString -oldText $supportedDiagToken -newText $vbLanguageFacadeToken -modifiableString $existingVBClassText
 
@@ -239,8 +238,8 @@ function AppendVbTestCase($ruleTestsFolder) {
     $usingToken = "using SonarAnalyzer.Rules.CSharp;"
     $usingTokenCS = "using CS = SonarAnalyzer.Rules.CSharp;"
     $usingTokenVB = "using VB = SonarAnalyzer.Rules.VisualBasic;"
-    $namespaceToken = "namespace SonarAnalyzer.UnitTest.Rules"
-    $token = "    }"
+    $namespaceToken = "namespace SonarAnalyzer.UnitTest.Rules;"
+    $token = "}"
 
     $text = Get-Content -Path "${ruleTestsFolder}\\${csClassName}Test.cs" -Raw
     $methodVB = Get-Content -Path "${RuleTemplateFolder}\\TestMethod.VB.cs" -Raw

--- a/scripts/rspec/rspec.ps1
+++ b/scripts/rspec/rspec.ps1
@@ -238,8 +238,9 @@ function AppendVbTestCase($ruleTestsFolder) {
     $usingToken = "using SonarAnalyzer.Rules.CSharp;"
     $usingTokenCS = "using CS = SonarAnalyzer.Rules.CSharp;"
     $usingTokenVB = "using VB = SonarAnalyzer.Rules.VisualBasic;"
-    $namespaceToken = "namespace SonarAnalyzer.UnitTest.Rules;"
-    $token = "}"
+    $namespaceToken = "namespace SonarAnalyzer.UnitTest.Rules"
+    $oldToken = "    }" # For files using old namespaces
+    $newToken = "}"     # For files using file scoped namespaces
 
     $text = Get-Content -Path "${ruleTestsFolder}\\${csClassName}Test.cs" -Raw
     $methodVB = Get-Content -Path "${RuleTemplateFolder}\\TestMethod.VB.cs" -Raw
@@ -249,6 +250,7 @@ function AppendVbTestCase($ruleTestsFolder) {
         $text = $text.Remove($usingTokenIdx, $usingToken.Length + 1)
     }
 
+    $token = if ($text.Contains("${namespaceToken};")) {$newToken} else {$oldToken}
     $idx = $text.LastIndexOf($token)
     if ($idx -gt -1) {
         $text = $text.Insert($idx, "`n${methodVB}")


### PR DESCRIPTION
Cleanup after #5590 

Changes:
* Removed `DiagnosticDescriptorBuilder.GetDescriptor` - will be deleted
* Using file scope namespaces
* `SonarDiagnosticAnalyzer<TSyntaxKind>` base class to lower boiler plate noise