### PR TITLE
SE: Set Null constraint to nullable types

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/TypeHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/TypeHelper.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Helpers
             self.IsStruct() || self.IsClass();
 
         public static bool Is(this ITypeSymbol self, TypeKind typeKind) =>
-            self is { } && self.TypeKind == typeKind;
+            self?.TypeKind == typeKind;
 
         public static bool IsNullableValueType(this ITypeSymbol self) =>
             self.IsStruct() && self.OriginalDefinition.Is(KnownType.System_Nullable_T);

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
@@ -60,6 +60,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
                 _ => null
             };
 
+        // FIXME: Use the extension from #6136 before merging
         private static bool CanBeNull(ITypeSymbol type) =>
             type is not null
             && (type.IsReferenceType || type.OriginalDefinition.Is(KnownType.System_Nullable_T));

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
                 // Update DefaultValue when adding new types
                 true => SymbolicValue.True,
                 false => SymbolicValue.False,
-                null when CanBeNull(operation.Instance.Type ?? ConvertedType(operation.Parent)) => SymbolicValue.Null,
+                null when CanBeNull(operation.Instance.Type ?? ConvertedType(operation.Parent)) => SymbolicValue.Null,  // ToDo: MMF-2401, this will need to be reviewed
                 string => SymbolicValue.NotNull,
                 _ => null
             };

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
@@ -55,15 +55,10 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
                 // Update DefaultValue when adding new types
                 true => SymbolicValue.True,
                 false => SymbolicValue.False,
-                null when CanBeNull(operation.Instance.Type ?? ConvertedType(operation.Parent)) => SymbolicValue.Null,  // ToDo: MMF-2401, this will need to be reviewed
+                null when (operation.Instance.Type ?? ConvertedType(operation.Parent)).CanBeNull() => SymbolicValue.Null,  // ToDo: MMF-2401, this will need to be reviewed
                 string => SymbolicValue.NotNull,
                 _ => null
             };
-
-        // FIXME: Use the extension from #6136 before merging
-        private static bool CanBeNull(ITypeSymbol type) =>
-            type is not null
-            && (type.IsReferenceType || type.OriginalDefinition.Is(KnownType.System_Nullable_T));
 
         private static ITypeSymbol ConvertedType(IOperation operation) =>
             // Some version of Roslyn can send null here with "return default;". It's not reproducible by UTs, as we have "Type" set in that case.

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
@@ -55,10 +55,14 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
                 // Update DefaultValue when adding new types
                 true => SymbolicValue.True,
                 false => SymbolicValue.False,
-                null when (operation.Instance.Type ?? ConvertedType(operation.Parent)) is { IsReferenceType: true } => SymbolicValue.Null,
+                null when CanBeNull(operation.Instance.Type ?? ConvertedType(operation.Parent)) => SymbolicValue.Null,
                 string => SymbolicValue.NotNull,
                 _ => null
             };
+
+        private static bool CanBeNull(ITypeSymbol type) =>
+            type is not null
+            && (type.IsReferenceType || type.OriginalDefinition.Is(KnownType.System_Nullable_T));
 
         private static ITypeSymbol ConvertedType(IOperation operation) =>
             // Some version of Roslyn can send null here with "return default;". It's not reproducible by UTs, as we have "Type" set in that case.

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationDispatcher.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationDispatcher.cs
@@ -46,6 +46,7 @@ internal static class OperationDispatcher
         { OperationKindEx.Await, new Await() },
         { OperationKindEx.Conversion, new Conversion() },
         { OperationKindEx.DeclarationPattern, new DeclarationPattern() },
