### PR TITLE
Update parent POM from 62.0.180 to 63.0.187

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>62.0.180</version>
+    <version>63.0.187</version>
   </parent>
 
   <groupId>org.sonarsource.dotnet</groupId>


### PR DESCRIPTION
Burgr is failing releasability with:
```
FAILED
ParentPOM
update your parent from to 62.0.180 to 63.0.187
```
This PR is updating the version.