### PR TITLE
Fix S3776 configuration: Cognitive complexity threshold for property is not registered properly

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/CognitiveComplexityBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CognitiveComplexityBase.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules
         [RuleParameter("threshold", PropertyType.Integer, "The maximum authorized complexity.", DefaultThreshold)]
         public int Threshold { get; set; } = DefaultThreshold;
 
-        [RuleParameter("propertyThreshold ", PropertyType.Integer, "The maximum authorized complexity in a property.", DefaultPropertyThreshold)]
+        [RuleParameter("propertyThreshold", PropertyType.Integer, "The maximum authorized complexity in a property.", DefaultPropertyThreshold)]
         public int PropertyThreshold { get; set; } = DefaultPropertyThreshold;
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
@@ -20,6 +20,8 @@
 
 extern alias csharp;
 extern alias vbnet;
+
+using System.Reflection;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.UnitTest.Helpers;
 
@@ -140,6 +142,18 @@ namespace SonarAnalyzer.UnitTest.Common
                 .Where(analyzer => !IsSecurityHotspot(analyzer))
                 .ToList()
                 .ForEach(diagnostic => diagnostic.IsEnabledByDefault.Should().BeFalse());
+
+        [TestMethod]
+        public void ParameterKey_DoesNotContainWhitespace()
+        {
+            foreach (var analyzer in RuleFinder.RuleAnalyzerTypes.Where(RuleFinder.IsParameterized))
+            {
+                foreach (var parameter in analyzer.GetRuntimeProperties().Select(x => x.GetCustomAttributes<RuleParameterAttribute>().SingleOrDefault()).WhereNotNull())
+                {
+                    parameter.Key.Any(char.IsWhiteSpace).Should().BeFalse($"{analyzer.FullName} should not contain whitespace in '{parameter.Key}' parameter key.");
+                }
+            }
+        }
 
         [TestMethod]
         public void AllRulesEnabledByDefault_ContainSonarWayCustomTag()


### PR DESCRIPTION
Fixes #5896
