### PR TITLE
Remove need for explicit WithNotConfigurable call

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/DescriptorFactory.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/DescriptorFactory.cs
@@ -28,6 +28,6 @@ namespace SonarAnalyzer
     {
         public static DiagnosticDescriptor Create(string id, string messageFormat, bool? isEnabledByDefault = null, bool fadeOutCode = false) =>
             // RuleCatalog class is created from SonarAnalyzer.SourceGenerator
-            DiagnosticDescriptorBuilder.Create(AnalyzerLanguage.CSharp, RuleCatalog.Rules[id], messageFormat, isEnabledByDefault, fadeOutCode);
+            DiagnosticDescriptorFactory.Create(AnalyzerLanguage.CSharp, RuleCatalog.Rules[id], messageFormat, isEnabledByDefault, fadeOutCode);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
@@ -46,8 +46,8 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string TelnetKey = "telnet";
         private const string EnableSslName = "EnableSsl";
 
-        private static readonly DiagnosticDescriptor DefaultRule = DescriptorFactory.Create(DiagnosticId, MessageFormat).WithNotConfigurable();
-        private static readonly DiagnosticDescriptor EnableSslRule = DescriptorFactory.Create(DiagnosticId, EnableSslMessage).WithNotConfigurable();
+        private static readonly DiagnosticDescriptor DefaultRule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
+        private static readonly DiagnosticDescriptor EnableSslRule = DescriptorFactory.Create(DiagnosticId, EnableSslMessage);
 
         private readonly Dictionary<string, string> recommendedProtocols = new Dictionary<string, string>
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Make sure disabling CSRF protection is safe here.";
         private const SyntaxKind ImplicitObjectCreationExpression = (SyntaxKind)8659;
 
-        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat).WithNotConfigurable();
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotUseRandom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotUseRandom.cs
@@ -31,27 +31,18 @@ namespace SonarAnalyzer.Rules.CSharp
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class DoNotUseRandom : HotspotDiagnosticAnalyzer
     {
-        internal const string DiagnosticId = "S2245";
+        private const string DiagnosticId = "S2245";
         private const string MessageFormat = "Make sure that using this pseudorandom number generator is safe here.";
 
-        private static readonly DiagnosticDescriptor rule =
-            DescriptorFactory.Create(DiagnosticId, MessageFormat)
-                .WithNotConfigurable();
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
-        public DoNotUseRandom()
-            : base(AnalyzerConfiguration.Hotspot)
-        {
-        }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-        public DoNotUseRandom(IAnalyzerConfiguration analyzerConfiguration)
-            : base(analyzerConfiguration)
-        {
-        }
+        public DoNotUseRandom() : base(AnalyzerConfiguration.Hotspot) { }
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
+        public DoNotUseRandom(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration) { }
 
-        protected override void Initialize(SonarAnalysisContext context)
-        {
+        protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterCompilationStartAction(
                 ccc =>
                 {
@@ -64,18 +55,16 @@ namespace SonarAnalyzer.Rules.CSharp
                         c =>
                         {
                             var objectCreationSyntax = (ObjectCreationExpressionSyntax)c.Node;
-
                             var argumentsCount = objectCreationSyntax.ArgumentList?.Arguments.Count;
 
-                            if (argumentsCount <= 1 && // Random has two ctors - with zero and one parameter
-                                c.SemanticModel.GetSymbolInfo(objectCreationSyntax).Symbol is IMethodSymbol methodSymbol &&
-                                methodSymbol.ContainingType.Is(KnownType.System_Random))
+                            if (argumentsCount <= 1 // Random has two ctors - with zero and one parameter
+                                && c.SemanticModel.GetSymbolInfo(objectCreationSyntax).Symbol is IMethodSymbol methodSymbol
+                                && methodSymbol.ContainingType.Is(KnownType.System_Random))
                             {
-                                c.ReportIssue(Diagnostic.Create(rule, objectCreationSyntax.GetLocation()));
+                                c.ReportIssue(Diagnostic.Create(Rule, objectCreationSyntax.GetLocation()));
                             }
                         },
                         SyntaxKind.ObjectCreationExpression);
                 });
-        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/InsecureDeserialization.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/InsecureDeserialization.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S5766";
         private const string MessageFormat = "Make sure not performing data validation after deserialization is safe here.";
 
-        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat).WithNotConfigurable();
+        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.Common/Common/RuleDescriptor.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/RuleDescriptor.cs
@@ -34,5 +34,7 @@ namespace SonarAnalyzer.Common
                 "SECURITY_HOTSPOT" => "Security Hotspot",
                 _ => throw new UnexpectedValueException(nameof(Type), Type)
             };
