### PR TITLE
Fix CodeFix S3217: Using directives are not moved to the closest namespace when this is file scoped

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ForeachLoopExplicitConversionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ForeachLoopExplicitConversionTest.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.IO;
 using SonarAnalyzer.Rules.CSharp;
 
 namespace SonarAnalyzer.UnitTest.Rules
@@ -25,30 +27,36 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class ForeachLoopExplicitConversionTest
     {
+        private readonly VerifierBuilder verifier = new VerifierBuilder<ForeachLoopExplicitConversion>();
+
         [TestMethod]
         public void ForeachLoopExplicitConversion() =>
-            OldVerifier.VerifyAnalyzer(@"TestCases\ForeachLoopExplicitConversion.cs", new ForeachLoopExplicitConversion());
+            verifier.AddPaths("ForeachLoopExplicitConversion.cs").Verify();
 
         [TestMethod]
         public void ForeachLoopExplicitConversion_CSharp10() =>
-            OldVerifier.VerifyAnalyzerFromCSharp10Library(@"TestCases\ForeachLoopExplicitConversion.CSharp10.cs", new ForeachLoopExplicitConversion());
+           // OldVerifier.VerifyAnalyzerFromCSharp10Library(@"TestCases\ForeachLoopExplicitConversion.CSharp10.cs", new ForeachLoopExplicitConversion());
+        verifier
+                .AddPaths("ForeachLoopExplicitConversion.CSharp10.cs")
+                .WithConcurrentAnalysis(false)
+                .WithOptions(ParseOptionsHelper.FromCSharp10)
+                .Verify();
 
         [TestMethod]
         public void ForeachLoopExplicitConversion_CodeFix() =>
-            OldVerifier.VerifyCodeFix<ForeachLoopExplicitConversionCodeFix>(
-                @"TestCases\ForeachLoopExplicitConversion.cs",
-                @"TestCases\ForeachLoopExplicitConversion.Fixed.cs",
-                new ForeachLoopExplicitConversion());
-
+            verifier.WithCodeFix<ForeachLoopExplicitConversionCodeFix>()
+                .AddPaths("ForeachLoopExplicitConversion.cs")
+                .WithCodeFixedPaths("ForeachLoopExplicitConversion.Fixed.cs")
+                .VerifyCodeFix();
 #if NET
         [TestMethod]
         public void ForeachLoopExplicitConversion_CSharp10_CodeFix() =>
-            OldVerifier.VerifyCodeFix<ForeachLoopExplicitConversionCodeFix>(
-                @"TestCases\ForeachLoopExplicitConversion.CSharp10.cs",
-                @"TestCases\ForeachLoopExplicitConversion.CSharp10.Fixed.cs",
-                new ForeachLoopExplicitConversion(),
-                ParseOptionsHelper.FromCSharp10,
-                OutputKind.DynamicallyLinkedLibrary);
+            verifier.WithCodeFix<ForeachLoopExplicitConversionCodeFix>()
+                .AddPaths("ForeachLoopExplicitConversion.CSharp10.cs")
+                .WithCodeFixedPaths("ForeachLoopExplicitConversion.CSharp10.Fixed.cs")
+                .WithOptions(ParseOptionsHelper.FromCSharp10)
+                .WithOutputKind(OutputKind.DynamicallyLinkedLibrary)
+                .VerifyCodeFix();
 #endif
 
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ForeachLoopExplicitConversionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ForeachLoopExplicitConversionTest.cs
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.CodeAnalysis.Diagnostics;
-using System.IO;
 using SonarAnalyzer.Rules.CSharp;
 
 namespace SonarAnalyzer.UnitTest.Rules
@@ -35,9 +33,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void ForeachLoopExplicitConversion_CSharp10() =>
-           // OldVerifier.VerifyAnalyzerFromCSharp10Library(@"TestCases\ForeachLoopExplicitConversion.CSharp10.cs", new ForeachLoopExplicitConversion());
-        verifier
-                .AddPaths("ForeachLoopExplicitConversion.CSharp10.cs")
+            verifier.AddPaths("ForeachLoopExplicitConversion.CSharp10.cs")
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .Verify();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ForeachLoopExplicitConversionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ForeachLoopExplicitConversionTest.cs
@@ -25,34 +25,36 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class ForeachLoopExplicitConversionTest
     {
-        private readonly VerifierBuilder verifier = new VerifierBuilder<ForeachLoopExplicitConversion>();
+        private readonly VerifierBuilder builder = new VerifierBuilder<ForeachLoopExplicitConversion>();
 
         [TestMethod]
         public void ForeachLoopExplicitConversion() =>
-            verifier.AddPaths("ForeachLoopExplicitConversion.cs").Verify();
-
-        [TestMethod]
-        public void ForeachLoopExplicitConversion_CSharp10() =>
-            verifier.AddPaths("ForeachLoopExplicitConversion.CSharp10.cs")
-                .WithConcurrentAnalysis(false)
-                .WithOptions(ParseOptionsHelper.FromCSharp10)
-                .Verify();
+            builder.AddPaths("ForeachLoopExplicitConversion.cs").Verify();
 
         [TestMethod]
         public void ForeachLoopExplicitConversion_CodeFix() =>
-            verifier.WithCodeFix<ForeachLoopExplicitConversionCodeFix>()
+            builder.WithCodeFix<ForeachLoopExplicitConversionCodeFix>()
                 .AddPaths("ForeachLoopExplicitConversion.cs")
                 .WithCodeFixedPaths("ForeachLoopExplicitConversion.Fixed.cs")
                 .VerifyCodeFix();
 #if NET
+
+        [TestMethod]
+        public void ForeachLoopExplicitConversion_CSharp10() =>
+            builder.AddPaths("ForeachLoopExplicitConversion.CSharp10.cs")
+                .WithAutogenerateConcurrentFiles(false)
+                .WithOptions(ParseOptionsHelper.FromCSharp10)
+                .Verify();
+
         [TestMethod]
         public void ForeachLoopExplicitConversion_CSharp10_CodeFix() =>
-            verifier.WithCodeFix<ForeachLoopExplicitConversionCodeFix>()
+            builder.WithCodeFix<ForeachLoopExplicitConversionCodeFix>()
                 .AddPaths("ForeachLoopExplicitConversion.CSharp10.cs")
                 .WithCodeFixedPaths("ForeachLoopExplicitConversion.CSharp10.Fixed.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .WithOutputKind(OutputKind.DynamicallyLinkedLibrary)
                 .VerifyCodeFix();
+
 #endif
 
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ForeachLoopExplicitConversion.CSharp10.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ForeachLoopExplicitConversion.CSharp10.Fixed.cs
@@ -1,10 +1,9 @@
 ﻿global using System.Collections;
 global using System.Collections.Generic;
-using System.Linq;
 
 namespace Tests.Diagnostics;
 using System;
-// the System.Linq using should be here as this is the closest namespace
+using System.Linq;
 
 interface I { }
 class A : I { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ForeachLoopExplicitConversion.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ForeachLoopExplicitConversion.CSharp10.cs
@@ -3,7 +3,6 @@ global using System.Collections.Generic;
 
 namespace Tests.Diagnostics;
 using System;
-// the System.Linq using should be here as this is the closest namespace
 
 interface I { }
 class A : I { }


### PR DESCRIPTION
Fixes #5980 
