### PR TITLE
SE: Learn IsNull constraints directly from operation

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -253,7 +253,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 OperationKindEx.FlowCapture => FlowCapture.Process(context, As(IFlowCaptureOperationWrapper.FromOperation)),
                 OperationKindEx.InstanceReference => References.ProcessThis(context),
                 OperationKindEx.Invocation => Invocation.Process(context, As(IInvocationOperationWrapper.FromOperation)),
-                OperationKindEx.IsNull => IsNull.Process(context, As(IIsNullOperationWrapper.FromOperation)),
                 OperationKindEx.LocalReference => References.Process(context, As(ILocalReferenceOperationWrapper.FromOperation)),
                 OperationKindEx.ObjectCreation => Creation.Process(context),
                 OperationKindEx.ParameterReference => References.Process(context, As(IParameterReferenceOperationWrapper.FromOperation)),
@@ -271,6 +270,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             var states = context.Operation.Instance.Kind switch
             {
                 OperationKindEx.Binary => Binary.Process(context, As(IBinaryOperationWrapper.FromOperation)),
+                OperationKindEx.IsNull => IsNull.Process(context, As(IIsNullOperationWrapper.FromOperation)),
                 OperationKindEx.IsPattern => Pattern.Process(context, As(IIsPatternOperationWrapper.FromOperation)),
                 _ => new[] { context.State }
             };
@@ -308,7 +308,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 : operation.Kind switch
                 {
                     OperationKindEx.Conversion => LearnBranchingConstraintsFromOperation(state, As(IConversionOperationWrapper.FromOperation).Operand, useOpposite),
-                    OperationKindEx.IsNull => IsNull.LearnBranchingConstraint(state, As(IIsNullOperationWrapper.FromOperation), useOpposite),
                     OperationKindEx.IsType => IsType.LearnBranchingConstraint(state, As(IIsTypeOperationWrapper.FromOperation), useOpposite),
                     _ => state
                 };

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
@@ -507,14 +507,14 @@ Tag(""End"", arg);";
             {
                 var result = validator.Symbol("result");
                 var testedSymbol = validator.Symbol(testedSymbolName);
-                var state = validator.TagStates("Result").Single(x => x[result].HasConstraint(branchConstraint));
+                var testedSymbolicValue = validator.TagStates("Result").Should().ContainSingle(x => x[result].HasConstraint(branchConstraint)).Which[testedSymbol];
                 if (expected is null)
                 {
-                    state[testedSymbol].Should().BeNull("we should not learn about the tested symbol in {0} branch", branchConstraint);
+                    testedSymbolicValue.Should().BeNull("we should not learn about the tested symbol in {0} branch", branchConstraint);
                 }
                 else
                 {
-                    var testedSymbolConstraints = state[testedSymbol].AllConstraints.Select(x => x.ToString()).OrderBy(x => x).JoinStr(", "); // Rename for better assertion message
+                    var testedSymbolConstraints = testedSymbolicValue.AllConstraints.Select(x => x.ToString()).OrderBy(x => x).JoinStr(", "); // Rename for better assertion message
                     testedSymbolConstraints.Should().Be(expected, "we are in {0} branch", branchConstraint);
                 }
             }


### PR DESCRIPTION
Prerequisite for #349

Learn IsNull constraints directly from the operation. Until now, they were learned only when branching.

This is a draft now, `Squash IsPattern` doesn't need a review.