+
+        public bool IsHotspot => Type == "SECURITY_HOTSPOT";
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/DiagnosticDescriptorFactory.cs
+++ b/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/DiagnosticDescriptorFactory.cs
@@ -26,7 +26,7 @@ using SonarAnalyzer.Common;
 
 namespace SonarAnalyzer.Helpers
 {
-    public static class DiagnosticDescriptorBuilder
+    public static class DiagnosticDescriptorFactory
     {
         public static readonly string SonarWayTag = "SonarWay";
         public static readonly string UtilityTag = "Utility";

--- a/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/DiagnosticDescriptorFactory.cs
+++ b/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/DiagnosticDescriptorFactory.cs
@@ -48,38 +48,27 @@ namespace SonarAnalyzer.Helpers
                 messageFormat,
                 rule.Category,
                 fadeOutCode ? DiagnosticSeverity.Info : DiagnosticSeverity.Warning,
-                isEnabledByDefault ?? rule.SonarWay,
+                rule.IsHotspot || (isEnabledByDefault ?? rule.SonarWay),
                 rule.Description,
                 language.HelpLink(rule.Id),
-                BuildTags(language.LanguageName, rule.SonarWay, rule.Scope, fadeOutCode));
+                BuildTags(language, rule, fadeOutCode));
 
-        /// <summary>
-        /// Indicates that the Roslyn diagnostic cannot be suppressed, filtered or have its severity changed.
-        /// </summary>
-        public static DiagnosticDescriptor WithNotConfigurable(this DiagnosticDescriptor dd) =>
-            new(dd.Id,
-                dd.Title,
-                dd.MessageFormat,
-                dd.Category,
-                dd.DefaultSeverity,
-                true,
-                dd.Description,
-                dd.HelpLinkUri,
-                dd.CustomTags.Union(new[] { WellKnownDiagnosticTags.NotConfigurable }).ToArray());
-
-        private static string[] BuildTags(string languageName, bool sonarWay, SourceScope scope, bool fadeOutCode)
+        private static string[] BuildTags(AnalyzerLanguage language, RuleDescriptor rule, bool fadeOutCode)
         {
-            var tags = new List<string> { languageName };
-            tags.AddRange(scope.ToTags());
-            if (sonarWay)
-            {
-                tags.Add(SonarWayTag);
-            }
-            if (fadeOutCode)
-            {
-                tags.Add(WellKnownDiagnosticTags.Unnecessary);
-            }
+            var tags = new List<string> { language.LanguageName };
+            tags.AddRange(rule.Scope.ToTags());
+            Add(rule.SonarWay, SonarWayTag);
+            Add(fadeOutCode, WellKnownDiagnosticTags.Unnecessary);
+            Add(rule.IsHotspot, WellKnownDiagnosticTags.NotConfigurable);
             return tags.ToArray();
+
+            void Add(bool condition, string tag)
+            {
+                if (condition)
+                {
+                    tags.Add(tag);
+                }
+            }
         }
 
         private static IEnumerable<string> ToTags(this SourceScope sourceScope) =>
@@ -91,15 +80,12 @@ namespace SonarAnalyzer.Helpers
                 _ => throw new NotSupportedException($"{sourceScope} is not supported 'SourceScope' value."),
             };
 