+        { OperationKindEx.DefaultValue, new DefaultValue() },
         { OperationKindEx.DelegateCreation, new Creation() },
         { OperationKindEx.DynamicObjectCreation, new Creation() },
         { OperationKindEx.EventReference, new EventReference() },

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/DefaultValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/DefaultValue.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.Helpers;
+using SonarAnalyzer.SymbolicExecution.Constraints;
+
+namespace SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors;
+
+internal sealed class DefaultValue : ISimpleProcessor
+{
+    public ProgramState Process(SymbolicContext context) =>
+        context.Operation.Instance.Type.OriginalDefinition.Is(KnownType.System_Nullable_T)
+            ? context.SetOperationConstraint(ObjectConstraint.Null)
+            : context.State;
+}

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/DefaultValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/DefaultValue.cs
@@ -26,7 +26,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors;
 internal sealed class DefaultValue : ISimpleProcessor
 {
     public ProgramState Process(SymbolicContext context) =>
-        context.Operation.Instance.Type.OriginalDefinition.Is(KnownType.System_Nullable_T)
+        context.Operation.Instance.Type.IsNullableValueType()
             ? context.SetOperationConstraint(ObjectConstraint.Null) // ToDo: MMF-2401, this will need to be reviewed
             : context.State;
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/DefaultValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/DefaultValue.cs
@@ -27,6 +27,6 @@ internal sealed class DefaultValue : ISimpleProcessor
 {
     public ProgramState Process(SymbolicContext context) =>
         context.Operation.Instance.Type.OriginalDefinition.Is(KnownType.System_Nullable_T)
-            ? context.SetOperationConstraint(ObjectConstraint.Null)
+            ? context.SetOperationConstraint(ObjectConstraint.Null) // ToDo: MMF-2401, this will need to be reviewed
             : context.State;
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -805,8 +805,6 @@ public async System.Threading.Tasks.Task Main(System.Threading.Tasks.Task T)
         [DataRow("bool", "false", "True")]
         [DataRow("bool?", "default", "Null")]
         [DataRow("bool?", "null", "Null")]
-        [DataRow("int?", "default", "Null")]
-        [DataRow("int?", "null", "Null")]
         public void Unary_Not_SupportsBoolAndNull(string type, string defaultValue, string expectedConstraints)
         {
             var code = $@"

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -804,7 +804,9 @@ public async System.Threading.Tasks.Task Main(System.Threading.Tasks.Task T)
         [DataRow("bool", "true", "False")]
         [DataRow("bool", "false", "True")]
         [DataRow("bool?", "default", "Null")]
-        [DataRow("bool?", "null", null)]    // FIXME: Should behave same as default
+        [DataRow("bool?", "null", "Null")]
+        [DataRow("int?", "default", "Null")]
+        [DataRow("int?", "null", "Null")]
         public void Unary_Not_SupportsBoolAndNull(string type, string defaultValue, string expectedConstraints)
         {
             var code = $@"

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
@@ -318,15 +318,15 @@ Tag(""End"", arg);";
         [DataRow("objectNotNull", "is false", "False, NotNull", "NotNull")]
         [DataRow("objectNull", "is 1", "NotNull", "Null")]          // Should recognize that objectNull doesn't match instead
         [DataRow("objectNull", @"is """"", "NotNull", "Null")]      // Should recognize that objectNull doesn't match instead
-        [DataRow("objectNull", "is true", "Null, True", "Null")]    // Should recognize that objectNull doesn't match instead
-        [DataRow("objectNull", "is false", "False, Null", "Null")]  // Should recognize that objectNull doesn't match instead
+        [DataRow("objectNull", "is true", "Null, True", "Null")]    // Should recognize that objectNull doesn't match instead, should not have BoolConstraint and Null at the same time
+        [DataRow("objectNull", "is false", "False, Null", "Null")]  // Should recognize that objectNull doesn't match instead, should not have BoolConstraint and Null at the same time
         [DataRow("objectUnknown", "is null", "Null", "NotNull")]
         [DataRow("objectUnknown", "is 1", "NotNull", null)]
         [DataRow("objectUnknown", @"is """"", "NotNull", null)]
         [DataRow("objectUnknown", "is true", "True", null)]
         [DataRow("objectUnknown", "is false", "False", null)]
-        [DataRow("nullableBoolNull", "is true", "True", null)]      // Should recognize that nullableBoolNull doesn't match instead
-        [DataRow("nullableBoolNull", "is false", "False", null)]    // Should recognize that nullableBoolNull doesn't match instead
+        [DataRow("nullableBoolNull", "is true", "Null, True", "Null")]    // Should recognize that nullableBoolNull doesn't match instead, should not have BoolConstraint and Null at the same time
+        [DataRow("nullableBoolNull", "is false", "False, Null", "Null")]  // Should recognize that nullableBoolNull doesn't match instead, should not have BoolConstraint and Null at the same time
         [DataRow("nullableBoolUnknown", "is true", "True", null)]
         [DataRow("nullableBoolUnknown", "is false", "False", null)]
         public void ConstantPatternSetBoolConstraint_TwoStates(string testedSymbol, string isPattern, string expectedForTrue, string expectedForFalse) =>
@@ -426,10 +426,10 @@ Tag(""End"", arg);";
         [DataRow("objectUnknown", "is not string { }", OperationKindEx.NegatedPattern, null, "NotNull")]
         [DataRow("objectUnknown", "is not object { }", OperationKindEx.NegatedPattern, "Null", "NotNull")]
         [DataRow("objectUnknown", "is not not null", OperationKindEx.NegatedPattern, "Null", "NotNull")]
-        [DataRow("nullableBoolTrue", "is not false", OperationKindEx.NegatedPattern, "True", "False")]  // Should generate only single state with "true" result instead
-        [DataRow("nullableBoolFalse", "is not true", OperationKindEx.NegatedPattern, "False", "True")]  // Should generate only single state with "true" result instead
-        [DataRow("nullableBoolNull", "is not true", OperationKindEx.NegatedPattern, null, "True")]      // Should generate only single state with "true" result instead
-        [DataRow("nullableBoolNull", "is not false", OperationKindEx.NegatedPattern, null, "False")]    // Should generate only single state with "true" result instead
+        [DataRow("nullableBoolTrue", "is not false", OperationKindEx.NegatedPattern, "True", "False")]          // Should generate only single state with "true" result instead
+        [DataRow("nullableBoolFalse", "is not true", OperationKindEx.NegatedPattern, "False", "True")]          // Should generate only single state with "true" result instead
+        [DataRow("nullableBoolNull", "is not true", OperationKindEx.NegatedPattern, "Null", "Null, True")]      // Should generate only single state with "true" result instead
+        [DataRow("nullableBoolNull", "is not false", OperationKindEx.NegatedPattern, "Null", "False, Null")]    // Should generate only single state with "true" result instead
         [DataRow("nullableBoolUnknown", "is not true", OperationKindEx.NegatedPattern, null, "True")]
         [DataRow("nullableBoolUnknown", "is not false", OperationKindEx.NegatedPattern, null, "False")]
         [DataRow("objectUnknown", "is not object", OperationKindEx.TypePattern, null, "NotNull")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp6.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp6.cs
@@ -156,10 +156,10 @@ namespace Tests.Diagnostics
                     Console.ForegroundColor = obj.Color; // Noncompliant
                     break;
                 case ConsoleColor.Red:
-                    Console.ForegroundColor = obj.Color; // Noncompliant FP, requires nullability support in captured flow operation
+                    Console.ForegroundColor = obj.Color;
                     break;
                 default:
-                    Console.WriteLine($"Color {obj.Color} is not supported."); // Noncompliant FP, requires nullability support in captured flow operation
+                    Console.WriteLine($"Color {obj.Color} is not supported.");
                     break;
             }
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -1082,9 +1082,9 @@ namespace Tests.Diagnostics
             string someString = null;
 
             if (!someString?.Contains("a") ?? true)
-                Console.WriteLine("It's null or doesn't contain 'a'");
+                someString.ToString();  // Noncompliant, it's null or doesn't contain 'a'
             else
-                Console.WriteLine(someString.Length); // Noncompliant FP, this path is unreachable
+                someString.ToString();  // Compliant, this path is unreachable
         }
     }
 
@@ -1320,7 +1320,7 @@ namespace Repro_3395
                     continue;
                 }
 
-                _ = providerCourse.Items; // Noncompliant FP
+                _ = providerCourse.Items; // Compliant
             }
 
             foreach (var providerCourse in providerCourses)
@@ -1331,8 +1331,7 @@ namespace Repro_3395
                     continue;
                 }
 
-                _ = providerCourse.Items.Where(items => items == "item1"); // Noncompliant FP
-                //  ^^^^^^^^^^^^^^
+                _ = providerCourse.Items.Where(items => items == "item1"); // Compliant
             }
         }
 


### PR DESCRIPTION
Fixes #4537 
Fixes #4989 

Adds support for unary `Not` and `!` for nullable types with `null` value.