### PR TITLE
Fix FP S6421: Don't raise issue for Azure Functions with already wrapped body in try/catch block.

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/BaseMethodDeclarationSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/BaseMethodDeclarationSyntaxExtensions.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Extensions
             methodDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword);
 
         public static bool HasBodyOrExpressionBody(this BaseMethodDeclarationSyntax node) =>
-            node?.Body != null || node?.ExpressionBody() != null;
+            node.GetBodyOrExpressionBody() is not null;
 
         public static SyntaxNode GetBodyOrExpressionBody(this BaseMethodDeclarationSyntax node) =>
             (node?.Body as SyntaxNode) ?? node?.ExpressionBody()?.Expression;

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/BaseMethodDeclarationSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/BaseMethodDeclarationSyntaxExtensions.cs
@@ -36,5 +36,11 @@ namespace SonarAnalyzer.Extensions
 
         public static bool IsStatic(this BaseMethodDeclarationSyntax methodDeclaration) =>
             methodDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword);
+
+        public static bool HasBodyOrExpressionBody(this BaseMethodDeclarationSyntax node) =>
+            node?.Body != null || node?.ExpressionBody() != null;
+
+        public static SyntaxNode GetBodyOrExpressionBody(this BaseMethodDeclarationSyntax node) =>
+            (node?.Body as SyntaxNode) ?? node?.ExpressionBody()?.Expression;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
@@ -293,12 +293,6 @@ namespace SonarAnalyzer.Helpers
         public static bool HasBodyOrExpressionBody(this AccessorDeclarationSyntax node) =>
             node.Body != null || node.ExpressionBody() != null;
 
-        public static bool HasBodyOrExpressionBody(this BaseMethodDeclarationSyntax node) =>
-            node?.Body != null || node?.ExpressionBody() != null;
-
-        public static SyntaxNode GetBodyOrExpressionBody(this BaseMethodDeclarationSyntax node) =>
-            (node?.Body as SyntaxNode) ?? node?.ExpressionBody()?.Expression;
-
         public static SimpleNameSyntax GetIdentifier(this ExpressionSyntax expression) =>
             expression switch
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
@@ -296,6 +296,9 @@ namespace SonarAnalyzer.Helpers
         public static bool HasBodyOrExpressionBody(this BaseMethodDeclarationSyntax node) =>
             node?.Body != null || node?.ExpressionBody() != null;
 
+        public static SyntaxNode GetBodyOrExpressionBody(this BaseMethodDeclarationSyntax node) =>
+            (node?.Body as SyntaxNode) ?? node?.ExpressionBody()?.Expression;
+
         public static SimpleNameSyntax GetIdentifier(this ExpressionSyntax expression) =>
             expression switch
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsCatchExceptions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsCatchExceptions.cs
@@ -61,7 +61,8 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             private readonly SemanticModel semanticModel;
 
-            public Walker(SemanticModel semanticModel) => this.semanticModel = semanticModel;
+            public Walker(SemanticModel semanticModel) =>
+                this.semanticModel = semanticModel;
 
             public bool HasInvocationOutsideTryCatch { get; private set; }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsCatchExceptions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsCatchExceptions.cs
