### PR TITLE
S2259 Copy test files for Roslyn CFG

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp10.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Text;
+
+public class Sample
+{
+    private string field;
+
+    public void Examples()
+    {
+        StringBuilder sb;
+
+        (sb, int a) = (null, 42);
+        sb.ToString(); // FN
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp6.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp6.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Tests.Diagnostics
+{
+    public class A { }
+
+    class NullPointerDereferenceWithFieldsCSharp6 : A
+    {
+        private object _foo1;
+
+        void ConditionalThisFieldAccess()
+        {
+            object o = null;
+            this._foo1 = o;
+            this?._foo1.ToString(); // Noncompliant
+        }
+
+        string TryCatch3()
+        {
+            object o = null;
+            try
+            {
+                o = new object();
+            }
+            catch (Exception e) when (e.Message != null)
+            {
+                o = new object();
+            }
+            return o.ToString(); // If e.Message is null, the exception won't be caught and this is not reachable
+        }
+
+        // https://github.com/SonarSource/sonar-dotnet/issues/1324
+        public void FlasePositive(object o)
+        {
+            try
+            {
+                var a = o?.ToString();
+            }
+            catch (InvalidOperationException) when (o != null)
+            {
+                var b = o.ToString(); // Compliant, o is checked for null in this branch
+            }
+            catch (ApplicationException) when (o == null)
+            {
+                var b = o.ToString(); // Noncompliant
+            }
+        }
+
+        public void TryCatch4(object o)
+        {
+            o = null;
+            try
+            {
+                var a = o?.ToString();
+            }
+            catch (Exception e) when (e.Message != null)
+            {
+                var b = o.ToString(); // Noncompliant, o could be null here
+            }
+        }
+
+    public void Compliant(List<int> list)
+    {
+      var row = list?.Count;
+      if (row != null)
+      {
+        var type = list.ToArray();
+      }
+    }
+
+    public class A
+    {
+      public bool booleanVal { get; set; }
+    }
+
+    public void Compliant1(List<int> list, A a)
+    {
+      var row = list?.Count;
+      if (a.booleanVal = (row != null))
+      {
+        var type = list.ToArray();
+      }
+    }
+
+    public void NonCompliant(List<int> list)
+    {
+      var row = list?.Count;
+      if (row == null)
+      {
+        var type = list.ToArray(); // Noncompliant
+      }
+    }
+
+    public void NonCompliant1(List<int> list, A a)
+    {
+      var row = list?.Count;
+      if (a.booleanVal = (row == null))
+      {
+        var type = list.ToArray(); // Noncompliant
+      }
+    }
+
+    void Compliant2(object o)
+    {
+      switch (o?.GetHashCode())
+      {
+        case 1:
+          o.ToString();
+          break;
+        default:
+          break;
+      }
+    }
+
+    void NonCompliant2()
+    {
+      object o = null;
+      switch (o?.GetHashCode())
+      {
+        case null:
+          o.ToString(); // Noncompliant
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  public class ReproForIssue2338
+  {
+    public ConsoleColor Color { get; set; }
+
+    public void Method1(ReproForIssue2338 obj)
+    {
+      switch (obj?.Color)
+      {
+        case null:
+          Console.ForegroundColor = obj.Color; // Noncompliant
+          break;
+        case ConsoleColor.Red:
+          Console.ForegroundColor = obj.Color; //compliant
+          break;
+        default:
+          Console.WriteLine($"Color {obj.Color} is not supported."); //compliant
+          break;
+      }
+    }
+
+    public void Method2(ReproForIssue2338 obj)
+    {
+      obj = null;
+      switch (obj?.Color)
+      {
+        case ConsoleColor.Red:
+          Console.ForegroundColor = obj.Color; //compliant
+          break;
+        default:
+          Console.WriteLine($"Color {obj.Color} is not supported."); // Noncompliant
+          break;
+      }
+    }
+  }
+
+    public class ReproFor2593
+    {
+        public int id;
+        public string name;
+
+        public void Repro(ReproFor2593 obj)
+        {
+            obj = null;
+            var objId = obj?.id;
+            if (objId.HasValue)
+            {
+                var objName = obj.name; // Ok
+            }
+        }
+    }
+
+
+    public enum MyEnum
+    {
+        ONE,
+        TWO,
+        THREE,
+        FOUR,
+        FIVE
+    }
+
+    public class ValueHolder
+    {
+        public string Value { get; }
+        public MyEnum MyEnum { get; }
+    }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/3416
+    public class ReproCommunityIssue3416
+    {
+        public int Compare(ValueHolder left, ValueHolder right)
+        {
+            string leftName = left?.Value;
+            string rightName = right?.Value;
+
+            if (string.Equals(leftName, rightName))
+                // this will return if both are NULL or if they have equal non-null values
+                return 0;
+
+            // at this point, leftName can be NULL if rightName is not NULL
+            if (leftName == null)
+            {
+                // rightName is not null
+                if (rightName.EndsWith("foo")) // Noncompliant FP
+                    return 1;
+                return 0;
+            }
+
+            return 0;
+        }
+
+        public string Foo(ValueHolder valueHolder)
+        {
+            switch (valueHolder?.MyEnum)
+            {
+                case MyEnum.ONE:
+                    return valueHolder.Value;
+                case MyEnum.TWO:
+                case MyEnum.THREE:
+                    return valueHolder.Value;
+                case MyEnum.FOUR:
+                    return valueHolder.Value;
+                case MyEnum.FIVE:
+                case null:
+                    return valueHolder.Value; // Noncompliant Ok
+                default:
+                    return string.Empty;
+            }
+        }
+    }
+
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp6.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp6.cs
@@ -13,7 +13,7 @@ namespace Tests.Diagnostics
         {
             object o = null;
             this._foo1 = o;
-            this?._foo1.ToString(); // Noncompliant
+            this?._foo1.ToString(); // FIXME Non-compliant
         }
 
         string TryCatch3()
@@ -43,7 +43,7 @@ namespace Tests.Diagnostics
             }
             catch (ApplicationException) when (o == null)
             {
-                var b = o.ToString(); // Noncompliant
+                var b = o.ToString(); // FIXME Non-compliant
             }
         }
 
@@ -56,7 +56,7 @@ namespace Tests.Diagnostics
             }
             catch (Exception e) when (e.Message != null)
             {
-                var b = o.ToString(); // Noncompliant, o could be null here
+                var b = o.ToString(); // FIXME Non-compliant, o could be null here
             }
         }
 
@@ -88,7 +88,7 @@ namespace Tests.Diagnostics
       var row = list?.Count;
       if (row == null)
       {
-        var type = list.ToArray(); // Noncompliant
+        var type = list.ToArray(); // FIXME Non-compliant
       }
     }
 
@@ -97,7 +97,7 @@ namespace Tests.Diagnostics
       var row = list?.Count;
       if (a.booleanVal = (row == null))
       {
-        var type = list.ToArray(); // Noncompliant
+        var type = list.ToArray(); // FIXME Non-compliant
       }
     }
 
@@ -119,7 +119,7 @@ namespace Tests.Diagnostics
       switch (o?.GetHashCode())
       {
         case null:
-          o.ToString(); // Noncompliant
+          o.ToString(); // FIXME Non-compliant
           break;
         default:
           break;
@@ -136,7 +136,7 @@ namespace Tests.Diagnostics
       switch (obj?.Color)
       {
         case null:
-          Console.ForegroundColor = obj.Color; // Noncompliant
+          Console.ForegroundColor = obj.Color; // FIXME Non-compliant
           break;
         case ConsoleColor.Red:
           Console.ForegroundColor = obj.Color; //compliant
@@ -156,7 +156,7 @@ namespace Tests.Diagnostics
           Console.ForegroundColor = obj.Color; //compliant
           break;
         default:
-          Console.WriteLine($"Color {obj.Color} is not supported."); // Noncompliant
+          Console.WriteLine($"Color {obj.Color} is not supported."); // FIXME Non-compliant
           break;
       }
     }
@@ -210,7 +210,7 @@ namespace Tests.Diagnostics
             if (leftName == null)
             {
                 // rightName is not null
-                if (rightName.EndsWith("foo")) // Noncompliant FP
+                if (rightName.EndsWith("foo")) // FIXME Non-compliant FP
                     return 1;
                 return 0;
             }
@@ -231,7 +231,7 @@ namespace Tests.Diagnostics
                     return valueHolder.Value;
                 case MyEnum.FIVE:
                 case null:
-                    return valueHolder.Value; // Noncompliant Ok
+                    return valueHolder.Value; // FIXME Non-compliant Ok
                 default:
                     return string.Empty;
             }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp7.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp7.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections;
