### PR TITLE
Add UnaryOperatorKind to ShimLayer

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/UnaryOperatorKind.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/UnaryOperatorKind.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    public enum UnaryOperatorKind
+    {
+        /// <summary>
+        /// Represents unknown or error operator kind.
+        /// </summary>
+        None = 0x0,
+
+        /// <summary>
+        /// Represents the C# '~' operator.
+        /// </summary>
+        BitwiseNegation = 0x1,
+
+        /// <summary>
+        /// Represents the C# '!' operator and VB 'Not' operator.
+        /// </summary>
+        Not = 0x2,
+
+        /// <summary>
+        /// Represents the unary '+' operator.
+        /// </summary>
+        Plus = 0x3,
+
+        /// <summary>
+        /// Represents the unary '-' operator.
+        /// </summary>
+        Minus = 0x4,
+
+        /// <summary>
+        /// Represents the C# 'true' operator and VB 'IsTrue' operator.
+        /// </summary>
+        True = 0x5,
+
+        /// <summary>
+        /// Represents the C# 'false' operator and VB 'IsFalse' operator.
+        /// </summary>
+        False = 0x6,
+
+        /// <summary>
+        /// Represents the C# '^' operator.
+        /// </summary>
+        Hat = 0x7,
+    }
+}

--- a/analyzers/src/SonarAnalyzer.ShimLayer.CodeGeneration/OperationLightupGenerator.cs
+++ b/analyzers/src/SonarAnalyzer.ShimLayer.CodeGeneration/OperationLightupGenerator.cs
@@ -1048,7 +1048,6 @@ namespace StyleCop.Analyzers.CodeGeneration
                     "InstanceReferenceKind" => true,
                     "LoopKind" => true,
                     "PlaceholderKind" => true,
-                    "UnaryOperatorKind" => true,
                     _ => !this.IsPublicProperty,
                 };
 


### PR DESCRIPTION
Prerequisite for #6030

To validate that this works:
- pull
- rebuild
- restart VS
- place this somewhere in `RoslynSymbolicExecution.cs`:
```
        public void Something(IUnaryOperationWrapper unary)
        {
            UnaryOperatorKind kind = unary.OperatorKind;
        }
```
It should compile. Before, it would complaint that `object` cannot be converted to `UnaryOperatorKind`