### PR TITLE
SE: Support string.IsNullOrEmpty

### DIFF
--- a/analyzers/its/expected/Ember-MM/Ember Media Manager-{9B57D3AB-AF12-4012-B945-284C2448DC81}-S2259.json
+++ b/analyzers/its/expected/Ember-MM/Ember Media Manager-{9B57D3AB-AF12-4012-B945-284C2448DC81}-S2259.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S2259",
+"message":  "'bReturn' is Nothing on at least one execution path.",
+"location":  {
+"uri":  "sources\Ember-MM\Ember%20Media%20Manager\dlgErrorViewer.vb",
+"region":  {
+"startLine":  64,
+"startColumn":  65,
+"endLine":  64,
+"endColumn":  72
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Ember-MM/EmberAPI-{208AA35E-C6AE-4D2D-A9DD-B6EFD19A4279}-S2259.json
+++ b/analyzers/its/expected/Ember-MM/EmberAPI-{208AA35E-C6AE-4D2D-A9DD-B6EFD19A4279}-S2259.json
@@ -1,0 +1,82 @@
+{
+"issues":  [
+{
+"id":  "S2259",
+"message":  "'movieName' is Nothing on at least one execution path.",
+"location":  {
+"uri":  "sources\Ember-MM\EmberAPI\clsAPIStringUtils.vb",
+"region":  {
+"startLine":  161,
+"startColumn":  55,
+"endLine":  161,
+"endColumn":  64
+}
+}
+},
+{
+"id":  "S2259",
+"message":  "'movieName' is Nothing on at least one execution path.",
+"location":  {
+"uri":  "sources\Ember-MM\EmberAPI\clsAPIStringUtils.vb",
+"region":  {
+"startLine":  162,
+"startColumn":  60,
+"endLine":  162,
+"endColumn":  69
+}
+}
+},
+{
+"id":  "S2259",
+"message":  "'movieName' is Nothing on at least one execution path.",
+"location":  {
+"uri":  "sources\Ember-MM\EmberAPI\clsAPIStringUtils.vb",
+"region":  {
+"startLine":  164,
+"startColumn":  20,
+"endLine":  164,
+"endColumn":  29
+}
+}
+},
+{
+"id":  "S2259",
+"message":  "'movieName' is Nothing on at least one execution path.",
+"location":  {
+"uri":  "sources\Ember-MM\EmberAPI\clsAPIStringUtils.vb",
+"region":  {
+"startLine":  169,
+"startColumn":  20,
+"endLine":  169,
+"endColumn":  29
+}
+}
+},
+{
+"id":  "S2259",
+"message":  "'TVEpName' is Nothing on at least one execution path.",
+"location":  {
+"uri":  "sources\Ember-MM\EmberAPI\clsAPIStringUtils.vb",
+"region":  {
+"startLine":  227,
+"startColumn":  20,
+"endLine":  227,
+"endColumn":  28
+}
+}
+},
+{
+"id":  "S2259",
+"message":  "'TVShowName' is Nothing on at least one execution path.",
+"location":  {
+"uri":  "sources\Ember-MM\EmberAPI\clsAPIStringUtils.vb",
+"region":  {
+"startLine":  269,
+"startColumn":  20,
+"endLine":  269,
+"endColumn":  30
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Ember-MM/generic.EmberCore.NMT-{84B2143A-D04F-4262-923D-21AEDF86E2B7}-S2259.json
+++ b/analyzers/its/expected/Ember-MM/generic.EmberCore.NMT-{84B2143A-D04F-4262-923D-21AEDF86E2B7}-S2259.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S2259",
+"message":  "'mediaPath' is Nothing on at least one execution path.",
+"location":  {
+"uri":  "sources\Ember-MM\Addons\generic.EmberCore.NMT\dlgNMTMovies.vb",
+"region":  {
+"startLine":  523,
+"startColumn":  25,
+"endLine":  523,
+"endColumn":  34
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Nancy/Nancy--net452-S2259.json
+++ b/analyzers/its/expected/Nancy/Nancy--net452-S2259.json
@@ -2,19 +2,6 @@
 "issues":  [
 {
 "id":  "S2259",
-"message":  "'extension' is null on at least one execution path.",
-"location":  {
-"uri":  "sources\Nancy\src\Nancy\Routing\DefaultRequestDispatcher.cs",
-"region":  {
-"startLine":  146,
-"startColumn":  73,
-"endLine":  146,
-"endColumn":  82
-}
-}
-},
-{
-"id":  "S2259",
 "message":  "'substitutionBool' is null on at least one execution path.",
 "location":  {
 "uri":  "sources\Nancy\src\Nancy\ViewEngines\SuperSimpleViewEngine\SuperSimpleViewEngine.cs",

--- a/analyzers/its/expected/Nancy/Nancy--netstandard2.0-S2259.json
+++ b/analyzers/its/expected/Nancy/Nancy--netstandard2.0-S2259.json
@@ -2,19 +2,6 @@
 "issues":  [
 {
 "id":  "S2259",
-"message":  "'extension' is null on at least one execution path.",
-"location":  {
-"uri":  "sources\Nancy\src\Nancy\Routing\DefaultRequestDispatcher.cs",
-"region":  {
-"startLine":  146,
-"startColumn":  73,
-"endLine":  146,
-"endColumn":  82
-}
-}
-},
-{
-"id":  "S2259",
 "message":  "'substitutionBool' is null on at least one execution path.",
 "location":  {
 "uri":  "sources\Nancy\src\Nancy\ViewEngines\SuperSimpleViewEngine\SuperSimpleViewEngine.cs",

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/ObjectConstraint.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/ObjectConstraint.cs
@@ -20,10 +20,16 @@
 
 namespace SonarAnalyzer.SymbolicExecution.Constraints
 {
+    internal enum ObjectConstraintKind
+    {
+        Null,
+        NotNull,
+    }
+
     internal sealed class ObjectConstraint : SymbolicConstraint
     {
-        public static readonly ObjectConstraint Null = new();
-        public static readonly ObjectConstraint NotNull = new();
+        public static readonly ObjectConstraint Null = new(ObjectConstraintKind.Null);
+        public static readonly ObjectConstraint NotNull = new(ObjectConstraintKind.NotNull);
 
         public override SymbolicConstraint Opposite =>
             // x == null ? <Null> : <NotNull>
@@ -33,6 +39,9 @@ namespace SonarAnalyzer.SymbolicExecution.Constraints
         protected override string Name =>
             this == Null ? nameof(Null) : nameof(NotNull);
 
-        private ObjectConstraint() { }
+        private ObjectConstraint(ObjectConstraintKind kind) =>
+            Kind = kind;
+
+        public ObjectConstraintKind Kind { get; }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/ObjectConstraint.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/ObjectConstraint.cs
@@ -20,16 +20,10 @@
 
 namespace SonarAnalyzer.SymbolicExecution.Constraints
 {
-    internal enum ObjectConstraintKind
-    {
-        Null,
-        NotNull,
-    }
-
     internal sealed class ObjectConstraint : SymbolicConstraint
     {
-        public static readonly ObjectConstraint Null = new(ObjectConstraintKind.Null);
-        public static readonly ObjectConstraint NotNull = new(ObjectConstraintKind.NotNull);
+        public static readonly ObjectConstraint Null = new();
+        public static readonly ObjectConstraint NotNull = new();
 
         public override SymbolicConstraint Opposite =>
             // x == null ? <Null> : <NotNull>
@@ -38,10 +32,5 @@ namespace SonarAnalyzer.SymbolicExecution.Constraints
 
         protected override string Name =>
             this == Null ? nameof(Null) : nameof(NotNull);
-
-        private ObjectConstraint(ObjectConstraintKind kind) =>
-            Kind = kind;
-
-        public ObjectConstraintKind Kind { get; }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/ObjectConstraint.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/ObjectConstraint.cs
@@ -32,5 +32,7 @@ namespace SonarAnalyzer.SymbolicExecution.Constraints
 
         protected override string Name =>
             this == Null ? nameof(Null) : nameof(NotNull);
+
+        private ObjectConstraint() { }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
             {
                 if (state[symbol] is { } symbolicValue && symbolicValue.HasConstraint(ObjectConstraint.Null))
                 {
-                    // IsNullOrEmpty will always return "true". For the opposite case, we can not tell for sure
+                    // IsNullOrEmpty will always return "true". For the NotNull case, we can not tell for sure (string could be empty)
                     return new[] { SetOperationConstraint(BoolConstraint.True) };
                 }
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
 
         private ProgramState[] PreProcessInvocation(ProgramState state, IInvocationOperationWrapper invocation)
         {
-            if (ArgumentIsNullOrEmpty(invocation) is { } symbol)
+            if (ArgumentOfIsNullOrEmpty(invocation) is { } symbol)
             {
                 if (state[symbol] is { } symbolicValue && symbolicValue.HasConstraint(ObjectConstraint.Null))
                 {
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
                 state.SetOperationConstraint(invocation.WrappedOperation, boolConstraint);
         }
 
-        private static ISymbol ArgumentIsNullOrEmpty(IInvocationOperationWrapper invocation) =>
+        private static ISymbol ArgumentOfIsNullOrEmpty(IInvocationOperationWrapper invocation) =>
             invocation is
             {
                 TargetMethod:

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
@@ -42,8 +42,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
                 ? context.State[argumentSymbol]?.Constraint<ObjectConstraint>() switch
                 {
                     ObjectConstraint constraint when constraint == ObjectConstraint.NotNull => null, // The "normal" state handling reflects already what is going on.
-                    ObjectConstraint constraint when constraint == ObjectConstraint.Null =>
-                        context.SetOperationConstraint(BoolConstraint.True), // Method will return "True" if argument is known to be Null
+                    ObjectConstraint constraint when constraint == ObjectConstraint.Null => context.SetOperationConstraint(BoolConstraint.True), // IsNullOrEmpty(arg) returns true if arg is null
                     _ => new[] // Explode the known states, these methods can create.
                     {
                             context.SetOperationConstraint(BoolConstraint.True).SetSymbolConstraint(argumentSymbol, ObjectConstraint.Null),

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
@@ -39,7 +39,13 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
         {
             if (invocation is
                 {
-                    TargetMethod: { Name: nameof(string.IsNullOrEmpty), Parameters: { Length: 1 } parameters },
+                    TargetMethod:
+                    {
+                        IsStatic: true,
+                        ContainingType: { SpecialType: SpecialType.System_String },
+                        Name: nameof(string.IsNullOrEmpty) or nameof(string.IsNullOrWhiteSpace),
+                        Parameters: { Length: 1 } parameters
+                    },
                     Arguments: { Length: 1 } arguments,
                 }
                 && parameters[0] is { Name: "value", Type: { SpecialType: SpecialType.System_String } }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
                 ? context.State[argumentSymbol]?.Constraint<ObjectConstraint>() switch
                 {
                     ObjectConstraint constraint when constraint == ObjectConstraint.NotNull => null, // The "normal" state handling reflects already what is going on.
-                    ObjectConstraint constraint when constraint == ObjectConstraint.Null => context.SetOperationConstraint(BoolConstraint.True), // IsNullOrEmpty(arg) returns true if arg is null
+                    ObjectConstraint constraint when constraint == ObjectConstraint.Null => new[] { context.SetOperationConstraint(BoolConstraint.True) }, // IsNullOrEmpty() is true if arg is null
                     _ => new[] // Explode the known states, these methods can create.
                     {
                             context.SetOperationConstraint(BoolConstraint.True).SetSymbolConstraint(argumentSymbol, ObjectConstraint.Null),

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
@@ -43,8 +43,8 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
                     && context.State[argumentSymbol]?.Constraint<ObjectConstraint>() is var objectConstraint
                         => objectConstraint switch
                         {
-                            { Kind: ObjectConstraintKind.NotNull } => null, // The "normal" state handling reflects already what is going on.
-                            { Kind: ObjectConstraintKind.Null } =>
+                            _ when objectConstraint == ObjectConstraint.NotNull => null, // The "normal" state handling reflects already what is going on.
+                            _ when objectConstraint == ObjectConstraint.Null =>
                                 // If the argument to IsNullOrEmpty is known to be null, the methods are known to return true.
                                 context.SetOperationConstraint(BoolConstraint.True),
                             _ => new[] // Explode the known states, these methods can create.

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using SonarAnalyzer.SymbolicExecution.Constraints;
+using StyleCop.Analyzers.Lightup;
+
+namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
+{
+    internal class InvocationCheck : SymbolicCheck
+    {
+        public override ProgramState[] PreProcess(SymbolicContext context) =>
+            context.Operation.Instance.Kind switch
+            {
+                OperationKindEx.Invocation => PreProcessInvocation(context.State, IInvocationOperationWrapper.FromOperation(context.Operation.Instance)),
+                _ => null,
+            } is { } newState
+                ? newState
+                : base.PreProcess(context);
+
+        private ProgramState[] PreProcessInvocation(ProgramState state, IInvocationOperationWrapper invocation)
+        {
+            if (invocation is
+                {
+                    TargetMethod: { Name: nameof(string.IsNullOrEmpty), Parameters: { Length: 1 } parameters },
+                    Arguments: { Length: 1 } arguments,
+                }
+                && parameters[0] is { Name: "value", Type: { SpecialType: SpecialType.System_String } }
+                && arguments[0].TrackedSymbol() is { } symbol)
+            {
+                return new[]
+                {
+                    state.SetOperationConstraint(invocation.WrappedOperation, BoolConstraint.True).SetSymbolConstraint(symbol, ObjectConstraint.Null),
+                    state.SetOperationConstraint(invocation.WrappedOperation, BoolConstraint.True).SetSymbolConstraint(symbol, ObjectConstraint.NotNull),
+                    state.SetOperationConstraint(invocation.WrappedOperation, BoolConstraint.False).SetSymbolConstraint(symbol, ObjectConstraint.NotNull),
+                };
+            }
+
+            return null;
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
@@ -28,9 +28,9 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
     {
         public override ProgramState[] PreProcess(SymbolicContext context) =>
             context.Operation.Instance.Kind == OperationKindEx.Invocation
-                && PreProcessInvocation(context.State, IInvocationOperationWrapper.FromOperation(context.Operation.Instance)) is { } newState
-                    ? newState
-                    : base.PreProcess(context);
+            && PreProcessInvocation(context.State, IInvocationOperationWrapper.FromOperation(context.Operation.Instance)) is { } newState
+                ? newState
+                : base.PreProcess(context);
 
         private ProgramState[] PreProcessInvocation(ProgramState state, IInvocationOperationWrapper invocation)
         {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
@@ -27,13 +27,10 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
     internal class InvocationCheck : SymbolicCheck
     {
         public override ProgramState[] PreProcess(SymbolicContext context) =>
-            context.Operation.Instance.Kind switch
-            {
-                OperationKindEx.Invocation => PreProcessInvocation(context.State, IInvocationOperationWrapper.FromOperation(context.Operation.Instance)),
-                _ => null,
-            } is { } newState
-                ? newState
-                : base.PreProcess(context);
+            context.Operation.Instance.Kind == OperationKindEx.Invocation
+                && PreProcessInvocation(context.State, IInvocationOperationWrapper.FromOperation(context.Operation.Instance)) is { } newState
+                    ? newState
+                    : base.PreProcess(context);
 
         private ProgramState[] PreProcessInvocation(ProgramState state, IInvocationOperationWrapper invocation)
         {
@@ -53,11 +50,10 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
                 };
             }
 
-            return null;
+            return default;
 
             ProgramState SetOperationConstraint(BoolConstraint boolConstraint) =>
                 state.SetOperationConstraint(invocation.WrappedOperation, boolConstraint);
-
         }
 
         private static ISymbol ArgumentIsNullOrEmpty(IInvocationOperationWrapper invocation) =>

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/InvocationCheck.cs
@@ -32,12 +32,12 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
                 ? newState
                 : base.PreProcess(context);
 
-        private ProgramState[] PreProcess(SymbolicContext context, IInvocationOperationWrapper invocation) =>
+        private static ProgramState[] PreProcess(SymbolicContext context, IInvocationOperationWrapper invocation) =>
             invocation.TargetMethod.IsAny(KnownType.System_String, nameof(string.IsNullOrEmpty), nameof(string.IsNullOrWhiteSpace))
                 ? ProcessStringIsNullOrEmpty(context, invocation)
                 : null;
 
-        private ProgramState[] ProcessStringIsNullOrEmpty(SymbolicContext context, IInvocationOperationWrapper invocation) =>
+        private static ProgramState[] ProcessStringIsNullOrEmpty(SymbolicContext context, IInvocationOperationWrapper invocation) =>
             invocation.Arguments[0].TrackedSymbol() is { } argumentSymbol
                 ? context.State[argumentSymbol]?.Constraint<ObjectConstraint>() switch
                 {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
@@ -34,6 +34,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 OperationKindEx.FieldReference when IFieldReferenceOperationWrapper.FromOperation(operation) is var fieldReference && IsStaticOrThis(fieldReference) => fieldReference.Field,
                 OperationKindEx.LocalReference => ILocalReferenceOperationWrapper.FromOperation(operation).Local,
                 OperationKindEx.ParameterReference => IParameterReferenceOperationWrapper.FromOperation(operation).Parameter,
+                OperationKindEx.Argument => IArgumentOperationWrapper.FromOperation(operation).Value.TrackedSymbol(),
                 _ => null
             };
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -142,7 +142,8 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         public override string ToString() =>
             Equals(Empty) ? "Empty" + Environment.NewLine : SerializeExceptions() + SerializeSymbols() + SerializeOperations() + SerializeCaptures();
 
-        public static implicit operator ProgramState[](ProgramState from) => new[] { from };
+        public static implicit operator ProgramState[](ProgramState from) =>
+            new[] { from };
 
         private string SerializeExceptions() =>
             Exceptions.IsEmpty ? null : Exceptions.JoinStr(string.Empty, x => $"Exception: {x}{Environment.NewLine}");

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -131,7 +131,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 HashCode.EnumerableContentHash(Exceptions));
 
         public bool Equals(ProgramState other) =>
-            // VisitCount is not compared, two ProgramState are equal if their current state is equal. No matter was historical path led to it.
+            // VisitCount is not compared, two ProgramState are equal if their current state is equal. No matter what historical path led to it.
             other is not null
             && other.OperationValue.DictionaryEquals(OperationValue)
             && other.SymbolValue.DictionaryEquals(SymbolValue)
@@ -143,7 +143,9 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             Equals(Empty) ? "Empty" + Environment.NewLine : SerializeExceptions() + SerializeSymbols() + SerializeOperations() + SerializeCaptures();
 
         public static implicit operator ProgramState[](ProgramState from) =>
-            new[] { from };
+            from is null
+                ? ProgramState.Empty
+                : new[] { from };
 
         private string SerializeExceptions() =>
             Exceptions.IsEmpty ? null : Exceptions.JoinStr(string.Empty, x => $"Exception: {x}{Environment.NewLine}");

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -144,7 +144,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
 
         public static implicit operator ProgramState[](ProgramState from) =>
             from is null
-                ? ProgramState.Empty
+                ? Array.Empty<ProgramState>()
                 : new[] { from };
 
         private string SerializeExceptions() =>

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -142,6 +142,8 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         public override string ToString() =>
             Equals(Empty) ? "Empty" + Environment.NewLine : SerializeExceptions() + SerializeSymbols() + SerializeOperations() + SerializeCaptures();
 
+        public static implicit operator ProgramState[](ProgramState from) => new[] { from };
+
         private string SerializeExceptions() =>
             Exceptions.IsEmpty ? null : Exceptions.JoinStr(string.Empty, x => $"Exception: {x}{Environment.NewLine}");
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -142,11 +142,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         public override string ToString() =>
             Equals(Empty) ? "Empty" + Environment.NewLine : SerializeExceptions() + SerializeSymbols() + SerializeOperations() + SerializeCaptures();
 
-        public static implicit operator ProgramState[](ProgramState from) =>
-            from is null
-                ? Array.Empty<ProgramState>()
-                : new[] { from };
-
         private string SerializeExceptions() =>
             Exceptions.IsEmpty ? null : Exceptions.JoinStr(string.Empty, x => $"Exception: {x}{Environment.NewLine}");
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -302,7 +302,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                     OperationKindEx.IsPattern => Pattern.LearnBranchingConstraint(state, As(IIsPatternOperationWrapper.FromOperation), useOpposite),
                     OperationKindEx.IsType => IsType.LearnBranchingConstraint(state, As(IIsTypeOperationWrapper.FromOperation), useOpposite),
                     OperationKindEx.Unary when operation.ToUnary() is { OperatorKind: UnaryOperatorKind.Not } unary => LearnBranchingConstraintsFromOperation(state, unary.Operand, !useOpposite),
-                    OperationKindEx.Invocation => Invocation.LearnBranchingConstraint(state, As(IInvocationOperationWrapper.FromOperation), useOpposite),
                     _ => state
                 };
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -302,6 +302,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                     OperationKindEx.IsPattern => Pattern.LearnBranchingConstraint(state, As(IIsPatternOperationWrapper.FromOperation), useOpposite),
                     OperationKindEx.IsType => IsType.LearnBranchingConstraint(state, As(IIsTypeOperationWrapper.FromOperation), useOpposite),
                     OperationKindEx.Unary when operation.ToUnary() is { OperatorKind: UnaryOperatorKind.Not } unary => LearnBranchingConstraintsFromOperation(state, unary.Operand, !useOpposite),
+                    OperationKindEx.Invocation => Invocation.LearnBranchingConstraint(state, As(IInvocationOperationWrapper.FromOperation), useOpposite),
                     _ => state
                 };
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             {
                 throw new ArgumentException("At least one check is expected", nameof(checks));
             }
-            this.checks = new(new[] { new ConstantCheck() }.Concat(checks).ToArray());
+            this.checks = new(new SymbolicCheck[] { new ConstantCheck(), new InvocationCheck() }.Concat(checks).ToArray());
             this.cancel = cancel;
             exceptionCandidate = new(cfg.OriginalOperation.ToSonar().SemanticModel.Compilation);
             lva = new(cfg, cancel);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
@@ -290,21 +290,6 @@ Captures:
 ");
         }
 
-        [TestMethod]
-        public void ProgramStateToArrayEncapsulatesSingleElement()
-        {
-            var programState = ProgramState.Empty;
-            ProgramState[] target = programState;
-            target.Should().NotBeNull().And.HaveCount(1).And.Equal(new[] { ProgramState.Empty });
-        }
-
-        [TestMethod]
-        public void ProgramStateToArrayConversionHandlesNull()
-        {
-            ProgramState[] target = (ProgramState)null;
-            target.Should().BeEmpty();
-        }
-
         private static ISymbol[] CreateSymbols()
         {
             const string code = @"public class Sample { public void Main() { var variable = 0; } }";

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
@@ -302,7 +302,7 @@ Captures:
         public void ProgramStateToArrayConversionHandlesNull()
         {
             ProgramState[] target = (ProgramState)null;
-            target.Should().NotBeNull().And.HaveCount(1).And.Equal(new[] { ProgramState.Empty });
+            target.Should().NotBeNull().And.HaveCount(0).And.BeOfType<ProgramState[]>();
         }
 
         private static ISymbol[] CreateSymbols()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
@@ -222,7 +222,7 @@ Main: Second
 SimpleAssignmentOperation / VariableDeclaratorSyntax: a = true: No constraints
 ");
             var valueWithConstraint = new SymbolicValue().WithConstraint(TestConstraint.Second);
-            sut = sut.SetOperationValue(assignment.Children.First(), valueWithConstraint);
+            sut = sut.SetOperationValue(assignment.ChildOperations.First(), valueWithConstraint);
             sut.ToString().Should().BeIgnoringLineEndings(
 @"Operations:
 LocalReferenceOperation / VariableDeclaratorSyntax: a = true: Second
@@ -265,15 +265,15 @@ Exception: Unknown
         public void ToString_WithAll()
         {
             var assignment = TestHelper.CompileCfgBodyCS("var a = true;").Blocks[1].Operations[0];
-            var variableSymbol = assignment.Children.First().TrackedSymbol();
+            var variableSymbol = assignment.ChildOperations.First().TrackedSymbol();
             var valueWithConstraint = new SymbolicValue().WithConstraint(TestConstraint.First);
             var sut = ProgramState.Empty
                 .SetSymbolValue(variableSymbol, new())
                 .SetSymbolValue(variableSymbol.ContainingSymbol, valueWithConstraint)
                 .SetOperationValue(assignment, new())
-                .SetOperationValue(assignment.Children.First(), valueWithConstraint).Preserve(variableSymbol)
+                .SetOperationValue(assignment.ChildOperations.First(), valueWithConstraint).Preserve(variableSymbol)
                 .SetCapture(new CaptureId(0), assignment)
-                .SetCapture(new CaptureId(1), assignment.Children.First())
+                .SetCapture(new CaptureId(1), assignment.ChildOperations.First())
                 .PushException(ExceptionState.UnknownException);
 
             sut.ToString().Should().BeIgnoringLineEndings(

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
@@ -290,6 +290,14 @@ Captures:
 ");
         }
 
+        [TestMethod]
+        public void ProgramStateToArrayEncapsulatesSingleElement()
+        {
+            var programState = ProgramState.Empty;
+            ProgramState[] target = programState;
+            target.Should().NotBeNull().And.HaveCount(1).And.Equal(new[] { ProgramState.Empty });
+        }
+
         private static ISymbol[] CreateSymbols()
         {
             const string code = @"public class Sample { public void Main() { var variable = 0; } }";

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
@@ -184,8 +184,8 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         public void ToString_WithSymbols()
         {
             var assignment = TestHelper.CompileCfgBodyCS("var a = arg;", "bool arg").Blocks[1].Operations[0];
-            var variableSymbol = assignment.Children.First().TrackedSymbol();
-            var parameterSymbol = assignment.Children.Last().TrackedSymbol();
+            var variableSymbol = assignment.ChildOperations.First().TrackedSymbol();
+            var parameterSymbol = assignment.ChildOperations.Last().TrackedSymbol();
             var sut = ProgramState.Empty.SetSymbolValue(variableSymbol, null);
             sut.ToString().Should().BeIgnoringLineEndings(
 @"Empty

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
@@ -298,6 +298,13 @@ Captures:
             target.Should().NotBeNull().And.HaveCount(1).And.Equal(new[] { ProgramState.Empty });
         }
 
+        [TestMethod]
+        public void ProgramStateToArrayConversionHandlesNull()
+        {
+            ProgramState[] target = (ProgramState)null;
+            target.Should().NotBeNull().And.HaveCount(1).And.Equal(new[] { ProgramState.Empty });
+        }
+
         private static ISymbol[] CreateSymbols()
         {
             const string code = @"public class Sample { public void Main() { var variable = 0; } }";

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.cs
@@ -302,7 +302,7 @@ Captures:
         public void ProgramStateToArrayConversionHandlesNull()
         {
             ProgramState[] target = (ProgramState)null;
-            target.Should().NotBeNull().And.HaveCount(0).And.BeOfType<ProgramState[]>();
+            target.Should().BeEmpty();
         }
 
         private static ISymbol[] CreateSymbols()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -551,16 +551,16 @@ Tag(""End"");";
         public void Branching_IsNullOrEmpty_SetsNullConstraintsInBranches(string methodName)
         {
             var code = $@"
-if (string.{methodName}(s))
+if (string.{methodName}(arg))
 {{
-    Tag(""If"", s);
+    Tag(""If"", arg);
 }}
 else
 {{
-    Tag(""Else"", s);
+    Tag(""Else"", arg);
 }}
-Tag(""End"", s);";
-            var validator = SETestContext.CreateCS(code, ", string s").Validator;
+Tag(""End"", arg);";
+            var validator = SETestContext.CreateCS(code, ", string arg").Validator;
             validator.TagValues("If").Should().HaveCount(2)
                 .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
                 .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -596,7 +596,7 @@ Tag(""End"", s);";
         public void Branching_IsNullOrEmpty_VisitsBothBranchesIfNotNull(string methodName)
         {
             var code = @$"
-string s = ""some text"";
+string s = new string('c', 42);
 if (string.{methodName}(s))
 {{
     Tag(""If"", s);
@@ -607,13 +607,9 @@ else
 }}
 Tag(""End"", s);";
             var validator = SETestContext.CreateCS(code).Validator;
-            validator.TagValues("If").Should().HaveCount(2)
-                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
-                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
+            validator.ValidateTag("If", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
             validator.ValidateTag("Else", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-            validator.TagValues("End").Should().HaveCount(2)
-                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
-                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
+            validator.ValidateTag("End", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -550,11 +550,11 @@ else
 }
 Tag(""End"", arg);";
             var validator = SETestContext.CreateCS(code, ", string arg").Validator;
-            validator.ValidateTag("If", x => x.Should().BeNull());
+            validator.TagValues("If").Should().HaveCount(2)
+                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
+                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
             validator.ValidateTag("Else", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-            validator.TagValues("End").Should().HaveCount(2)
-                .And.ContainSingle(x => x == null)
-                .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
+            // TODO validator.TagValues("End")
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -574,16 +574,16 @@ Tag(""End"", arg);";
         public void Branching_IsNullOrEmpty_VisitsTrueBranchIfNull(string methodName)
         {
             var code = $@"
-string s = null;
-if (string.{methodName}(s))
+string isNull = null;
+if (string.{methodName}(isNull))
 {{
-    Tag(""If"", s);
+    Tag(""If"", isNull);
 }}
 else
 {{
-    Tag(""Else"", s);
+    Tag(""Else"", isNull);
 }}
-Tag(""End"", s);";
+Tag(""End"", isNull);";
             var validator = SETestContext.CreateCS(code).Validator;
             validator.ValidateTag("If", x => x.HasConstraint(ObjectConstraint.Null));
             validator.TagValues("Else").Should().BeEmpty();
@@ -595,16 +595,16 @@ Tag(""End"", s);";
         public void Branching_IsNullOrEmpty_VisitsBothBranchesIfNotNull(string methodName)
         {
             var code = @$"
-string s = new string('c', 42);
-if (string.{methodName}(s))
+string notNull = new string('c', 42);
+if (string.{methodName}(notNull))
 {{
-    Tag(""If"", s);
+    Tag(""If"", notNull);
 }}
 else
 {{
-    Tag(""Else"", s);
+    Tag(""Else"", notNull);
 }}
-Tag(""End"", s);";
+Tag(""End"", notNull);";
             var validator = SETestContext.CreateCS(code).Validator;
             validator.ValidateTag("If", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
             validator.ValidateTag("Else", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -595,7 +595,7 @@ Tag(""End"", isNull);";
         public void Branching_IsNullOrEmpty_VisitsBothBranchesIfNotNull(string methodName)
         {
             var code = @$"
-string notNull = new string('c', 42);
+string notNull = ""Some NotNull text"";
 if (string.{methodName}(notNull))
 {{
     Tag(""If"", notNull);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -297,7 +297,7 @@ else
     Tag(""GetHashCode"", value);
 }";
             var postProcess = new PostProcessTestCheck(x =>
-                x.Operation.Instance is IInvocationOperation { TargetMethod: { Name: "ToString" } } invocation
+                x.Operation.Instance is IInvocationOperation { TargetMethod.Name: "ToString" } invocation
                     ? x.SetSymbolConstraint(invocation.Instance.TrackedSymbol(), TestConstraint.First)
                     : x.State);
             var validator = SETestContext.CreateCS(code, postProcess).Validator;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -27,6 +27,16 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
 {
     public partial class RoslynSymbolicExecutionTest
     {
+
+        private static IEnumerable<object[]> StringIsNullOrEmptyMethods
+        {
+            get
+            {
+                yield return new object[] { nameof(string.IsNullOrEmpty) };
+                yield return new object[] { nameof(string.IsNullOrWhiteSpace) };
+            }
+        }
+
         [TestMethod]
         public void Branching_BlockProcessingOrder_CS()
         {
@@ -604,15 +614,6 @@ Tag(""End"", s);";
             validator.TagValues("End").Should().HaveCount(2)
                 .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
                 .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
-        }
-
-        private static IEnumerable<object[]> StringIsNullOrEmptyMethods
-        {
-            get
-            {
-                yield return new object[] { nameof(string.IsNullOrEmpty) };
-                yield return new object[] { nameof(string.IsNullOrWhiteSpace) };
-            }
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -578,5 +578,29 @@ Tag(""End"", s);";
             validator.TagValues("Else").Should().BeEmpty();
             validator.ValidateTag("End", x => x.HasConstraint(ObjectConstraint.Null));
         }
+
+        [TestMethod]
+        public void Branching_IsNullOrEmpty_VisitsBothBranchesIfNotNull()
+        {
+            const string code = @"
+string s = ""some text"";
+if (string.IsNullOrEmpty(s))
+{
+    Tag(""If"", s);
+}
+else
+{
+    Tag(""Else"", s);
+}
+Tag(""End"", s);";
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.TagValues("If").Should().HaveCount(2)
+                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
+                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
+            validator.ValidateTag("Else", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+            validator.TagValues("End").Should().HaveCount(2)
+                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
+                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
+        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -536,18 +536,19 @@ Tag(""End"");";
                 "End");
         }
 
-        [TestMethod]
-        public void Branching_IsNullOrEmpty_SetsNullConstraintsInBranches()
+        [DataTestMethod]
+        [DynamicData(nameof(StringIsNullOrEmptyMethods))]
+        public void Branching_IsNullOrEmpty_SetsNullConstraintsInBranches(string methodName)
         {
-            const string code = @"
-if (string.IsNullOrEmpty(s))
-{
+            var code = $@"
+if (string.{methodName}(s))
+{{
     Tag(""If"", s);
-}
+}}
 else
-{
+{{
     Tag(""Else"", s);
-}
+}}
 Tag(""End"", s);";
             var validator = SETestContext.CreateCS(code, ", string s").Validator;
             validator.TagValues("If").Should().HaveCount(2)
@@ -559,19 +560,20 @@ Tag(""End"", s);";
                 .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
         }
 
-        [TestMethod]
-        public void Branching_IsNullOrEmpty_VisitsTrueBranchIfNull()
+        [DataTestMethod]
+        [DynamicData(nameof(StringIsNullOrEmptyMethods))]
+        public void Branching_IsNullOrEmpty_VisitsTrueBranchIfNull(string methodName)
         {
-            const string code = @"
+            var code = $@"
 string s = null;
-if (string.IsNullOrEmpty(s))
-{
+if (string.{methodName}(s))
+{{
     Tag(""If"", s);
-}
+}}
 else
-{
+{{
     Tag(""Else"", s);
-}
+}}
 Tag(""End"", s);";
             var validator = SETestContext.CreateCS(code).Validator;
             validator.ValidateTag("If", x => x.HasConstraint(ObjectConstraint.Null));
@@ -579,19 +581,20 @@ Tag(""End"", s);";
             validator.ValidateTag("End", x => x.HasConstraint(ObjectConstraint.Null));
         }
 
-        [TestMethod]
-        public void Branching_IsNullOrEmpty_VisitsBothBranchesIfNotNull()
+        [DataTestMethod]
+        [DynamicData(nameof(StringIsNullOrEmptyMethods))]
+        public void Branching_IsNullOrEmpty_VisitsBothBranchesIfNotNull(string methodName)
         {
-            const string code = @"
+            var code = @$"
 string s = ""some text"";
-if (string.IsNullOrEmpty(s))
-{
+if (string.{methodName}(s))
+{{
     Tag(""If"", s);
-}
+}}
 else
-{
+{{
     Tag(""Else"", s);
-}
+}}
 Tag(""End"", s);";
             var validator = SETestContext.CreateCS(code).Validator;
             validator.TagValues("If").Should().HaveCount(2)
@@ -601,6 +604,15 @@ Tag(""End"", s);";
             validator.TagValues("End").Should().HaveCount(2)
                 .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
                 .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
+        }
+
+        private static IEnumerable<object[]> StringIsNullOrEmptyMethods
+        {
+            get
+            {
+                yield return new object[] { nameof(string.IsNullOrEmpty) };
+                yield return new object[] { nameof(string.IsNullOrWhiteSpace) };
+            }
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -535,5 +535,26 @@ Tag(""End"");";
                 "Else",
                 "End");
         }
+
+        [TestMethod]
+        public void Branching_IsNullOrEmpty_SetsNotNullWhenFalse()
+        {
+            const string code = @"
+if (string.IsNullOrEmpty(arg))
+{
+    Tag(""If"", arg);
+}
+else
+{
+    Tag(""Else"", arg);
+}
+Tag(""End"", arg);";
+            var validator = SETestContext.CreateCS(code, ", string arg").Validator;
+            validator.ValidateTag("If", x => x.Should().BeNull());
+            validator.ValidateTag("Else", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+            validator.TagValues("End").Should().HaveCount(2)
+                .And.ContainSingle(x => x == null)
+                .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
+        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -27,7 +27,6 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
 {
     public partial class RoslynSymbolicExecutionTest
     {
-
         private static IEnumerable<object[]> StringIsNullOrEmptyMethods
         {
             get

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -81,5 +81,26 @@ Tag(""ExceptionAfterCheck"", exception);";
                 new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)
             });
         }
+
+        [TestMethod]
+        public void Invocation_IsNullOrEmpty_TryFinally()
+        {
+            const string code = @"
+try
+{
+    if (string.IsNullOrEmpty(arg)) return;
+}
+finally
+{
+    Tag(""ArgInFinally"", arg);
+}";
+            var validator = SETestContext.CreateCS(code, ", string arg").Validator;
+            validator.TagValues("ArgInFinally").Should().Equal(new[]
+            {
+                null,
+                new SymbolicValue().WithConstraint(ObjectConstraint.Null),    // Wrong. IsNullOrEmpty does not throw and "arg" is known to be not null.
+                new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)
+            });
+        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -27,11 +27,9 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
     public partial class RoslynSymbolicExecutionTest
     {
         [TestMethod]
-        public void PreProcess_IsNullOrEmpty_ExplodesGraph_ValidateOrder()
+        public void Invocation_IsNullOrEmpty_ValidateOrder()
         {
-            const string code = @"var isNullOrEmpy = string.IsNullOrEmpty(arg);";
-
-            var validator = SETestContext.CreateCS(code, ", string arg").Validator;
+            var validator = SETestContext.CreateCS(@"var isNullOrEmpy = string.IsNullOrEmpty(arg);", ", string arg").Validator;
             validator.ValidateOrder(
 "LocalReference: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)",
 "ParameterReference: arg",
@@ -45,13 +43,12 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
-        public void PreProcess_IsNullOrEmpty_Tags()
+        public void Invocation_IsNullOrEmpty_Tags()
         {
             const string code = @"
 var isNullOrEmpy = string.IsNullOrEmpty(arg);
 Tag(""IsNullOrEmpy"", isNullOrEmpy);
 Tag(""Arg"", arg);";
-
             var validator = SETestContext.CreateCS(code, ", string arg").Validator;
             validator.TagValues("IsNullOrEmpy").Should().Equal(
                 new SymbolicValue().WithConstraint(BoolConstraint.True),

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -59,5 +59,19 @@ Tag(""Arg"", arg);";
                 new SymbolicValue().WithConstraint(ObjectConstraint.NotNull),  // True/NotNull
                 new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)); // False/NotNull
         }
+
+        [TestMethod]
+        public void Invocation_IsNullOrEmpty_NestedProperty()
+        {
+            const string code = @"
+if (!string.IsNullOrEmpty(exception?.Message))
+{
+    Tag(""ExceptionChecked"", exception);
+}
+Tag(""ExceptionAfterCheck"", exception);";
+            var validator = SETestContext.CreateCS(code, ", InvalidOperationException exception").Validator;
+            validator.TagValues("ExceptionChecked").Should().Equal(new SymbolicValue[] { null }); // Should be 'new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)'
+            validator.TagValues("ExceptionAfterCheck").Should().Equal(new SymbolicValue[] { null });
+        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -1,0 +1,66 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.SymbolicExecution.Constraints;
+using SonarAnalyzer.SymbolicExecution.Roslyn;
+using SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution;
+
+namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
+{
+    public partial class RoslynSymbolicExecutionTest
+    {
+        [TestMethod]
+        public void PreProcess_IsNullOrEmpty_ExplodesGraph_ValidateOrder()
+        {
+            const string code = @"var isNullOrEmpy = string.IsNullOrEmpty(arg);";
+
+            var validator = SETestContext.CreateCS(code, ", string arg").Validator;
+            validator.ValidateOrder(
+"LocalReference: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)",
+"ParameterReference: arg",
+"Argument: arg",
+"Invocation: string.IsNullOrEmpty(arg)",
+"Invocation: string.IsNullOrEmpty(arg)",
+"Invocation: string.IsNullOrEmpty(arg)",
+"SimpleAssignment: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)",
+"SimpleAssignment: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)",
+"SimpleAssignment: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)");
+        }
+
+        [TestMethod]
+        public void PreProcess_IsNullOrEmpty_Tags()
+        {
+            const string code = @"
+var isNullOrEmpy = string.IsNullOrEmpty(arg);
+Tag(""IsNullOrEmpy"", isNullOrEmpy);
+Tag(""Arg"", arg);";
+
+            var validator = SETestContext.CreateCS(code, ", string arg").Validator;
+            validator.TagValues("IsNullOrEmpy").Should().Equal(
+                new SymbolicValue().WithConstraint(BoolConstraint.True),
+                new SymbolicValue().WithConstraint(BoolConstraint.True),
+                new SymbolicValue().WithConstraint(BoolConstraint.False));
+            validator.TagValues("Arg").Should().Equal(
+                new SymbolicValue().WithConstraint(ObjectConstraint.Null),
+                new SymbolicValue().WithConstraint(ObjectConstraint.NotNull),
+                new SymbolicValue().WithConstraint(ObjectConstraint.NotNull));
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -34,12 +34,12 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
 "LocalReference: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)",
 "ParameterReference: arg",
 "Argument: arg",
-"Invocation: string.IsNullOrEmpty(arg)",
-"Invocation: string.IsNullOrEmpty(arg)",
-"Invocation: string.IsNullOrEmpty(arg)",
-"SimpleAssignment: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)",
-"SimpleAssignment: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)",
-"SimpleAssignment: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)");
+"Invocation: string.IsNullOrEmpty(arg)", // True/Null
+"Invocation: string.IsNullOrEmpty(arg)", // True/NotNull
+"Invocation: string.IsNullOrEmpty(arg)", // False/NotNull
+"SimpleAssignment: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)",  // True/Null
+"SimpleAssignment: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)",  // True/NotNull
+"SimpleAssignment: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)"); // False/NotNull
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -72,9 +72,9 @@ Tag(""ExceptionAfterCheck"", exception);";
             var validator = SETestContext.CreateCS(code, ", InvalidOperationException exception").Validator;
             validator.TagValues("ExceptionChecked").Should().Equal(new[]
             {
-                new SymbolicValue().WithConstraint(ObjectConstraint.Null),
+                new SymbolicValue().WithConstraint(ObjectConstraint.Null),   // Wrong. Exception is known to be not null here.
                 new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)
-            }); // Should be 'new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)'
+            });
             validator.TagValues("ExceptionAfterCheck").Should().Equal(new[]
             {
                 new SymbolicValue().WithConstraint(ObjectConstraint.Null),

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -51,13 +51,13 @@ Tag(""IsNullOrEmpy"", isNullOrEmpy);
 Tag(""Arg"", arg);";
             var validator = SETestContext.CreateCS(code, ", string arg").Validator;
             validator.TagValues("IsNullOrEmpy").Should().Equal(
-                new SymbolicValue().WithConstraint(BoolConstraint.True),
-                new SymbolicValue().WithConstraint(BoolConstraint.True),
-                new SymbolicValue().WithConstraint(BoolConstraint.False));
+                new SymbolicValue().WithConstraint(BoolConstraint.True),       // True/Null
+                new SymbolicValue().WithConstraint(BoolConstraint.True),       // True/NotNull
+                new SymbolicValue().WithConstraint(BoolConstraint.False));     // False/NotNull
             validator.TagValues("Arg").Should().Equal(
-                new SymbolicValue().WithConstraint(ObjectConstraint.Null),
-                new SymbolicValue().WithConstraint(ObjectConstraint.NotNull),
-                new SymbolicValue().WithConstraint(ObjectConstraint.NotNull));
+                new SymbolicValue().WithConstraint(ObjectConstraint.Null),     // True/Null
+                new SymbolicValue().WithConstraint(ObjectConstraint.NotNull),  // True/NotNull
+                new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)); // False/NotNull
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -79,7 +79,7 @@ Tag(""ExceptionAfterCheck"", exception);";
             {
                 new SymbolicValue().WithConstraint(ObjectConstraint.Null),
                 new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)
-            }); // Should be 'new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)'
+            });
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -70,8 +70,16 @@ if (!string.IsNullOrEmpty(exception?.Message))
 }
 Tag(""ExceptionAfterCheck"", exception);";
             var validator = SETestContext.CreateCS(code, ", InvalidOperationException exception").Validator;
-            validator.TagValues("ExceptionChecked").Should().Equal(new SymbolicValue[] { null }); // Should be 'new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)'
-            validator.TagValues("ExceptionAfterCheck").Should().Equal(new SymbolicValue[] { null });
+            validator.TagValues("ExceptionChecked").Should().Equal(new[]
+            {
+                new SymbolicValue().WithConstraint(ObjectConstraint.Null),
+                new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)
+            }); // Should be 'new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)'
+            validator.TagValues("ExceptionAfterCheck").Should().Equal(new[]
+            {
+                new SymbolicValue().WithConstraint(ObjectConstraint.Null),
+                new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)
+            }); // Should be 'new SymbolicValue().WithConstraint(ObjectConstraint.NotNull)'
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -311,6 +311,18 @@ namespace Tests.Diagnostics
             }
         }
 
+        public void StringIsNullOrWhiteSpace(string s1)
+        {
+            if (string.IsNullOrWhiteSpace(s1))
+            {
+                s1.ToString(); // Noncompliant
+            }
+            else
+            {
+                s1.ToString(); // Compliant
+            }
+        }
+
         public void StringEmpty1(string s1)
         {
             if (s1 == "" || s1 == null)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -303,7 +303,7 @@ namespace Tests.Diagnostics
         {
             if (string.IsNullOrEmpty(s1))
             {
-                s1.ToString(); // FIXME Non-compliant
+                s1.ToString(); // Noncompliant
             }
             else
             {
@@ -340,7 +340,7 @@ namespace Tests.Diagnostics
 
         void StringEmpty6(string path)
         {
-            var s = string.IsNullOrEmpty(path) ? path.Split('/') : new string[] { }; // FIXME Non-compliant
+            var s = string.IsNullOrEmpty(path) ? path.Split('/') : new string[] { }; // Noncompliant
         }
 
         void StringEmpty7(string path)


### PR DESCRIPTION
Part of #5973

This seems similar to supporting [`[NotNullWhen]`](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/nullable-analysis#conditional-post-conditions-notnullwhen-maybenullwhen-and-notnullifnotnull), but there is a twist to this one. While NotNullWhen just sets constraints on branching, this one actually explodes the graph to find NREs in the "true" path.