### PR TITLE
Add UT test case to S1854 and S1481 for unused variable.

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.RoslynCfg.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.RoslynCfg.cs
@@ -633,6 +633,9 @@ namespace Tests.Diagnostics
 
             var y = 5;  // Noncompliant
             y = 6;      // Noncompliant
+
+            string f;
+            f = "something"; // Noncompliant
         }
 
         // https://github.com/SonarSource/sonar-dotnet/issues/4937

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/VariableUnused.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/VariableUnused.cs
@@ -48,6 +48,9 @@ namespace Tests.Diagnostics
             var d = "";
             var e = new List<String> { d };
             Console.WriteLine(e);
+
+            string f;
+            f = "something"; // Compliant, S1854 (Deadstores) reports on this.
         }
 
         private object DoSomething(string foo, string p1)


### PR DESCRIPTION
Add the same test case for an unused variable to the S1854 (DeadStores) and S1481(VariableUnsused) for the sake of showing that it's handled by one of the two rules.
