### PR TITLE
Tests: Issue(s) expected but not raised should have a stacktrace with a link to the test file

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DoNotCallGCSuppressFinalize.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DoNotCallGCSuppressFinalize.cs
@@ -23,7 +23,7 @@ namespace Tests.Diagnostics
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this); // Noncompliant
+            GC.SuppressFinalize(this); // Compliant
         }
 
         protected virtual void Dispose(bool disposing)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DoNotCallGCSuppressFinalize.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DoNotCallGCSuppressFinalize.cs
@@ -23,7 +23,7 @@ namespace Tests.Diagnostics
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this); // Compliant
+            GC.SuppressFinalize(this); // Noncompliant
         }
 
         protected virtual void Dispose(bool disposing)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
@@ -196,7 +196,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                     var expectedIssuesDescription = fileWithIssues.IssueLocations.Select(i => $"{Environment.NewLine}Line: {i.LineNumber}, Type: {IssueType(i.IsPrimary)}, Id: '{i.IssueId}'");
                     issuesString.AppendLine(expectedIssuesDescription.JoinStr(string.Empty));
                 }
-                throw new UnexpectedDiagnosticException(firstLocation.FileName, firstLocation.IssueLocations.First().LineNumber, $"{languageVersion}: Issue(s) expected but not raised in file(s):{issuesString}");
+                throw new MissingDiagnosticException(firstLocation.FileName,
+                                                     firstLocation.IssueLocations.First().LineNumber,
+                                                     $"{languageVersion}: Issue(s) expected but not raised in file(s):{issuesString}");
             }
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/DiagnosticVerifier.cs
@@ -188,13 +188,15 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             if (expectedIssuesPerFile.Any(x => x.IssueLocations.Any()))
             {
                 var issuesString = new StringBuilder();
+                FileIssueLocations firstLocation = null;
                 foreach (var fileWithIssues in expectedIssuesPerFile.Where(x => x.IssueLocations.Any()).OrderBy(x => x.IssueLocations.First().Start))
                 {
+                    firstLocation ??= fileWithIssues;
                     issuesString.Append($"{Environment.NewLine}File: {fileWithIssues.FileName}");
                     var expectedIssuesDescription = fileWithIssues.IssueLocations.Select(i => $"{Environment.NewLine}Line: {i.LineNumber}, Type: {IssueType(i.IsPrimary)}, Id: '{i.IssueId}'");
                     issuesString.AppendLine(expectedIssuesDescription.JoinStr(string.Empty));
                 }
-                Execute.Assertion.FailWith($"{languageVersion}: Issue(s) expected but not raised in file(s):{issuesString}");
+                throw new UnexpectedDiagnosticException(firstLocation.FileName, firstLocation.IssueLocations.First().LineNumber, $"{languageVersion}: Issue(s) expected but not raised in file(s):{issuesString}");
             }
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/DiagnosticVerifierTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/DiagnosticVerifierTest.cs
@@ -165,7 +165,7 @@ public class UnexpectedRemainingCurlyBrace
 
         [TestMethod]
         public void ExpectedIssuesNotRaised() =>