-        private static string[] BuildUtilityTags()
-        {
-            return SourceScope.All.ToTags().Concat(new[] { UtilityTag })
+        private static string[] BuildUtilityTags() =>
+            SourceScope.All.ToTags().Concat(new[] { UtilityTag })
 #if !DEBUG
-                // Allow to configure the analyzers in debug mode only.
-                // This allows to run test selectively (for example to test only one rule)
+                // Allow to configure the analyzers in debug mode only. This allows to run test selectively (for example to test only one rule)
                 .Union(new[] { WellKnownDiagnosticTags.NotConfigurable })
 #endif
                 .ToArray();
-        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/DiagnosticDescriptorFactory.cs
+++ b/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/DiagnosticDescriptorFactory.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly string MainSourceScopeTag = "MainSourceScope";
         public static readonly string TestSourceScopeTag = "TestSourceScope";
 
-        public static DiagnosticDescriptor GetUtilityDescriptor(string diagnosticId, string title) =>
+        public static DiagnosticDescriptor CreateUtility(string diagnosticId, string title) =>
             new(diagnosticId,
                 title,
                 string.Empty,

--- a/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/TrackerHotspotDiagnosticAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/TrackerHotspotDiagnosticAnalyzer.cs
@@ -34,14 +34,8 @@ namespace SonarAnalyzer.Helpers
 
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        protected TrackerHotspotDiagnosticAnalyzer(IAnalyzerConfiguration configuration, string diagnosticId, string messageFormat) : base(configuration)
-        {
+        protected TrackerHotspotDiagnosticAnalyzer(IAnalyzerConfiguration configuration, string diagnosticId, string messageFormat) : base(configuration) =>
             Rule = Language.CreateDescriptor(diagnosticId, messageFormat);
-            if (configuration == AnalyzerConfiguration.Hotspot)
-            {
-                Rule = Rule.WithNotConfigurable();
-            }
-        }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             Initialize(new TrackerInput(context, Configuration, Rule));

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/SonarAnalysisContext.cs
@@ -28,7 +28,7 @@ using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
-using static SonarAnalyzer.Helpers.DiagnosticDescriptorBuilder;
+using static SonarAnalyzer.Helpers.DiagnosticDescriptorFactory;
 
 namespace SonarAnalyzer.Helpers
 {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DisablingRequestValidationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DisablingRequestValidationBase.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected DisablingRequestValidationBase(IAnalyzerConfiguration configuration) : base(configuration) =>
-            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat).WithNotConfigurable();
+            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
 
         protected override void Initialize(SonarAnalysisContext context)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.Rules
         protected DoNotHardcodeCredentialsBase(IAnalyzerConfiguration configuration)
         {
             this.configuration = configuration;
-            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat).WithNotConfigurable();
+            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
             CredentialWords = DefaultCredentialWords;   // Property will initialize multiple state variables
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/HardcodedIpAddressBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/HardcodedIpAddressBase.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected HardcodedIpAddressBase(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration) =>
-            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat).WithNotConfigurable();
+            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, CheckForHardcodedIpAddresses, SyntaxKind);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/LooseFilePermissionsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/LooseFilePermissionsBase.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules
         protected abstract void VisitInvocations(SyntaxNodeAnalysisContext context);
 
         protected LooseFilePermissionsBase(IAnalyzerConfiguration configuration) : base(configuration) =>
-            Rule = Language.CreateDescriptor(DiagnosticId, MessageFormat).WithNotConfigurable();
+            Rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterCompilationStartAction(c =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.Rules
 
         protected PubliclyWritableDirectoriesBase(IAnalyzerConfiguration configuration) : base(configuration)
         {
-            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat).WithNotConfigurable();
+            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
             linuxDirectories = new Regex($@"^({linuxDirs.JoinStr("|", x => Regex.Escape(x))})(\/|$)", RegexOptions.Compiled);
             macDirectories = new Regex($@"^({macDirs.JoinStr("|", x => Regex.Escape(x))})(\/|$)", WindowsAndUnixOptions);
             environmentVariables = new Regex($@"^%({InsecureEnvironmentVariables.JoinStr("|")})%([\\\/]|$)", WindowsAndUnixOptions);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
@@ -66,8 +66,8 @@ namespace SonarAnalyzer.Rules
 
         protected RequestsWithExcessiveLengthBase(IAnalyzerConfiguration analyzerConfiguration)
         {
-            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat).WithNotConfigurable();
             this.analyzerConfiguration = analyzerConfiguration;
+            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
         }
 
         protected override void Initialize(ParameterLoadingAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/UsingNonstandardCryptographyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/UsingNonstandardCryptographyBase.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected UsingNonstandardCryptographyBase(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration) =>
-            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat).WithNotConfigurable();
+            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, c =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules
         protected override bool EnableConcurrentExecution => false;
 
         protected UtilityAnalyzerBase(string diagnosticId, string title) =>
-            rule = DiagnosticDescriptorBuilder.GetUtilityDescriptor(diagnosticId, title);
+            rule = DiagnosticDescriptorFactory.GetUtilityDescriptor(diagnosticId, title);
 
         internal static TextRange GetTextRange(FileLinePositionSpan lineSpan) =>
             new TextRange

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules
         protected override bool EnableConcurrentExecution => false;
 
         protected UtilityAnalyzerBase(string diagnosticId, string title) =>
