### PR TITLE
SE: Learn Unary and Binary constraints directly from operation

### DIFF
--- a/analyzers/its/expected/Nancy/Nancy--net452-S2259.json
+++ b/analyzers/its/expected/Nancy/Nancy--net452-S2259.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S2259",
+"message":  "'viewName' is null on at least one execution path.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\ViewEngines\DefaultViewFactory.cs",
+"region":  {
+"startLine":  58,
+"startColumn":  34,
+"endLine":  58,
+"endColumn":  42
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/Nancy/Nancy--netstandard2.0-S2259.json
+++ b/analyzers/its/expected/Nancy/Nancy--netstandard2.0-S2259.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S2259",
+"message":  "'viewName' is null on at least one execution path.",
+"location":  {
+"uri":  "sources\Nancy\src\Nancy\ViewEngines\DefaultViewFactory.cs",
+"region":  {
+"startLine":  58,
+"startColumn":  34,
+"endLine":  58,
+"endColumn":  42
+}
+}
+}
+]
+}

--- a/analyzers/its/expected/akka.net/Akka.Persistence.TCK--netstandard2.0-S2259.json
+++ b/analyzers/its/expected/akka.net/Akka.Persistence.TCK--netstandard2.0-S2259.json
@@ -1,0 +1,17 @@
+{
+"issues":  [
+{
+"id":  "S2259",
+"message":  "'fieldInfo' is null on at least one execution path.",
+"location":  {
+"uri":  "sources\akka.net\src\core\Akka.Persistence.TCK\Query\PersistenceIdsSpec.cs",
+"region":  {
+"startLine":  209,
+"startColumn":  29,
+"endLine":  209,
+"endColumn":  38
+}
+}
+}
+]
+}

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Unary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Unary.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.SymbolicExecution.Constraints;
+using StyleCop.Analyzers.Lightup;
+
+namespace SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors
+{
+    internal static class Unary
+    {
+        public static ProgramState Process(SymbolicContext context, IUnaryOperationWrapper unary) =>
+            unary.OperatorKind == UnaryOperatorKind.Not
+                ? ProcessNot(context.State, unary)
+                : context.State;
+
+        private static ProgramState ProcessNot(ProgramState state, IUnaryOperationWrapper unary) =>
+            state[unary.Operand] is { } value && value.Constraint<BoolConstraint>() is { } boolConstraint
+                ? state.SetOperationConstraint(unary.WrappedOperation, boolConstraint.Opposite)
+                : state;
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -180,14 +180,16 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         {
             foreach (var preProcessed in checks.PreProcess(new(node.Operation, node.State)))
             {
-                var processed = preProcessed.WithState(ProcessOperation(preProcessed));
-                foreach (var postProcessed in checks.PostProcess(processed))
+                foreach (var processed in ProcessOperation(preProcessed))
                 {
-                    // When operation doesn't have a parent it is the outer statement. We need to reset operation states:
-                    // * We don't need to preserve the inner subexpression intermediate states after the outer statement.
-                    // * We don't want ProgramState to contain the path-history data, because we want to avoid exploring the same state twice.
-                    // When the operation is a BranchValue, we need to preserve it to evaluate branching. The state will be reset after branching.
-                    yield return node.CreateNext(node.Operation.Parent is null && node.Block.BranchValue != node.Operation.Instance ? postProcessed.State.ResetOperations() : postProcessed.State);
+                    foreach (var postProcessed in checks.PostProcess(processed))
+                    {
+                        // When operation doesn't have a parent it is the outer statement. We need to reset operation states:
+                        // * We don't need to preserve the inner subexpression intermediate states after the outer statement.
+                        // * We don't want ProgramState to contain the path-history data, because we want to avoid exploring the same state twice.
+                        // When the operation is a BranchValue, we need to preserve it to evaluate branching. The state will be reset after branching.
+                        yield return node.CreateNext(node.Operation.Parent is null && node.Block.BranchValue != node.Operation.Instance ? postProcessed.State.ResetOperations() : postProcessed.State);
+                    }
                 }
             }
 
@@ -232,9 +234,10 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 _ => null
             };
 
-        private static ProgramState ProcessOperation(SymbolicContext context)
+        private static IEnumerable<SymbolicContext> ProcessOperation(SymbolicContext context)
         {
-            return context.Operation.Instance.Kind switch
+            // Operations that return single state
+            var state = context.Operation.Instance.Kind switch
             {
                 OperationKindEx.Argument => Invocation.Process(context, As(IArgumentOperationWrapper.FromOperation)),
                 OperationKindEx.ArrayCreation => Creation.Process(context),
@@ -263,6 +266,14 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 OperationKindEx.TypeParameterObjectCreation => Creation.Process(context),
                 _ => context.State
             };
+            context = context.WithState(state);
+
+            // Operations that can return multiple states
+            var states = context.Operation.Instance.Kind switch
+            {
+                _ => new[] { context.State }
+            };
+            return states.Select(x => context.WithState(x));
 
             T As<T>(Func<IOperation, T> fromOperation) =>
                 fromOperation(context.Operation.Instance);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -355,139 +355,200 @@ Tag(""End"");";
         }
 
         [TestMethod]
-        public void BinaryEqualsNull_SetsBoolConstraint_CS()
+        public void BinaryEqualsNull_SetsBoolConstraint_KnownResult_CS()
         {
             const string code = @"
 object nullValue = null;
 object notNullValue = new object();
 var isTrue = nullValue == null;
 var isFalse = notNullValue == null;
-var isUnknown = arg == null;
 var forNullNull = null == null;
 var forNullSymbol = null == nullValue;
 var forSymbolSymbolTrue = nullValue == nullValue;
 var forSymbolSymbolFalse = notNullValue == nullValue;
-var forSymbolSymbolNone1 = notNullValue == notNullValue;
-var forSymbolSymbolNone2 = notNullValue == arg;
-var forSymbolSymbolNone3 = nullValue == arg;
+var forSymbolSymbolNone = notNullValue == notNullValue;
 Tag(""IsTrue"", isTrue);
 Tag(""IsFalse"", isFalse);
-Tag(""IsUnknown"", isUnknown);
 Tag(""ForNullNull"", forNullNull);
 Tag(""ForNullSymbol"", forNullSymbol);
 Tag(""ForSymbolSymbolTrue"", forSymbolSymbolTrue);
 Tag(""ForSymbolSymbolFalse"", forSymbolSymbolFalse);
-Tag(""ForSymbolSymbolNone1"", forSymbolSymbolNone1);
-Tag(""ForSymbolSymbolNone2"", forSymbolSymbolNone1);
-Tag(""ForSymbolSymbolNone3"", forSymbolSymbolNone1);";
-            var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+Tag(""ForSymbolSymbolNone"", forSymbolSymbolNone);";
+            var validator = SETestContext.CreateCS(code).Validator;
             validator.ValidateContainsOperation(OperationKind.Binary);
             validator.ValidateTag("IsTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
             validator.ValidateTag("IsFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-            validator.ValidateTag("IsUnknown", x => x.Should().BeNull());
             validator.ValidateTag("ForNullNull", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());  // null == null is Literal with constant value 'true'
             validator.ValidateTag("ForNullSymbol", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
             validator.ValidateTag("ForSymbolSymbolTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
             validator.ValidateTag("ForSymbolSymbolFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-            validator.ValidateTag("ForSymbolSymbolNone1", x => x.Should().BeNull("We can't tell if two instances are equivalent."));
-            validator.ValidateTag("ForSymbolSymbolNone2", x => x.Should().BeNull("We can't tell if two instances are equivalent."));
-            validator.ValidateTag("ForSymbolSymbolNone3", x => x.Should().BeNull("We can't tell if arg was null."));
+            validator.ValidateTag("ForSymbolSymbolNone", x => x.Should().BeNull("We can't tell if two instances are equivalent."));
+        }
+
+        [DataTestMethod]
+        [DataRow("arg == null")]
+        [DataRow("arg == nullValue")]
+        public void BinaryEqualsNull_SetsBoolConstraint_Unknown_ComparedToNull_CS(string expression)
+        {
+            var code = @$"
+object nullValue = null;
+var value = {expression};
+Tag(""End"");";
+            var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+            validator.ValidateContainsOperation(OperationKind.Binary);
+            validator.TagStates("End").Should().HaveCount(2)
+                .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.True).Any(x => x.Name == "value") && state.SymbolsWith(ObjectConstraint.Null).Any(x => x.Name == "arg"))
+                .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.False).Any(x => x.Name == "value") && state.SymbolsWith(ObjectConstraint.NotNull).Any(x => x.Name == "arg"));
         }
 
         [TestMethod]
-        public void BinaryEqualsNull_SetsBoolConstraint_VB()
+        public void BinaryEqualsNull_SetsBoolConstraint_Unknown_ComparedToNotNull_CS()
+        {
+            const string code = @"
+object notNullValue = new object();
+var value = arg == notNullValue;
+Tag(""End"");";
+            var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+            validator.ValidateContainsOperation(OperationKind.Binary);
+            validator.TagStates("End").Should().HaveCount(2)    // When False, we can't tell what constraints "args" have
+                .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.True).Any(x => x.Name == "value") && state.SymbolsWith(ObjectConstraint.NotNull).Any(x => x.Name == "arg"))
+                .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.False).Any(x => x.Name == "value") && state.SymbolsWith(ObjectConstraint.NotNull).All(x => x.Name != "arg"));
+        }
+
+        [TestMethod]
+        public void BinaryEqualsNull_SetsBoolConstraint_KnownResult_VB()
         {
             const string code = @"
 Dim NullValue As Object = Nothing
 Dim NotNullValue As New Object()
 Dim IsTrue As Boolean = NullValue Is Nothing
 Dim IsFalse = NotNullValue Is Nothing
-Dim IsUnknown = Arg Is Nothing
 Dim EqualsTrue As Boolean = NullValue = Nothing
 Dim EqualsFalse = NotNullValue = Nothing
-Dim EqualsUnknown = Arg = Nothing
 Tag(""IsTrue"", IsTrue)
 Tag(""IsFalse"", IsFalse)
-Tag(""IsUnknown"", IsUnknown)
 Tag(""EqualsTrue"", EqualsTrue)
-Tag(""EqualsFalse"", EqualsFalse)
-Tag(""EqualsUnknown"", EqualsUnknown)";
-            var validator = SETestContext.CreateVB(code, ", Arg As Object").Validator;
+Tag(""EqualsFalse"", EqualsFalse)";
+            var validator = SETestContext.CreateVB(code).Validator;
             validator.ValidateContainsOperation(OperationKind.Binary);
             validator.ValidateTag("IsTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
             validator.ValidateTag("IsFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-            validator.ValidateTag("IsUnknown", x => x.Should().BeNull());
             validator.ValidateTag("EqualsTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
             validator.ValidateTag("EqualsFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-            validator.ValidateTag("EqualsUnknown", x => x.Should().BeNull());
+        }
+
+        [DataTestMethod]
+        [DataRow("Arg Is Nothing")]
+        [DataRow("Arg = Nothing")]
+        public void BinaryEqualsNull_SetsBoolConstraint_Unknown_ComparedToNull_VB(string expression)
+        {
+            var code = @$"
+Dim Value = {expression}
+Tag(""End"")";
+            var validator = SETestContext.CreateVB(code, ", Arg As Object").Validator;
+            validator.ValidateContainsOperation(OperationKind.Binary);
+            validator.TagStates("End").Should().HaveCount(2)
+                .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.True).Any(x => x.Name == "Value") && state.SymbolsWith(ObjectConstraint.Null).Any(x => x.Name == "Arg"))
+                .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.False).Any(x => x.Name == "Value") && state.SymbolsWith(ObjectConstraint.NotNull).Any(x => x.Name == "Arg"));
         }
 
         [TestMethod]
