### PR TITLE
FP S2259: Reproducer: Null check with two variables

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -1102,6 +1102,24 @@ public class Repro_5289
     }
 }
 
+namespace SonarLint_S2259_False_Positive_Replication
+{
+    public class FPReplication
+    {
+        public int PartialChecksForSemanticVersionComparison(string preRelease, string otherPreRelease)
+        {
+            if (preRelease == otherPreRelease) return 0;
+            if (preRelease != null && otherPreRelease == null) return -1;
+            if (preRelease == null && otherPreRelease != null) return 1;
+
+            preRelease.Split('.'); // Compliant
+            otherPreRelease.Split('.');
+
+            return 0;
+        }
+    }
+}
+
 namespace ValidatedNotNullAttributeTest
 {
     public sealed class ValidatedNotNullAttribute : Attribute { }


### PR DESCRIPTION
This adds the reproducer for this [community post](https://community.sonarsource.com/t/s2259-false-positive-null-pointers-should-not-be-dereferenced/69959/3).

The new engine is handling this case gracefully. The issue is solved once we ship the new implementation.