### PR TITLE
SE: Add repro from ITs

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp8.cs
@@ -25,9 +25,13 @@ namespace Tests.Diagnostics.CSharp8
             name = name ?? name.ToString(); // Noncompliant
         }
 
-        public void NullCoalesce_Conversion(Exception arg)  // Classes doesn't make sense here. They just demonstrate the flow.
+        public void NullCoalesce_Conversion_DownCast(ArgumentException arg)
         {
-            var value = arg as IDisposable ?? new FileStream(arg.Message, FileMode.Open);  // Noncompliant, if arg is null, it will throw
+            var value = arg as Exception ?? new Exception(arg.Message);     // Noncompliant, arg must be null on the right side
+        }
+        public void NullCoalesce_Conversion_UpCast(Exception arg)
+        {
+            var value = arg as ArgumentException ?? new ArgumentException(arg.Message);     // Noncompliant, arg can be null or another Exception type on the right side
         }
 
         public void NullCoalescenceAssignment_Null()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp8.cs
@@ -25,13 +25,14 @@ namespace Tests.Diagnostics.CSharp8
             name = name ?? name.ToString(); // Noncompliant
         }
 
-        public void NullCoalesce_Conversion_DownCast(ArgumentException arg)
+        public void NullCoalesce_Conversion_DownCast(AggregateException arg)
         {
             var value = arg as Exception ?? new Exception(arg.Message);     // Noncompliant, arg must be null on the right side
         }
+
         public void NullCoalesce_Conversion_UpCast(Exception arg)
         {
-            var value = arg as ArgumentException ?? new ArgumentException(arg.Message);     // Noncompliant, arg can be null or another Exception type on the right side
+            var value = arg as AggregateException ?? new AggregateException(arg.Message);     // Noncompliant, arg can be null or another Exception type on the right side
         }
 
         public void NullCoalescenceAssignment_Null()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp8.cs
@@ -1,4 +1,7 @@
-﻿namespace Tests.Diagnostics.CSharp8
+﻿using System;
+using System.IO;
+
+namespace Tests.Diagnostics.CSharp8
 {
     public class NullCoalescenceAssignment
     {
@@ -20,6 +23,11 @@
         {
             string name = null;
             name = name ?? name.ToString(); // Noncompliant
+        }
+
+        public void NullCoalesce_Conversion(Exception arg)  // Classes doesn't make sense here. They just demonstrate the flow.
+        {
+            var value = arg as IDisposable ?? new FileStream(arg.Message, FileMode.Open);  // Noncompliant, if arg is null, it will throw
         }
 
         public void NullCoalescenceAssignment_Null()


### PR DESCRIPTION
Related to #6070

Accepts it as TP. The `??` is visited because of the type mismatch, or because the original value was null.

>as check with null-coalescing sets misleading null constraint in the Null case => graph as Flow<TIn, TOut, TMat> ?? new Flow<TIn, TOut, TMat>(graph.Module); sources\akka.net\src\core\Akka.Streams\Dsl\Flow.cs