### PR TITLE
Use serial comma in error messages

### DIFF
--- a/analyzers/its/expected/Ember-MM/Ember.Plugins-{9496C697-5AFD-4813-AEDC-AF33FACEADF0}-S1210.json
+++ b/analyzers/its/expected/Ember-MM/Ember.Plugins-{9496C697-5AFD-4813-AEDC-AF33FACEADF0}-S1210.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T>, you should also override Equals, ==, !=, <, <=, >, >=.",
+"message":  "When implementing IComparable<T>, you should also override Equals, ==, !=, <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\Ember-MM\Ember.Plugins\PluginManager.cs",
 "region":  {

--- a/analyzers/its/expected/Nancy/Nancy--net452-S1210.json
+++ b/analyzers/its/expected/Nancy/Nancy--net452-S1210.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T>, you should also override Equals, ==, !=, <, <=, >, >=.",
+"message":  "When implementing IComparable<T>, you should also override Equals, ==, !=, <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\Nancy\src\Nancy\Routing\Trie\MatchResult.cs",
 "region":  {

--- a/analyzers/its/expected/Nancy/Nancy--netstandard2.0-S1210.json
+++ b/analyzers/its/expected/Nancy/Nancy--netstandard2.0-S1210.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T>, you should also override Equals, ==, !=, <, <=, >, >=.",
+"message":  "When implementing IComparable<T>, you should also override Equals, ==, !=, <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\Nancy\src\Nancy\Routing\Trie\MatchResult.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka--netstandard2.0-S1210.json
+++ b/analyzers/its/expected/akka.net/Akka--netstandard2.0-S1210.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T>, you should also override <, <=, >, >=.",
+"message":  "When implementing IComparable<T>, you should also override <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Actor\ActorPath.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T> or IComparable, you should also override <, <=, >, >=.",
+"message":  "When implementing IComparable<T> or IComparable, you should also override <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Actor\Address.cs",
 "region":  {
@@ -28,7 +28,7 @@
 },
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T>, you should also override ==, !=, <, <=, >, >=.",
+"message":  "When implementing IComparable<T>, you should also override ==, !=, <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\NotUsed.cs",
 "region":  {
@@ -41,7 +41,7 @@
 },
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T>, you should also override <, <=, >, >=.",
+"message":  "When implementing IComparable<T>, you should also override <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Util\AppVersion.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.Cluster--netstandard2.0-S1210.json
+++ b/analyzers/its/expected/akka.net/Akka.Cluster--netstandard2.0-S1210.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T> or IComparable, you should also override ==, !=, <, <=, >, >=.",
+"message":  "When implementing IComparable<T> or IComparable, you should also override ==, !=, <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Cluster\Member.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T> or IComparable, you should also override <, <=, >, >=.",
+"message":  "When implementing IComparable<T> or IComparable, you should also override <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Cluster\Member.cs",
 "region":  {
@@ -28,7 +28,7 @@
 },
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T>, you should also override ==, !=, <, <=, >, >=.",
+"message":  "When implementing IComparable<T>, you should also override ==, !=, <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Cluster\VectorClock.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.DistributedData--netstandard2.0-S1210.json
+++ b/analyzers/its/expected/akka.net/Akka.DistributedData--netstandard2.0-S1210.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T> or IComparable, you should also override ==, !=, <, <=, >, >=.",
+"message":  "When implementing IComparable<T> or IComparable, you should also override ==, !=, <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\akka.net\src\contrib\cluster\Akka.DistributedData\Flag.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner.Shared--netstandard2.0-S1210.json
+++ b/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner.Shared--netstandard2.0-S1210.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T>, you should also override ==, !=, <, <=, >, >=.",
+"message":  "When implementing IComparable<T>, you should also override ==, !=, <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\MultiNodeMessage.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.Persistence.Query--netstandard2.0-S1210.json
+++ b/analyzers/its/expected/akka.net/Akka.Persistence.Query--netstandard2.0-S1210.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S1210",
-"message":  "When implementing IComparable<T>, you should also override Equals, ==, !=, <, <=, >, >=.",
+"message":  "When implementing IComparable<T>, you should also override Equals, ==, !=, <, <=, >, and >=.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Persistence.Query\Offset.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.Tests.Performance--netcoreapp3.1-S2931.json
+++ b/analyzers/its/expected/akka.net/Akka.Tests.Performance--netcoreapp3.1-S2931.json
@@ -54,7 +54,7 @@
 },
 {
 "id":  "S2931",
-"message":  "Implement 'IDisposable' in this class and use the 'Dispose' method to call 'Dispose' on 'cancel', 'clientSocket', 'resetEvent', 'stream'.",
+"message":  "Implement 'IDisposable' in this class and use the 'Dispose' method to call 'Dispose' on 'cancel', 'clientSocket', 'resetEvent', and 'stream'.",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Tests.Performance\IO\TcpInboundOnlySpec.cs",
 "region":  {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ComparableInterfaceImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ComparableInterfaceImplementation.cs
@@ -90,7 +90,7 @@ namespace SonarAnalyzer.Rules.CSharp
                             Rule,
                             classDeclaration.Identifier.GetLocation(),
                             string.Join(" or ", implementedComparableInterfaces),
-                            string.Join(", ", membersToOverride)));
+                            membersToOverride.JoinAnd()));
                     }
                 },
                 SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableMemberInNonDisposableClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableMemberInNonDisposableClass.cs
