### PR TITLE
Fix S2222 FP: Consider symbols released only if they were previously held

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/LocksReleasedAllPathsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/LocksReleasedAllPathsBase.cs
@@ -202,7 +202,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks
 
         private ProgramState RemoveLock(SymbolicContext context, ISymbol symbol)
         {
-            if (symbol == null)
+            if (symbol == null || !context.HasConstraint(symbol, LockConstraint.Held))
             {
                 return context.State;
             }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/NullPointerDereferenceBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/NullPointerDereferenceBase.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks
                 OperationKindEx.ArrayElementReference => context.Operation.Instance.ToArrayElementReference().ArrayReference,
                 _ => null,
             };
-            if (reference != null && context.HasConstraint(ObjectConstraint.Null, reference))
+            if (reference != null && context.HasConstraint(reference, ObjectConstraint.Null))
             {
                 ReportIssue(reference, reference.Syntax.ToString());
             }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicContext.cs
@@ -44,7 +44,10 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         public SymbolicContext WithState(ProgramState newState) =>
             State == newState ? this : new(Operation, newState);
 
-        public bool HasConstraint(SymbolicConstraint constraint, IOperation operation) =>
+        public bool HasConstraint(IOperation operation, SymbolicConstraint constraint) =>
             State[operation]?.HasConstraint(constraint) is true;
+
+        public bool HasConstraint(ISymbol symbol, SymbolicConstraint constraint) =>
+            State[symbol]?.HasConstraint(constraint) is true;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Conditions.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Conditions.cs
@@ -5,6 +5,7 @@ namespace Monitor_Conditions
 {
     class Program
     {
+        private readonly static object staticObj = new object();
         private object obj = new object();
         private object other = new object();
 
@@ -437,6 +438,64 @@ namespace Monitor_Conditions
                     Monitor.Exit(obj);
                 }
             }
+        }
+
+        public void FieldReference_Standalone(string arg)
+        {
+            Monitor.Enter(obj); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            if(condition)
+                Monitor.Exit(obj);
+        }
+
+        public void FieldReference_WithThis(string arg)
+        {
+            Monitor.Enter(this.obj); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            if(condition)
+                Monitor.Exit(this.obj);
+        }
+
+        public void FieldReference_WithThis_Mixed1(string arg)
+        {
+            Monitor.Enter(this.obj); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            if(condition)
+                Monitor.Exit(obj);
+        }
+
+        public void FieldReference_WithThis_Mixed2(string arg)
+        {
+            Monitor.Enter(obj); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            if (condition)
+                Monitor.Exit(this.obj);
+        }
+
+        public void StaticFieldReference(string arg)
+        {
+            Monitor.Enter(staticObj); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            if (condition)
+                Monitor.Exit(staticObj);
+        }
+
+        public void StaticFieldReference_Class(string arg)
+        {
+            Monitor.Enter(Program.staticObj); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            if (condition)
+                Monitor.Exit(Program.staticObj);
+        }
+
+        public void LocalVariable(string arg)
+        {
+            var l = new object();
+
+            Monitor.Enter(l); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            if (condition)
+                Monitor.Exit(l);
+        }
+
+        public void Parameter(object arg)
+        {
+            Monitor.Enter(arg); // Noncompliant
+            if (condition)
+                Monitor.Exit(arg);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Conditions.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Conditions.cs
@@ -497,5 +497,59 @@ namespace Monitor_Conditions
             if (condition)
                 Monitor.Exit(arg);
         }
