### PR TITLE
S3881: Improve invocation detection

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementIDisposableCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementIDisposableCorrectly.cs
@@ -243,22 +243,17 @@ namespace SonarAnalyzer.Rules.CSharp
 
             private bool CallsSuppressFinalize(BaseMethodDeclarationSyntax methodDeclaration) =>
                 methodDeclaration.ContainsMethodInvocation(semanticModel,
-                    method => method is
-                    {
-                        Expression: MemberAccessExpressionSyntax { Name.Identifier.Text: nameof(GC.SuppressFinalize) },
-                        ArgumentList.Arguments: { Count: 1 } arguments
-                    } && arguments[0] is { Expression: ThisExpressionSyntax },
+                    method => method.Expression.GetName() == nameof(GC.SuppressFinalize)
+                        && method is { ArgumentList.Arguments: { Count: 1 } arguments }
+                        && arguments[0] is { Expression: ThisExpressionSyntax },
                     KnownMethods.IsGcSuppressFinalize);
 
             private bool CallsVirtualDispose(BaseMethodDeclarationSyntax methodDeclaration, Func<ArgumentSyntax, bool> argumentValue) =>
                 methodDeclaration.ContainsMethodInvocation(semanticModel,
-                    method => method is
-                    {
-                        Expression: MemberAccessExpressionSyntax { Name.Identifier.Text: nameof(IDisposable.Dispose) } or IdentifierNameSyntax { Identifier.Text: nameof(IDisposable.Dispose)},
-                        ArgumentList.Arguments: { Count: 1 } arguments,
-                    }
-                    && arguments[0] is var argument
-                    && argumentValue(argument),
+                    method => method.Expression.GetName() == nameof(IDisposable.Dispose)
+                        && method is { ArgumentList.Arguments: { Count: 1 } arguments }
+                        && arguments[0] is var argument
+                        && argumentValue(argument),
                     IsDisposeBool);
 
             private static bool IsDisposeBool(IMethodSymbol method) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementIDisposableCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementIDisposableCorrectly.cs
@@ -287,7 +287,6 @@ namespace SonarAnalyzer.Rules.CSharp
 
             private static bool IsLiteralArgument(ArgumentSyntax argument, SyntaxKind literalTokenKind) =>
                 argument is { Expression: LiteralExpressionSyntax { Token: var token } } && token.IsKind(literalTokenKind);
-
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementIDisposableCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementIDisposableCorrectly.cs
@@ -242,14 +242,14 @@ namespace SonarAnalyzer.Rules.CSharp
 
             private bool CallsSuppressFinalize(BaseMethodDeclarationSyntax methodDeclaration) =>
                 methodDeclaration.ContainsMethodInvocation(semanticModel,
-                    method => method.Expression.GetName() == nameof(GC.SuppressFinalize)
+                    method => method.Expression.NameIs(nameof(GC.SuppressFinalize))
                         && method is { ArgumentList.Arguments: { Count: 1 } arguments }
                         && arguments[0] is { Expression: ThisExpressionSyntax },
                     KnownMethods.IsGcSuppressFinalize);
 
             private bool CallsVirtualDispose(BaseMethodDeclarationSyntax methodDeclaration, Func<ArgumentSyntax, bool> argumentValue) =>
                 methodDeclaration.ContainsMethodInvocation(semanticModel,
-                    method => method.Expression.GetName() == nameof(IDisposable.Dispose)
+                    method => method.Expression.NameIs(nameof(IDisposable.Dispose))
                         && method is { ArgumentList.Arguments: { Count: 1 } arguments }
                         && arguments[0] is var argument
                         && argumentValue(argument),


### PR DESCRIPTION
CallsSuppressFinalize and CallsVirtualDispose had some flaws in it:

* The name of the invoked method was not checked syntactically before semantic
* Both called `HasArgumentValues` which was not using `Language.MethodParameterLookup` and therefore was not working properly with named arguments.
* Both were relying on "ToString()" on syntax nodes much too often.