@@ -86,11 +86,12 @@ namespace SonarAnalyzer.Rules.CSharp
                                                         .SelectMany(m => GetAssignmentsToFieldsIn(m, analysisContext.Compilation))
                                                         .Where(f => disposableFields.Contains(f));
 
-            return string.Join(", ", disposableFields.Where(IsOwnerSinceDeclaration)
-                                                     .Union(otherInitializationsOfFields)
-                                                     .Distinct()
-                                                     .Select(symbol => $"'{symbol.Name}'")
-                                                     .OrderBy(name => name));
+            return disposableFields.Where(IsOwnerSinceDeclaration)
+                                   .Union(otherInitializationsOfFields)
+                                   .Distinct()
+                                   .Select(symbol => $"'{symbol.Name}'")
+                                   .OrderBy(name => name)
+                                   .JoinAnd();
         }
 
         private static IEnumerable<IFieldSymbol> GetAssignmentsToFieldsIn(ISymbol m, Compilation compilation)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableReturnedFromUsing.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableReturnedFromUsing.cs
@@ -106,9 +106,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (returnedSymbols.Any())
             {
-                c.ReportIssue(Diagnostic.Create(rule, usingKeyword.GetLocation(),
-                    string.Join(", ",
-                        returnedSymbols.Select(s => $"'{s.Name}'").OrderBy(s => s))));
+                c.ReportIssue(Diagnostic.Create(rule, usingKeyword.GetLocation(), returnedSymbols.Select(s => $"'{s.Name}'").OrderBy(s => s).JoinAnd()));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopCounterCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopCounterCondition.cs
@@ -61,14 +61,10 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    var incrementedVariables = string.Join(",", incrementedSymbols
-                                                                .Select(s => $"'{s.Name}'")
-                                                                .OrderBy(s => s));
+                    var incrementedVariables = incrementedSymbols.Select(s => $"'{s.Name}'").OrderBy(s => s).JoinAnd();
                     if (conditionSymbols.Any())
                     {
-                        var conditionVariables = string.Join(",", conditionSymbols
-                                                                  .Select(s => $"'{s.Name}'")
-                                                                  .OrderBy(s => s));
+                        var conditionVariables = conditionSymbols.Select(s => $"'{s.Name}'").OrderBy(s => s).JoinAnd();
                         c.ReportIssue(Diagnostic.Create(Rule, forNode.Condition.GetLocation(),
                             string.Format(CultureInfo.InvariantCulture, MessageFormatNotEmpty, conditionVariables, incrementedVariables)));
                     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementISerializableCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementISerializableCorrectly.cs
@@ -103,7 +103,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 var serializableFields = GetSerializableFieldNames(typeSymbol).ToList();
                 if (serializableFields.Any())
                 {
-                    yield return new(typeDeclaration.Keyword.GetLocation(), $"Override 'GetObjectData(SerializationInfo, StreamingContext)' and serialize '{serializableFields.JoinStr(", ")}'.");
+                    yield return new(typeDeclaration.Keyword.GetLocation(), $"Override 'GetObjectData(SerializationInfo, StreamingContext)' and serialize '{serializableFields.JoinAnd()}'.");
                 }
             }
             else if (getObjectData.IsOverride && !IsCallingBase(getObjectData))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VirtualEventField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VirtualEventField.cs
@@ -48,9 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (eventField.Modifiers.Any(SyntaxKind.VirtualKeyword))
                     {
                         var virt = eventField.Modifiers.First(modifier => modifier.IsKind(SyntaxKind.VirtualKeyword));
-                        var names = string.Join(", ", eventField.Declaration.Variables
-                                                                .Select(syntax => $"'{syntax.Identifier.ValueText}'")
-                                                                .OrderBy(s => s));
+                        var names = string.Join(", ", eventField.Declaration.Variables.Select(syntax => $"'{syntax.Identifier.ValueText}'").OrderBy(s => s).JoinAnd());
                         c.ReportIssue(Diagnostic.Create(Rule, virt.GetLocation(), names));
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -141,7 +141,7 @@ namespace SonarAnalyzer.Rules
                         var bannedWords = FindCredentialWords(GetVariableName(declarator), variableValue);
                         if (bannedWords.Any())
                         {
-                            context.ReportIssue(Diagnostic.Create(analyzer.rule, declarator.GetLocation(), string.Format(MessageFormatCredential, bannedWords.JoinStr(", "))));
+                            context.ReportIssue(Diagnostic.Create(analyzer.rule, declarator.GetLocation(), string.Format(MessageFormatCredential, bannedWords.JoinAnd())));
                         }
                         else if (ContainsUriUserInfo(variableValue))
                         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ComparableInterfaceImplementation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ComparableInterfaceImplementation.cs
@@ -217,7 +217,7 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
         }
     }
 