+
+        public void FirstReleasedThanAcquired_ConditionalEnter()
+        {
+            Monitor.Exit(obj);
+            try
+            {
+                Console.WriteLine();
+            }
+            finally
+            {
+                if (condition)
+                {
+                    Monitor.Enter(obj); // Not supported by this rule
+                }
+            }
+        }
+
+        public void FirstReleasedThanAcquired_ConditionalExit()
+        {
+            if (condition)
+            {
+                Monitor.Exit(obj);
+            }
+            try
+            {
+                Console.WriteLine();
+            }
+            finally
+            {
+                if (condition)
+                {
+                    Monitor.Enter(obj); // Compliant, even when the exit is weirdly conditional. Not in scope of this rule.
+                }
+            }
+        }
+
+        public void FirstReleasedThanAcquired_Complex()
+        {
+            Monitor.Exit(obj);
+            try
+            {
+                Console.WriteLine();
+                Monitor.Enter(obj);     // Noncompliant
+                Console.WriteLine();
+            }
+            finally
+            {
+                if (condition)
+                {
+                    Monitor.Exit(obj);
+                }
+            }
+        }
+
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Conditions.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Conditions.vb
@@ -1,4 +1,5 @@
-﻿Imports System.Threading
+﻿Imports System
+Imports System.Threading
 
 Namespace Monitor_Conditions
 
@@ -7,6 +8,7 @@ Namespace Monitor_Conditions
         Public PublicObject As New Object()
         Private Obj As New Object()
         Private Other As New Object()
+        Private Shared ReadOnly StaticObj As New Object()
 
         Private Condition As Boolean
 
@@ -224,10 +226,52 @@ Namespace Monitor_Conditions
 
         Public Sub Lambda()
             Dim l = Function(value)
-                Monitor.Enter(Obj) ' Noncompliant
-                If value = 42 Then Monitor.Exit(Obj)
-                Return value
-            End Function
+                        Monitor.Enter(Obj) ' Noncompliant
+                        If value = 42 Then Monitor.Exit(Obj)
+                        Return value
+                    End Function
         End Sub
