### PR TITLE
ITs: Net5 sln contains a compiler error for newer versions of the compiler

### DIFF
--- a/analyzers/its/expected/Net5/Net5--net5.0-S1067.json
+++ b/analyzers/its/expected/Net5/Net5--net5.0-S1067.json
@@ -54,14 +54,14 @@
 },
 {
 "id":  "S1067",
-"message":  "Reduce the number of conditional operators (5) used in the expression (maximum allowed 3).",
+"message":  "Reduce the number of conditional operators (4) used in the expression (maximum allowed 3).",
 "location":  {
 "uri":  "sources\Net5\Net5\S4201.cs",
 "region":  {
-"startLine":  42,
+"startLine":  37,
 "startColumn":  20,
-"endLine":  42,
-"endColumn":  52
+"endLine":  37,
+"endColumn":  46
 }
 }
 }

--- a/analyzers/its/expected/Net5/Net5--net5.0-S1301.json
+++ b/analyzers/its/expected/Net5/Net5--net5.0-S1301.json
@@ -54,26 +54,13 @@
 },
 {
 "id":  "S1301",
-"message":  "Replace this 'switch' expression with a ternary conditional operator to increase readability.",
-"location":  {
-"uri":  "sources\Net5\Net5\S4201.cs",
-"region":  {
-"startLine":  29,
-"startColumn":  24,
-"endLine":  29,
-"endColumn":  30
-}
-}
-},
-{
-"id":  "S1301",
 "message":  "Replace this 'switch' statement with 'if' statements to increase readability.",
 "location":  {
 "uri":  "sources\Net5\Net5\S4201.cs",
 "region":  {
-"startLine":  34,
+"startLine":  29,
 "startColumn":  13,
-"endLine":  34,
+"endLine":  29,
 "endColumn":  19
 }
 }

--- a/analyzers/its/expected/Net5/Net5--net5.0-S1541.json
+++ b/analyzers/its/expected/Net5/Net5--net5.0-S1541.json
@@ -1457,7 +1457,7 @@
 },
 {
 "id":  "S1541",
-"message":  "The Cyclomatic Complexity of this method is 19 which is greater than 10 authorized.",
+"message":  "The Cyclomatic Complexity of this method is 15 which is greater than 10 authorized.",
 "location":  [
 {
 "uri":  "sources\Net5\Net5\S4201.cs",
@@ -1562,80 +1562,44 @@
 "uri":  "sources\Net5\Net5\S4201.cs",
 "region":  {
 "startLine":  31,
-"startColumn":  36,
-"endLine":  31,
-"endColumn":  38
-}
-},
-{
-"uri":  "sources\Net5\Net5\S4201.cs",
-"region":  {
-"startLine":  31,
-"startColumn":  27,
-"endLine":  31,
-"endColumn":  30
-}
-},
-{
-"uri":  "sources\Net5\Net5\S4201.cs",
-"region":  {
-"startLine":  32,
-"startColumn":  19,
-"endLine":  32,
-"endColumn":  21
-}
-},
-{
-"uri":  "sources\Net5\Net5\S4201.cs",
-"region":  {
-"startLine":  36,
 "startColumn":  31,
-"endLine":  36,
+"endLine":  31,
 "endColumn":  33
 }
 },
 {
 "uri":  "sources\Net5\Net5\S4201.cs",
 "region":  {
-"startLine":  42,
-"startColumn":  47,
-"endLine":  42,
-"endColumn":  49
-}
-},
-{
-"uri":  "sources\Net5\Net5\S4201.cs",
-"region":  {
-"startLine":  42,
+"startLine":  37,
 "startColumn":  41,
-"endLine":  42,
+"endLine":  37,
 "endColumn":  43
 }
 },
 {
 "uri":  "sources\Net5\Net5\S4201.cs",
 "region":  {
-"startLine":  42,
+"startLine":  37,
 "startColumn":  35,
-"endLine":  42,
+"endLine":  37,
 "endColumn":  37
 }
 },
 {
 "uri":  "sources\Net5\Net5\S4201.cs",
 "region":  {
-"startLine":  42,
+"startLine":  37,
 "startColumn":  29,
-"endLine":  42,
+"endLine":  37,
 "endColumn":  31
 }
 },
 {
 "uri":  "sources\Net5\Net5\S4201.cs",
 "region":  {
-"startLine":  42,
+"startLine":  37,
 "startColumn":  23,
-"endLine":  42,
+"endLine":  37,
 "endColumn":  25
 }
 }

--- a/analyzers/its/expected/Net5/Net5--net5.0-S3532.json
+++ b/analyzers/its/expected/Net5/Net5--net5.0-S3532.json
@@ -6,9 +6,9 @@
 "location":  {
 "uri":  "sources\Net5\Net5\S4201.cs",
 "region":  {
-"startLine":  38,
+"startLine":  33,
 "startColumn":  17,
-"endLine":  39,
+"endLine":  34,
 "endColumn":  27
 }
 }

--- a/analyzers/its/sources/Net5/Net5/S4201.cs
+++ b/analyzers/its/sources/Net5/Net5/S4201.cs
@@ -26,11 +26,6 @@ namespace Net5
 
             // Compliant
             var r5 = apple != null && apple is not { Taste: "Sweet", Color: "Red" };
-            var r6 = m switch
-            {
-                string s2 and null => r1, // rule ConditionEvaluatesToConstant should raise here
-                _ => r2
-            };
             switch (n)
             {
                 case not null or Apple:
@@ -39,7 +34,7 @@ namespace Net5
                     break;
             }
 
-            return r1 && r2 && r3 && r4 && r5 && r6;
+            return r1 && r2 && r3 && r4 && r5;
         }
     }
 }


### PR DESCRIPTION
The Net5.sln in the analyzer/ITs folder contains code that no longer compiles with a new version of the .Net SDK. This prevents an upgrade of the SDKs on peach. The error is:

Error CS8510: The pattern is unreachable. It has already been handled by a previous arm of the switch expression or it is impossible to match. in C:\Projects\sonar-dotnet\analyzers\its\sources\Net5\Net5\S4201.cs:31

The test case was removed.

See also https://github.com/SonarSource/peachee-languages/pull/287
