### PR TITLE
Do not build netstandard2.0

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
+++ b/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SonarAnalyzer.CFG</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
+    <!-- See SonarAnalyzer.Common.csproj for more details-->
     <TargetFrameworks Condition="$(BuildOnlyNet46) != 'true'">net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(BuildOnlyNet46) == 'true'">net46</TargetFrameworks>
   </PropertyGroup>

--- a/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
+++ b/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <AssemblyName>SonarAnalyzer.CFG</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
-    <ProjectGuid>{F766F556-CB91-408A-9149-EB963DE1B817}</ProjectGuid>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(BuildOnlyNet46) != 'true'">net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(BuildOnlyNet46) == 'true'">net46</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />

--- a/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
+++ b/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
@@ -3,9 +3,8 @@
   <PropertyGroup>
     <AssemblyName>SonarAnalyzer.CFG</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
-    <!-- See SonarAnalyzer.Common.csproj for more details-->
-    <TargetFrameworks Condition="$(BuildOnlyNet46) != 'true'">net46;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(BuildOnlyNet46) == 'true'">net46</TargetFrameworks>
+    <!-- CFG needs netstandard2.0 for NuGet package -->
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />

--- a/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SonarAnalyzer.CSharp</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
+    <!-- See SonarAnalyzer.Common.csproj for more details-->
     <TargetFrameworks Condition="$(BuildOnlyNet46) != 'true'">net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(BuildOnlyNet46) == 'true'">net46</TargetFrameworks>
     <DefineConstants>TRACE;CS</DefineConstants>

--- a/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <AssemblyName>SonarAnalyzer.CSharp</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
-    <ProjectGuid>{ca8eec07-8775-42e3-91eb-e51f4db72a48}</ProjectGuid>
+    <TargetFrameworks Condition="$(BuildOnlyNet46) != 'true'">net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(BuildOnlyNet46) == 'true'">net46</TargetFrameworks>
     <DefineConstants>TRACE;CS</DefineConstants>
   </PropertyGroup>
 

--- a/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <AssemblyName>SonarAnalyzer</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
-    <ProjectGuid>{8a8a663e-1318-4361-bc97-2e63666feadb}</ProjectGuid>
+    <TargetFrameworks Condition="$(BuildOnlyNet46) != 'true'">net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(BuildOnlyNet46) == 'true'">net46</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -3,6 +3,14 @@
   <PropertyGroup>
     <AssemblyName>SonarAnalyzer</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
+    <!--
+      We need to target netstandard2.0 during:
+      - local builds, to properly generate packages.lock.json
+      - "restore" on CI builds due to a NuGet bug https://github.com/NuGet/Home/issues/12010
+      We need to target net46
+      - during CI build to speed up the pipeline. We do not use netstandard2.0 binaries anywhere.
+      We should be able to remove this complication from project files and azure-pipelines.yml once NuGet issue is fixed.
+    -->
     <TargetFrameworks Condition="$(BuildOnlyNet46) != 'true'">net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(BuildOnlyNet46) == 'true'">net46</TargetFrameworks>
   </PropertyGroup>

--- a/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -4,12 +4,12 @@
     <AssemblyName>SonarAnalyzer</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
     <!--
-      We need to target netstandard2.0 during:
-      - local builds, to properly generate packages.lock.json
-      - "restore" on CI builds due to a NuGet bug https://github.com/NuGet/Home/issues/12010
-      We need to target net46
-      - during CI build to speed up the pipeline. We do not use netstandard2.0 binaries anywhere.
-      We should be able to remove this complication from project files and azure-pipelines.yml once NuGet issue is fixed.
+      We need to target "net46;netstandard2.0" for:
+      - local builds to properly generate packages.lock.json
+      - CI restore due to a NuGet bug https://github.com/NuGet/Home/issues/12010
+      We need to target "net46" for:
+      - CI build to speed up the pipeline. We do not use netstandard2.0 binaries anywhere.
+      We should be able to remove netstandard2.0 and this complication from project files and azure-pipelines.yml once NuGet issue is fixed.
     -->
     <TargetFrameworks Condition="$(BuildOnlyNet46) != 'true'">net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(BuildOnlyNet46) == 'true'">net46</TargetFrameworks>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>SonarAnalyzer.VisualBasic</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