-        public void BinaryNotEqualsNull_SetsBoolConstraint_CS()
+        public void BinaryNotEqualsNull_SetsBoolConstraint_KnownResult_CS()
         {
             const string code = @"
 object nullValue = null;
 object notNullValue = new object();
 var isTrue = notNullValue != null;
 var isFalse = nullValue != null;
-var isUnknown = arg != null;
 var forNullNull = null != null;
 var forNullSymbol = null != nullValue;
 var forSymbolSymbolTrue = notNullValue != nullValue;
 var forSymbolSymbolFalse = nullValue != nullValue;
-var forSymbolSymbolNone1 = notNullValue != notNullValue;
-var forSymbolSymbolNone2 = notNullValue != arg;
-var forSymbolSymbolNone3 = nullValue != arg;
+var forSymbolSymbolNone = notNullValue != notNullValue;
 Tag(""IsTrue"", isTrue);
 Tag(""IsFalse"", isFalse);
-Tag(""IsUnknown"", isUnknown);
 Tag(""ForNullNull"", forNullNull);
 Tag(""ForNullSymbol"", forNullSymbol);
 Tag(""ForSymbolSymbolTrue"", forSymbolSymbolTrue);
 Tag(""ForSymbolSymbolFalse"", forSymbolSymbolFalse);
-Tag(""ForSymbolSymbolNone1"", forSymbolSymbolNone1);
-Tag(""ForSymbolSymbolNone2"", forSymbolSymbolNone1);
-Tag(""ForSymbolSymbolNone3"", forSymbolSymbolNone1);";
-            var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+Tag(""ForSymbolSymbolNone"", forSymbolSymbolNone);";
+            var validator = SETestContext.CreateCS(code).Validator;
             validator.ValidateContainsOperation(OperationKind.Binary);
             validator.ValidateTag("IsTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
             validator.ValidateTag("IsFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-            validator.ValidateTag("IsUnknown", x => x.Should().BeNull());
             validator.ValidateTag("ForNullNull", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());  // null != null is Literal with constant value 'false'
             validator.ValidateTag("ForNullSymbol", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
             validator.ValidateTag("ForSymbolSymbolTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
             validator.ValidateTag("ForSymbolSymbolFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-            validator.ValidateTag("ForSymbolSymbolNone1", x => x.Should().BeNull("We can't tell if two instances are equivalent."));
-            validator.ValidateTag("ForSymbolSymbolNone2", x => x.Should().BeNull("We can't tell if two instances are equivalent."));
-            validator.ValidateTag("ForSymbolSymbolNone3", x => x.Should().BeNull("We can't tell if arg was null."));
+            validator.ValidateTag("ForSymbolSymbolNone", x => x.Should().BeNull("We can't tell if two instances are equivalent."));
+        }
+
+        [DataTestMethod]
+        [DataRow("arg != null")]
+        [DataRow("arg != nullValue")]
+
+        public void BinaryNotEqualsNull_SetsBoolConstraint_ComparedToNull_CS(string expression)
+        {
+            var code = @$"
+object nullValue = null;
+var value = {expression};
+Tag(""End"");";
+            var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+            validator.ValidateContainsOperation(OperationKind.Binary);
+            validator.TagStates("End").Should().HaveCount(2)
+                .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.True).Any(x => x.Name == "value") && state.SymbolsWith(ObjectConstraint.NotNull).Any(x => x.Name == "arg"))
+                .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.False).Any(x => x.Name == "value") && state.SymbolsWith(ObjectConstraint.Null).Any(x => x.Name == "arg"));
         }
 
         [TestMethod]
-        public void BinaryNotEqualsNull_SetsBoolConstraint_VB()
+        public void BinaryNotEqualsNull_SetsBoolConstraint_ComparedToNotNull_CS()
+        {
+            const string code = @"
+object notNullValue = new object();
+var value = arg != notNullValue;
+Tag(""End"");";
+            var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+            validator.ValidateContainsOperation(OperationKind.Binary);
+            validator.TagStates("End").Should().HaveCount(2)    // When True, we can't tell what constraints "args" have
+                .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.True).Any(x => x.Name == "value") && state.SymbolsWith(ObjectConstraint.NotNull).All(x => x.Name != "arg"))
+                .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.False).Any(x => x.Name == "value") && state.SymbolsWith(ObjectConstraint.NotNull).Any(x => x.Name == "arg"));
+        }
+
+        [TestMethod]
+        public void BinaryNotEqualsNull_SetsBoolConstraint_KnownResult_VB()
         {
             const string code = @"
 Dim NullValue As Object = Nothing
 Dim NotNullValue As New Object()
 Dim IsTrue = NotNullValue IsNot Nothing
 Dim IsFalse As Boolean = NullValue IsNot Nothing
-Dim IsUnknown = Arg IsNot Nothing
 Dim EqualsTrue = NotNullValue <> Nothing
 Dim EqualsFalse As Boolean = NullValue <> Nothing
-Dim EqualsUnknown = Arg <> Nothing
 Tag(""IsTrue"", IsTrue)
 Tag(""IsFalse"", IsFalse)
-Tag(""IsUnknown"", IsUnknown)
 Tag(""EqualsTrue"", EqualsTrue)
-Tag(""EqualsFalse"", EqualsFalse)
-Tag(""EqualsUnknown"", EqualsUnknown)";
-            var validator = SETestContext.CreateVB(code, ", Arg As Object").Validator;
+Tag(""EqualsFalse"", EqualsFalse)";
+            var validator = SETestContext.CreateVB(code).Validator;
             validator.ValidateContainsOperation(OperationKind.Binary);
             validator.ValidateTag("IsTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
             validator.ValidateTag("IsFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-            validator.ValidateTag("IsUnknown", x => x.Should().BeNull());
             validator.ValidateTag("EqualsTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
             validator.ValidateTag("EqualsFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-            validator.ValidateTag("EqualsUnknown", x => x.Should().BeNull());
+        }
+
+        [DataTestMethod]
+        [DataRow("Arg IsNot Nothing")]
+        [DataRow("Arg <> Nothing")]
+        public void BinaryNotEqualsNull_SetsBoolConstraint_Unknown_ComparedToNull_VB(string expression)
+        {
+            var code = @$"
+Dim Value = {expression}
+Tag(""End"")";
+            var validator = SETestContext.CreateVB(code, ", Arg As Object").Validator;
+            validator.ValidateContainsOperation(OperationKind.Binary);
+            validator.TagStates("End").Should().HaveCount(2)
+                .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.True).Any(x => x.Name == "Value") && state.SymbolsWith(ObjectConstraint.NotNull).Any(x => x.Name == "Arg"))
+                .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.False).Any(x => x.Name == "Value") && state.SymbolsWith(ObjectConstraint.Null).Any(x => x.Name == "Arg"));
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -285,12 +285,12 @@ namespace Tests.Diagnostics
             public string MyProperty { get; set; }
         }
 
