### PR TITLE
S3353: Move test case

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UnchangedLocalVariablesShouldBeConstTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/UnchangedLocalVariablesShouldBeConstTest.cs
@@ -31,6 +31,10 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void UnchangedLocalVariablesShouldBeConst() =>
             verifier.AddPaths("UnchangedLocalVariablesShouldBeConst.cs").Verify();
 
+        [TestMethod]
+        public void UnchangedLocalVariablesShouldBeConst_CSharp7() =>
+            verifier.AddPaths("UnchangedLocalVariablesShouldBeConst.CSharp7.cs").WithOptions(ParseOptionsHelper.OnlyCSharp7).Verify();
+
 #if NET
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.CSharp7.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.CSharp7.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Tests.Diagnostics
+{
+    class Tests
+    {
+        public void Message()
+        {
+            var s1 = "Test";                              // Noncompliant {{Add the 'const' modifier to 's1', and replace 'var' with 'string'.}}
+            string s2 = $"This is a {nameof(Message)}";   // Compliant - constant string interpolation is only valid in C# 10 and above
+            var s3 = $"This is a {nameof(Message)}";      // Compliant - constant string interpolation is only valid in C# 10 and above
+            var s4 = "This is a" + $" {nameof(Message)}"; // Compliant - constant string interpolation is only valid in C# 10 and above
+            var s5 = $@"This is a {nameof(Message)}";     // Compliant - constant string interpolation is only valid in C# 10 and above
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.CSharp7.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.CSharp7.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-
-namespace Tests.Diagnostics
+﻿namespace Tests.Diagnostics
 {
     class Tests
     {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.cs
@@ -473,13 +473,4 @@ public class Repro_4015
         }
         set { }
     }
-
-    public void Message()
-    {
-        var s1 = "Test";                              // Noncompliant {{Add the 'const' modifier to 's1', and replace 'var' with 'string'.}}
-        string s2 = $"This is a {nameof(Message)}";   // Compliant - constant string interpolation is only valid in C# 10 and above
-        var s3 = $"This is a {nameof(Message)}";      // Compliant - constant string interpolation is only valid in C# 10 and above
-        var s4 = "This is a" + $" {nameof(Message)}"; // Compliant - constant string interpolation is only valid in C# 10 and above
-        var s5 = $@"This is a {nameof(Message)}";     // Compliant - constant string interpolation is only valid in C# 10 and above
-    }
 }


### PR DESCRIPTION
master CI was failing, because it was executing a test with C#10, which was assumed to be executed only with lang versions 7 to 9. I moved the test to a new test file.

Test failure:
https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=53655&view=ms.vss-test-web.build-test-results-tab&runId=1201082&resultId=101432&paneView=debug