### PR TITLE
Fix serilog build error in CI

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/MetadataReferences/NuGetMetadataReference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/MetadataReferences/NuGetMetadataReference.cs
@@ -126,7 +126,7 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
         public static References RhinoMocks(string packageVersion) => Create("RhinoMocks", packageVersion);
         public static References Shouldly(string packageVersion) => Create("Shouldly", packageVersion);
         public static References Serilog(string packageVersion) => Create("Serilog", packageVersion);
-        public static References SerilogSinksConsole(string packageVersion, string consoleSinkPackageVersion = null) => Create("Serilog.Sinks.Console", packageVersion);
+        public static References SerilogSinksConsole(string packageVersion) => Create("Serilog.Sinks.Console", packageVersion);
         public static References ServiceStackOrmLite(string packageVersion = "5.1.0") => Create("ServiceStack.OrmLite", packageVersion);
         public static References SpecFlow(string packageVersion) => Create("SpecFlow", packageVersion);
         public static References SystemCollectionsImmutable(string packageVersion) => Create("System.Collections.Immutable", packageVersion);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/MetadataReferences/NuGetMetadataReference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/MetadataReferences/NuGetMetadataReference.cs
@@ -125,9 +125,8 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
         public static References PetaPocoCompiled(string packageVersion = "6.0.353") => Create("PetaPoco.Compiled", packageVersion);
         public static References RhinoMocks(string packageVersion) => Create("RhinoMocks", packageVersion);
         public static References Shouldly(string packageVersion) => Create("Shouldly", packageVersion);
-        public static References SerilogPackages(string packageVersion, string consoleSinkPackageVersion = null) =>
-            Create("Serilog", packageVersion)
-            .Concat(Create("Serilog.Sinks.Console", consoleSinkPackageVersion ?? packageVersion));
+        public static References Serilog(string packageVersion) => Create("Serilog", packageVersion);
+        public static References SerilogSinksConsole(string packageVersion, string consoleSinkPackageVersion = null) => Create("Serilog.Sinks.Console", packageVersion);
         public static References ServiceStackOrmLite(string packageVersion = "5.1.0") => Create("ServiceStack.OrmLite", packageVersion);
         public static References SpecFlow(string packageVersion) => Create("SpecFlow", packageVersion);
         public static References SystemCollectionsImmutable(string packageVersion) => Create("System.Collections.Immutable", packageVersion);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/MetadataReferences/NuGetMetadataReference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/MetadataReferences/NuGetMetadataReference.cs
@@ -125,9 +125,9 @@ namespace SonarAnalyzer.UnitTest.MetadataReferences
         public static References PetaPocoCompiled(string packageVersion = "6.0.353") => Create("PetaPoco.Compiled", packageVersion);
         public static References RhinoMocks(string packageVersion) => Create("RhinoMocks", packageVersion);
         public static References Shouldly(string packageVersion) => Create("Shouldly", packageVersion);
-        public static References SerilogPackages(string packageVersion) =>
+        public static References SerilogPackages(string packageVersion, string consoleSinkPackageVersion = null) =>
             Create("Serilog", packageVersion)
-            .Concat(Create("Serilog.Sinks.Console", packageVersion));
+            .Concat(Create("Serilog.Sinks.Console", consoleSinkPackageVersion ?? packageVersion));
         public static References ServiceStackOrmLite(string packageVersion = "5.1.0") => Create("ServiceStack.OrmLite", packageVersion);
         public static References SpecFlow(string packageVersion) => Create("SpecFlow", packageVersion);
         public static References SystemCollectionsImmutable(string packageVersion) => Create("System.Collections.Immutable", packageVersion);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/ConfiguringLoggersTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/ConfiguringLoggersTest.cs
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             NuGetMetadataReference.NLog(Constants.NuGetLatestVersion);
 
         private static IEnumerable<MetadataReference> SeriLogReferences =>
-            NuGetMetadataReference.SerilogPackages(Constants.NuGetLatestVersion);
+            NuGetMetadataReference.SerilogPackages("2.11.0", "4.1.0");
 
 #if NET
         private static IEnumerable<MetadataReference> AspNetCore2LoggingReferences =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/ConfiguringLoggersTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/ConfiguringLoggersTest.cs
@@ -95,7 +95,9 @@ namespace SonarAnalyzer.UnitTest.Rules
             NuGetMetadataReference.NLog(Constants.NuGetLatestVersion);
 
         private static IEnumerable<MetadataReference> SeriLogReferences =>
-            NuGetMetadataReference.SerilogPackages("2.11.0", "4.1.0");
+            Enumerable.Empty<MetadataReference>()
+                .Concat(NuGetMetadataReference.Serilog("2.11.0"))
+                .Concat(NuGetMetadataReference.SerilogSinksConsole("4.1.0"));
 
 #if NET
         private static IEnumerable<MetadataReference> AspNetCore2LoggingReferences =>
@@ -107,7 +109,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 .Concat(NuGetMetadataReference.MicrosoftExtensionsConfigurationAbstractions(Constants.DotNetCore220Version))
                 .Concat(NuGetMetadataReference.MicrosoftExtensionsOptions(Constants.DotNetCore220Version))
                 .Concat(NuGetMetadataReference.MicrosoftExtensionsLoggingPackages(Constants.DotNetCore220Version))
-                .Concat(new[] {CoreMetadataReference.MicrosoftExtensionsDependencyInjectionAbstractions});
+                .Concat(new[] { CoreMetadataReference.MicrosoftExtensionsDependencyInjectionAbstractions });
 
         private static IEnumerable<MetadataReference> AspNetCoreLoggingReferences(string version) =>
             new[]


### PR DESCRIPTION
Tries to fix a CI error
```
Test method SonarAnalyzer.UnitTest.Rules.ConfiguringLoggersTest.ConfiguringLoggers_Serilog_CS threw exception:
SonarAnalyzer.UnitTest.TestFramework.UnexpectedDiagnosticException: CSharp7: Unexpected build error [CS1705]: Assembly 'Serilog' with identity 'Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10' uses 'netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' which has a higher version than referenced assembly 'netstandard' with identity 'netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' on line 1
```

https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=53933&view=ms.vss-test-web.build-test-results-tab&runId=1202772&resultId=102266&paneView=debug