+
+        Public Sub Method13(Arg As String)
+            Monitor.Enter(Obj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            If Condition Then Monitor.Exit(Obj)
+        End Sub
+
+        Public Sub FieldReference_WithThis(Arg As String)
+            Monitor.Enter(Me.Obj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            If Condition Then Monitor.Exit(Me.Obj)
+        End Sub
+
+        Public Sub FieldReference_WithThis_Mixed1(Arg As String)
+            Monitor.Enter(Me.Obj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            If Condition Then Monitor.Exit(Obj)
+        End Sub
+
+        Public Sub FieldReference_WithThis_Mixed2(Arg As String)
+            Monitor.Enter(Obj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            If Condition Then Monitor.Exit(Me.Obj)
+        End Sub
+
+        Public Sub StaticFieldReference(Arg As String)
+            Monitor.Enter(StaticObj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            If Condition Then Monitor.Exit(StaticObj)
+        End Sub
+
+        Public Sub StaticFieldReference_Class(Arg As String)
+            Monitor.Enter(Program.StaticObj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            If Condition Then Monitor.Exit(Program.StaticObj)
+        End Sub
+
+        Public Sub Method13_LocalVar(Arg As String)
+            Dim l As New Object()
+            Monitor.Enter(l) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            If Condition Then Monitor.Exit(l)
+        End Sub
+
+        Public Sub Method13_Parameter(Arg As Object)
+            Monitor.Enter(Arg) ' Noncompliant
+            If Condition Then Monitor.Exit(Arg)
+        End Sub
+
     End Class
 End Namespace

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Linear.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Linear.cs
@@ -261,6 +261,19 @@ namespace Monitor_Linear
             Monitor.Enter(first.obj);
         }
 
+        public void FirstReleasedThanAcquired() // Issues from Peach
+        {
+            Monitor.Exit(obj);
+            try
+            {
+                Console.WriteLine();
+            }
+            finally
+            {
+                Monitor.Enter(obj); // Noncompliant FP
+            }
+        }
+
         static int Property
         {
             get // Adds coverage for handling FlowCaptureReference operations.

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Linear.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Linear.cs
@@ -7,7 +7,6 @@ namespace Monitor_Linear
 {
     class Program
     {
-        private readonly static object staticObj = new object();
         private object obj = new object();
         private object other = new object();
 
@@ -132,63 +131,6 @@ namespace Monitor_Linear
             a();
         }
 
-        public void Method13(string arg)
-        {
-            Monitor.Exit(obj);
-            Console.WriteLine(arg.Length);
-            Monitor.Enter(obj); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        }
-
-        public void FieldReference_WithThis(string arg)
-        {
-            Monitor.Exit(this.obj);
-            Console.WriteLine(arg.Length);
-            Monitor.Enter(this.obj); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        }
-
-        public void FieldReference_WithThis_Mixed1(string arg)
-        {
-            Monitor.Exit(obj);
-            Console.WriteLine(arg.Length);
-            Monitor.Enter(this.obj); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        }
-
-        public void FieldReference_WithThis_Mixed2(string arg)
-        {
-            Monitor.Exit(this.obj);
-            Console.WriteLine(arg.Length);
-            Monitor.Enter(obj); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        }
-
-        public void StaticFieldReference(string arg)
-        {
-            Monitor.Exit(staticObj);
-            Console.WriteLine(arg.Length);
-            Monitor.Enter(staticObj); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        }
-
-        public void StaticFieldReference_Class(string arg)
-        {
-            Monitor.Exit(Program.staticObj);
-            Console.WriteLine(arg.Length);
-            Monitor.Enter(Program.staticObj); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        }
-
-        public void Method13_LocalVar(string arg)
-        {
-            var l = new object();
-
-            Monitor.Exit(l);
-            Console.WriteLine(arg.Length);
-            Monitor.Enter(l); // Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        }
-
-        public void Method13_Parameter(object arg)
-        {
-            Monitor.Exit(arg);
-            Monitor.Enter(arg); // Noncompliant
-        }
-
         public void Method14(string arg)
         {
             Monitor.Exit(obj);
@@ -270,7 +212,7 @@ namespace Monitor_Linear
             }
             finally
             {
-                Monitor.Enter(obj); // Noncompliant FP
+                Monitor.Enter(obj); // Compliant, source of FPs on Peach
             }
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Linear.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Linear.vb
@@ -6,7 +6,6 @@ Namespace Monitor_Linear
     Class Program
 
         Public PublicObject As New Object()
-        Private Shared ReadOnly StaticObj As New Object()
         Private Obj As New Object()
         Private Other As New Object()
 
@@ -93,54 +92,6 @@ Namespace Monitor_Linear
             Monitor.Enter(Obj) ' Compliant
             Dim A As Action = Sub() Monitor.Exit(Obj)
             A()
-        End Sub
-
-        Public Sub Method13(Arg As String)
-            Monitor.Exit(Obj)
-            Console.WriteLine(Arg.Length)
-            Monitor.Enter(Obj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        End Sub
-
-        Public Sub FieldReference_WithThis(Arg As String)
-            Monitor.Exit(Me.Obj)
-            Console.WriteLine(Arg.Length)
-            Monitor.Enter(Me.Obj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        End Sub
-
-        Public Sub FieldReference_WithThis_Mixed1(Arg As String)
-            Monitor.Exit(Obj)
-            Console.WriteLine(Arg.Length)
-            Monitor.Enter(Me.Obj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        End Sub
-
-        Public Sub FieldReference_WithThis_Mixed2(Arg As String)
-            Monitor.Exit(Me.Obj)
-            Console.WriteLine(Arg.Length)
-            Monitor.Enter(Obj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        End Sub
-
-        Public Sub StaticFieldReference(Arg As String)
-            Monitor.Exit(StaticObj)
-            Console.WriteLine(Arg.Length)
-            Monitor.Enter(StaticObj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        End Sub
-
-        Public Sub StaticFieldReference_Class(Arg As String)
-            Monitor.Exit(Program.StaticObj)
-            Console.WriteLine(Arg.Length)
-            Monitor.Enter(Program.StaticObj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        End Sub
-
-        Public Sub Method13_LocalVar(Arg As String)
-            Dim l As New Object()
-            Monitor.Exit(l)
-            Console.WriteLine(Arg.Length)
-            Monitor.Enter(l) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
-        End Sub
-
-        Public Sub Method13_Parameter(Arg As Object)
-            Monitor.Exit(Arg)
-            Monitor.Enter(Arg) ' Noncompliant
         End Sub
 
         Public Sub Method14(Arg As String)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.TryEnter.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.TryEnter.cs
@@ -11,7 +11,7 @@ namespace Monitor_TryEnter
 
         public void TryEnter_ExitedInElse()
         {
-            if (Monitor.TryEnter(obj)) // Compliant, never exited in this method
+            if (Monitor.TryEnter(obj)) // Compliant, never exited in this method. It's a programming error not covered by this rule.
             {
             }
             else
@@ -167,7 +167,6 @@ namespace Monitor_TryEnter
                     if (condition)
                     {
                         Monitor.Exit(obj);
-
                     }
                     break;
             }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.TryEnter.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.TryEnter.vb
@@ -8,8 +8,7 @@ Namespace Monitor_TryEnter
         Private Obj As New Object()
 
         Public Sub Method1()
-            If Monitor.TryEnter(Obj) Then ' Noncompliant
-            Else
+            If Monitor.TryEnter(Obj) AndAlso Condition Then ' Noncompliant
                 Monitor.Exit(Obj)
             End If
         End Sub
@@ -22,8 +21,7 @@ Namespace Monitor_TryEnter
         End Sub
 
         Public Sub Method3()
-            If Monitor.TryEnter(Obj, 42) Then ' Noncompliant
-            Else
+            If Monitor.TryEnter(Obj, 42) AndAlso Condition Then ' Noncompliant
                 Monitor.Exit(Obj)
             End If
         End Sub
@@ -35,8 +33,7 @@ Namespace Monitor_TryEnter
         End Sub
 
         Public Sub Method5()
-            If Monitor.TryEnter(Obj, New TimeSpan(42)) Then ' Noncompliant
-            Else
+            If Monitor.TryEnter(Obj, New TimeSpan(42)) AndAlso Condition Then ' Noncompliant
                 Monitor.Exit(Obj)
             End If
         End Sub
@@ -49,8 +46,7 @@ Namespace Monitor_TryEnter
 
         Public Sub Method7()
             Dim IsAcquired As Boolean = Monitor.TryEnter(Obj, 42) ' Noncompliant
-            If IsAcquired Then
-            Else
+            If IsAcquired AndAlso Condition Then
                 Monitor.Exit(Obj)
             End If
         End Sub
@@ -66,15 +62,15 @@ Namespace Monitor_TryEnter
         End Sub
 
         Public Sub Method10()
-            Monitor.Exit(Obj)
             Monitor.TryEnter(Obj) ' Noncompliant {{Unlock this lock along all executions paths of this method.}}
+            If Condition Then Monitor.Exit(Obj)
         End Sub
 
         Public Sub Method12()
             Select Case Monitor.TryEnter(Obj) ' Noncompliant
                 Case False
-                    Monitor.Exit(Obj)
                 Case Else
+                    If Condition Then Monitor.Exit(Obj)
             End Select
         End Sub
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Mutex.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Mutex.cs
@@ -68,14 +68,14 @@ namespace Mutex_Type
             }
 
             var m = new Mutex(false);
-            var mIsAcquired = m.WaitOne(200, true); // Noncompliant
+            var mIsAcquired = m.WaitOne(200, true);
             if (mIsAcquired)
             {
                 // here it should be released
             }
             else
             {
-                m.ReleaseMutex(); // this is a programming error
+                m.ReleaseMutex(); // this is a programming error, but not subject of this rule
             }
 
             var paramMutexIsAcquired = paramMutex.WaitOne(400, false); // Noncompliant
@@ -253,7 +253,7 @@ namespace Mutex_Type
             {
                 paramMutex.ReleaseMutex();
             }
-            paramMutex.WaitOne(); // Noncompliant
+            paramMutex.WaitOne(); // Compliant, source of FPs
         }
 
         public void CompliantComplex(string mutexName, bool shouldAcquire)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Mutex.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Mutex.vb
@@ -56,11 +56,11 @@ Namespace Mutex_Type
             End If
 
             Dim m = New Mutex(False)
-            Dim mIsAcquired = m.WaitOne(200, True) ' Noncompliant
+            Dim mIsAcquired = m.WaitOne(200, True)
             If mIsAcquired Then
                 ' here it should be released
             Else
-                m.ReleaseMutex() ' this Is a programming Error
+                m.ReleaseMutex() ' this Is a programming Error, not detected by this rule
             End If
 
             Dim paramMutexIsAcquired = ParamMutex.WaitOne(400, False) ' Noncompliant
@@ -188,8 +188,8 @@ Namespace Mutex_Type
         End Sub
 
         Public Sub ReleasedThenAcquired(ParamMutex As Mutex)
-            If Cond Then ParamMutex.ReleaseMutex()
             ParamMutex.WaitOne() ' Noncompliant
+            If Cond Then ParamMutex.ReleaseMutex()
         End Sub
 
         Public Sub CompliantComplex(MutexName As String, ShouldAcquire As Boolean)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.ReaderWriterLock.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.ReaderWriterLock.cs
@@ -171,15 +171,15 @@ namespace ReaderWriterLock_Type
         public void WrongOrder()
         {
             readerWriterLock.ReleaseReaderLock();
-            readerWriterLock.AcquireReaderLock(1); // Noncompliant
+            readerWriterLock.AcquireReaderLock(1);  // Compliant, source of FPs on Peach
 
             var a = new ReaderWriterLock();
             a.ReleaseLock();
-            a.AcquireWriterLock(1); // Noncompliant
+            a.AcquireWriterLock(1);
 
             var b = new ReaderWriterLock();
             b.ReleaseWriterLock();
-            b.AcquireWriterLock(1); // Noncompliant
+            b.AcquireWriterLock(1);
         }
 
         public void IsReaderLockHeld()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.ReaderWriterLock.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.ReaderWriterLock.vb
@@ -101,15 +101,15 @@ Namespace ReaderWriterLock_Type
 
         Public Sub WrongOrder()
             rwLock.ReleaseReaderLock()
-            rwLock.AcquireReaderLock(1) ' Noncompliant
+            rwLock.AcquireReaderLock(1) ' Compliant, source Of FPs On Peach
 
             Dim a As New ReaderWriterLock()
             a.ReleaseLock()
-            a.AcquireWriterLock(1) ' Noncompliant
+            a.AcquireWriterLock(1)
 
             Dim b As New ReaderWriterLock()
             b.ReleaseWriterLock()
-            b.AcquireWriterLock(1) ' Noncompliant
+            b.AcquireWriterLock(1)
         End Sub
 
         Public Sub IsReaderLockHeld()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.ReaderWriterLockSlim.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.ReaderWriterLockSlim.cs
@@ -35,12 +35,20 @@ namespace ReaderWriterLockSlim_Type
             }
         }
 
-        public void Method4()
+        public void TryEnterReadLock_Compliant()
         {
-            if (readerWriterLockSlim.TryEnterReadLock(42)) // Noncompliant
+            if (readerWriterLockSlim.TryEnterReadLock(42)) // Compliant, never released in this method
             {
             }
             else
+            {
+                readerWriterLockSlim.ExitReadLock();
+            }
+        }
+
+        public void TryEnterReadLock_Noncompliant()
+        {
+            if (readerWriterLockSlim.TryEnterReadLock(42) && condition) // Noncompliant
             {
                 readerWriterLockSlim.ExitReadLock();
             }
@@ -48,10 +56,7 @@ namespace ReaderWriterLockSlim_Type
 
         public void Method5()
         {
-            if (readerWriterLockSlim.TryEnterReadLock(new TimeSpan(42))) // Noncompliant
-            {
-            }
-            else
+            if (readerWriterLockSlim.TryEnterReadLock(new TimeSpan(42)) && condition) // Noncompliant
             {
                 readerWriterLockSlim.ExitReadLock();
             }
@@ -59,10 +64,7 @@ namespace ReaderWriterLockSlim_Type
 
         public void Method6()
         {
-            if (readerWriterLockSlim.TryEnterWriteLock(42)) // Noncompliant
-            {
-            }
-            else
+            if (readerWriterLockSlim.TryEnterWriteLock(42) && condition) // Noncompliant
             {
                 readerWriterLockSlim.ExitWriteLock();
             }
@@ -70,10 +72,7 @@ namespace ReaderWriterLockSlim_Type
 
         public void Method7()
         {
-            if (readerWriterLockSlim.TryEnterWriteLock(new TimeSpan(42))) // Noncompliant
-            {
-            }
-            else
+            if (readerWriterLockSlim.TryEnterWriteLock(new TimeSpan(42)) && condition) // Noncompliant
             {
                 readerWriterLockSlim.ExitWriteLock();
             }
@@ -81,10 +80,7 @@ namespace ReaderWriterLockSlim_Type
 
         public void Method8()
         {
-            if (readerWriterLockSlim.TryEnterUpgradeableReadLock(42)) // Noncompliant
-            {
-            }
-            else
+            if (readerWriterLockSlim.TryEnterUpgradeableReadLock(42) && condition) // Noncompliant
             {
                 readerWriterLockSlim.ExitReadLock();
             }
@@ -92,10 +88,7 @@ namespace ReaderWriterLockSlim_Type
 
         public void Method9()
         {
-            if (readerWriterLockSlim.TryEnterUpgradeableReadLock(new TimeSpan(42))) // Noncompliant
-            {
-            }
-            else
+            if (readerWriterLockSlim.TryEnterUpgradeableReadLock(new TimeSpan(42)) && condition) // Noncompliant
             {
                 readerWriterLockSlim.ExitReadLock();
             }
@@ -169,27 +162,27 @@ namespace ReaderWriterLockSlim_Type
         public void WrongOrder()
         {
             readerWriterLockSlim.ExitReadLock();
-            readerWriterLockSlim.EnterReadLock(); // Noncompliant
+            readerWriterLockSlim.EnterReadLock(); // Compliant
 
             var a = new ReaderWriterLockSlim();
             a.ExitWriteLock();
-            a.EnterWriteLock(); // Noncompliant
+            a.EnterWriteLock();
 
             var b = new ReaderWriterLockSlim();
             b.ExitUpgradeableReadLock();
-            b.TryEnterReadLock(1); // Noncompliant
+            b.TryEnterReadLock(1);
 
             var c = new ReaderWriterLockSlim();
             c.ExitReadLock();
-            c.TryEnterWriteLock(1); // Noncompliant
+            c.TryEnterWriteLock(1);
 
             var d = new ReaderWriterLockSlim();
             d.ExitReadLock();
-            d.EnterUpgradeableReadLock(); // Noncompliant
+            d.EnterUpgradeableReadLock();
 
             var e = new ReaderWriterLockSlim();
             e.ExitReadLock();
-            e.TryEnterUpgradeableReadLock(1); // Noncompliant
+            e.TryEnterUpgradeableReadLock(1);
         }
 
         public void Method14()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.ReaderWriterLockSlim.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.ReaderWriterLockSlim.vb
@@ -23,47 +23,40 @@ Namespace ReaderWriterLockSlim_Type
         End Sub
 
         Public Sub Method4()
-            If rwLockSlim.TryEnterReadLock(42) Then ' Noncompliant
-            Else
+            If rwLockSlim.TryEnterReadLock(42) AndAlso Condition Then ' Noncompliant
                 rwLockSlim.ExitReadLock()
             End If
         End Sub
 
         Public Sub Method5()
-            If rwLockSlim.TryEnterReadLock(New TimeSpan(42)) Then ' Noncompliant
-            Else
+            If rwLockSlim.TryEnterReadLock(New TimeSpan(42)) AndAlso Condition Then ' Noncompliant
                 rwLockSlim.ExitReadLock()
             End If
         End Sub
 
         Public Sub Method6()
-            If rwLockSlim.TryEnterWriteLock(42) Then ' Noncompliant
-            Else
+            If rwLockSlim.TryEnterWriteLock(42) AndAlso Condition Then ' Noncompliant
                 rwLockSlim.ExitWriteLock()
             End If
         End Sub
 
         Public Sub Method7()
-            If rwLockSlim.TryEnterWriteLock(New TimeSpan(42)) Then ' Noncompliant
-            Else
+            If rwLockSlim.TryEnterWriteLock(New TimeSpan(42)) AndAlso Condition Then ' Noncompliant
                 rwLockSlim.ExitWriteLock()
             End If
         End Sub
 
         Public Sub Method8()
-            If rwLockSlim.TryEnterUpgradeableReadLock(42) Then ' Noncompliant
-            Else
+            If rwLockSlim.TryEnterUpgradeableReadLock(42) AndAlso Condition Then ' Noncompliant
                 rwLockSlim.ExitReadLock()
             End If
         End Sub
 
         Public Sub Method9()
-            If rwLockSlim.TryEnterUpgradeableReadLock(New TimeSpan(42)) Then ' Noncompliant
-            Else
+            If rwLockSlim.TryEnterUpgradeableReadLock(New TimeSpan(42)) AndAlso Condition Then ' Noncompliant
                 rwLockSlim.ExitReadLock()
             End If
         End Sub
-
 
         Public Sub Method10()
             Try
@@ -107,27 +100,27 @@ Namespace ReaderWriterLockSlim_Type
 
         Public Sub WrongOrder()
             rwLockSlim.ExitReadLock()
-            rwLockSlim.EnterReadLock()  ' Noncompliant
+            rwLockSlim.EnterReadLock()  ' Compliant, source of FPs on Peach
 
             Dim a = New ReaderWriterLockSlim()
             a.ExitWriteLock()
-            a.EnterWriteLock()          ' Noncompliant
+            a.EnterWriteLock()
 
             Dim b = New ReaderWriterLockSlim()
             b.ExitUpgradeableReadLock()
-            b.TryEnterReadLock(1)       ' Noncompliant
+            b.TryEnterReadLock(1)
 
             Dim c = New ReaderWriterLockSlim()
             c.ExitReadLock()
-            c.TryEnterWriteLock(1)      ' Noncompliant
+            c.TryEnterWriteLock(1)
 
             Dim d = New ReaderWriterLockSlim()
             d.ExitReadLock()
-            d.EnterUpgradeableReadLock()        ' Noncompliant
+            d.EnterUpgradeableReadLock()
 
             Dim e = New ReaderWriterLockSlim()
             e.ExitReadLock()
-            e.TryEnterUpgradeableReadLock(1)    ' Noncompliant
+            e.TryEnterUpgradeableReadLock(1)
         End Sub
 
         Public Sub Method14()


### PR DESCRIPTION
Fixes #6048

Bunch of cases from `.Linear.` was moved to `.Condition.` as they were meant to demonstrate that we support the signature of the method.
Same idea is for those `if lock then nothing else unlock end if` - they demonstrate the method signature and not the flow