-            VerifyThrows<AssertFailedException>(@"
+            VerifyThrows<MissingDiagnosticException>(@"
 public class ExpectedIssuesNotRaised
 {
     public void Test(bool a, bool b) // Noncompliant [MyId0]
@@ -186,7 +186,7 @@ public class ExpectedIssuesNotRaised
                 .AddPaths("ExpectedIssuesNotRaised.cs", "ExpectedIssuesNotRaised2.cs")
                 .WithConcurrentAnalysis(false)
                 .Invoking(x => x.Verify())
-                .Should().Throw<AssertFailedException>().WithMessage(
+                .Should().Throw<MissingDiagnosticException>().WithMessage(
                     @"CSharp*: Issue(s) expected but not raised in file(s):" + Environment.NewLine +
                     "File: DiagnosticsVerifier\\ExpectedIssuesNotRaised.cs" + Environment.NewLine +
                     "Line: 3, Type: primary, Id: 'MyId0'" + Environment.NewLine +

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierTest.cs
@@ -176,7 +176,7 @@ End Class").Invoking(x => x.Verify()).Should().Throw<UnexpectedDiagnosticExcepti
     private bool a = true;   // Noncompliant - FN
     private bool b = true;   // Noncompliant - FN
     private bool c = true;
-}").Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage(
+}").Invoking(x => x.Verify()).Should().Throw<MissingDiagnosticException>().WithMessage(
 @"CSharp7: Issue(s) expected but not raised in file(s):
 File: File.cs
 Line: 3, Type: primary, Id: ''
@@ -214,7 +214,7 @@ Line: 4, Type: primary, Id: ''
     private bool a = true;     // Noncompliant - FN in Second.cs
 }"))
             .WithConcurrentAnalysis(false)
-            .Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage(
+            .Invoking(x => x.Verify()).Should().Throw<MissingDiagnosticException>().WithMessage(
 @"CSharp7: Issue(s) expected but not raised in file(s):
 File: File.cs
 Line: 3, Type: primary, Id: ''
@@ -228,7 +228,7 @@ Line: 3, Type: primary, Id: ''
         {
             var builder = WithSnippetCS("// Noncompliant - FN");
             // Concurrent analysis by-default automatically generates concurrent files - File.Concurrent.cs
-            builder.Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage(
+            builder.Invoking(x => x.Verify()).Should().Throw<MissingDiagnosticException>().WithMessage(
     @"CSharp7: Issue(s) expected but not raised in file(s):
 File: File.cs
 Line: 1, Type: primary, Id: ''
@@ -237,7 +237,7 @@ File: File.Concurrent.cs
 Line: 1, Type: primary, Id: ''
 ");
             // When AutogenerateConcurrentFiles is turned off, only the provided snippet is analyzed
-            builder.WithAutogenerateConcurrentFiles(false).Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage(
+            builder.WithAutogenerateConcurrentFiles(false).Invoking(x => x.Verify()).Should().Throw<MissingDiagnosticException>().WithMessage(
     @"CSharp7: Issue(s) expected but not raised in file(s):
 File: File.cs
 Line: 1, Type: primary, Id: ''
@@ -332,7 +332,7 @@ Line: 1, Type: primary, Id: ''
         public void Verify_Snippets() =>
             DummyCS.AddSnippet("public class First { } // Noncompliant [first]  - not raised")
                 .AddSnippet("public class Second { } // Noncompliant [second] - not raised")
-                .Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage(
+                .Invoking(x => x.Verify()).Should().Throw<MissingDiagnosticException>().WithMessage(
 @"CSharp7: Issue(s) expected but not raised in file(s):
 File: snippet1.cs
 Line: 1, Type: primary, Id: 'first'

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/UnexpectedDiagnosticException.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/UnexpectedDiagnosticException.cs
@@ -38,21 +38,22 @@ namespace SonarAnalyzer.UnitTest.TestFramework
     {
         private readonly string additionalLine;
 
-        public UnexpectedDiagnosticException(Location location, string message) : base(message)
+        public UnexpectedDiagnosticException(Location location, string message) : this(location.GetLineSpan().Path, location.GetLineNumberToReport(), message)
         {
-            var locationPath = location.GetLineSpan().Path;
-            if (string.IsNullOrEmpty(locationPath))
+        }
+
+        public UnexpectedDiagnosticException(string filePath, int lineNumber, string message) : base(message)
+        {
+            if (string.IsNullOrEmpty(filePath))
             {
                 return;
             }
-
-            var testCasePath = GetTestCasePath(locationPath);
-            var testCaseLine = location.GetLineNumberToReport();
+            var testCasePath = GetTestCasePath(filePath);
 
 #if NETFRAMEWORK
-            additionalLine = NetFrameworkFormatter.GetAdditionalLine(testCasePath, testCaseLine) + Environment.NewLine;
+            additionalLine = NetFrameworkFormatter.GetAdditionalLine(testCasePath, lineNumber) + Environment.NewLine;
 #else
-            additionalLine = NetCoreFormatter.GetAdditionalLine(testCasePath, testCaseLine) + Environment.NewLine;
+            additionalLine = NetCoreFormatter.GetAdditionalLine(testCasePath, lineNumber) + Environment.NewLine;
 #endif
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/UnexpectedDiagnosticException.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/UnexpectedDiagnosticException.cs
@@ -28,21 +28,20 @@ namespace SonarAnalyzer.UnitTest.TestFramework
     /// <summary>
     /// This exception class is used in unit tests that analyze some code to report a violation.
     /// It differs from classical unit test failure reporting in that it injects in its call
-    /// stack a location that correspond to the source file that is being analyzed (when analysing
+    /// stack a location that correspond to the source file that is being analyzed (when analyzing
     /// inline code snippets, this location will be incorrect).
     /// As a result, in the UI, we can just click on this line to directly open the right file at
     /// the right place to see the actual issue.
     /// </summary>
-    ///
-    public class UnexpectedDiagnosticException : Exception
+    public abstract class TestfileDiagnosticException : Exception
     {
         private readonly string additionalLine;
 
-        public UnexpectedDiagnosticException(Location location, string message) : this(location.GetLineSpan().Path, location.GetLineNumberToReport(), message)
+        protected TestfileDiagnosticException(Location location, string message) : this(location.GetLineSpan().Path, location.GetLineNumberToReport(), message)
         {
         }
 
-        public UnexpectedDiagnosticException(string filePath, int lineNumber, string message) : base(message)
+        protected TestfileDiagnosticException(string filePath, int lineNumber, string message) : base(message)
         {
             if (string.IsNullOrEmpty(filePath))
             {
@@ -83,5 +82,17 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 $"at Test Case in {path}:line {line}";
         }
 #endif
+    }
+
+    /// <inheritdoc/>
+    public sealed class UnexpectedDiagnosticException : TestfileDiagnosticException
+    {
+        public UnexpectedDiagnosticException(Location location, string message) : base(location, message) { }
+    }
+
+    /// <inheritdoc/>
+    public sealed class MissingDiagnosticException : TestfileDiagnosticException
+    {
+        public MissingDiagnosticException(string filePath, int lineNumber, string message) : base(filePath, lineNumber, message) { }
     }
 }


### PR DESCRIPTION
If an issue is expected (Noncompliant) but not raised, the test fails, but the stack trace with the link to the location is missing.

**Note** `IssueLocationCollector.GetExpectedIssueLocations` throws `InvalidOperationException`s which should be turned (by the caller?) into  a `class InvalidTestAnnotationException: TestfileDiagnosticException` in a follow up PR. I made a note to myself.