@@ -47,9 +47,8 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (c.IsAzureFunction())
                     {
                         var method = (MethodDeclarationSyntax)c.Node;
-                        var body = method.GetBodyOrExpressionBody();
                         var walker = new Walker(c.SemanticModel);
-                        if (walker.SafeVisit(body) && walker.HasInvocationOutsideTryCatch)
+                        if (walker.SafeVisit(method.GetBodyOrExpressionBody()) && walker.HasInvocationOutsideTryCatch)
                         {
                             c.ReportIssue(Diagnostic.Create(Rule, method.Identifier.GetLocation()));
                         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsCatchExceptions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsCatchExceptions.cs
@@ -47,8 +47,9 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (c.IsAzureFunction())
                     {
                         var method = (MethodDeclarationSyntax)c.Node;
-                        var walker = new Walker();
-                        if (walker.SafeVisit(c.Node) && walker.HasInvocationOutsideTryCatch)
+                        var body = method.GetBodyOrExpressionBody();
+                        var walker = new Walker(c.SemanticModel);
+                        if (walker.SafeVisit(body) && walker.HasInvocationOutsideTryCatch)
                         {
                             c.ReportIssue(Diagnostic.Create(Rule, method.Identifier.GetLocation()));
                         }
@@ -58,6 +59,10 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private sealed class Walker : SafeCSharpSyntaxWalker
         {
+            private readonly SemanticModel semanticModel;
+
+            public Walker(SemanticModel semanticModel) => this.semanticModel = semanticModel;
+
             public bool HasInvocationOutsideTryCatch { get; private set; }
 
             public override void Visit(SyntaxNode node)
@@ -74,8 +79,13 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             }
 
-            public override void VisitInvocationExpression(InvocationExpressionSyntax node) =>
-                HasInvocationOutsideTryCatch = true;
+            public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+            {
+                if (!node.IsNameof(semanticModel))
+                {
+                    HasInvocationOutsideTryCatch = true;
+                }
+            }
 
             public override void VisitTryStatement(TryStatementSyntax node)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PartialMethodNoImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PartialMethodNoImplementation.cs
@@ -25,6 +25,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/BaseMethodDeclarationSyntaxExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/BaseMethodDeclarationSyntaxExtensionsTest.cs
@@ -77,7 +77,8 @@ namespace SonarAnalyzer.UnitTest.Helpers
             yield return new object[] { methodWithExpressionBody, methodWithExpressionBody.ExpressionBody.Expression };
             yield return new object[] { methodWithBoth, methodWithBoth.Body };
 
-            static BaseMethodDeclarationSyntax Method() => MethodDeclaration(PredefinedType(Token(SyntaxKind.BoolKeyword)), "Test");
+            static BaseMethodDeclarationSyntax Method() =>
+                MethodDeclaration(PredefinedType(Token(SyntaxKind.BoolKeyword)), "Test");
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/BaseMethodDeclarationSyntaxExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/BaseMethodDeclarationSyntaxExtensionsTest.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
         public void GivenNullMethodDeclaration_GetBodyDescendantNodes_ThrowsArgumentNullException()
         {
 #if NETFRAMEWORK
-             var messageFormat = "Value cannot be null." + Environment.NewLine + "Parameter name: {0}";
+            var messageFormat = "Value cannot be null." + Environment.NewLine + "Parameter name: {0}";
 #else
             var messageFormat = "Value cannot be null. (Parameter '{0}')";
 #endif

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/BaseMethodDeclarationSyntaxExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/BaseMethodDeclarationSyntaxExtensionsTest.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetMethodDeclarations), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetMethodDeclarationsAndExpectedBody), DynamicDataSourceType.Method)]
         public void HasBodyOrExpressionBody(BaseMethodDeclarationSyntax methodDeclaration, SyntaxNode expectedBody)
         {
             if (expectedBody is null)
@@ -59,20 +59,21 @@ namespace SonarAnalyzer.UnitTest.Helpers
         }
 
         [TestMethod]
-        [DynamicData(nameof(GetMethodDeclarations), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetMethodDeclarationsAndExpectedBody), DynamicDataSourceType.Method)]
         public void GetBodyOrExpressionBody(BaseMethodDeclarationSyntax methodDeclaration, SyntaxNode expectedBody) =>
             methodDeclaration.GetBodyOrExpressionBody().Should().Be(expectedBody);
 
