### PR TITLE
Fix S2222 FN: Support methods with throw

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/LocksReleasedAllPaths.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/LocksReleasedAllPaths.cs
@@ -60,12 +60,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.CSharp
                 collector.RegisterIdentifier(node.Identifier.ValueText);
                 base.VisitIdentifierName(node);
             }
-
-            public override void VisitThrowStatement(ThrowStatementSyntax node)
-            {
-                collector.ContainsThrow = true;
-                base.VisitThrowStatement(node);
-            }
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/LocksReleasedAllPathsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/LocksReleasedAllPathsBase.cs
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks
             {
                 walker.SafeVisit(child);
             }
-            return collector.LockAcquiredAndReleased && !collector.ContainsThrow;
+            return collector.LockAcquiredAndReleased;
         }
 
         public override ProgramState[] PostProcess(SymbolicContext context)
@@ -293,8 +293,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks
 
             private bool lockAcquired;
             private bool lockReleased;
-
-            public bool ContainsThrow { get; set; } // ToDo: Should be removed in MMF-2393
 
             public bool LockAcquiredAndReleased =>
                 lockAcquired && lockReleased;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/LocksReleasedAllPaths.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/LocksReleasedAllPaths.cs
@@ -57,12 +57,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.VisualBasic
                 collector.RegisterIdentifier(node.Identifier.ValueText);
                 base.VisitIdentifierName(node);
             }
-
-            public override void VisitThrowStatement(ThrowStatementSyntax node)
-            {
-                collector.ContainsThrow = true;
-                base.VisitThrowStatement(node);
-            }
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.TryCatch.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.TryCatch.cs
@@ -40,7 +40,7 @@ namespace Monitor_TryCatch
 
         public void Method4(bool condition)
         {
-            Monitor.Enter(obj); // FN, we don't run for methods with throw until MMF-2393
+            Monitor.Enter(obj); // Noncompliant
 
             if (condition)
             {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.TryCatch.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.TryCatch.vb
@@ -29,7 +29,7 @@ Namespace Monitor_TryCatch
         End Sub
 
         Public Sub Method4()
-            Monitor.Enter(Obj) ' FN, we don't run for methods with throw until MMF-2393
+            Monitor.Enter(Obj) ' Noncompliant
             If Condition Then Throw New Exception()
             Monitor.Exit(Obj)
         End Sub


### PR DESCRIPTION
S2222 did not support methods containing `throw`. These are now supported as SE understands different flows containing `try/catch` scenarios