+    <!-- See SonarAnalyzer.Common.csproj for more details-->
     <TargetFrameworks Condition="$(BuildOnlyNet46) != 'true'">net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(BuildOnlyNet46) == 'true'">net46</TargetFrameworks>
     <DefineConstants>TRACE;VB</DefineConstants>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <AssemblyName>SonarAnalyzer.VisualBasic</AssemblyName>
     <RootNamespace>SonarAnalyzer</RootNamespace>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
-    <ProjectGuid>{7cfa8fa5-8842-4e89-bb90-39d5c0f20ba8}</ProjectGuid>
+    <TargetFrameworks Condition="$(BuildOnlyNet46) != 'true'">net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(BuildOnlyNet46) == 'true'">net46</TargetFrameworks>
     <DefineConstants>TRACE;VB</DefineConstants>
   </PropertyGroup>
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/ITupleOperationWrapperExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/ITupleOperationWrapperExtensionsTests.cs
@@ -60,8 +60,8 @@ namespace SonarAnalyzer.UnitTest.Extensions
         public void AllElements_Performance_LargeTuple()
         {
             var largeTuple = LargeTuple(500); // (1, 2,... , 500)
-            // Actual execution time is about 0.5ms.
-            AssertAllElementsExecutionTimeBeLessThan(largeTuple, 5.Milliseconds());
+            // Actual execution time is about 0.4ms - 0.7ms
+            AssertAllElementsExecutionTimeBeLessThan(largeTuple, 10.Milliseconds());
 
             static string LargeTuple(int length)
             {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ stages:
           solution: '$(solution)'
           platform: '$(buildPlatform)'
           configuration: '$(buildConfiguration)'
-          msbuildArgs: '/p:DeployExtension=false /p:SignAssembly=$(isReleaseBranch) /p:AssemblyOriginatorKeyFile="$(snk.secureFilePath)" /p:Sha1=$(Build.SourceVersion) /p:BuildNumber=$(Build.BuildId) /p:WarningLevel=0'
+          msbuildArgs: '/p:DeployExtension=false /p:SignAssembly=$(isReleaseBranch) /p:AssemblyOriginatorKeyFile="$(snk.secureFilePath)" /p:Sha1=$(Build.SourceVersion) /p:BuildNumber=$(Build.BuildId) /p:WarningLevel=0 /p:BuildOnlyNet46=true'
           vsVersion: $(vsVersion)
 
       - task: NuGetCommand@2
@@ -271,7 +271,7 @@ stages:
           solution: '$(solution)'
           platform: '$(buildPlatform)'
           configuration: '$(buildConfiguration)'
-          msbuildArgs: '/p:DeployExtension=false /p:RunAnalyzers=true'
+          msbuildArgs: '/p:DeployExtension=false /p:RunAnalyzers=true /p:BuildOnlyNet46=true'
           vsVersion: $(vsVersion)
 
       - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
## Improve CI performance.

We do not use `netstandard2.0` builds and we do not ship them. So we don't need to wait for them to be built and analyzed.

With this change, we also unit test the build that we ship.

## Summary 

`Build and package` is 41% faster. Making every build 0:47 shorter in average.

`.NET Analysis / Run .Net code analysis - before` is 28% faster (0:40), but it doesn't help with total CI run too much yet, because Java ITs take longer anyway. And we already know how to speed them up.

## Details

**Build and package - before**
Min: 1:07
Max: 3:30
Average: 1:52

_Side note:_ Why the hell do we have such volatile differences on the same VMs anyway?

**Build and package - before**
Min: 0:52
Max: 1:47
Average: 1:05


**.NET Analysis / Run .Net code analysis - before**
Min: 2:11
Max: 2:58
Average: 2:25

**.NET Analysis / Run .Net code analysis - after**
Min: 1:35
Max: 1:59
Average: 1:44