-    public class MissingGreaterThan : IComparable // Noncompliant {{When implementing IComparable, you should also override <, >.}}
+    public class MissingGreaterThan : IComparable // Noncompliant {{When implementing IComparable, you should also override < and >.}}
 //               ^^^^^^^^^^^^^^^^^^
     {
         public string Name { get; set; }
@@ -274,7 +274,7 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
         }
     }
 
-    public class MissingNotEqual : IComparable // Noncompliant {{When implementing IComparable, you should also override ==, !=.}}
+    public class MissingNotEqual : IComparable // Noncompliant {{When implementing IComparable, you should also override == and !=.}}
 //               ^^^^^^^^^^^^^^^
     {
         public string Name { get; set; }
@@ -455,7 +455,7 @@ namespace Tests.Diagnostics.ComparableInterfaceImplementation
         }
     }
 
-    public struct Struct : IComparable // Noncompliant {{When implementing IComparable, you should also override Equals, ==, !=, <, <=, >, >=.}}
+    public struct Struct : IComparable // Noncompliant {{When implementing IComparable, you should also override Equals, ==, !=, <, <=, >, and >=.}}
     {
         public int CompareTo(object obj)
         {
@@ -665,7 +665,7 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
         }
     }
 
-    public class MissingGreaterThan : IComparable<MissingGreaterThan> // Noncompliant {{When implementing IComparable<T>, you should also override <, >.}}
+    public class MissingGreaterThan : IComparable<MissingGreaterThan> // Noncompliant {{When implementing IComparable<T>, you should also override < and >.}}
 //               ^^^^^^^^^^^^^^^^^^
     {
         public string Name { get; set; }
@@ -722,7 +722,7 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
         }
     }
 