-        public void Assert1(object o1)
+        public void Assert1(object o)
         {
-            System.Diagnostics.Debug.Assert(o1 != null);
-            o1.ToString(); // Noncompliant FP
-            System.Diagnostics.Debug.Assert(o1 == null);
-            o1.ToString(); // Compliant, because we already know that _foo1 is not null from o1.ToString()
+            System.Diagnostics.Debug.Assert(o != null);
+            o.ToString(); // Noncompliant FP
+            System.Diagnostics.Debug.Assert(o == null);
+            o.ToString(); // Compliant, because we already know that o is not null from o.ToString()
         }
 
         public void Assert2(object o1)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -288,9 +288,9 @@ namespace Tests.Diagnostics
         public void Assert1(object o1)
         {
             System.Diagnostics.Debug.Assert(o1 != null);
-            o1.ToString(); // Compliant
+            o1.ToString(); // Noncompliant FP
             System.Diagnostics.Debug.Assert(o1 == null);
-            o1.ToString(); // Compliant
+            o1.ToString(); // Compliant, because we already know that _foo1 is not null from o1.ToString()
         }
 
         public void Assert2(object o1)
@@ -732,9 +732,9 @@ namespace Tests.Diagnostics
         void Assert1()
         {
             System.Diagnostics.Debug.Assert(_foo1 != null);
-            _foo1.ToString(); // Compliant
+            _foo1.ToString(); // Noncompliant FP
             System.Diagnostics.Debug.Assert(_foo1 == null);
-            _foo1.ToString(); // Compliant
+            _foo1.ToString(); // Compliant, because we already know that _foo1 is not null from _foo1.ToString()
         }
 
         void CallToExtensionMethodsShouldNotRaise()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -296,7 +296,13 @@ namespace Tests.Diagnostics
         public void Assert2(object o1)
         {
             System.Diagnostics.Debug.Assert(o1 == null);
-            o1.ToString(); // Compliant, we don't learn on Assert
+            o1.ToString(); // Noncompliant FP
+        }
+
+        public void LearnFromArguments(object o)
+        {
+            LearnFromArguments(o == null);
+            o.ToString(); // Noncompliant
         }
 
         public void StringEmpty(string s1)


### PR DESCRIPTION
Prerequisite for #349

Learn Unary and Binary constraints directly from the operation. Until now, they were learned only when branching.