### PR TITLE
Fix FN S5332: No issue is raised if an insecure protocol is used as part of a constant interpolated string

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/ClearTextProtocolsAreSensitive.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/ClearTextProtocolsAreSensitive.CSharp10.cs
@@ -5,7 +5,7 @@ using System.Net.Mail;
 const string protocol1 = "http://";
 const string protocol2 = "https://";
 const string address = "foo.com";
-const string noncompliant = $"{protocol1}{address}"; // FN
+const string noncompliant = $"{protocol1}{address}"; // Noncompliant
 const string compliant = $"{protocol2}{address}";
 
 public record struct RecordStruct

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/ClearTextProtocolsAreSensitive.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/ClearTextProtocolsAreSensitive.CSharp10.cs
@@ -8,6 +8,9 @@ const string address = "foo.com";
 const string noncompliant = $"{protocol1}{address}"; // Noncompliant
 const string compliant = $"{protocol2}{address}";
 
+string nestedNoncompliant = $"{$"{protocol1}somtehing."}{address}"; // Noncompliant
+// Noncompliant@-1
+
 public record struct RecordStruct
 {
     public string Address { get; init; } = "http://foo.com"; // Noncompliant


### PR DESCRIPTION
Fixes #5943