-        private static IEnumerable<object[]> GetMethodDeclarations()
+        private static IEnumerable<object[]> GetMethodDeclarationsAndExpectedBody()
         {
-            var methodWithBlock = Method().WithBody(Block());
-            var methodWithExpressionBody = Method().WithExpressionBody(ArrowExpressionClause(LiteralExpression(SyntaxKind.TrueLiteralExpression)));
-            var methodWithBoth = Method().WithBody(Block()).WithExpressionBody(ArrowExpressionClause(LiteralExpression(SyntaxKind.TrueLiteralExpression)));
+            var methodWithBody = Method().WithBody(Block());
+            var expressionBody = ArrowExpressionClause(LiteralExpression(SyntaxKind.TrueLiteralExpression));
+            var methodWithExpressionBody = Method().WithExpressionBody(expressionBody);
+            var methodWithBoth = Method().WithBody(Block()).WithExpressionBody(expressionBody);
+
+            // Corresponds to (BaseMethodDeclarationSyntax methodDeclaration, SyntaxNode expectedBody)
             yield return new object[] { null, null };
             yield return new object[] { Method(), null };
-            yield return new object[] { methodWithBlock, methodWithBlock.Body };
-            yield return new object[] { Method().WithBody(null), null };
-            yield return new object[] { Method().WithExpressionBody(null), null };
+            yield return new object[] { methodWithBody, methodWithBody.Body };
             yield return new object[] { methodWithExpressionBody, methodWithExpressionBody.ExpressionBody.Expression };
             yield return new object[] { methodWithBoth, methodWithBoth.Body };
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/BaseMethodDeclarationSyntaxExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/BaseMethodDeclarationSyntaxExtensionsTest.cs
@@ -48,13 +48,14 @@ namespace SonarAnalyzer.UnitTest.Helpers
         [DynamicData(nameof(GetMethodDeclarationsAndExpectedBody), DynamicDataSourceType.Method)]
         public void HasBodyOrExpressionBody(BaseMethodDeclarationSyntax methodDeclaration, SyntaxNode expectedBody)
         {
+            var hasBody = methodDeclaration.HasBodyOrExpressionBody();
             if (expectedBody is null)
             {
-                methodDeclaration.HasBodyOrExpressionBody().Should().BeFalse();
+                hasBody.Should().BeFalse();
             }
             else
             {
-                methodDeclaration.HasBodyOrExpressionBody().Should().BeTrue();
+                hasBody.Should().BeTrue();
             }
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CloudNative/AzureFunctionsCatchExceptions.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CloudNative/AzureFunctionsCatchExceptions.cs
@@ -552,3 +552,19 @@ public class ConditionalAccess
 
     private ConditionalAccess DoSomething() => null;
 }
+
+public class Repro
+{
+
+    [FunctionName(nameof(CheckLicense))]
+    public async Task CheckLicense() // Noncompliant FP
+    {
+        try
+        {
+            //check authorization
+        }
+        catch (Exception e)
+        {
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CloudNative/AzureFunctionsCatchExceptions.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CloudNative/AzureFunctionsCatchExceptions.cs
@@ -553,9 +553,10 @@ public class ConditionalAccess
     private ConditionalAccess DoSomething() => null;
 }
 
-public class Repro
+public class Foo
 {
 
+    // Repro for https://github.com/SonarSource/sonar-dotnet/issues/5995
     [FunctionName(nameof(CheckLicense))]
     public async Task CheckLicense() // Noncompliant FP
     {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CloudNative/AzureFunctionsCatchExceptions.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CloudNative/AzureFunctionsCatchExceptions.cs
@@ -558,7 +558,7 @@ public class Foo
 
     // Repro for https://github.com/SonarSource/sonar-dotnet/issues/5995
     [FunctionName(nameof(CheckLicense))]
-    public async Task CheckLicense() // Noncompliant FP
+    public async Task CheckLicense()
     {
         try
         {
@@ -567,5 +567,31 @@ public class Foo
         catch (Exception e)
         {
         }
+    }
+
+    [FunctionName("Sample")]
+    public async Task NameOfOutsideTry()
+    {
+        var x = nameof(NameOfOutsideTry);
+        try
+        {
+        }
+        catch (Exception e)
+        {
+        }
+    }
+
+    [FunctionName("Sample")]
+    public async Task NameOfOutsideTryWithNameOfMethodInScope() // Noncompliant
+    {
+        var x = nameof(NameOfOutsideTryWithNameOfMethodInScope);
+        try
+        {
+        }
+        catch (Exception e)
+        {
+        }
+
+        string nameof(Func<Task> x) => "";
     }
 }


### PR DESCRIPTION
Fixes #5995
Based on #6016

Root cause was
* method attributes were visited by the walker -> only body is visited now
* `nameof()` was treated as an invocation -> check for `IsNameOf` added

