### PR TITLE
Improve S2259: Variables of caught exceptions are known to be NotNull

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationDispatcher.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationDispatcher.cs
@@ -44,6 +44,7 @@ internal static class OperationDispatcher
         { OperationKindEx.ArrayElementReference, new ArrayElementReference() },
         { OperationKindEx.AnonymousObjectCreation, new Creation() },
         { OperationKindEx.Await, new Await() },
+        { OperationKindEx.CaughtException, new CaughtException() },
         { OperationKindEx.Conversion, new Conversion() },
         { OperationKindEx.DeclarationPattern, new DeclarationPattern() },
         { OperationKindEx.DefaultValue, new DefaultValue() },

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/CaughtException.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/CaughtException.cs
@@ -26,12 +26,9 @@ using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer
 {
-    internal sealed class CaughtException : SimpleProcessor<ICaughtExceptionOperationWrapper>
-    {
-        protected override ICaughtExceptionOperationWrapper Convert(IOperation operation) =>
-            ICaughtExceptionOperationWrapper.FromOperation(operation);
-
-        protected override ProgramState Process(SymbolicContext context, ICaughtExceptionOperationWrapper operation) =>
-            context.SetOperationConstraint(ObjectConstraint.NotNull);
-    }
+internal sealed class CaughtException : ISimpleProcessor
+{
+    public ProgramState Process(SymbolicContext context) =>
+        context.SetOperationConstraint(ObjectConstraint.NotNull);
+}
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/CaughtException.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/CaughtException.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis;
+using SonarAnalyzer.SymbolicExecution.Constraints;
+using SonarAnalyzer.SymbolicExecution.Roslyn;
+using SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors;
+using StyleCop.Analyzers.Lightup;
+
+namespace SonarAnalyzer
+{
+    internal sealed class CaughtException : SimpleProcessor<ICaughtExceptionOperationWrapper>
+    {
+        protected override ICaughtExceptionOperationWrapper Convert(IOperation operation) =>
+            ICaughtExceptionOperationWrapper.FromOperation(operation);
+
+        protected override ProgramState Process(SymbolicContext context, ICaughtExceptionOperationWrapper operation) =>
+            context.SetOperationConstraint(ObjectConstraint.NotNull);
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/CaughtException.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/CaughtException.cs
@@ -18,17 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.CodeAnalysis;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 using SonarAnalyzer.SymbolicExecution.Roslyn;
 using SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors;
-using StyleCop.Analyzers.Lightup;
 
-namespace SonarAnalyzer
-{
+namespace SonarAnalyzer;
+
 internal sealed class CaughtException : ISimpleProcessor
 {
     public ProgramState Process(SymbolicContext context) =>
         context.SetOperationConstraint(ObjectConstraint.NotNull);
-}
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 using SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution;
 
@@ -209,11 +208,11 @@ Tag(""End"", lastEx);
             var validator = SETestContext.CreateCS(code).Validator;
             validator.ValidateTagOrder("End", "BeforeReturn", "InCatch", "End", "BeforeReturn");
             validator.TagValues("BeforeReturn").Should().SatisfyRespectively(
-                x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue(), // InstanceMethod did not throw
-                x => x.Should().BeNull());                                     // InstanceMethod did throw, was caught, and flow continues
+                x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue(),     // InstanceMethod did not throw
+                x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue()); // InstanceMethod did throw, was caught, and flow continues
             validator.TagValues("End").Should().SatisfyRespectively(
-                x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue(), // Loop was never entered
-                x => x.Should().BeNull());                                     // InstanceMethod did throw and was caught
+                x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue(),     // Loop was never entered
+                x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue()); // InstanceMethod did throw and was caught
         }
 
         [TestMethod]
@@ -241,9 +240,9 @@ Tag(""End"", lastEx);
             var validator = SETestContext.CreateCS(code).Validator;
             validator.ValidateTagOrder("BeforeReturn", "InCatch", "End", "BeforeReturn", "InCatch");
             validator.TagValues("BeforeReturn").Should().SatisfyRespectively(
-                x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue(), // InstanceMethod did not throw
-                x => x.Should().BeNull());                                     // InstanceMethod did throw, was caught, and flow continues
-            validator.ValidateTag("End", x => x.Should().BeNull());            // InstanceMethod did throw and was caught
+                x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue(),                              // InstanceMethod did not throw
+                x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());                          // InstanceMethod did throw, was caught, and flow continues
+            validator.ValidateTag("End", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue()); // InstanceMethod did throw and was caught
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -209,7 +209,7 @@ Tag(""End"", lastEx);
             validator.ValidateTagOrder("End", "BeforeReturn", "InCatch", "End", "BeforeReturn");
             validator.TagValues("BeforeReturn").Should().SatisfyRespectively(
                 x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue(),     // InstanceMethod did not throw
-                x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue()); // InstanceMethod did throw, was caught, and flow continues
+                x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue()); // InstanceMethod did throw, was caught, and flow continued
             validator.TagValues("End").Should().SatisfyRespectively(
                 x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue(),     // Loop was never entered
                 x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue()); // InstanceMethod did throw and was caught
@@ -241,7 +241,7 @@ Tag(""End"", lastEx);
             validator.ValidateTagOrder("BeforeReturn", "InCatch", "End", "BeforeReturn", "InCatch");
             validator.TagValues("BeforeReturn").Should().SatisfyRespectively(
                 x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue(),                              // InstanceMethod did not throw
-                x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());                          // InstanceMethod did throw, was caught, and flow continues
+                x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());                          // InstanceMethod did throw, was caught, and flow continued
             validator.ValidateTag("End", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue()); // InstanceMethod did throw and was caught
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -184,38 +184,6 @@ Tag(""End"");";
         }
 
         [TestMethod]