+
+namespace Tests.Diagnostics
+{
+    class Foo
+    {
+        private string field;
+
+        string Method(string s) =>
+            s != null
+            ? null
+            : s.ToLower(); // Noncompliant
+
+        string Prop =>
+            field != null
+            ? null
+            : field.ToLower(); // Noncompliant
+
+        string PropGet
+        {
+            get =>
+                field != null
+                ? null
+                : field.ToLower(); // Noncompliant
+        }
+
+        void ConstantPattern(object o)
+        {
+            if (o is null)
+            {
+                o.ToString(); // Noncompliant
+            }
+            else
+            {
+                o.ToString(); // Compliant
+            }
+        }
+
+        void VariableDesignationPattern_Variable(object o)
+        {
+            if (o is string s)
+            {
+                if (s == null)
+                {
+                    // This is unreachable, s has NotNull constraint from the outer if condition
+                    s.ToString(); // Compliant
+                }
+
+                // s still has NotNull constraint from the outer if statement
+                s.ToString(); // Compliant
+            }
+        }
+
+        void VariableDesignationPattern_Source(object o)
+        {
+            // We can set NotNull constraint only for one of the variables in the if condition
+            // and we choose the declared variable because it is more likely to have usages of
+            // it inside the statement body.
+            if (o is string s)
+            {
+                if (o == null)
+                {
+                    o.ToString(); // Noncompliant, False Positive
+                }
+            }
+        }
+
+        void VariableDesignationPattern_Discard(object o)
+        {
+            if (o is string _) // Ensure that the discard does not throw exception when processed
+            {
+                if (o == null)
+                {
+                    o.ToString(); // Noncompliant, False Positive
+                }
+            }
+        }
+
+        void Patterns_In_Loops(object o, object[] items, int length)
+        {
+            while (o is string s)
+            {
+                if (s == null)
+                {
+                    // This is unreachable, s has NotNull constraint from the while condition
+                    s.ToString(); // Compliant
+                }
+            }
+
+            do
+            {
+                // The condition is evaluated after the first execution, so we cannot test s
+            }
+            while (o is string s);
+
+            for (int i = 0; i < length && items[i] is string s; i++)
+            {
+                if (s == null)
+                {
+                    // This is unreachable, s has NotNull constraint from the for condition
+                    s.ToString();
+                }
+            }
+        }
+
+        void Patterns_In_Loops_With_Discard(object o, object[] items)
+        {
+            // The following should not throw exceptions
+            while (o is string _) { }
+
+            do { } while (o is string _);
+
+            for (int i = 0; i < items.Length && items[i] is string _; i++) { }
+        }
+
+        void Switch_Pattern_Source(object o)
+        {
+            switch (o)
+            {
+                case string s:
+                    // We don't set constraints on the switch expression
+                    if (o == null)
+                    {
+                        o.ToString(); // Noncompliant, False Positive
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        void Switch_Pattern(object o)
+        {
+            switch (o)
+            {
+                case string s:
+                    if (s == null)
+                    {
+                        // This is unreachable, s has NotNull constraint from the outer if condition
+                        s.ToString(); // Compliant
+                    }
+                    // s still has NotNull constraint from the outer if statement
+                    s.ToString(); // Compliant
+                    break;
+
+                case Foo f when f == null:
+                    if (f == null)
+                    {
+                        f.ToString(); // Compliant, this code is not reachable
+                    }
+                    break;
+
+                case int _: // The discard is redundant, but still allowed
+                    o.ToString();
+                    break;
+
+                case null:
+                    o.ToString(); // Noncompliant
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        void Compliant1()
+        {
+            Exception exception = null;
+            if (exception?.Data is IDictionary data)
+            {
+                if (exception?.InnerException?.Data is IDictionary innerexceptiondata)
+                {
+
+                }
+            }
+        }
+
+        void NonCompliant1()
+        {
+            Exception exception = null;
+            if (exception.Data is IDictionary data) // Noncompliant
+            {
+                if (exception.InnerException?.Data is IDictionary innerexceptiondata)
+                {
+
+                }
+            }
+        }
+
+        void Repro_2361(Exception exception)
+        {
+            if (exception?.Data is IDictionary data)
+            {
+                if (exception.InnerException?.Data is IDictionary innerexceptiondata)
+                {
+
+                }
+            }
+        }
+
+        void Null_Conditional_Is_Null(Exception exception)
+        {
+            if (exception?.Data is null)
+            {
+                if (exception.InnerException?.Data is IDictionary innerexceptiondata) // Noncompliant
+                {
+
+                }
+            }
+        }
+
+    public void Method1(object obj)
+    {
+      switch (obj)
+      {
+        case string s1:
+          break;
+        default:
+          return;
+      }
+      var s = obj.ToString();
+    }
+
+    public void Method2(object obj)
+    {
+      switch (obj)
+      {
+        case null:
+          break;
+        default:
+          return;
+      }
+      var s1 = obj.ToString(); // Noncompliant
+    }
+
+    public void Method3(object obj)
+    {
+      obj = null;
+      switch (obj)
+      {
+        case string s1:
+          return;
+        default:
+          break;
+      }
+      var s = obj.ToString(); // Noncompliant
+    }
+
+    public void Method4(object obj)
+    {
+      obj = null;
+      switch (obj)
+      {
+        case null:
+          return;
+        default:
+          break;
+      }
+      var s = obj.ToString();
+    }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/2528
+    public int Repro_2528(Dictionary<string, string> dict)
+    {
+        if ((dict?.Count ?? 0) == 0)
+        {
+            return -1;
+        }
+
+        return dict.Count; // Noncompliant FP
+    }
+  }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp7.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp7.cs
@@ -11,26 +11,26 @@ namespace Tests.Diagnostics
         string Method(string s) =>
             s != null
             ? null
-            : s.ToLower(); // Noncompliant
+            : s.ToLower(); // FIXME Non-compliant
 
         string Prop =>
             field != null
             ? null
-            : field.ToLower(); // Noncompliant
+            : field.ToLower(); // FIXME Non-compliant
 
         string PropGet
         {
             get =>
                 field != null
                 ? null
-                : field.ToLower(); // Noncompliant
+                : field.ToLower(); // FIXME Non-compliant
         }
 
         void ConstantPattern(object o)
         {
             if (o is null)
             {
-                o.ToString(); // Noncompliant
+                o.ToString(); // FIXME Non-compliant
             }
             else
             {
@@ -62,7 +62,7 @@ namespace Tests.Diagnostics
             {
                 if (o == null)
                 {
-                    o.ToString(); // Noncompliant, False Positive
+                    o.ToString(); // FIXME Non-compliant, False Positive
                 }
             }
         }
@@ -73,7 +73,7 @@ namespace Tests.Diagnostics
             {
                 if (o == null)
                 {
-                    o.ToString(); // Noncompliant, False Positive
+                    o.ToString(); // FIXME Non-compliant, False Positive
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace Tests.Diagnostics
                     // We don't set constraints on the switch expression
                     if (o == null)
                     {
-                        o.ToString(); // Noncompliant, False Positive
+                        o.ToString(); // FIXME Non-compliant, False Positive
                     }
                     break;
 
@@ -158,7 +158,7 @@ namespace Tests.Diagnostics
                     break;
 
                 case null:
-                    o.ToString(); // Noncompliant
+                    o.ToString(); // FIXME Non-compliant
                     break;
 
                 default:
@@ -181,7 +181,7 @@ namespace Tests.Diagnostics
         void NonCompliant1()
         {
             Exception exception = null;
-            if (exception.Data is IDictionary data) // Noncompliant
+            if (exception.Data is IDictionary data) // FIXME Non-compliant
             {
                 if (exception.InnerException?.Data is IDictionary innerexceptiondata)
                 {
@@ -205,7 +205,7 @@ namespace Tests.Diagnostics
         {
             if (exception?.Data is null)
             {
-                if (exception.InnerException?.Data is IDictionary innerexceptiondata) // Noncompliant
+                if (exception.InnerException?.Data is IDictionary innerexceptiondata) // FIXME Non-compliant
                 {
 
                 }
@@ -233,7 +233,7 @@ namespace Tests.Diagnostics
         default:
           return;
       }
-      var s1 = obj.ToString(); // Noncompliant
+      var s1 = obj.ToString(); // FIXME Non-compliant
     }
 
     public void Method3(object obj)
@@ -246,7 +246,7 @@ namespace Tests.Diagnostics
         default:
           break;
       }
-      var s = obj.ToString(); // Noncompliant
+      var s = obj.ToString(); // FIXME Non-compliant
     }
 
     public void Method4(object obj)
@@ -270,7 +270,7 @@ namespace Tests.Diagnostics
             return -1;
         }
 
-        return dict.Count; // Noncompliant FP
+        return dict.Count; // FIXME Non-compliant FP
     }
   }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp8.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections;
+
+namespace Tests.Diagnostics.CSharp8
+{
+    public class NullCoalescenceAssignment
+    {
+        public void NullCoalescenceOperator_Null()
+        {
+            string name = null;
+            name = name ?? "Laxmi";
+            name.ToString();
+        }
+
+        public void NullCoalescenceOperator_Null_Noncompliant1()
+        {
+            string name = null;
+            name = name ?? null;
+            name.ToString(); // Noncompliant {{'name' is null on at least one execution path.}}
+        }
+
+        public void NullCoalescenceOperator_Null_Noncompliant2()
+        {
+            string name = null;
+            name = name ?? name.ToString(); // Noncompliant
+        }
+
+        public void NullCoalescenceAssignment_Null()
+        {
+            string name = null;
+            name ??= name.ToString(); // Noncompliant
+        }
+
+        public void NullCoalescenceAssignment_NotNull_Noncompliant()
+        {
+            string name1 = null;
+            string name2 = null;
+            name1 ??= name2.ToString(); // Noncompliant {{'name2' is null on at least one execution path.}}
+        }
+
+        public void NullCoalescenceAssignment_NotNull()
+        {
+            string name1 = "";
+            string name2 = null;
+            name1 ??= name2.ToString(); //  Ok - name1 is not null
+        }
+    }
+
+    public class NullablePrimitiveType
+    {
+        public void NullablePrimitiveType_FN()
+        {
+            int? i1 = null;
+            i1 = i1 ?? i1.GetHashCode(); // FN - nullable primitive type not supported
+        }
+    }
+
+    public class SwitchExpressions
+    {
+        public void Nullable_In_Arm_Noncompliant(string s)
+        {
+            var result = s switch
+            {
+                null => s.ToString(), // Noncompliant
+                _ => s.ToString()
+            };
+        }
+
+        public void AlwaysNull_Noncompliant(int val)
+        {
+            string result = val switch
+            {
+                1 => null,
+                2 => null,
+                _ => null
+            };
+            result.ToString(); // Noncompliant
+        }
+
+        public void MaybeNull_Noncompliant(int val)
+        {
+            string result = val switch
+            {
+                1 => "1",
+                2 => "Not 1",
+                _ => null
+            };
+            result.ToString(); // Noncompliant
+        }
+
+        public void AlwaysNonNull(int val)
+        {
+            string result = val switch
+            {
+                1 => "1",
+                2 => "2",
+                _ => "Neither 1 or 2"
+            };
+            result.ToString();
+        }
+
+        public void Nullable_In_Arm(string s)
+        {
+            var result = s switch
+            {
+                var x when x != null => s.ToString(),
+                _ => s.ToString() // FN Switch expressions are not constrained (See #2949)
+            };
+        }
+    }
+
+    public class DefaultLiteral
+    {
+        void NoncompliantDefaultLiteral()
+        {
+            object obj = default;
+            obj.ToString(); // Noncompliant
+        }
+
+        void CompliantDefaultLiteral()
+        {
+            int i = default;
+            i.ToString();
+        }
+    }
+
+    public interface IWithDefaultMembers
+    {
+        string NoncompliantDefaultInterfaceMethod(string obj) =>
+            obj != null ? null : obj.ToLower(); // Noncompliant
+
+        string CompliantDefaultInterfaceMethod(string obj) =>
+            obj == null ? null : obj.ToLower();
+    }
+
+    public class LocalStaticFunctions
+    {
+        public void Method()
+        {
+            string LocalFunction(string obj) =>
+                obj != null ? null : obj.ToLower(); //  Compliant - FN: local functions are not supported by the CFG
+
+            static string LocalStaticFunction(string obj) =>
+                obj != null ? null : obj.ToLower(); //  Compliant - FN: local functions are not supported by the CFG
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp8.cs
@@ -17,26 +17,26 @@ namespace Tests.Diagnostics.CSharp8
         {
             string name = null;
             name = name ?? null;
-            name.ToString(); // Noncompliant {{'name' is null on at least one execution path.}}
+            name.ToString(); // FIXME Non-compliant {{'name' is null on at least one execution path.}}
         }
 
         public void NullCoalescenceOperator_Null_Noncompliant2()
         {
             string name = null;
-            name = name ?? name.ToString(); // Noncompliant
+            name = name ?? name.ToString(); // FIXME Non-compliant
         }
 
         public void NullCoalescenceAssignment_Null()
         {
             string name = null;
-            name ??= name.ToString(); // Noncompliant
+            name ??= name.ToString(); // FIXME Non-compliant
         }
 
         public void NullCoalescenceAssignment_NotNull_Noncompliant()
         {
             string name1 = null;
             string name2 = null;
-            name1 ??= name2.ToString(); // Noncompliant {{'name2' is null on at least one execution path.}}
+            name1 ??= name2.ToString(); // FIXME Non-compliant {{'name2' is null on at least one execution path.}}
         }
 
         public void NullCoalescenceAssignment_NotNull()
@@ -62,7 +62,7 @@ namespace Tests.Diagnostics.CSharp8
         {
             var result = s switch
             {
-                null => s.ToString(), // Noncompliant
+                null => s.ToString(), // FIXME Non-compliant
                 _ => s.ToString()
             };
         }
@@ -75,7 +75,7 @@ namespace Tests.Diagnostics.CSharp8
                 2 => null,
                 _ => null
             };
-            result.ToString(); // Noncompliant
+            result.ToString(); // FIXME Non-compliant
         }
 
         public void MaybeNull_Noncompliant(int val)
@@ -86,7 +86,7 @@ namespace Tests.Diagnostics.CSharp8
                 2 => "Not 1",
                 _ => null
             };
-            result.ToString(); // Noncompliant
+            result.ToString(); // FIXME Non-compliant
         }
 
         public void AlwaysNonNull(int val)
@@ -115,7 +115,7 @@ namespace Tests.Diagnostics.CSharp8
         void NoncompliantDefaultLiteral()
         {
             object obj = default;
-            obj.ToString(); // Noncompliant
+            obj.ToString(); // FIXME Non-compliant
         }
 
         void CompliantDefaultLiteral()
@@ -128,7 +128,7 @@ namespace Tests.Diagnostics.CSharp8
     public interface IWithDefaultMembers
     {
         string NoncompliantDefaultInterfaceMethod(string obj) =>
-            obj != null ? null : obj.ToLower(); // Noncompliant
+            obj != null ? null : obj.ToLower(); // FIXME Non-compliant
 
         string CompliantDefaultInterfaceMethod(string obj) =>
             obj == null ? null : obj.ToLower();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp9.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Text;
+
+object topLevel = "Value";
+topLevel.ToString();
+
+topLevel = null;
+topLevel.ToString();   // FN
+
+void TopLevelLocalFunction()
+{
+    object local = "Value";
+    local.ToString();
+
+    local = null;
+    local.ToString();   // FN
+}
+
+public class Sample
+{
+    private string field;
+
+    public void TargetTypedNew()
+    {
+        StringBuilder sb;
+
+        sb = new();
+        sb.Append("Value");
+
+        sb = new(42);
+        sb.Append("Value");
+
+        sb = null;
+        sb.ToString(); // FN, can't build CFG for this method
+    }
+
+    public void PatternMatching(object arg)
+    {
+        if (arg is string)
+        {
+            arg.ToString();     // Compliant
+        }
+
+        if (arg is int and > 0 and > 1)
+        {
+            arg.ToString();     // Compliant
+        }
+
+        if (arg is int or bool or long)
+        {
+            arg.ToString();     // Compliant
+        }
+
+        if (arg is null)
+        {
+            arg.ToString();     // FN
+        }
+        if (arg is int or bool or null)
+        {
+            arg.ToString();     // FN
+        }
+        else if (arg is not not null)
+        {
+            arg.ToString();     // FN
+        }
+        else if (!(arg is not null))
+        {
+            arg.ToString();     // FN
+        }
+        else
+        {
+            object o = null;
+            if (o is not null)
+            {
+                o.ToString();
+            }
+            o.ToString();       // FN, can't build CFG for this method
+        }
+    }
+
+    public void PatternMatchingSwitch(object arg)
+    {
+        var res = arg switch
+        {
+            not null => arg,
+            _ => ""
+        };
+        res.ToString();
+
+        res = arg switch
+        {
+            string and not null => arg,
+            _ => ""
+        };
+        res.ToString();
+
+        res = arg switch
+        {
+            string x => x,
+            not not null => arg,
+            _ => ""
+        };
+        res.ToString();     // FN
+
+        object o = null;
+        o.ToString();       // FN, can't build CFG for this method
+    }
+
+    public void StaticLambda()
+    {
+        Func<string> a = static () =>
+        {
+            object o = null;
+            return o.ToString();    // Noncompliant
+        };
+        a();
+    }
+
+    public int PropertySimple
+    {
+        get => 42;
+        init
+        {
+            object o = null;
+            field = o.ToString();   // Noncompliant
+        }
+    }
+
+    public object PropertyWithValue
+    {
+        get => null;
+        init
+        {
+            if (value == null)
+            {
+                field = value.ToString();   // Noncompliant
+            }
+        }
+    }
+}
+
+public record Record
+{
+    public void Method()
+    {
+        object o = null;
+        o.ToString();   // Noncompliant
+    }
+}
+
+public partial class Partial
+{
+    public partial void Method();
+}
+
+public partial class Partial
+{
+    public partial void Method()
+    {
+        object o = null;
+        o.ToString();   // Noncompliant
+    }
+}
+
+namespace TartetTypedConditional
+{
+    public interface IAlpha { }
+    public interface IBeta { }
+    public class AlphaAndBeta : IAlpha, IBeta { }
+    public class BetaAndAlpha : IAlpha, IBeta { }
+
+    public class Sample
+    {
+        public void Go(bool condition)
+        {
+            AlphaAndBeta ab = new AlphaAndBeta();
+            BetaAndAlpha ba = null;
+            IAlpha result = condition ? ab : ba;
+            result.ToString();  // Noncompliant
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp9.cs
@@ -111,7 +111,7 @@ public class Sample
         Func<string> a = static () =>
         {
             object o = null;
-            return o.ToString();    // Noncompliant
+            return o.ToString();    // FIXME Non-compliant
         };
         a();
     }
@@ -122,7 +122,7 @@ public class Sample
         init
         {
             object o = null;
-            field = o.ToString();   // Noncompliant
+            field = o.ToString();   // FIXME Non-compliant
         }
     }
 
@@ -133,7 +133,7 @@ public class Sample
         {
             if (value == null)
             {
-                field = value.ToString();   // Noncompliant
+                field = value.ToString();   // FIXME Non-compliant
             }
         }
     }
@@ -144,7 +144,7 @@ public record Record
     public void Method()
     {
         object o = null;
-        o.ToString();   // Noncompliant
+        o.ToString();   // FIXME Non-compliant
     }
 }
 
@@ -158,7 +158,7 @@ public partial class Partial
     public partial void Method()
     {
         object o = null;
-        o.ToString();   // Noncompliant
+        o.ToString();   // FIXME Non-compliant
     }
 }
 
@@ -176,7 +176,7 @@ namespace TartetTypedConditional
             AlphaAndBeta ab = new AlphaAndBeta();
             BetaAndAlpha ba = null;
             IAlpha result = condition ? ab : ba;
-            result.ToString();  // Noncompliant
+            result.ToString();  // FIXME Non-compliant
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -27,7 +27,7 @@ namespace Tests.Diagnostics
             if (condition)
             {
                 M1(o.ToString()); // FIXME Non-compliant {{'o' is null on at least one execution path.}}
-//                 ^
+//                 * FIXME
             }
             else
             {
@@ -367,7 +367,7 @@ namespace Tests.Diagnostics
         void DoLearnFromConstants()
         {
             NullConst.ToString(); // FIXME Non-compliant
-//          ^^^^^^^^^
+//          ********* FIXME
         }
 
         void DoLearnFromAnyConstant1()
@@ -396,42 +396,42 @@ namespace Tests.Diagnostics
             object o = null;
             _foo1 = o;
             _foo1.ToString(); // FIXME Non-compliant
-//          ^^^^^
+//          ***** FIXME
         }
         void DumbestTestOnFoo2()
         {
             object o = null;
             _foo2 = o;
             _foo2.ToString(); // FIXME Non-compliant
-//          ^^^^^
+//          ***** FIXME
         }
         void DumbestTestOnFoo3()
         {
             object o = null;
             _foo3 = o;
             _foo3.ToString(); // FIXME Non-compliant
-//          ^^^^^
+//          ***** FIXME
         }
         void DumbestTestOnFoo4()
         {
             object o = null;
             _foo4 = o;
             _foo4.ToString(); // FIXME Non-compliant
-//          ^^^^^
+//          ***** FIXME
         }
         void DumbestTestOnFoo5()
         {
             object o = null;
             _foo5 = o;
             _foo5.ToString(); // FIXME Non-compliant
-//          ^^^^^
+//          ***** FIXME
         }
         void DumbestTestOnFoo8()
         {
             object o = null;
             _foo8 = o;
             _foo8.ToString(); // FIXME Non-compliant
-//          ^^^^^
+//          ***** FIXME
         }
         void DumbestTestOnFoo6()
         {
@@ -501,7 +501,7 @@ namespace Tests.Diagnostics
             _foo1 = null;
             var o = _foo1;
             o.ToString(); // FIXME Non-compliant
-//          ^
+//          * FIXME
         }
 
         void LearntConstraintsOnField()
@@ -509,7 +509,7 @@ namespace Tests.Diagnostics
             if (_foo1 == null)
             {
                 _foo1.ToString(); // FIXME Non-compliant
-//              ^^^^^
+//              ***** FIXME
             }
         }
 
@@ -518,7 +518,7 @@ namespace Tests.Diagnostics
             if (_bar == null)
             {
                 _bar.ToString(); // FIXME Non-compliant
-//              ^^^^
+//              **** FIXME
             }
         }
 
@@ -528,7 +528,7 @@ namespace Tests.Diagnostics
             {
                 var o = _foo1;
                 o.ToString(); // FIXME Non-compliant
-//              ^
+//              * FIXME
             }
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -1,0 +1,1070 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using X = global::Tests.Diagnostics.NullPointerDereferenceWithFields;
+
+namespace Tests.Diagnostics
+{
+    class NullPointerDereference
+    {
+        void Test_0()
+        {
+            int i = 0, j = 0;
+            for (i = 0, j = 2; i < 2; i++)
+            {
+                Console.WriteLine();
+            }
+        }
+
+        public void M1(string s) { }
+        public void M2(string s) { }
+
+        void Test_1(bool condition)
+        {
+            object o = null;
+            if (condition)
+            {
+                M1(o.ToString()); // Noncompliant {{'o' is null on at least one execution path.}}
+//                 ^
+            }
+            else
+            {
+                o = new object();
+            }
+            M2(o.ToString()); // Compliant
+        }
+
+        void Test_2(bool condition)
+        {
+            object o = new object();
+            if (condition)
+            {
+                o = null;
+            }
+            else
+            {
+                o = new object();
+            }
+            M2(o.ToString()); // Noncompliant
+        }
+
+        void Test_ExtensionMethodWithNull()
+        {
+            object o = null;
+            o.MyExtension(); // Compliant
+        }
+
+        void Test_Out()
+        {
+            object o1;
+            object o2;
+            if (OutP(out o1) &&
+                OutP(out o2) &&
+                o2.ToString() != "")
+            {
+            }
+        }
+        bool OutP(out object o) { o = new object(); return true; }
+
+        void Test_Struct()
+        {
+            int? i = null;
+            if (i.HasValue) // Compliant
+            { }
+        }
+
+        void Test_Foreach()
+        {
+            IEnumerable<int> en = null;
+            foreach (var item in en) // Noncompliant
+            {
+
+            }
+        }
+
+        async System.Threading.Tasks.Task Test_Await()
+        {
+            System.Threading.Tasks.Task t = null;
+            await t; // Noncompliant
+        }
+
+        void Test_Exception()
+        {
+            Exception exc = null;
+            throw exc; // Noncompliant
+        }
+
+        void Test_Exception_Ok()
+        {
+            Exception exc = new Exception();
+            throw exc;
+        }
+
+        public NullPointerDereference()
+        {
+            object o = null;
+            Console.WriteLine(o.ToString()); // Noncompliant
+
+            var a = new Action(() =>
+            {
+                object o1 = null;
+                Console.WriteLine(o1.ToString()); // Noncompliant
+            });
+        }
+
+        public int MyProperty
+        {
+            get
+            {
+                object o1 = null;
+                Console.WriteLine(o1.ToString()); // Noncompliant
+                return 42;
+            }
+        }
+
+        object myObject = null;
+
+        void Test_ConditionEqualsNull(bool condition)
+        {
+            object o = myObject; // can be null
+            if (o == null)
+            {
+                M1(o.ToString()); // Noncompliant, always null
+            }
+            else
+            {
+                o = new object();
+            }
+            M2(o.ToString()); // Compliant
+        }
+
+        void Test_ConditionNotEqualsNull(bool condition)
+        {
+            object o = myObject; // can be null
+            if (null != o)
+            {
+                M1(o.ToString()); // Compliant
+            }
+            else
+            {
+                o = new object();
+            }
+            M2(o.ToString()); // Compliant
+        }
+
+        void Test_Foreach_Item(bool condition)
+        {
+            foreach (var item in new object[0])
+            {
+                if (item == null)
+                {
+                    Console.WriteLine(item.ToString()); // Noncompliant
+                }
+            }
+        }
+
+        void Test_Complex(bool condition)
+        {
+            var item = new object();
+            if (item != null && item.ToString() == "")
+            {
+                Console.WriteLine(item.ToString());
+            }
+        }
+
+        void Constraint()
+        {
+            object a = GetObject();
+            var b = a;
+            if (a == null)
+            {
+                var s = b.ToString(); // Noncompliant
+            }
+        }
+
+        object GetObject() => null;
+
+        void Equals(object b)
+        {
+            object a = null;
+            if (a == b)
+            {
+                b.ToString(); // Noncompliant
+            }
+            else
+            {
+                b.ToString();
+            }
+
+            a = new object();
+            if (a == b)
+            {
+                b.ToString();
+            }
+            else
+            {
+                b.ToString();
+            }
+        }
+
+        void NotEquals(object b)
+        {
+            object a = null;
+            if (a != b)
+            {
+                b.ToString();
+            }
+            else
+            {
+                b.ToString(); // Noncompliant
+            }
+
+            a = new object();
+            if (a != b)
+            {
+                b.ToString();
+            }
+            else
+            {
+                b.ToString();
+            }
+        }
+
+        void ElementAccess(int[,] arr)
+        {
+            if (arr == null)
+            {
+                Console.WriteLine(arr[10, 10]); // Noncompliant
+            }
+            else
+            {
+                Console.WriteLine(arr[10, 10]);
+            }
+        }
+
+        void NullableGetTypeCall()
+        {
+            int? i = null;
+            var v = i.HasValue;
+            var s = i.ToString();
+
+            i = 5;
+            var t = i.GetType();
+
+            i = null;
+            var t2 = i.GetType(); // Noncompliant
+        }
+
+        static void MultiplePop()
+        {
+            MyClass o = null;
+            o = new MyClass
+            {
+                MyProperty = ""
+            };
+            o.ToString(); // Compliant
+        }
+
+        class MyClass
+        {
+            public string MyProperty { get; set; }
+        }
+
+        public void Assert1(object o1)
+        {
+            System.Diagnostics.Debug.Assert(o1 != null);
+            o1.ToString(); // Compliant
+            System.Diagnostics.Debug.Assert(o1 == null);
+            o1.ToString(); // Compliant
+        }
+
+        public void Assert2(object o1)
+        {
+            System.Diagnostics.Debug.Assert(o1 == null);
+            o1.ToString(); // Compliant, we don't learn on Assert
+        }
+
+        public void StringEmpty(string s1)
+        {
+            if (string.IsNullOrEmpty(s1))
+            {
+                s1.ToString(); // Noncompliant
+            }
+            else
+            {
+                s1.ToString(); // Compliant
+            }
+        }
+
+        public void StringEmpty1(string s1)
+        {
+            if (s1 == "" || s1 == null)
+            {
+                s1.ToString(); // Noncompliant
+            }
+            else
+            {
+                s1.ToString(); // Compliant
+            }
+        }
+
+        void StringEmpty3(string path)
+        {
+            var s = path == "" ? new string[] { } : path.Split('/');
+        }
+
+        void StringEmpty4(string path)
+        {
+            var s = path == null ? new string[] { } : path.Split('/');
+        }
+
+        void StringEmpty5(string path)
+        {
+            var s = path == null ? path.Split('/') : new string[] { }; // Noncompliant
+        }
+
+        void StringEmpty6(string path)
+        {
+            var s = string.IsNullOrEmpty(path) ? path.Split('/') : new string[] { }; // Noncompliant
+        }
+
+        void StringEmpty7(string path)
+        {
+            var s = string.IsNullOrEmpty(path) ? new string[] { } : path.Split('/');
+        }
+    }
+
+    class A
+    {
+        protected object _bar;
+    }
+
+    class B
+    {
+        public const string Whatever = null;
+    }
+
+    class NullPointerDereferenceWithFields : A
+    {
+        private object _foo1;
+        protected object _foo2;
+        internal object _foo3;
+        public object _foo4;
+        protected internal object _foo5;
+        object _foo6;
+        private readonly object _foo7 = new object();
+        private static object _foo8;
+        private const object NullConst = null;
+        private readonly object NullReadOnly = null;
+
+        void DoNotLearnFromReadonly()
+        {
+            NullReadOnly.ToString(); // Compliant. TODO: SLVS-1140
+        }
+
+        void DoLearnFromConstants()
+        {
+            NullConst.ToString(); // Noncompliant
+//          ^^^^^^^^^
+        }
+
+        void DoLearnFromAnyConstant1()
+        {
+            NullConst.ToString(); // Noncompliant
+        }
+        void DoLearnFromAnyConstant2()
+        {
+            NullPointerDereferenceWithFields.NullConst.ToString(); // Noncompliant
+        }
+        void DoLearnFromAnyConstant3()
+        {
+            Tests.Diagnostics.NullPointerDereferenceWithFields.NullConst.ToString(); // Noncompliant
+        }
+        void DoLearnFromAnyConstant4()
+        {
+            X.NullConst.ToString(); // Noncompliant
+        }
+        void DoLearnFromAnyConstant5()
+        {
+            B.Whatever.ToString(); // Noncompliant
+        }
+
+        void DumbestTestOnFoo1()
+        {
+            object o = null;
+            _foo1 = o;
+            _foo1.ToString(); // Noncompliant
+//          ^^^^^
+        }
+        void DumbestTestOnFoo2()
+        {
+            object o = null;
+            _foo2 = o;
+            _foo2.ToString(); // Noncompliant
+//          ^^^^^
+        }
+        void DumbestTestOnFoo3()
+        {
+            object o = null;
+            _foo3 = o;
+            _foo3.ToString(); // Noncompliant
+//          ^^^^^
+        }
+        void DumbestTestOnFoo4()
+        {
+            object o = null;
+            _foo4 = o;
+            _foo4.ToString(); // Noncompliant
+//          ^^^^^
+        }
+        void DumbestTestOnFoo5()
+        {
+            object o = null;
+            _foo5 = o;
+            _foo5.ToString(); // Noncompliant
+//          ^^^^^
+        }
+        void DumbestTestOnFoo8()
+        {
+            object o = null;
+            _foo8 = o;
+            _foo8.ToString(); // Noncompliant
+//          ^^^^^
+        }
+        void DumbestTestOnFoo6()
+        {
+            _foo6.ToString(); // compliant
+        }
+        void DumbestTestOnFoo7()
+        {
+            _foo7.ToString(); // compliant
+        }
+
+        void DifferentFieldAccess1()
+        {
+            object o = null;
+            this._foo1 = o;
+            this._foo1.ToString(); // Noncompliant
+        }
+        void DifferentFieldAccess2()
+        {
+            this._foo1 = null;
+            _foo1.ToString(); // Noncompliant
+        }
+        void DifferentFieldAccess3()
+        {
+            _foo1 = null;
+            this._foo1.ToString(); // Noncompliant
+        }
+        void DifferentFieldAccess4()
+        {
+            _foo1 = null;
+            (((this)))._foo1.ToString(); // Noncompliant
+        }
+        void DifferentFieldAccess5()
+        {
+            _foo1 = null;
+            (((this._foo1))).ToString(); // Noncompliant
+        }
+
+        void OtherInstanceFieldAccess()
+        {
+            object o = null;
+            var other = new NullPointerDereferenceWithFields();
+            other._foo1 = o;
+            other._foo1.ToString(); // Compliant
+        }
+        void OtherInstanceFieldAccess2()
+        {
+            object o = null;
+            _foo1 = o;
+            (new NullPointerDereferenceWithFields())._foo1.ToString(); // Compliant
+        }
+
+        void ParenthesizedAccess1()
+        {
+            object o = null;
+            _foo1 = o;
+            (_foo1).ToString(); // Noncompliant
+        }
+        void ParenthesizedAccess2()
+        {
+            object o = null;
+            ((((((this)))._foo1))) = o;
+            (((_foo1))).ToString(); // Noncompliant
+        }
+
+        void VariableFromField()
+        {
+            _foo1 = null;
+            var o = _foo1;
+            o.ToString(); // Noncompliant
+//          ^
+        }
+
+        void LearntConstraintsOnField()
+        {
+            if (_foo1 == null)
+            {
+                _foo1.ToString(); // Noncompliant
+//              ^^^^^
+            }
+        }
+
+        void LearntConstraintsOnBaseField()
+        {
+            if (_bar == null)
+            {
+                _bar.ToString(); // Noncompliant
+//              ^^^^
+            }
+        }
+
+        void LearntConstraintsOnFieldAssignedToVar()
+        {
+            if (_foo1 == null)
+            {
+                var o = _foo1;
+                o.ToString(); // Noncompliant
+//              ^
+            }
+        }
+
+        void LambdaConstraint()
+        {
+            _foo1 = null;
+            var a = new Action(() =>
+            {
+                _foo1.ToString(); // Compliant
+            });
+            a();
+        }
+
+        void Assert1()
+        {
+            System.Diagnostics.Debug.Assert(_foo1 != null);
+            _foo1.ToString(); // Compliant
+            System.Diagnostics.Debug.Assert(_foo1 == null);
+            _foo1.ToString(); // Compliant
+        }
+
+        void CallToExtensionMethodsShouldNotRaise()
+        {
+            object o = null;
+            _foo1 = o;
+            _foo1.MyExtension(); // Compliant
+        }
+
+        void CallToMethodsShouldResetFieldConstraints()
+        {
+            object o = null;
+            _foo1 = o;
+            (((this))).DoSomething();
+            _foo1.ToString(); // Compliant
+        }
+
+        void CallToExtensionMethodsShouldResetFieldConstraints()
+        {
+            object o = null;
+            _foo1 = o;
+            this.MyExtension();
+            _foo1.ToString(); // Compliant
+        }
+
+        void CallToStaticMethodsShouldResetFieldConstraints()
+        {
+            object o = null;
+            _foo1 = o;
+            Console.WriteLine(); // This particular method has no side effects
+            _foo1.ToString(); // Compliant, False Negative
+            o.ToString(); // Noncompliant, local variable constraints are not cleared
+        }
+
+        // https://github.com/SonarSource/sonar-dotnet/issues/947
+        void CallToMonitorWaitShouldResetFieldConstraints()
+        {
+            object o = null;
+            _foo1 = o;
+            System.Threading.Monitor.Wait(this); // This is a multi-threaded application, the fields could change
+            _foo1.ToString(); // Compliant
+            o.ToString(); // Noncompliant, local variable constraints are not cleared
+        }
+
+        void CallToNameOfShouldNotResetFieldConstraints()
+        {
+            object o = null;
+            _foo1 = o;
+            var name = nameof(DoSomething);
+            _foo1.ToString(); // Noncompliant
+        }
+
+        void DereferenceInNameOfShouldNotRaise()
+        {
+            object o = null;
+            var name = nameof(o.ToString);
+        }
+
+        void DoSomething() { }
+
+        void TestNameOf(int a)
+        {
+            var x = nameof(a);
+            x.ToString();
+        }
+
+        string TryCatch1()
+        {
+            object o = null;
+            try
+            {
+                o = new object();
+            }
+            catch
+            {
+                o = new object();
+            }
+            return o.ToString();
+        }
+
+        string TryCatch2()
+        {
+            object o = null;
+            try
+            {
+                o = new object();
+            }
+            catch (Exception)
+            {
+                o = new object();
+            }
+            return o.ToString();
+        }
+
+        string TryCatch3()
+        {
+            object o = null;
+            try
+            {
+                o = new object();
+            }
+            catch (ApplicationException)
+            {
+                o = new object();
+            }
+            return o.ToString();
+        }
+    }
+
+    static class Extensions
+    {
+        public static void MyExtension(this object o) { }
+    }
+
+    class Foo // https://github.com/SonarSource/sonar-dotnet/issues/538
+    {
+        private string bar;
+
+        private void Invoke()
+        {
+            this.bar = null;
+            if (this.bar != null)
+                this.bar.GetHashCode();
+        }
+    }
+
+    public static class GuardedTests
+    {
+        public static void Guarded(string s1)
+        {
+            Guard1(s1);
+
+            if (s1 == null) s1.ToUpper(); // Compliant, this code is unreachable
+        }
+
+        public static void Guard1<T>([ValidatedNotNull]T value) where T : class { }
+
+        // https://github.com/SonarSource/sonar-dotnet/issues/3850
+        public static void UsedAsExtension()
+        {
+            object a = null;
+            if (a.IsNotNull())
+            {
+                a.ToString();
+            }
+        }
+
+        public static void UsedAsMethod()
+        {
+            object a = null;
+            if (IsNotNull(a))
+            {
+                a.ToString();   // Compliant
+            }
+        }
+
+        public static bool IsNotNull([ValidatedNotNull] this object item) => item != null;
+
+        [AttributeUsage(AttributeTargets.Parameter)]
+        public sealed class ValidatedNotNullAttribute : Attribute { }
+    }
+
+    class AsyncAwait
+    {
+        string x;
+        async Task Foo(Task t)
+        {
+            string s = null;
+            x = s;
+            await t; // awaiting clears the constraints
+            x.ToString(); // Compliant
+            s.ToString(); // Noncompliant
+        }
+    }
+
+    class TestLoopWithBreak
+    {
+        public static void LoopWithBreak(IEnumerable<string> list)
+        {
+            foreach (string x in list)
+            {
+                try
+                {
+                    if (x == null)
+                    {
+                        x.ToString(); // Noncompliant
+                    }
+                    break;
+                }
+                catch (Exception)
+                {
+                    continue;
+                }
+            }
+        }
+
+        public static IEnumerable<string> LoopWithYieldBreak(IEnumerable<string> list)
+        {
+            foreach (string x in list)
+            {
+                try
+                {
+                    if (x == null)
+                    {
+                        yield return x.ToString(); // Noncompliant
+                    }
+                    yield break;
+                }
+                finally
+                {
+                    // do stuff
+                }
+            }
+        }
+
+    }
+
+    // see https://github.com/SonarSource/sonar-dotnet/issues/890
+    class TestForLoop
+    {
+        string Foo()
+        {
+            string s = null;
+            for (int i = 0; i < 10; i++)
+            {
+                s = "";
+            }
+            return s.Trim(); // Noncompliant FP due to loop traversal
+        }
+    }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/3156
+    class ForEachCollection
+    {
+        string DoSomething(IEnumerable<object> list, object current)
+        {
+            if (current == null)
+            {
+                //SE creates both constrains for 'current'
+            }
+            foreach(var item in list)
+            {
+                if (item == current)
+                {
+                    return item.ToString(); // Noncompliant FP, null constraint is inherited from 'current == null' check
+                }
+                else if (item.ToString() == "xxx") // 'item' does not contain constraints by default, issue is not raised here anyway
+                {
+                    return item.ToString();
+                }
+            }
+            return null;
+        }
+    }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/3290
+    class Linq_OrDefault
+    {
+        // All XxxOrDefault Linq extensions should create both null and not-null constraints.
+        string DoSomething(IEnumerable<object> list)
+        {
+            var item = list.FirstOrDefault();
+            return item.ToString(); // False Negative, item could be null here
+        }
+
+        string DoSomethingArg(IEnumerable<object> list)
+        {
+            var item = list.SingleOrDefault(x => x != null);
+            return item.ToString(); // False Negative, item could be null here
+        }
+    }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/4537
+    class Repro_4537
+    {
+        private void ConditionalAccess_NullCoalescing()
+        {
+            string someString = null;
+
+            if (!someString?.Contains("a") ?? true)
+                Console.WriteLine("It's null or doesn't contain 'a'");
+            else
+                Console.WriteLine(someString.Length); // Noncompliant FP, this path is unreachable
+        }
+    }
+}
+
+// https://github.com/SonarSource/sonar-dotnet/issues/3395
+namespace Repro_3395
+{
+    public enum Helper
+    {
+        A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P
+    }
+    public static class Test
+    {
+        public static void SupportedSize()
+        {
+            var helper = Helper.A;
+            object o = null;
+            if (helper == Helper.A | helper == Helper.B | helper == Helper.C | helper == Helper.D
+                | helper == Helper.E | helper == Helper.F | helper == Helper.G | helper == Helper.H)
+            {
+                o.ToString(); // Noncompliant, this condition size is within the limit
+            }
+        }
+
+        public static void UnsupportedSize()
+        {
+            var helper = Helper.A;
+            object o = null;
+            if (helper == Helper.A | helper == Helper.B | helper == Helper.C | helper == Helper.D
+                | helper == Helper.E | helper == Helper.F | helper == Helper.G | helper == Helper.H
+                | helper == Helper.I)
+            {
+                o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
+            }
+        }
+
+        public static void OrConstraint()
+        {
+            var helper = Helper.A;
+            object o = null;
+            if (helper == Helper.A | helper == Helper.B | helper == Helper.C | helper == Helper.D
+                | helper == Helper.E | helper == Helper.F | helper == Helper.G | helper == Helper.H
+                | helper == Helper.I | helper == Helper.A | helper == Helper.B | helper == Helper.C
+                | helper == Helper.D | helper == Helper.E | helper == Helper.F | helper == Helper.G
+                | helper == Helper.H | helper == Helper.I | helper == Helper.A | helper == Helper.B
+                | helper == Helper.C | helper == Helper.D | helper == Helper.E | helper == Helper.F
+                | helper == Helper.G | helper == Helper.H | helper == Helper.I | helper == Helper.J)
+            {
+                o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
+            }
+        }
+
+        public static void AndConstraint()
+        {
+            var helper = Helper.A;
+            object o = null;
+            if (helper == Helper.A & helper == Helper.B & helper == Helper.C & helper == Helper.D
+                & helper == Helper.E & helper == Helper.F & helper == Helper.G & helper == Helper.H
+                & helper == Helper.I & helper == Helper.A & helper == Helper.B & helper == Helper.C
+                & helper == Helper.D & helper == Helper.E & helper == Helper.F & helper == Helper.G
+                & helper == Helper.H & helper == Helper.I & helper == Helper.A & helper == Helper.B
+                & helper == Helper.C & helper == Helper.D & helper == Helper.E & helper == Helper.F
+                & helper == Helper.G & helper == Helper.H & helper == Helper.I & helper == Helper.J)
+            {
+                o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
+            }
+        }
+
+        public static void XorConstraint()
+        {
+            var helper = Helper.A;
+            object o = null;
+            if (helper == Helper.A ^ helper == Helper.B ^ helper == Helper.C ^ helper == Helper.D
+                ^ helper == Helper.E ^ helper == Helper.F ^ helper == Helper.G ^ helper == Helper.H
+                ^ helper == Helper.I ^ helper == Helper.A ^ helper == Helper.B ^ helper == Helper.C
+                ^ helper == Helper.D ^ helper == Helper.E ^ helper == Helper.F ^ helper == Helper.G
+                ^ helper == Helper.H ^ helper == Helper.I ^ helper == Helper.A ^ helper == Helper.B
+                ^ helper == Helper.C ^ helper == Helper.D ^ helper == Helper.E ^ helper == Helper.F
+                ^ helper == Helper.G ^ helper == Helper.H ^ helper == Helper.I ^ helper == Helper.J)
+            {
+                o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
+            }
+        }
+
+        public static void ComparisonConstraint()
+        {
+            var helper = Helper.A;
+            object o = null;
+            if (helper > Helper.A | helper > Helper.B | helper > Helper.C | helper > Helper.D
+                | helper >= Helper.E | helper >= Helper.F | helper >= Helper.G | helper >= Helper.H
+                | helper == Helper.I | helper == Helper.A | helper == Helper.B | helper == Helper.C
+                | helper < Helper.D | helper < Helper.E | helper < Helper.F | helper < Helper.G
+                | helper >= Helper.H | helper >= Helper.I | helper >= Helper.A | helper >= Helper.B
+                | helper != Helper.C | helper != Helper.D | helper != Helper.E | helper != Helper.F
+                | helper == Helper.G | helper == Helper.H | helper == Helper.I | helper == Helper.J)
+            {
+                o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
+            }
+        }
+
+        public static void MixedConstraints()
+        {
+            var helper = Helper.A;
+            object o = null;
+            if (helper == Helper.A & helper == Helper.B ^ helper == Helper.C & helper == Helper.D
+                | helper == Helper.E & helper == Helper.F ^ helper == Helper.G & helper == Helper.H
+                | helper == Helper.I & helper == Helper.A ^ helper == Helper.B & helper == Helper.C
+                | helper == Helper.D & helper == Helper.E ^ helper == Helper.F & helper == Helper.G
+                | helper == Helper.H & helper == Helper.I ^ helper == Helper.A & helper == Helper.B
+                | helper == Helper.C & helper == Helper.D ^ helper == Helper.E & helper == Helper.F
+                | helper == Helper.G & helper == Helper.H ^ helper == Helper.I & helper == Helper.J)
+            {
+                o.ToString(); // FN, the condition state generation is too big to explore all constraint combinations
+            }
+        }
+    }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/4784
+    class Repro_4784
+    {
+        public static int Reproducer()
+        {
+            List<long> test = new[] { 1L, 2L, 3L }.ToList();
+            if (test?.Count == 0)
+            {
+                // Do something
+            }
+
+            return test.Count; // Noncompliant FP
+        }
+
+        public static int NoIssueReported()
+        {
+            var something = new Something();
+            if (something?.SomeProperty == 0)
+            {
+                // Do something
+            }
+
+            return something.SomeProperty;
+        }
+
+        public static int IssueReported()
+        {
+            var something = GetSomething();
+            if (something?.SomeProperty == 0)
+            {
+                // Do something
+            }
+
+            return something.SomeProperty; // Noncompliant
+        }
+
+        public static Something GetSomething()
+        {
+            return new Something();
+        }
+
+        public class Something
+        {
+            public int SomeProperty { get; set; }
+        }
+    }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/4989
+    class Repro_4989
+    {
+        static void Main(string[] args)
+        {
+            var providerCourses = new List<ProviderCourse>
+            {
+                new ProviderCourse
+                {
+                    Items = new List<string>
+                    {
+                        "item1",
+                        "item2"
+                    }
+                },
+                new ProviderCourse
+                {
+                    Items = new List<string>
+                    {
+                        "item1",
+                        "item2"
+                    }
+                }
+            };
+
+            foreach (var providerCourse in providerCourses)
+            {
+                if (!providerCourse?.Items?.Any() ?? true)
+                {
+                    Console.WriteLine("FAIL");
+                    continue;
+                }
+
+                var _ = providerCourse.Items.Where(items => items == "item1"); // Noncompliant FP
+            }
+        }
+
+        class ProviderCourse
+        {
+            public IEnumerable<string> Items { get; set; }
+        }
+    }
+}
+
+// https://github.com/SonarSource/sonar-dotnet/issues/5285
+public class Repro_5289
+{
+    public void A(ref string s)
+    {
+        s = "not null";
+    }
+
+    public void B(int i)
+    {
+        // empty
+    }
+
+    public void C(double[] a)
+    {
+        if (a == null)
+        {
+            B(0);
+        }
+
+        string s = null;
+        A(ref s);
+
+        if (a != null)
+        {
+            B(a.Length); // Noncompliant FP, the unrelated "A(ref s)" call breaks constraint on "a" variable
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -26,7 +26,7 @@ namespace Tests.Diagnostics
             object o = null;
             if (condition)
             {
-                M1(o.ToString()); // Noncompliant {{'o' is null on at least one execution path.}}
+                M1(o.ToString()); // FIXME Non-compliant {{'o' is null on at least one execution path.}}
 //                 ^
             }
             else
@@ -47,7 +47,7 @@ namespace Tests.Diagnostics
             {
                 o = new object();
             }
-            M2(o.ToString()); // Noncompliant
+            M2(o.ToString()); // FIXME Non-compliant
         }
 
         void Test_ExtensionMethodWithNull()
@@ -78,7 +78,7 @@ namespace Tests.Diagnostics
         void Test_Foreach()
         {
             IEnumerable<int> en = null;
-            foreach (var item in en) // Noncompliant
+            foreach (var item in en) // FIXME Non-compliant
             {
 
             }
@@ -87,13 +87,13 @@ namespace Tests.Diagnostics
         async System.Threading.Tasks.Task Test_Await()
         {
             System.Threading.Tasks.Task t = null;
-            await t; // Noncompliant
+            await t; // FIXME Non-compliant
         }
 
         void Test_Exception()
         {
             Exception exc = null;
-            throw exc; // Noncompliant
+            throw exc; // FIXME Non-compliant
         }
 
         void Test_Exception_Ok()
@@ -105,12 +105,12 @@ namespace Tests.Diagnostics
         public NullPointerDereference()
         {
             object o = null;
-            Console.WriteLine(o.ToString()); // Noncompliant
+            Console.WriteLine(o.ToString()); // FIXME Non-compliant
 
             var a = new Action(() =>
             {
                 object o1 = null;
-                Console.WriteLine(o1.ToString()); // Noncompliant
+                Console.WriteLine(o1.ToString()); // FIXME Non-compliant
             });
         }
 
@@ -119,7 +119,7 @@ namespace Tests.Diagnostics
             get
             {
                 object o1 = null;
-                Console.WriteLine(o1.ToString()); // Noncompliant
+                Console.WriteLine(o1.ToString()); // FIXME Non-compliant
                 return 42;
             }
         }
@@ -131,7 +131,7 @@ namespace Tests.Diagnostics
             object o = myObject; // can be null
             if (o == null)
             {
-                M1(o.ToString()); // Noncompliant, always null
+                M1(o.ToString()); // FIXME Non-compliant, always null
             }
             else
             {
@@ -160,7 +160,7 @@ namespace Tests.Diagnostics
             {
                 if (item == null)
                 {
-                    Console.WriteLine(item.ToString()); // Noncompliant
+                    Console.WriteLine(item.ToString()); // FIXME Non-compliant
                 }
             }
         }
@@ -180,7 +180,7 @@ namespace Tests.Diagnostics
             var b = a;
             if (a == null)
             {
-                var s = b.ToString(); // Noncompliant
+                var s = b.ToString(); // FIXME Non-compliant
             }
         }
 
@@ -191,7 +191,7 @@ namespace Tests.Diagnostics
             object a = null;
             if (a == b)
             {
-                b.ToString(); // Noncompliant
+                b.ToString(); // FIXME Non-compliant
             }
             else
             {
@@ -218,7 +218,7 @@ namespace Tests.Diagnostics
             }
             else
             {
-                b.ToString(); // Noncompliant
+                b.ToString(); // FIXME Non-compliant
             }
 
             a = new object();
@@ -236,7 +236,7 @@ namespace Tests.Diagnostics
         {
             if (arr == null)
             {
-                Console.WriteLine(arr[10, 10]); // Noncompliant
+                Console.WriteLine(arr[10, 10]); // FIXME Non-compliant
             }
             else
             {
@@ -254,7 +254,7 @@ namespace Tests.Diagnostics
             var t = i.GetType();
 
             i = null;
-            var t2 = i.GetType(); // Noncompliant
+            var t2 = i.GetType(); // FIXME Non-compliant
         }
 
         static void MultiplePop()
@@ -290,7 +290,7 @@ namespace Tests.Diagnostics
         {
             if (string.IsNullOrEmpty(s1))
             {
-                s1.ToString(); // Noncompliant
+                s1.ToString(); // FIXME Non-compliant
             }
             else
             {
@@ -302,7 +302,7 @@ namespace Tests.Diagnostics
         {
             if (s1 == "" || s1 == null)
             {
-                s1.ToString(); // Noncompliant
+                s1.ToString(); // FIXME Non-compliant
             }
             else
             {
@@ -322,12 +322,12 @@ namespace Tests.Diagnostics
 
         void StringEmpty5(string path)
         {
-            var s = path == null ? path.Split('/') : new string[] { }; // Noncompliant
+            var s = path == null ? path.Split('/') : new string[] { }; // FIXME Non-compliant
         }
 
         void StringEmpty6(string path)
         {
-            var s = string.IsNullOrEmpty(path) ? path.Split('/') : new string[] { }; // Noncompliant
+            var s = string.IsNullOrEmpty(path) ? path.Split('/') : new string[] { }; // FIXME Non-compliant
         }
 
         void StringEmpty7(string path)
@@ -366,71 +366,71 @@ namespace Tests.Diagnostics
 
         void DoLearnFromConstants()
         {
-            NullConst.ToString(); // Noncompliant
+            NullConst.ToString(); // FIXME Non-compliant
 //          ^^^^^^^^^
         }
 
         void DoLearnFromAnyConstant1()
         {
-            NullConst.ToString(); // Noncompliant
+            NullConst.ToString(); // FIXME Non-compliant
         }
         void DoLearnFromAnyConstant2()
         {
-            NullPointerDereferenceWithFields.NullConst.ToString(); // Noncompliant
+            NullPointerDereferenceWithFields.NullConst.ToString(); // FIXME Non-compliant
         }
         void DoLearnFromAnyConstant3()
         {
-            Tests.Diagnostics.NullPointerDereferenceWithFields.NullConst.ToString(); // Noncompliant
+            Tests.Diagnostics.NullPointerDereferenceWithFields.NullConst.ToString(); // FIXME Non-compliant
         }
         void DoLearnFromAnyConstant4()
         {
-            X.NullConst.ToString(); // Noncompliant
+            X.NullConst.ToString(); // FIXME Non-compliant
         }
         void DoLearnFromAnyConstant5()
         {
-            B.Whatever.ToString(); // Noncompliant
+            B.Whatever.ToString(); // FIXME Non-compliant
         }
 
         void DumbestTestOnFoo1()
         {
             object o = null;
             _foo1 = o;
-            _foo1.ToString(); // Noncompliant
+            _foo1.ToString(); // FIXME Non-compliant
 //          ^^^^^
         }
         void DumbestTestOnFoo2()
         {
             object o = null;
             _foo2 = o;
-            _foo2.ToString(); // Noncompliant
+            _foo2.ToString(); // FIXME Non-compliant
 //          ^^^^^
         }
         void DumbestTestOnFoo3()
         {
             object o = null;
             _foo3 = o;
-            _foo3.ToString(); // Noncompliant
+            _foo3.ToString(); // FIXME Non-compliant
 //          ^^^^^
         }
         void DumbestTestOnFoo4()
         {
             object o = null;
             _foo4 = o;
-            _foo4.ToString(); // Noncompliant
+            _foo4.ToString(); // FIXME Non-compliant
 //          ^^^^^
         }
         void DumbestTestOnFoo5()
         {
             object o = null;
             _foo5 = o;
-            _foo5.ToString(); // Noncompliant
+            _foo5.ToString(); // FIXME Non-compliant
 //          ^^^^^
         }
         void DumbestTestOnFoo8()
         {
             object o = null;
             _foo8 = o;
-            _foo8.ToString(); // Noncompliant
+            _foo8.ToString(); // FIXME Non-compliant
 //          ^^^^^
         }
         void DumbestTestOnFoo6()
@@ -446,27 +446,27 @@ namespace Tests.Diagnostics
         {
             object o = null;
             this._foo1 = o;
-            this._foo1.ToString(); // Noncompliant
+            this._foo1.ToString(); // FIXME Non-compliant
         }
         void DifferentFieldAccess2()
         {
             this._foo1 = null;
-            _foo1.ToString(); // Noncompliant
+            _foo1.ToString(); // FIXME Non-compliant
         }
         void DifferentFieldAccess3()
         {
             _foo1 = null;
-            this._foo1.ToString(); // Noncompliant
+            this._foo1.ToString(); // FIXME Non-compliant
         }
         void DifferentFieldAccess4()
         {
             _foo1 = null;
-            (((this)))._foo1.ToString(); // Noncompliant
+            (((this)))._foo1.ToString(); // FIXME Non-compliant
         }
         void DifferentFieldAccess5()
         {
             _foo1 = null;
-            (((this._foo1))).ToString(); // Noncompliant
+            (((this._foo1))).ToString(); // FIXME Non-compliant
         }
 
         void OtherInstanceFieldAccess()
@@ -487,20 +487,20 @@ namespace Tests.Diagnostics
         {
             object o = null;
             _foo1 = o;
-            (_foo1).ToString(); // Noncompliant
+            (_foo1).ToString(); // FIXME Non-compliant
         }
         void ParenthesizedAccess2()
         {
             object o = null;
             ((((((this)))._foo1))) = o;
-            (((_foo1))).ToString(); // Noncompliant
+            (((_foo1))).ToString(); // FIXME Non-compliant
         }
 
         void VariableFromField()
         {
             _foo1 = null;
             var o = _foo1;
-            o.ToString(); // Noncompliant
+            o.ToString(); // FIXME Non-compliant
 //          ^
         }
 
@@ -508,7 +508,7 @@ namespace Tests.Diagnostics
         {
             if (_foo1 == null)
             {
-                _foo1.ToString(); // Noncompliant
+                _foo1.ToString(); // FIXME Non-compliant
 //              ^^^^^
             }
         }
@@ -517,7 +517,7 @@ namespace Tests.Diagnostics
         {
             if (_bar == null)
             {
-                _bar.ToString(); // Noncompliant
+                _bar.ToString(); // FIXME Non-compliant
 //              ^^^^
             }
         }
@@ -527,7 +527,7 @@ namespace Tests.Diagnostics
             if (_foo1 == null)
             {
                 var o = _foo1;
-                o.ToString(); // Noncompliant
+                o.ToString(); // FIXME Non-compliant
 //              ^
             }
         }
@@ -579,7 +579,7 @@ namespace Tests.Diagnostics
             _foo1 = o;
             Console.WriteLine(); // This particular method has no side effects
             _foo1.ToString(); // Compliant, False Negative
-            o.ToString(); // Noncompliant, local variable constraints are not cleared
+            o.ToString(); // FIXME Non-compliant, local variable constraints are not cleared
         }
 
         // https://github.com/SonarSource/sonar-dotnet/issues/947
@@ -589,7 +589,7 @@ namespace Tests.Diagnostics
             _foo1 = o;
             System.Threading.Monitor.Wait(this); // This is a multi-threaded application, the fields could change
             _foo1.ToString(); // Compliant
-            o.ToString(); // Noncompliant, local variable constraints are not cleared
+            o.ToString(); // FIXME Non-compliant, local variable constraints are not cleared
         }
 
         void CallToNameOfShouldNotResetFieldConstraints()
@@ -597,7 +597,7 @@ namespace Tests.Diagnostics
             object o = null;
             _foo1 = o;
             var name = nameof(DoSomething);
-            _foo1.ToString(); // Noncompliant
+            _foo1.ToString(); // FIXME Non-compliant
         }
 
         void DereferenceInNameOfShouldNotRaise()
@@ -719,7 +719,7 @@ namespace Tests.Diagnostics
             x = s;
             await t; // awaiting clears the constraints
             x.ToString(); // Compliant
-            s.ToString(); // Noncompliant
+            s.ToString(); // FIXME Non-compliant
         }
     }
 
@@ -733,7 +733,7 @@ namespace Tests.Diagnostics
                 {
                     if (x == null)
                     {
-                        x.ToString(); // Noncompliant
+                        x.ToString(); // FIXME Non-compliant
                     }
                     break;
                 }
@@ -752,7 +752,7 @@ namespace Tests.Diagnostics
                 {
                     if (x == null)
                     {
-                        yield return x.ToString(); // Noncompliant
+                        yield return x.ToString(); // FIXME Non-compliant
                     }
                     yield break;
                 }
@@ -775,7 +775,7 @@ namespace Tests.Diagnostics
             {
                 s = "";
             }
-            return s.Trim(); // Noncompliant FP due to loop traversal
+            return s.Trim(); // FIXME Non-compliant FP due to loop traversal
         }
     }
 
@@ -792,7 +792,7 @@ namespace Tests.Diagnostics
             {
                 if (item == current)
                 {
-                    return item.ToString(); // Noncompliant FP, null constraint is inherited from 'current == null' check
+                    return item.ToString(); // FIXME Non-compliant FP, null constraint is inherited from 'current == null' check
                 }
                 else if (item.ToString() == "xxx") // 'item' does not contain constraints by default, issue is not raised here anyway
                 {
@@ -830,7 +830,7 @@ namespace Tests.Diagnostics
             if (!someString?.Contains("a") ?? true)
                 Console.WriteLine("It's null or doesn't contain 'a'");
             else
-                Console.WriteLine(someString.Length); // Noncompliant FP, this path is unreachable
+                Console.WriteLine(someString.Length); // FIXME Non-compliant FP, this path is unreachable
         }
     }
 }