-            rule = DiagnosticDescriptorFactory.GetUtilityDescriptor(diagnosticId, title);
+            rule = DiagnosticDescriptorFactory.CreateUtility(diagnosticId, title);
 
         internal static TextRange GetTextRange(FileLinePositionSpan lineSpan) =>
             new TextRange

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/DescriptorFactory.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/DescriptorFactory.cs
@@ -28,6 +28,6 @@ namespace SonarAnalyzer
     {
         public static DiagnosticDescriptor Create(string id, string messageFormat, bool? isEnabledByDefault = null, bool fadeOutCode = false) =>
             // RuleCatalog class is created from SonarAnalyzer.SourceGenerator
-            DiagnosticDescriptorBuilder.Create(AnalyzerLanguage.VisualBasic, RuleCatalog.Rules[id], messageFormat, isEnabledByDefault, fadeOutCode);
+            DiagnosticDescriptorFactory.Create(AnalyzerLanguage.VisualBasic, RuleCatalog.Rules[id], messageFormat, isEnabledByDefault, fadeOutCode);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
@@ -207,7 +207,7 @@ namespace SonarAnalyzer.UnitTest.Common
                 if (IsSecurityHotspot(diagnostic))
                 {
                     // Security hotspots are enabled by default, but they will report issues only when their ID is contained in SonarLint.xml
-                    // Rule activation is done in DiagnosticDescriptorBuilder.WithNotConfigurable() to prevent rule supression and deactivation.
+                    // DiagnosticDescriptorFactory adds WellKnownDiagnosticTags.NotConfigurable to prevent rule supression and deactivation.
                     diagnostic.IsEnabledByDefault.Should().BeTrue($"{diagnostic.Id} should be enabled by default");
                 }
                 else if (IsDeprecated(diagnostic))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
@@ -335,7 +335,7 @@ namespace SonarAnalyzer.UnitTest.Common
         [DiagnosticAnalyzer(LanguageNames.CSharp)]
         private class ConcurrentExecutionReader : SonarDiagnosticAnalyzer
         {
-            private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorFactory.GetUtilityDescriptor("S9999", "Rule test");
+            private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorFactory.CreateUtility("S9999", "Rule test");
 
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
             public new bool? IsConcurrentExecutionEnabled { get; private set; }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
@@ -154,7 +154,7 @@ namespace SonarAnalyzer.UnitTest.Common
             {
                 if (descriptor.IsEnabledByDefault)
                 {
-                    descriptor.CustomTags.Should().Contain(DiagnosticDescriptorBuilder.SonarWayTag, $"{descriptor.Id} should be in SonarWay");
+                    descriptor.CustomTags.Should().Contain(DiagnosticDescriptorFactory.SonarWayTag, $"{descriptor.Id} should be in SonarWay");
                 }
             }
         }
@@ -181,7 +181,7 @@ namespace SonarAnalyzer.UnitTest.Common
         {
             foreach (var diagnostic in RuleFinder.RuleAnalyzerTypes.SelectMany(SupportedDiagnostics))
             {
-                diagnostic.CustomTags.Should().NotContain(DiagnosticDescriptorBuilder.UtilityTag);
+                diagnostic.CustomTags.Should().NotContain(DiagnosticDescriptorFactory.UtilityTag);
             }
         }
 
@@ -190,7 +190,7 @@ namespace SonarAnalyzer.UnitTest.Common
         {
             foreach (var diagnostic in RuleFinder.UtilityAnalyzerTypes.SelectMany(SupportedDiagnostics))
             {
-                diagnostic.CustomTags.Should().Contain(DiagnosticDescriptorBuilder.UtilityTag);
+                diagnostic.CustomTags.Should().Contain(DiagnosticDescriptorFactory.UtilityTag);
             }
         }
 
@@ -297,7 +297,7 @@ namespace SonarAnalyzer.UnitTest.Common
             ((DiagnosticAnalyzer)Activator.CreateInstance(type)).SupportedDiagnostics;
 
         private static bool IsSonarWay(DiagnosticDescriptor diagnostic) =>
-            diagnostic.CustomTags.Contains(DiagnosticDescriptorBuilder.SonarWayTag);
+            diagnostic.CustomTags.Contains(DiagnosticDescriptorFactory.SonarWayTag);
 
         private static bool IsDeprecated(DiagnosticDescriptor diagnostic)
         {
@@ -335,7 +335,7 @@ namespace SonarAnalyzer.UnitTest.Common
         [DiagnosticAnalyzer(LanguageNames.CSharp)]
         private class ConcurrentExecutionReader : SonarDiagnosticAnalyzer
         {
-            private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorBuilder.GetUtilityDescriptor("S9999", "Rule test");
+            private static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorFactory.GetUtilityDescriptor("S9999", "Rule test");
 
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
             public new bool? IsConcurrentExecutionEnabled { get; private set; }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticDescriptorFactoryTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticDescriptorFactoryTest.cs
@@ -23,12 +23,12 @@ using SonarAnalyzer.Common;
 namespace SonarAnalyzer.UnitTest.Helpers
 {
     [TestClass]
-    public class DiagnosticDescriptorBuilderTest
+    public class DiagnosticDescriptorFactoryTest
     {
         [TestMethod]
         public void GetUtilityDescriptor_Should_Contain_NotConfigurable_CustomTag()
         {
-            var result = DiagnosticDescriptorBuilder.GetUtilityDescriptor("Foo", "");
+            var result = DiagnosticDescriptorFactory.GetUtilityDescriptor("Foo", "");
 #if DEBUG
             result.CustomTags.Should().NotContain(WellKnownDiagnosticTags.NotConfigurable);
 #else
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
         [TestMethod]
         public void Create_ConfiguresProperties_CS()
         {
-            var result = DiagnosticDescriptorBuilder.Create(AnalyzerLanguage.CSharp, CreateRuleDescriptor(SourceScope.Main, true), "Sxxxx Message", null, false);
+            var result = DiagnosticDescriptorFactory.Create(AnalyzerLanguage.CSharp, CreateRuleDescriptor(SourceScope.Main, true), "Sxxxx Message", null, false);
 
             result.Id.Should().Be("Sxxxx");
             result.Title.ToString().Should().Be("Sxxxx Title");
@@ -49,13 +49,13 @@ namespace SonarAnalyzer.UnitTest.Helpers
             result.IsEnabledByDefault.Should().BeTrue();
             result.Description.ToString().Should().Be("Sxxxx Description");
             result.HelpLinkUri.Should().Be("https://rules.sonarsource.com/csharp/RSPEC-xxxx");
-            result.CustomTags.Should().OnlyContain(LanguageNames.CSharp, DiagnosticDescriptorBuilder.MainSourceScopeTag, DiagnosticDescriptorBuilder.SonarWayTag);
+            result.CustomTags.Should().OnlyContain(LanguageNames.CSharp, DiagnosticDescriptorFactory.MainSourceScopeTag, DiagnosticDescriptorFactory.SonarWayTag);
         }
 
         [TestMethod]
         public void Create_ConfiguresProperties_VB()
         {
-            var result = DiagnosticDescriptorBuilder.Create(AnalyzerLanguage.VisualBasic, CreateRuleDescriptor(SourceScope.Main, true), "Sxxxx Message", null, false);
+            var result = DiagnosticDescriptorFactory.Create(AnalyzerLanguage.VisualBasic, CreateRuleDescriptor(SourceScope.Main, true), "Sxxxx Message", null, false);
 
             result.Id.Should().Be("Sxxxx");
             result.Title.ToString().Should().Be("Sxxxx Title");
@@ -65,13 +65,13 @@ namespace SonarAnalyzer.UnitTest.Helpers
             result.IsEnabledByDefault.Should().BeTrue();
             result.Description.ToString().Should().Be("Sxxxx Description");
             result.HelpLinkUri.Should().Be("https://rules.sonarsource.com/vbnet/RSPEC-xxxx");
-            result.CustomTags.Should().OnlyContain(LanguageNames.VisualBasic, DiagnosticDescriptorBuilder.MainSourceScopeTag, DiagnosticDescriptorBuilder.SonarWayTag);
+            result.CustomTags.Should().OnlyContain(LanguageNames.VisualBasic, DiagnosticDescriptorFactory.MainSourceScopeTag, DiagnosticDescriptorFactory.SonarWayTag);
         }
 
         [TestMethod]
         public void Create_FadeOutCode_HasUnnecessaryTag_HasInfoSeverity()
         {
-            var result = DiagnosticDescriptorBuilder.Create(AnalyzerLanguage.CSharp, CreateRuleDescriptor(SourceScope.Main, true), "Sxxxx Message", null, true);
+            var result = DiagnosticDescriptorFactory.Create(AnalyzerLanguage.CSharp, CreateRuleDescriptor(SourceScope.Main, true), "Sxxxx Message", null, true);
 
             result.DefaultSeverity.Should().Be(DiagnosticSeverity.Info);
             result.CustomTags.Should().Contain(WellKnownDiagnosticTags.Unnecessary);
@@ -80,29 +80,29 @@ namespace SonarAnalyzer.UnitTest.Helpers
         [TestMethod]
         public void Create_HasCorrectSonarWayTag()
         {
-            CreateTags(true).Should().Contain(DiagnosticDescriptorBuilder.SonarWayTag);
-            CreateTags(false).Should().NotContain(DiagnosticDescriptorBuilder.SonarWayTag);
+            CreateTags(true).Should().Contain(DiagnosticDescriptorFactory.SonarWayTag);
+            CreateTags(false).Should().NotContain(DiagnosticDescriptorFactory.SonarWayTag);
 
             static IEnumerable<string> CreateTags(bool sonarWay) =>
-                DiagnosticDescriptorBuilder.Create(AnalyzerLanguage.CSharp, CreateRuleDescriptor(SourceScope.Main, sonarWay), "Sxxxx Message", null, false).CustomTags;
+                DiagnosticDescriptorFactory.Create(AnalyzerLanguage.CSharp, CreateRuleDescriptor(SourceScope.Main, sonarWay), "Sxxxx Message", null, false).CustomTags;
         }
 
         [TestMethod]
         public void Create_HasCorrectScopeTags()
         {
-            CreateTags(SourceScope.Main).Should().Contain(DiagnosticDescriptorBuilder.MainSourceScopeTag).And.NotContain(DiagnosticDescriptorBuilder.TestSourceScopeTag);
-            CreateTags(SourceScope.Tests).Should().Contain(DiagnosticDescriptorBuilder.TestSourceScopeTag).And.NotContain(DiagnosticDescriptorBuilder.MainSourceScopeTag);
-            CreateTags(SourceScope.All).Should().Contain(DiagnosticDescriptorBuilder.MainSourceScopeTag, DiagnosticDescriptorBuilder.TestSourceScopeTag);
+            CreateTags(SourceScope.Main).Should().Contain(DiagnosticDescriptorFactory.MainSourceScopeTag).And.NotContain(DiagnosticDescriptorFactory.TestSourceScopeTag);
+            CreateTags(SourceScope.Tests).Should().Contain(DiagnosticDescriptorFactory.TestSourceScopeTag).And.NotContain(DiagnosticDescriptorFactory.MainSourceScopeTag);
+            CreateTags(SourceScope.All).Should().Contain(DiagnosticDescriptorFactory.MainSourceScopeTag, DiagnosticDescriptorFactory.TestSourceScopeTag);
 
             static IEnumerable<string> CreateTags(SourceScope scope) =>
-                DiagnosticDescriptorBuilder.Create(AnalyzerLanguage.CSharp, CreateRuleDescriptor(scope, true), "Sxxxx Message", null, false).CustomTags;
+                DiagnosticDescriptorFactory.Create(AnalyzerLanguage.CSharp, CreateRuleDescriptor(scope, true), "Sxxxx Message", null, false).CustomTags;
         }
 
         [TestMethod]
         public void Create_UnexpectedType_Throws()
         {
             var rule = new RuleDescriptor("Sxxxx", string.Empty, "Lorem Ipsum", string.Empty, string.Empty, SourceScope.Main, true, string.Empty);
-            var f = () => DiagnosticDescriptorBuilder.Create(AnalyzerLanguage.CSharp, rule, string.Empty, null, false);
+            var f = () => DiagnosticDescriptorFactory.Create(AnalyzerLanguage.CSharp, rule, string.Empty, null, false);
             f.Should().Throw<UnexpectedValueException>().WithMessage("Unexpected Type value: Lorem Ipsum");
         }
 
@@ -118,7 +118,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
         public void Create_ComputesCategory(string severity, string type, string expected)
         {
             var rule = new RuleDescriptor("Sxxxx", string.Empty, type, severity, string.Empty, SourceScope.Main, true, string.Empty);
-            DiagnosticDescriptorBuilder.Create(AnalyzerLanguage.CSharp, rule, "Sxxxx Message", null, false).Category.Should().Be(expected);
+            DiagnosticDescriptorFactory.Create(AnalyzerLanguage.CSharp, rule, "Sxxxx Message", null, false).Category.Should().Be(expected);
         }
 
         private static RuleDescriptor CreateRuleDescriptor(SourceScope scope, bool sonarWay) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticDescriptorFactoryTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticDescriptorFactoryTest.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
         [TestMethod]
         public void GetUtilityDescriptor_Should_Contain_NotConfigurable_CustomTag()
         {
-            var result = DiagnosticDescriptorFactory.GetUtilityDescriptor("Foo", "");
+            var result = DiagnosticDescriptorFactory.CreateUtility("Foo", "");
 #if DEBUG
             result.CustomTags.Should().NotContain(WellKnownDiagnosticTags.NotConfigurable);
 #else

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticDescriptorFactoryTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticDescriptorFactoryTest.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
         [TestMethod]
         public void GetUtilityDescriptor_Should_Contain_NotConfigurable_CustomTag()
         {
-            var result = DiagnosticDescriptorFactory.CreateUtility("Foo", "");
+            var result = DiagnosticDescriptorFactory.CreateUtility("Sxxx", "Title");
 #if DEBUG
             result.CustomTags.Should().NotContain(WellKnownDiagnosticTags.NotConfigurable);
 #else

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/SonarAnalysisContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/SonarAnalysisContextTest.cs
@@ -126,7 +126,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
             var sonarProjectConfig = TestHelper.CreateSonarProjectConfig(nameof(WhenProjectType_IsTest_RunRulesWithTestScope_SonarLint), ProjectType.Test, false);
             foreach (var testCase in testCases)
             {
-                var hasTestScope = testCase.Analyzer.SupportedDiagnostics.Any(d => d.CustomTags.Contains(DiagnosticDescriptorBuilder.TestSourceScopeTag));
+                var hasTestScope = testCase.Analyzer.SupportedDiagnostics.Any(d => d.CustomTags.Contains(DiagnosticDescriptorFactory.TestSourceScopeTag));
                 if (hasTestScope)
                 {
                     testCase.Verifier
@@ -151,7 +151,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
             var sonarProjectConfig = TestHelper.CreateSonarProjectConfig(nameof(WhenProjectType_IsTest_RunRulesWithTestScope_Scanner), ProjectType.Test);
             foreach (var testCase in testCases)
             {
-                var hasProductScope = testCase.Analyzer.SupportedDiagnostics.Any(d => d.CustomTags.Contains(DiagnosticDescriptorBuilder.MainSourceScopeTag));
+                var hasProductScope = testCase.Analyzer.SupportedDiagnostics.Any(d => d.CustomTags.Contains(DiagnosticDescriptorFactory.MainSourceScopeTag));
                 if (hasProductScope)
                 {
                     // MAIN-only and MAIN & TEST rules
@@ -176,7 +176,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
             var sonarProjectConfig = TestHelper.CreateSonarProjectConfig(nameof(WhenProjectType_IsTest_RunRulesWithMainScope), ProjectType.Product);
             foreach (var testCase in testCases)
             {
-                var hasProductScope = testCase.Analyzer.SupportedDiagnostics.Any(d => d.CustomTags.Contains(DiagnosticDescriptorBuilder.MainSourceScopeTag));
+                var hasProductScope = testCase.Analyzer.SupportedDiagnostics.Any(d => d.CustomTags.Contains(DiagnosticDescriptorFactory.MainSourceScopeTag));
                 if (hasProductScope)
                 {
                     testCase.Verifier

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionRunnerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionRunnerTest.cs
@@ -314,7 +314,7 @@ End Sub");
         string s = null;   // Noncompliant {{Message for SMain}} - this should be raised only once
     }
 }";
-            var another = TestHelper.CreateDescriptor("SAnother", DiagnosticDescriptorBuilder.MainSourceScopeTag);
+            var another = TestHelper.CreateDescriptor("SAnother", DiagnosticDescriptorFactory.MainSourceScopeTag);
             var sut = new ConfigurableSERunnerCS();
             sut.RegisterRule<MainScopeAssignmentRuleCheck>(MainScopeAssignmentRuleCheck.SMain);
             sut.RegisterRule<MainScopeAssignmentRuleCheck>(another);     // Register the same RuleCheck with another ID
@@ -349,7 +349,7 @@ End Sub");
         public void Analyze_Severity_DoesNotExecutesWhenNone() =>
             Verify(@"string s = null;   // Compliant, SMain and SAll are suppressed by test framework, because only 'SAnother' is active
                      s.ToString();      // Compliant, should not raise S2259",
-                TestHelper.CreateDescriptor("SAnother", DiagnosticDescriptorBuilder.MainSourceScopeTag));
+                TestHelper.CreateDescriptor("SAnother", DiagnosticDescriptorFactory.MainSourceScopeTag));
 
         [TestMethod]
         public void Analyze_ShouldExecute_ExcludesCheckFromExecution()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/AssignmentRuleCheck.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/AssignmentRuleCheck.cs
@@ -40,28 +40,28 @@ namespace SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution
 
     internal class MainScopeAssignmentRuleCheck : AssignmentRuleCheck
     {
-        public static readonly DiagnosticDescriptor SMain = TestHelper.CreateDescriptor("SMain", DiagnosticDescriptorBuilder.MainSourceScopeTag);
+        public static readonly DiagnosticDescriptor SMain = TestHelper.CreateDescriptor("SMain", DiagnosticDescriptorFactory.MainSourceScopeTag);
 
         protected override DiagnosticDescriptor Rule => SMain;
     }
 
     internal class TestScopeAssignmentRuleCheck : AssignmentRuleCheck
     {
-        public static readonly DiagnosticDescriptor STest = TestHelper.CreateDescriptor("STest", DiagnosticDescriptorBuilder.TestSourceScopeTag);
+        public static readonly DiagnosticDescriptor STest = TestHelper.CreateDescriptor("STest", DiagnosticDescriptorFactory.TestSourceScopeTag);
 
         protected override DiagnosticDescriptor Rule => STest;
     }
 
     internal class AllScopeAssignmentRuleCheck : AssignmentRuleCheck
     {
-        public static readonly DiagnosticDescriptor SAll = TestHelper.CreateDescriptor("SAll", DiagnosticDescriptorBuilder.MainSourceScopeTag, DiagnosticDescriptorBuilder.TestSourceScopeTag);
+        public static readonly DiagnosticDescriptor SAll = TestHelper.CreateDescriptor("SAll", DiagnosticDescriptorFactory.MainSourceScopeTag, DiagnosticDescriptorFactory.TestSourceScopeTag);
 
         protected override DiagnosticDescriptor Rule => SAll;
     }
 
     internal class InvocationAssignmentRuleCheck : AssignmentRuleCheck
     {
-        public static readonly DiagnosticDescriptor SInvocation = TestHelper.CreateDescriptor("SInvocation", DiagnosticDescriptorBuilder.MainSourceScopeTag);
+        public static readonly DiagnosticDescriptor SInvocation = TestHelper.CreateDescriptor("SInvocation", DiagnosticDescriptorFactory.MainSourceScopeTag);
 
         protected override DiagnosticDescriptor Rule => SInvocation;
 
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution
 
     internal class ThrowAssignmentRuleCheck : AssignmentRuleCheck
     {
-        public static readonly DiagnosticDescriptor SThrow = TestHelper.CreateDescriptor("SThrow", DiagnosticDescriptorBuilder.MainSourceScopeTag);
+        public static readonly DiagnosticDescriptor SThrow = TestHelper.CreateDescriptor("SThrow", DiagnosticDescriptorFactory.MainSourceScopeTag);
 
         protected override DiagnosticDescriptor Rule => SThrow;
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/BinaryRuleCheck.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/BinaryRuleCheck.cs
@@ -24,7 +24,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution
 {
     internal class BinaryRuleCheck : SymbolicRuleCheck
     {
-        public static readonly DiagnosticDescriptor SBinary = TestHelper.CreateDescriptor("SBinary", DiagnosticDescriptorBuilder.MainSourceScopeTag);
+        public static readonly DiagnosticDescriptor SBinary = TestHelper.CreateDescriptor("SBinary", DiagnosticDescriptorFactory.MainSourceScopeTag);
 
         protected override DiagnosticDescriptor Rule => SBinary;
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/OldVerifierTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/OldVerifierTest.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
         private class TestDuplicateLocationRule : SonarDiagnosticAnalyzer
         {
             public const string DiagnosticId = "Test42";
-            private readonly DiagnosticDescriptor rule = TestHelper.CreateDescriptor(DiagnosticId, DiagnosticDescriptorBuilder.MainSourceScopeTag);
+            private readonly DiagnosticDescriptor rule = TestHelper.CreateDescriptor(DiagnosticId, DiagnosticDescriptorFactory.MainSourceScopeTag);
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
             protected override void Initialize(SonarAnalysisContext context)


### PR DESCRIPTION
Cleanup after #5590 

Explicit `WithNotConfugrable` declaration was redundant in the code base. Rule type can be read from rspec.