-        public void ForLoopWithTryCatchAndNullFlows()
-        {
-            var code = @"
-Exception lastEx = null;
-for (int i = 0; i < 10; i++)
-{
-    try
-    {
-        InstanceMethod(); // May throw
-        Tag(""BeforeReturn"", lastEx);
-        return;
-    }
-    catch (InvalidOperationException e)
-    {
-        lastEx = e;
-        Tag(""InCatch"", lastEx);
-    }
-}
-
-Tag(""End"", lastEx);
-";
-            var validator = SETestContext.CreateCS(code).Validator;
-            validator.ValidateTagOrder("End", "BeforeReturn", "InCatch", "End", "BeforeReturn");
-            validator.TagValues("BeforeReturn").Should().SatisfyRespectively(
-                x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue(),     // InstanceMethod did not throw
-                x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue()); // InstanceMethod did throw, was caught, and flow continued
-            validator.TagValues("End").Should().SatisfyRespectively(
-                x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue(),     // Loop was never entered
-                x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue()); // InstanceMethod did throw and was caught
-        }
-
-        [TestMethod]
         public void DoWhileLoopWithTryCatchAndNullFlows()
         {
             var code = @"

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
@@ -919,7 +919,7 @@ finally
         }
 
         [TestMethod]
-        public void ExceptionVariableIsNotNull()
+        public void Catch_ExceptionVariableIsNotNull()
         {
             const string code = @"
 try
@@ -931,8 +931,7 @@ catch(InvalidOperationException ex) when (Tag(""InFilter"", ex))
     Tag(""InCatch"", ex);
 }
 
-static bool Tag<T>(string name, T value) => true;
-";
+static bool Tag<T>(string name, T value) => true;";
             var validator = SETestContext.CreateCS(code).Validator;
             validator.ValidateTag("InFilter", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
             validator.ValidateTag("InCatch", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
@@ -918,6 +918,26 @@ finally
             SETestContext.CreateCSLambda(code, "// Lambda marker").Validator.ValidateTagOrder("Before", "CanThrow", "After");
         }
 
+        [TestMethod]
+        public void ExceptionVariableIsNotNull()
+        {
+            const string code = @"
+try
+{
+    InstanceMethod();
+}
+catch(InvalidOperationException ex) when (Tag(""InFilter"", ex))
+{
+    Tag(""InCatch"", ex);
+}
+
+static bool Tag<T>(string name, T value) => true;
+";
+            var validator = SETestContext.CreateCS(code).Validator;
+            validator.ValidateTag("InFilter", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+            validator.ValidateTag("InCatch", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        }
+
         private static bool HasNoException(ProgramState state) =>
             state.Exception == null;
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -1402,6 +1402,27 @@ public class Repro_GridChecks
     }
 }
 
+public class Repo_890
+{
+    public void M()
+    {
+        Exception lastEx = null;
+        for (int i = 0; i < 10; i++)
+        {
+            try
+            {
+                ToString(); // May throw
+                return;
+            }
+            catch (InvalidOperationException e)
+            {
+                lastEx = e;
+            }
+        }
+        lastEx.ToString(); // Noncompliant FP. The loop is always entered and so lastEx is never null here.
+    }
+}
+
 namespace ValidatedNotNullAttributeTest
 {
     public sealed class ValidatedNotNullAttribute : Attribute { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -903,6 +903,21 @@ namespace Tests.Diagnostics
                 a.ToString(); // Noncompliant - only one issue should be reported
             }
         }
+
+        void TryCatch5()
+        {
+            try
+            {
+                bool.Parse("No");
+            }
+            catch(Exception ex)
+            {
+                if (ex == null)
+                {
+                    ex.ToString(); // Unreachable. Any caught exception is never null
+                }
+            }
+        }
     }
 
     static class Extensions

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -1402,6 +1402,7 @@ public class Repro_GridChecks
     }
 }
 
+// https://github.com/SonarSource/sonar-dotnet/issues/890
 public class Repo_890
 {
     public void M()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -1426,24 +1426,37 @@ public class Repo_890
 namespace ValidatedNotNullAttributeTest
 {
     public sealed class ValidatedNotNullAttribute : Attribute { }
+    public sealed class NotNullAttribute : Attribute { }
 
     public static class Guard
     {
-        public static void NotNull<T>([ValidatedNotNullAttribute] this T value, string name) where T : class
+        public static void ValidatedNotNull<T>([ValidatedNotNullAttribute] this T value, string name) where T : class
         {
             if (value == null)
                 throw new ArgumentNullException(name);
         }
+
+        public static void NotNull([NotNull] object value) { }
     }
 
     public static class Utils
     {
         public static string ToUpper(string value)
         {
-            Guard.NotNull(value, nameof(value));
+            Guard.ValidatedNotNull(value, nameof(value));
             if (value != null)
             {
-                return value.ToUpper(); // Compliant
+                return value.ToUpper(); // Compliant Unreachable
+            }
+            return value.ToUpper(); // Compliant
+        }
+
+        public static string NotNullTest(string value)
+        {
+            Guard.NotNull(value);
+            if (value != null)
+            {
+                return value.ToUpper(); // Compliant Unreachable
             }
             return value.ToUpper(); // Compliant
         }


### PR DESCRIPTION
Partially fixes #890

Note: To really fix #890, we need to be able to detect, that the loop is always entered. We can fix it for a `do/while` loop now, for all other loops it is assumed that there is one bypass flow.