### PR TITLE
Fix FN S1313: A hardcoded IP address is not recognized if it is assembled as part of a constant interpolated string

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/InterpolatedStringExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/InterpolatedStringExpressionSyntaxExtensions.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Text;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SonarAnalyzer.Helpers;
 
@@ -27,5 +29,29 @@ namespace SonarAnalyzer.Extensions
     {
         public static string GetContentsText(this InterpolatedStringExpressionSyntax interpolatedStringExpression) =>
             interpolatedStringExpression.Contents.JoinStr(null, content => content.ToString());
+
+        public static bool TryGetGetInterpolatedTextValue(this InterpolatedStringExpressionSyntax interpolatedStringExpression, SemanticModel semanticModel, out string interpolatedValue)
+        {
+            interpolatedValue = null;
+            var resolvedContent = new StringBuilder();
+            foreach (var interpolatedStringContent in interpolatedStringExpression.Contents)
+            {
+                if (interpolatedStringContent is InterpolationSyntax interpolation
+                    && interpolation.Expression.FindConstantValue(semanticModel) is string constantValue)
+                {
+                    resolvedContent.Append(constantValue);
+                }
+                else if (interpolatedStringContent is InterpolatedStringTextSyntax interpolatedText)
+                {
+                    resolvedContent.Append(interpolatedText.TextToken.Text);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            interpolatedValue = resolvedContent.ToString();
+            return true;
+        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/HardcodedIpAddress.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/HardcodedIpAddress.cs
@@ -18,11 +18,16 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.CSharp
@@ -37,13 +42,52 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public HardcodedIpAddress(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration) { }
 
+        protected override void Initialize(SonarAnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionInNonGenerated(c =>
+                {
+                    var stringContent = string.Empty;
+                    var interpolatedString = (InterpolatedStringExpressionSyntax)c.Node;
+                    foreach (var interpolatedStringContent in interpolatedString.Contents)
+                    {
+                        if (interpolatedStringContent is InterpolationSyntax interpolation
+                            && interpolation.Expression.FindConstantValue(c.SemanticModel) is string constantValue)
+                        {
+                            stringContent += constantValue;
+                        }
+                        else if (interpolatedStringContent is InterpolatedStringTextSyntax interpolatedText)
+                        {
+                            stringContent += interpolatedText.TextToken.Text;
+                        }
+                    }
+
+                    if (stringContent != IPv4Broadcast
+                        && !stringContent.StartsWith("2.5.")                                  // Looks like OID
+                        && IPAddress.TryParse(stringContent, out var address)
+                        && !IPAddress.IsLoopback(address)
+                        && !address.GetAddressBytes().All(x => x == 0)                       // Nonroutable 0.0.0.0 or 0::0
+                        && (address.AddressFamily != AddressFamily.InterNetwork
+                            || stringContent.Count(x => x == '.') == IPv4AddressParts - 1)
+                        && (!(GetAssignedVariableName(interpolatedString) is { } variableName)
+                            || !ignoredVariableNames.Any(x => variableName.IndexOf(x, StringComparison.InvariantCultureIgnoreCase) >= 0))
+                        && !HasAttributes(interpolatedString))
+                    {
+                        c.ReportIssue(Diagnostic.Create(rule, interpolatedString.GetLocation(), stringContent));
+                    }
+
+                },
+                SyntaxKind.InterpolatedStringExpression);
+
+            base.Initialize(context);
+        }
+
         protected override string GetValueText(LiteralExpressionSyntax literalExpression) =>
             literalExpression.Token.ValueText;
 
-        protected override bool HasAttributes(LiteralExpressionSyntax literalExpression) =>
+        protected override bool HasAttributes(SyntaxNode literalExpression) =>
             literalExpression.Ancestors().AnyOfKind(SyntaxKind.Attribute);
 
-        protected override string GetAssignedVariableName(LiteralExpressionSyntax stringLiteral) =>
+        protected override string GetAssignedVariableName(SyntaxNode stringLiteral) =>
             stringLiteral.FirstAncestorOrSelf<SyntaxNode>(IsVariableIdentifier)?.ToString();
 
         private static bool IsVariableIdentifier(SyntaxNode syntaxNode) =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/HardcodedIpAddressBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/HardcodedIpAddressBase.cs
@@ -34,56 +34,53 @@ namespace SonarAnalyzer.Rules
         where TSyntaxKind : struct
         where TLiteralExpression : SyntaxNode
     {
-        protected const string DiagnosticId = "S1313";
+        private const string DiagnosticId = "S1313";
         private const string MessageFormat = "Make sure using this hardcoded IP address '{0}' is safe here.";
-        protected const int IPv4AddressParts  = 4;
-        protected const string IPv4Broadcast = "255.255.255.255";
+        private const int IPv4AddressParts  = 4;
+        private const string IPv4Broadcast = "255.255.255.255";
 
-        protected readonly string[] ignoredVariableNames =
+        private readonly string[] ignoredVariableNames =
         {
             "VERSION",
             "ASSEMBLY",
         };
 
-        protected readonly DiagnosticDescriptor rule;
-
         protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
-        protected abstract TSyntaxKind SyntaxKind { get; }
 
         protected abstract string GetAssignedVariableName(SyntaxNode stringLiteral);
         protected abstract string GetValueText(TLiteralExpression literalExpression);
         protected abstract bool HasAttributes(SyntaxNode literalExpression);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        protected DiagnosticDescriptor Rule { get; init; }
 
         protected HardcodedIpAddressBase(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration) =>
-            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
+            Rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
 
         protected override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, CheckForHardcodedIpAddresses, SyntaxKind);
+            context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, CheckForHardcodedIpAddresses, Language.SyntaxKind.StringLiteralExpression);
+
+        protected bool IsHardcodedIp(string literalValue, SyntaxNode node) =>
+            literalValue != IPv4Broadcast
+            && !literalValue.StartsWith("2.5.")                                  // Looks like OID
+            && IPAddress.TryParse(literalValue, out var address)
+            && !IPAddress.IsLoopback(address)
+            && !address.GetAddressBytes().All(x => x == 0)                       // Nonroutable 0.0.0.0 or 0::0
+            && (address.AddressFamily != AddressFamily.InterNetwork
+                || literalValue.Count(x => x == '.') == IPv4AddressParts - 1)
+            && (!(GetAssignedVariableName(node) is { } variableName)
+                || !ignoredVariableNames.Any(x => variableName.IndexOf(x, StringComparison.InvariantCultureIgnoreCase) >= 0))
+            && !HasAttributes(node);
 
         private void CheckForHardcodedIpAddresses(SyntaxNodeAnalysisContext context)
         {
-            if (!IsEnabled(context.Options))
+            if (IsEnabled(context.Options)
+                && (TLiteralExpression)context.Node is var stringLiteral
+                && GetValueText(stringLiteral) is var literalValue
+                && IsHardcodedIp(literalValue, stringLiteral))
             {
-                return;
-            }
-
-            var stringLiteral = (TLiteralExpression)context.Node;
-            var literalValue = GetValueText(stringLiteral);
-
-            if (literalValue != IPv4Broadcast
-                && !literalValue.StartsWith("2.5.")                                  // Looks like OID
-                && IPAddress.TryParse(literalValue, out var address)
-                && !IPAddress.IsLoopback(address)
-                && !address.GetAddressBytes().All(x => x == 0)                       // Nonroutable 0.0.0.0 or 0::0
-                && (address.AddressFamily != AddressFamily.InterNetwork
-                    || literalValue.Count(x => x == '.') == IPv4AddressParts - 1)
-                && (!(GetAssignedVariableName(stringLiteral) is { } variableName)
-                    || !ignoredVariableNames.Any(x => variableName.IndexOf(x, StringComparison.InvariantCultureIgnoreCase) >= 0))
-                && !HasAttributes(stringLiteral))
-            {
-                context.ReportIssue(Diagnostic.Create(rule, stringLiteral.GetLocation(), literalValue));
+                context.ReportIssue(Diagnostic.Create(Rule, stringLiteral.GetLocation(), literalValue));
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/HardcodedIpAddress.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/HardcodedIpAddress.cs
@@ -31,7 +31,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
     public sealed class HardcodedIpAddress : HardcodedIpAddressBase<SyntaxKind, LiteralExpressionSyntax>
     {
         protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
-        protected override SyntaxKind SyntaxKind { get; } = SyntaxKind.StringLiteralExpression;
 
         public HardcodedIpAddress() : this(AnalyzerConfiguration.Hotspot) { }
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/HardcodedIpAddress.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/HardcodedIpAddress.cs
@@ -40,10 +40,10 @@ namespace SonarAnalyzer.Rules.VisualBasic
         protected override string GetValueText(LiteralExpressionSyntax literalExpression) =>
             literalExpression.Token.ValueText;
 
-        protected override bool HasAttributes(LiteralExpressionSyntax literalExpression) =>
+        protected override bool HasAttributes(SyntaxNode literalExpression) =>
             literalExpression.Ancestors().AnyOfKind(SyntaxKind.Attribute);
 
-        protected override string GetAssignedVariableName(LiteralExpressionSyntax stringLiteral) =>
+        protected override string GetAssignedVariableName(SyntaxNode stringLiteral) =>
             stringLiteral.FirstAncestorOrSelf<SyntaxNode>(IsVariableIdentifier)?.ToString();
 
         private static bool IsVariableIdentifier(SyntaxNode syntaxNode) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/HardcodedIpAddressTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/HardcodedIpAddressTest.cs
@@ -27,18 +27,25 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class HardcodedIpAddressTest
     {
+        private readonly VerifierBuilder builderCS = new VerifierBuilder().AddAnalyzer(() => new CS.HardcodedIpAddress(AnalyzerConfiguration.AlwaysEnabled));
+        private readonly VerifierBuilder builderVB = new VerifierBuilder().AddAnalyzer(() => new VB.HardcodedIpAddress(AnalyzerConfiguration.AlwaysEnabled));
+
         [TestMethod]
         public void HardcodedIpAddress_CS() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\Hotspots\HardcodedIpAddress.cs", new CS.HardcodedIpAddress(AnalyzerConfiguration.AlwaysEnabled));
+            builderCS.AddPaths(@"Hotspots\HardcodedIpAddress.cs").Verify();
 
 #if NET
+
         [TestMethod]
         public void HardcodedIpAddress_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(@"TestCases\Hotspots\HardcodedIpAddress.CSharp10.cs", new CS.HardcodedIpAddress(AnalyzerConfiguration.AlwaysEnabled));
+            builderCS.AddPaths(@"Hotspots\HardcodedIpAddress.CSharp10.cs")
+                .WithOptions(ParseOptionsHelper.FromCSharp10)
+                .Verify();
+
 #endif
 
         [TestMethod]
         public void HardcodedIpAddress_VB() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\Hotspots\HardcodedIpAddress.vb", new VB.HardcodedIpAddress(AnalyzerConfiguration.AlwaysEnabled));
+            builderVB.AddPaths(@"Hotspots\HardcodedIpAddress.vb").Verify();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/HardcodedIpAddress.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/HardcodedIpAddress.CSharp10.cs
@@ -5,15 +5,20 @@ namespace Tests.Diagnostics
 {
     public class HardcodedIpAddress
     {
-        public HardcodedIpAddress()
+        public HardcodedIpAddress(string unknownPart, string knownPart)
         {
             const string part1 = "192";
             const string part2 = "168";
             const string part3 = "0";
             const string part4 = "1";
+            knownPart = "255";
 
-            const string ip = $"{part1}.{part2}.{part3}.{part4}"; // Noncompliant
+            const string ip1 = $"{part1}.{part2}.{part3}.{part4}"; // Noncompliant
+//                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             const string nonIp = $"{part1}:{part2}";
+
+            string ip2 = $"{part1}.{part2}.{part3}.{knownPart}"; // Noncompliant
+            string ip3 = $"{part1}.{part2}.{part3}.{unknownPart}";
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/HardcodedIpAddress.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/HardcodedIpAddress.CSharp10.cs
@@ -12,7 +12,7 @@ namespace Tests.Diagnostics
             const string part3 = "0";
             const string part4 = "1";
 
-            const string ip = $"{part1}.{part2}.{part3}.{part4}"; // FN
+            const string ip = $"{part1}.{part2}.{part3}.{part4}"; // Noncompliant
             const string nonIp = $"{part1}:{part2}";
         }
     }


### PR DESCRIPTION
Fixes #5944
