### PR TITLE
SE: Fix S2259 AD0001 on ConstantCheck

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
@@ -48,6 +48,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
             };
 
         private static ITypeSymbol ConvertedType(IOperation operation) =>
-            operation.Kind == OperationKindEx.Conversion ? IConversionOperationWrapper.FromOperation(operation).Type : null;
+            // Some version of Roslyn can send null here with "return default;". It's not reproducible by UTs, as we have "Type" set in that case.
+            operation?.Kind == OperationKindEx.Conversion ? IConversionOperationWrapper.FromOperation(operation).Type : null;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -475,6 +475,13 @@ Tag(""Value"", value);";
         }
 
         [TestMethod]
+        public void Literal_Default_InferredFromReturnType()
+        {
+            var validator = SETestContext.CreateCSMethod("public object Main() => default;").Validator;
+            validator.ValidateContainsOperation(OperationKind.DefaultValue);    // And do not fail
+        }
+
+        [TestMethod]
         public void InstanceReference_SetsNotNull_CS()
         {
             const string code = @"

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp8.cs
@@ -58,6 +58,17 @@ namespace Tests.Diagnostics.CSharp8
             object nullObject = null;
             notNullObject ??= nullObject.ToString(); // Compliant, never visited
         }
+
+        public object SupportConversionFromDefault {
+            get {
+                object o = null;
+                o.ToString();   // Noncompliant, just to make sure it is analyzed
+                return default; // This should not fail the engine
+            }
+            set { }
+        }
+
+        public object ArrowProperty => default;
     }
 
     public class Nullables


### PR DESCRIPTION
Fixes

```
CSC : error AD0001: Analyzer 'SonarAnalyzer.Rules.CSharp.SymbolicExecutionRunner' threw an exception of type 'SonarAnalyzer.SymbolicExecution.SymbolicExecutionException' with message 'Error processing method: get_Use 
 Method file: C:\Project\src\System.ServiceModel.Primitives\ref\System.ServiceModel.Primitives.cs 
 Method line: 845,43 
 Inner exception: System.NullReferenceException: Object reference not set to an instance of an object. 
    at SonarAnalyzer.SymbolicExecution.Roslyn.Checks.ConstantCheck.ConvertedType(IOperation operation) 
    at SonarAnalyzer.SymbolicExecution.Roslyn.Checks.ConstantCheck.ConstraintFromConstantValue(IOperationWrapperSonar operation) 
    at SonarAnalyzer.SymbolicExecution.Roslyn.Checks.ConstantCheck.PreProcessSimple(SymbolicContext context) 
    at SonarAnalyzer.SymbolicExecution.Roslyn.SymbolicCheck.PreProcess(SymbolicContext context) 
    at SonarAnalyzer.SymbolicExecution.Roslyn.SymbolicCheckList.<>c.<PreProcess>b__5_0(SymbolicCheck check, SymbolicContext context) 
    at SonarAnalyzer.SymbolicExecution.Roslyn.SymbolicCheckList.<>c__DisplayClass7_1.<InvokeChecks>b__0(SymbolicContext x) 
    at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.ToArray() 
    at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source) 
    at SonarAnalyzer.SymbolicExecution.Roslyn.SymbolicCheckList.InvokeChecks(SymbolicContext context, Func`3 process) 
    at SonarAnalyzer.SymbolicExecution.Roslyn.SymbolicCheckList.PreProcess(SymbolicContext context) 
    at SonarAnalyzer.SymbolicExecution.Roslyn.RoslynSymbolicExecution.ProcessOperation(ExplodedNode node)+MoveNext() 
    at SonarAnalyzer.SymbolicExecution.Roslyn.RoslynSymbolicExecution.Execute() 
    at SonarAnalyzer.Rules.SymbolicExecutionRunnerBase.AnalyzeRoslyn(SonarAnalysisContext sonarContext, SyntaxNodeAnalysisContext nodeContext, Boolean isTestProject, Boolean isScannerRun, SyntaxNode body, ISymbol symbol)'. [C:\Project\src\System.ServiceModel.Primitives\ref\System.ServiceModel.Primitives.Ref.csproj]
```