@@ -851,7 +851,7 @@ namespace Repro_3395
             if (helper == Helper.A | helper == Helper.B | helper == Helper.C | helper == Helper.D
                 | helper == Helper.E | helper == Helper.F | helper == Helper.G | helper == Helper.H)
             {
-                o.ToString(); // Noncompliant, this condition size is within the limit
+                o.ToString(); // FIXME Non-compliant, this condition size is within the limit
             }
         }
 
@@ -959,7 +959,7 @@ namespace Repro_3395
                 // Do something
             }
 
-            return test.Count; // Noncompliant FP
+            return test.Count; // FIXME Non-compliant FP
         }
 
         public static int NoIssueReported()
@@ -981,7 +981,7 @@ namespace Repro_3395
                 // Do something
             }
 
-            return something.SomeProperty; // Noncompliant
+            return something.SomeProperty; // FIXME Non-compliant
         }
 
         public static Something GetSomething()
@@ -1028,7 +1028,7 @@ namespace Repro_3395
                     continue;
                 }
 
-                var _ = providerCourse.Items.Where(items => items == "item1"); // Noncompliant FP
+                var _ = providerCourse.Items.Where(items => items == "item1"); // FIXME Non-compliant FP
             }
         }
 
@@ -1064,7 +1064,7 @@ public class Repro_5289
 
         if (a != null)
         {
-            B(a.Length); // Noncompliant FP, the unrelated "A(ref s)" call breaks constraint on "a" variable
+            B(a.Length); // FIXME Non-compliant FP, the unrelated "A(ref s)" call breaks constraint on "a" variable
         }
     }
 }


### PR DESCRIPTION
The first part of #5862

This only copies the test files and prepares these for the new CFG by replacing "Noncompliant" with "FIXME". The new test files are not integrated in the test infrastructure. This follows the approach taken by the "LocksReleasedAllPaths" analyzer.

To see the replacement of "Noncompliant" with "FIXME", a commit by commit review should be done.