### PR TITLE
New rule: Async methods with yield statements should have a decorated cancelation token

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AysncYieldingMethodsShouldHaveDecoratedCancellation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AysncYieldingMethodsShouldHaveDecoratedCancellation.cs
@@ -1,0 +1,63 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.CSharp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class AsyncYieldingMethodsShouldHaveDecoratedCancellation : SonarDiagnosticAnalyzer
+{
+    private const string DiagnosticId = "S4581"; // TODO
+    private const string MessageFormat = "Provide a cancellation token that is decorated with the EnumeratorCancellation attribute.";
+
+    private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+    protected override void Initialize(SonarAnalysisContext context) =>
+        context.RegisterSyntaxNodeActionInNonGenerated(
+            c =>
+            {
+                var method = (MethodDeclarationSyntax)c.Node;
+                if (method.Modifiers.AnyOfKind(SyntaxKind.AsyncKeyword)
+                    && BodyYields(method)
+                    && c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol methodSymbol
+                    && methodSymbol.ReturnType.Is(KnownType.System_Collections_Generic_IAsyncEnumerable_T)
+                    && !HasDecoratedCancelationToken(methodSymbol))
+                {
+                    c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                }
+            },
+            SyntaxKind.MethodDeclaration);
+
+    private static bool BodyYields(MethodDeclarationSyntax method) =>
+        method.Body?.DescendantTokens().Any(x => x.IsKind(SyntaxKind.YieldKeyword)) == true;
+
+    private static bool HasDecoratedCancelationToken(IMethodSymbol method)
+        => method.Parameters.Any(x => x.IsType(KnownType.System_Threading_CancellationToken)
+        && x.HasAttribute(KnownType.System_Runtime_CompilerServices_EnumeratorCancellationAttribute));
+}

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -340,7 +340,8 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_Runtime_CompilerServices_CallerArgumentExpressionAttribute = new("System.Runtime.CompilerServices.CallerArgumentExpressionAttribute");
         internal static readonly KnownType System_Runtime_CompilerServices_CallerFilePathAttribute = new("System.Runtime.CompilerServices.CallerFilePathAttribute");
         internal static readonly KnownType System_Runtime_CompilerServices_CallerLineNumberAttribute = new("System.Runtime.CompilerServices.CallerLineNumberAttribute");
-        internal static readonly KnownType System_Runtime_CompilerServices_CallerMemberNameAttribute = new("System.Runtime.CompilerServices.CallerMemberNameAttribute");
+        internal static readonly KnownType System_Runtime_CompilerServices_CallerMemberNameAttribute = new("System.Runtime.CompilerServices.EnumeratorCancellationAttribute");
+        internal static readonly KnownType System_Runtime_CompilerServices_EnumeratorCancellationAttribute = new("System.Runtime.CompilerServices.EnumeratorCancellationAttribute");
         internal static readonly KnownType System_Runtime_CompilerServices_InternalsVisibleToAttribute = new("System.Runtime.CompilerServices.InternalsVisibleToAttribute");
         internal static readonly KnownType System_Runtime_CompilerServices_ModuleInitializerAttribute = new("System.Runtime.CompilerServices.ModuleInitializerAttribute");
         internal static readonly KnownType System_Runtime_CompilerServices_ValueTaskAwaiter = new("System.Runtime.CompilerServices.ValueTaskAwaiter");
@@ -432,6 +433,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_SystemException = new("System.SystemException");
         internal static readonly KnownType System_Text_RegularExpressions_Regex = new("System.Text.RegularExpressions.Regex");
         internal static readonly KnownType System_Text_StringBuilder = new("System.Text.StringBuilder");
+        internal static readonly KnownType System_Threading_CancellationToken = new("System.Threading.CancellationToken");
         internal static readonly KnownType System_Threading_Monitor = new("System.Threading.Monitor");
         internal static readonly KnownType System_Threading_Mutex = new("System.Threading.Mutex");
         internal static readonly KnownType System_Threading_ReaderWriterLock = new("System.Threading.ReaderWriterLock");

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AsyncYieldingMethodsShouldHaveDecoratedCancellationTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AsyncYieldingMethodsShouldHaveDecoratedCancellationTest.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.Rules.CSharp;
+
+namespace SonarAnalyzer.UnitTest.Rules;
+
+[TestClass]
+public class AsyncYieldingMethodsShouldHaveDecoratedCancellationTest
+{
+    [TestMethod]
+    public void AsyncYieldingMethodsShouldHaveDecoratedCancellation() =>
+        new VerifierBuilder<AsyncYieldingMethodsShouldHaveDecoratedCancellation>()
+            .AddPaths("AysncYieldingMethodsShouldHaveDecoratedCancellation.cs")
+            .WithOptions(ParseOptionsHelper.FromCSharp9)
+            .Verify();
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AsyncYieldingMethodsShouldHaveDecoratedCancellation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/AsyncYieldingMethodsShouldHaveDecoratedCancellation.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+class Conmpliant
+{
+    async IAsyncEnumerable<int> Yields([EnumeratorCancellation] CancellationToken token) // Compliant
+    {
+        yield return 13;
+    }
+    async IAsyncEnumerable<int> YieldsWithOptionalCancellation([EnumeratorCancellation] CancellationToken token = default) // Compliant
+    {
+        yield return 13;
+    }
+    public static async IAsyncEnumerable<int> YieldsWithMultipleModifiers([EnumeratorCancellation] CancellationToken token) // Compliant
+    {
+        yield return 13;
+    }
+    async IAsyncEnumerator<int> Iterates(CancellationToken token) // Compliant
+    {
+        yield return 13;
+    }
+    IAsyncEnumerable<int> WithoutYielding(CancellationToken token) // Compliant
+    {
+        return null;
+    }
+    IAsyncEnumerable<int> WithoutYielding() // Compliant
+    {
+        return null;
+    }
+    IAsyncEnumerable<int> WithoutBody() => null; // Compliant
+}
+
+class Noncompliant
+{
+    async IAsyncEnumerable<int> Yields(CancellationToken token) // Noncompliant
+    {
+        yield return 42;
+    }
+    async IAsyncEnumerable<int> YieldsWithoutCancelation() // Noncompliant
+    {
+        yield return 42;
+    }
+    internal static async IAsyncEnumerable<int> YieldsWithMultipleModifiers() // Noncompliant
+    {
+        yield return 42;
+    }
+    async IAsyncEnumerable<int> YieldsWithMisplacedDecoration([EnumeratorCancellation] int number) // Noncompliant
+    {
+        yield return number;
+    }
+}


### PR DESCRIPTION
Fixes #6003

As proposed at the [community](https://community.sonarsource.com/t/c-find-missing-enumeratorcancellation-parameter), when having an async yielding method, the cancellation token should exist and be decorated. #6003 

``` C#
async IAsyncEnumerable<int> Yields([EnumeratorCancellation] CancellationToken token)
{
    yield return 13;
}
```

As far as I know, this can not be achieved in VB.NET as the compiler forbids to have both the `Async` and the `Iterator` modifier on an method.