### PR TITLE
Introduction of Syntax node abstractions

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/BinaryExpressionAbstraction.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/BinaryExpressionAbstraction.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SonarAnalyzer.Helpers.Facade;
+
+namespace SonarAnalyzer.Helpers;
+
+public sealed class BinaryExpressionAbstraction : BinaryExpressionAbstractionBase
+{
+    internal BinaryExpressionAbstraction(BinaryExpressionSyntax node) : base(node) { }
+
+    private BinaryExpressionSyntax Casted => (BinaryExpressionSyntax)Node;
+
+    public override SyntaxNode Left => Casted.Left;
+
+    public override SyntaxNode Right => Casted.Right;
+
+    public override ComparisonKind ComparisonKind =>
+        Node.Kind() switch
+        {
+            SyntaxKind.EqualsExpression => ComparisonKind.Equals,
+            SyntaxKind.NotEqualsExpression => ComparisonKind.NotEquals,
+            SyntaxKind.LessThanExpression => ComparisonKind.LessThan,
+            SyntaxKind.LessThanOrEqualExpression => ComparisonKind.LessThanOrEqual,
+            SyntaxKind.GreaterThanExpression => ComparisonKind.GreaterThan,
+            SyntaxKind.GreaterThanOrEqualExpression => ComparisonKind.GreaterThanOrEqual,
+            _ => ComparisonKind.None,
+        };
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -31,6 +31,8 @@ namespace SonarAnalyzer.Helpers.Facade
 {
     internal sealed class CSharpSyntaxFacade : SyntaxFacade<SyntaxKind>
     {
+        public override SyntaxNodeAbstractionFactory<SyntaxKind> As { get; } = new SyntaxNodeAbstractionFactory();
+
         public override SyntaxKind Kind(SyntaxNode node) => node.Kind();
 
         public override ComparisonKind ComparisonKind(SyntaxNode node) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/SyntaxNodeAbstractionFactory.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/SyntaxNodeAbstractionFactory.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace SonarAnalyzer.Helpers.Facade;
+
+public sealed class SyntaxNodeAbstractionFactory : SyntaxNodeAbstractionFactory<SyntaxKind>
+{
+    public override BinaryExpressionAbstractionBase BinaryExpression(SyntaxNode node) =>
+        node is BinaryExpressionSyntax binary
+        ? new BinaryExpressionAbstraction(binary)
+        : null;
+}

--- a/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/SonarDiagnosticAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/SonarDiagnosticAnalyzer.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Helpers.Facade;
 
 namespace SonarAnalyzer.Helpers
 {
@@ -43,15 +44,8 @@ namespace SonarAnalyzer.Helpers
         }
 
         protected static bool IsConcurrentExecutionEnabled()
-        {
-            var value = Environment.GetEnvironmentVariable(EnableConcurrentExecutionVariable);
-
-            if (value != null && bool.TryParse(value, out var result))
-            {
-                return result;
-            }
-            return true;
-        }
+            => Environment.GetEnvironmentVariable(EnableConcurrentExecutionVariable) is { } value
+            && bool.TryParse(value, out var result) ? result : true;
     }
 
     public abstract class SonarDiagnosticAnalyzer<TSyntaxKind> : SonarDiagnosticAnalyzer
@@ -59,6 +53,7 @@ namespace SonarAnalyzer.Helpers
     {
         protected abstract string MessageFormat { get; }
         protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
+        protected SyntaxFacade<TSyntaxKind> Syntax => Language.Syntax;
         protected DiagnosticDescriptor Rule { get; }
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/analyzers/src/SonarAnalyzer.Common/Facade/BinaryExpressionAbstractionBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/BinaryExpressionAbstractionBase.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+
+namespace SonarAnalyzer.Helpers.Facade;
+
+public abstract class BinaryExpressionAbstractionBase : SyntaxNodeAbstraction
+{
+    protected BinaryExpressionAbstractionBase(SyntaxNode node) : base(node) { }
+
+    public abstract SyntaxNode Left { get; }
+    public abstract SyntaxNode Right { get; }
+    public abstract ComparisonKind ComparisonKind { get; }
+}

--- a/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
@@ -28,6 +28,8 @@ namespace SonarAnalyzer.Helpers.Facade
     public abstract class SyntaxFacade<TSyntaxKind>
         where TSyntaxKind : struct
     {
+        public abstract SyntaxNodeAbstractionFactory<TSyntaxKind> As { get; }
+
         public abstract TSyntaxKind Kind(SyntaxNode node);
         public abstract ComparisonKind ComparisonKind(SyntaxNode node);
 

--- a/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxNodeAbstraction.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxNodeAbstraction.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace SonarAnalyzer.Helpers.Facade;
+
+public class SyntaxNodeAbstraction
+{
+    protected SyntaxNodeAbstraction(SyntaxNode node) =>
+        Node = node ?? throw new ArgumentNullException(nameof(node));
+
+    protected SyntaxNode Node { get; }
+
+    public static implicit operator SyntaxNode(SyntaxNodeAbstraction abstraction) => abstraction?.Node;
+}

--- a/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxNodeAbstractionFactory.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxNodeAbstractionFactory.cs
@@ -1,0 +1,30 @@
+﻿#nullable enable
+/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+
+namespace SonarAnalyzer.Helpers.Facade;
+
+public abstract class SyntaxNodeAbstractionFactory<TSyntaxKind>
+    where TSyntaxKind : struct
+{
+    public abstract BinaryExpressionAbstractionBase? BinaryExpression(SyntaxNode node);
+}

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CollectionEmptinessCheckingBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CollectionEmptinessCheckingBase.cs
@@ -36,16 +36,15 @@ namespace SonarAnalyzer.Rules
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer,
                 c =>
                 {
-                    var binaryLeft = Language.Syntax.BinaryExpressionLeft(c.Node);
-                    var binaryRight = Language.Syntax.BinaryExpressionRight(c.Node);
+                    var binary = Syntax.As.BinaryExpression(c.Node);
 
-                    if (Language.ExpressionNumericConverter.TryGetConstantIntValue(binaryLeft, out var left))
+                    if (Language.ExpressionNumericConverter.TryGetConstantIntValue(binary.Left, out var left))
                     {
-                        CheckExpression(c, binaryRight, left, Language.Syntax.ComparisonKind(c.Node).Mirror());
+                        CheckExpression(c, binary.Right, left, binary.ComparisonKind.Mirror());
                     }
-                    else if (Language.ExpressionNumericConverter.TryGetConstantIntValue(binaryRight, out var right))
+                    else if (Language.ExpressionNumericConverter.TryGetConstantIntValue(binary.Right, out var right))
                     {
-                        CheckExpression(c, binaryLeft, right, Language.Syntax.ComparisonKind(c.Node));
+                        CheckExpression(c, binary.Left, right, binary.ComparisonKind);
                     }
                 },
                 Language.SyntaxKind.ComparisonKinds);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCheckZeroSizeCollectionBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCheckZeroSizeCollectionBase.cs
@@ -45,17 +45,15 @@ namespace SonarAnalyzer.Rules
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer,
                 c =>
                 {
-                    var binary = c.Node;
-                    var binaryLeft = Language.Syntax.BinaryExpressionLeft(binary);
-                    var binaryRight = Language.Syntax.BinaryExpressionRight(binary);
+                    var binary = Syntax.As.BinaryExpression(c.Node);
 
-                    if (Language.ExpressionNumericConverter.TryGetConstantIntValue(c.SemanticModel, binaryLeft, out var left))
+                    if (Language.ExpressionNumericConverter.TryGetConstantIntValue(c.SemanticModel, binary.Left, out var left))
                     {
-                        CheckExpression(c, binary, binaryRight, left, Language.Syntax.ComparisonKind(binary).Mirror());
+                        CheckExpression(c, binary, binary.Right, left, binary.ComparisonKind.Mirror());
                     }
-                    else if (Language.ExpressionNumericConverter.TryGetConstantIntValue(c.SemanticModel, binaryRight, out var right))
+                    else if (Language.ExpressionNumericConverter.TryGetConstantIntValue(c.SemanticModel, binary.Right, out var right))
                     {
-                        CheckExpression(c, binary, binaryLeft, right, Language.Syntax.ComparisonKind(binary));
+                        CheckExpression(c, binary, binary.Left, right, binary.ComparisonKind);
                     }
                 },
                 Language.SyntaxKind.ComparisonKinds);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/BinaryExpressionAbstraction.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/BinaryExpressionAbstraction.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using SonarAnalyzer.Helpers.Facade;
+
+namespace SonarAnalyzer.Helpers;
+
+public sealed class BinaryExpressionAbstraction : BinaryExpressionAbstractionBase
+{
+    internal BinaryExpressionAbstraction(BinaryExpressionSyntax node) : base(node) { }
+
+    private BinaryExpressionSyntax Casted => (BinaryExpressionSyntax)Node;
+
+    public override SyntaxNode Left => Casted.Left;
+
+    public override SyntaxNode Right => Casted.Right;
+
+    public override ComparisonKind ComparisonKind =>
+        Node.Kind() switch
+        {
+            SyntaxKind.EqualsExpression => ComparisonKind.Equals,
+            SyntaxKind.NotEqualsExpression => ComparisonKind.NotEquals,
+            SyntaxKind.LessThanExpression => ComparisonKind.LessThan,
+            SyntaxKind.LessThanOrEqualExpression => ComparisonKind.LessThanOrEqual,
+            SyntaxKind.GreaterThanExpression => ComparisonKind.GreaterThan,
+            SyntaxKind.GreaterThanOrEqualExpression => ComparisonKind.GreaterThanOrEqual,
+            _ => ComparisonKind.None,
+        };
+}

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/SyntaxNodeAbstractionFactory.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/SyntaxNodeAbstractionFactory.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+
+namespace SonarAnalyzer.Helpers.Facade;
+
+public sealed class SyntaxNodeAbstractionFactory : SyntaxNodeAbstractionFactory<SyntaxKind>
+{
+    public override BinaryExpressionAbstractionBase BinaryExpression(SyntaxNode node) =>
+        node is BinaryExpressionSyntax binary
+        ? new BinaryExpressionAbstraction(binary)
+        : null;
+}

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
@@ -30,6 +30,8 @@ namespace SonarAnalyzer.Helpers.Facade
 {
     internal sealed class VisualBasicSyntaxFacade : SyntaxFacade<SyntaxKind>
     {
+        public override SyntaxNodeAbstractionFactory<SyntaxKind> As { get; } = new SyntaxNodeAbstractionFactory();
+
         public override bool IsNullLiteral(SyntaxNode node) => node.IsNothingLiteral();
 
         public override SyntaxKind Kind(SyntaxNode node) => node.Kind();


### PR DESCRIPTION
Why at #5741 I had the idea that the code would have been easier if there was something possible like the following:

``` C#
var conditional = (Language.)Syntax.As.Conditional(epxression);
return Syntax.IsNullLiteral(conditional.WhenTrue) || Syntax.IsNullLiteral(conditional.WhenFalse);
```

As I did not want to mess up that PR with this idea, I made this one. I took another example: BinaryExpression, but the idea is the same. Add a builder/factory to the SyntaxFacade that returns an abstaction of a SyntaxNode that is a language independent wrapper on top of specify SyntaxNodes.

What do you think?