-    public class MissingNotEqual : IComparable<MissingNotEqual> // Noncompliant {{When implementing IComparable<T>, you should also override ==, !=.}}
+    public class MissingNotEqual : IComparable<MissingNotEqual> // Noncompliant {{When implementing IComparable<T>, you should also override == and !=.}}
 //               ^^^^^^^^^^^^^^^
     {
         public string Name { get; set; }
@@ -906,7 +906,7 @@ namespace Tests.Diagnostics.ComparableGenericInterfaceImplementation
 
 namespace Tests.Diagnostics.BothInterfacesImplementation
 {
-    public class NonCompliant : IComparable, IComparable<NonCompliant> // Noncompliant {{When implementing IComparable or IComparable<T>, you should also override Equals, ==, !=, <, <=, >, >=.}}
+    public class NonCompliant : IComparable, IComparable<NonCompliant> // Noncompliant {{When implementing IComparable or IComparable<T>, you should also override Equals, ==, !=, <, <=, >, and >=.}}
     {
         public string Name { get; set; }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DisposableMemberInNonDisposableClass.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DisposableMemberInNonDisposableClass.cs
@@ -68,7 +68,7 @@ namespace Tests.Diagnostics
     {
     }
 
-    public class ObserverVsOwner // Noncompliant {{Implement 'IDisposable' in this class and use the 'Dispose' method to call 'Dispose' on 'fs2', 'fs3'.}}
+    public class ObserverVsOwner // Noncompliant {{Implement 'IDisposable' in this class and use the 'Dispose' method to call 'Dispose' on 'fs2' and 'fs3'.}}
     {
         protected FileStream fs, fs2 = new FileStream("eee", FileMode.Open), fs3; // Only fs will be compliant
         public FileStream Stream

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DisposableReturnedFromUsing.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DisposableReturnedFromUsing.cs
@@ -74,7 +74,7 @@ namespace Tests.Diagnostics
 
         public FileStream MethodMultipleNoncompliantVariables(string path)
         {
-            // Noncompliant@+1 {{Remove the 'using' statement; it will cause automatic disposal of 'fs1', 'fs2'.}}
+            // Noncompliant@+1 {{Remove the 'using' statement; it will cause automatic disposal of 'fs1' and 'fs2'.}}
             using FileStream fs1 = File.Create(path), fs2 = File.Create(path);
 
             if (path != null)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DoNotHardcodeCredentials_DefaultValues.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DoNotHardcodeCredentials_DefaultValues.cs
@@ -28,7 +28,7 @@ namespace Tests.Diagnostics
             string foo, passwd = "a"; // Noncompliant {{"passwd" detected here, make sure this is not a hard-coded credential.}}
 //                      ^^^^^^^^^^^^
 
-            string pwdPassword = "a"; // Noncompliant {{"pwd, password" detected here, make sure this is not a hard-coded credential.}}
+            string pwdPassword = "a"; // Noncompliant {{"pwd and password" detected here, make sure this is not a hard-coded credential.}}
 
             string foo2 = @"Password=123"; // Noncompliant
             string multiline = // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DoNotHardcodeCredentials_DefaultValues.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DoNotHardcodeCredentials_DefaultValues.vb
@@ -26,7 +26,7 @@ Namespace Tests.Diagnostics
             '   ^^^^^^^^^^^^^^^^^^^^^^^^^^
             Dim foo As String, passwd As String = "a" 'Noncompliant {{"passwd" detected here, make sure this is not a hard-coded credential.}}
             '                  ^^^^^^^^^^^^^^^^^^^^^^
-            Dim pwdPassword As String = "a"     'Noncompliant {{"pwd, password" detected here, make sure this is not a hard-coded credential.}}
+            Dim pwdPassword As String = "a"     'Noncompliant {{"pwd and password" detected here, make sure this is not a hard-coded credential.}}
             Dim foo2 As String = "Password=123" 'Noncompliant
             Dim bar As String
             bar = "Password=p" 'Noncompliant ^13#18


### PR DESCRIPTION
Follow up to #6049

* [x] DoNotHardcodeCredentialsBase
* [ ] SymbolicValue (internal use only)
* [x] ImplementISerializableCorrectly
* [ ] InheritedCollidingInterfaceMembers (does not apply as it add ", ..." for more than two members)
* [x] ComparableInterfaceImplementation
* [x] DisposableMemberInNonDisposableClass
* [x] DisposableReturnedFromUsing
* [x] ForLoopCounterCondition
* [x] VirtualEventField
* [ ] SymbolicValueConstraints (internal use only)