### PR TITLE
New Rule: Use ContainsKey instead of Keys.Contains() on dictionaries 

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseContainsKey.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseContainsKey.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.CSharp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseContainsKey : UseContainsKeyBase<SyntaxKind>
+{
+    protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
+}

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseContainsKeyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseContainsKeyBase.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules;
+
+public abstract class UseContainsKeyBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
+    where TSyntaxKind : struct
+{
+    private const string DiagnosticId = "S4581"; // TODO: replace
+
+    protected override string MessageFormat => "Use ContainsKey() instead.";
+
+    protected UseContainsKeyBase() : base(DiagnosticId) { }
+
+    protected sealed override void Initialize(SonarAnalysisContext context) =>
+        context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, c =>
+        {
+            if (IsKeysProperty(Language.Syntax.NodeIdentifier(c.Node).Value.Text)
+                && FollowedByContains(c.Node)
+                && c.SemanticModel.GetSymbolInfo(c.Node).Symbol is IPropertySymbol property
+                && property.IsInType(KnownType.System_Collections_Generic_Dictionary_TKey_TValue))
+            {
+                c.ReportIssue(Diagnostic.Create(Rule, CandidateNext(c.Node).GetLocation()));
+            }
+        },
+        Language.SyntaxKind.IdentifierName);
+
+    private bool IsKeysProperty(string name) =>
+        nameof(Dictionary<int, int>.Keys).Equals(name, Language.NameComparison);
+
+    private bool IsContainsMethod(string name) =>
+        nameof(Enumerable.Contains).Equals(name, Language.NameComparison);
+
+    private bool FollowedByContains(SyntaxNode node) =>
+        CandidateNext(node) is { } next
+        && IsContainsMethod(Language.Syntax.NodeIdentifier(next).Value.Text);
+
+    private static SyntaxNode CandidateNext(SyntaxNode node) =>
+        node.Parent.Parent.ChildNodes().SkipWhile(x => x != node.Parent).Skip(1).FirstOrDefault();
+}

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseContainsKey.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseContainsKey.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.VisualBasic;
+using SonarAnalyzer.Helpers;
+
+namespace SonarAnalyzer.Rules.VisualBasic;
+
+[DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+public sealed class UseContainsKey : UseContainsKeyBase<SyntaxKind>
+{
+    protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UseContainsKeyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UseContainsKeyTest.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using CS = SonarAnalyzer.Rules.CSharp;
+using VB = SonarAnalyzer.Rules.VisualBasic;
+
+namespace SonarAnalyzer.UnitTest.Rules;
+
+[TestClass]
+public class UseContainsKeyTest
+{
+    private readonly VerifierBuilder builderCS = new VerifierBuilder<CS.UseContainsKey>();
+    private readonly VerifierBuilder builderVB = new VerifierBuilder<VB.UseContainsKey>();
+
+    [TestMethod]
+    public void UseContainsKey_CS() =>
+        builderCS.AddPaths("UseContainsKey.cs").Verify();
+
+    [TestMethod]
+    public void UseContainsKey_VB() =>
+        builderVB.AddPaths("UseContainsKey.vb").Verify();
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseContainsKey.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseContainsKey.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+class Compliant
+{
+    bool UsesContainsKey()
+    {
+        var dict = new Dictionary<int, int>();
+        return dict.ContainsKey(42); // Compliant
+    }
+
+    bool KeysNotFollowedByContains()
+    {
+        var dict = new Dictionary<int, int>();
+        return dict.Keys.Any(); // Compliant
+    }
+
+    IEnumerable<int> KeysNotFollowedByAnything()
+    {
+        var dict = new Dictionary<int, int>();
+        return dict.Keys; // Compliant
+    }
+
+    bool NoDictionary()
+    {
+        var dict = new NoDictionary();
+        return dict.Keys.Contains(42); // Compliant
+    }
+}
+
+class NonCompliant
+{
+    bool KeysContains()
+    { 
+        var dict = new Dictionary<int, int>();
+        return dict.Keys.Contains(42); // NonCompliant {{Use ContainsKey() instead.}}
+        //               ^^^^^^^^
+    }
+}
+
+class NoDictionary
+{
+    public List<int> Keys { get; }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseContainsKey.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UseContainsKey.vb
@@ -1,0 +1,36 @@
+﻿Imports System.Collections.Generic
+Imports System.Linq
+
+Class Compliant
+    Function UsesContainsKey() As Boolean
+        Dim dict = New Dictionary(Of Integer, Integer) ' Compliant
+        Return dict.ContainsKey(42)
+    End Function
+
+    Function KeysNotFollowedByContains() As Boolean
+        Dim dict = New Dictionary(Of Integer, Integer) ' Compliant
+        Return dict.Keys.Any()
+    End Function
+
+    Function KeysNotFollowedByAnything() As IEnumerable(Of Integer)
+        Dim dict = New Dictionary(Of Integer, Integer) ' Compliant
+        Return dict.Keys
+    End Function
+
+    Function NoDictionary() As Boolean
+        Dim dict = New NoDictionary()
+        Return dict.Keys.Contains(42) ' Compliant
+    End Function
+End Class
+
+Class NonCompliant
+    Function KeysContains() As Boolean
+        Dim dict = New Dictionary(Of Integer, Integer) ' NonCompliant {{Use ContainsKey() instead.}}
+        Return dict.Keys.Contains(42)
+        '                ^^^^^^^^
+    End Function
+End Class
+
+Class NoDictionary
+    Public ReadOnly Property Keys As List(Of Integer)
+End Class


### PR DESCRIPTION
For performance reasons, `ContainsKey()` is preferred over `.Keys.Contains()`.

See: #6009 