### PR TITLE
Fix S2259 FP: object.Equals method recognizes null arguments

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -936,6 +936,8 @@ f()();
         [DataRow("null", "null", true, "Null", "Null")]
         [DataRow("null", "new object()", false, "Null", "NotNull")]
         [DataRow("new object()", "null", false, "NotNull", "Null")]
+        [DataRow("new int?()", "null", false, "NotNull", "Null")]   // Should be "true" and "Null" because new int()? is still null
+        [DataRow("new int?(42)", "null", false, "NotNull", "Null")]
         public void Invocation_Equals_LearnResult(string left, string right, bool? expectedResult, string expectedConstraintsLeft, string expectedConstraintsRight)
         {
             var code = $@"
@@ -956,6 +958,7 @@ Tag(""Right"", right);";
         [DataRow("new object()", "Unknown<object>()")]
         [DataRow("Unknown<object>()", "new object()")]
         [DataRow("Unknown<object>()", "Unknown<object>()")]
+        [DataRow("new int?()", "5")]
         public void Invocation_Equals_DoesNotLearnResult(string left, string right)
         {
             var code = $@"

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp6.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp6.cs
@@ -239,7 +239,7 @@ namespace Tests.Diagnostics
             string value = arg?.ToString();
             if (string.Equals(value, null))
             {
-                value.ToString();   // Noncompliant
+                value.ToString();   // FN Suppressed #6117
             }
             else
             {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp6.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp6.cs
@@ -234,12 +234,33 @@ namespace Tests.Diagnostics
             return 0;
         }
 
+        public int Compare_NoIsNullOperation(ValueHolder left, ValueHolder right)
+        {
+            string leftName = left == null ? null : left.Value;
+            string rightName = right == null ? null : right.Value;
+
+            if (string.Equals(leftName, rightName))
+                // this will return if both are NULL or if they have equal non-null values
+                return 0;
+
+            // at this point, leftName can be NULL if rightName is not NULL
+            if (leftName == null)
+            {
+                // rightName is not null
+                if (rightName.EndsWith("foo")) // Compliant
+                    return 1;
+                return 0;
+            }
+
+            return 0;
+        }
+
         public void EqualsNull(object arg)
         {
-            string value = arg?.ToString();
+            string value = arg == null ? null : arg.ToString();
             if (string.Equals(value, null))
             {
-                value.ToString();   // FN Suppressed #6117
+                value.ToString();   // Noncompliant
             }
             else
             {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp6.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp6.cs
@@ -226,12 +226,25 @@ namespace Tests.Diagnostics
             if (leftName == null)
             {
                 // rightName is not null
-                if (rightName.EndsWith("foo")) // Compliant Suppressed #6117
+                if (rightName.EndsWith("foo")) // Compliant
                     return 1;
                 return 0;
             }
 
             return 0;
+        }
+
+        public void EqualsNull(object arg)
+        {
+            string value = arg?.ToString();
+            if (string.Equals(value, null))
+            {
+                value.ToString();   // Noncompliant
+            }
+            else
+            {
+                value.ToString();   // Compliant
+            }
         }
 
         public string Foo(ValueHolder valueHolder)


### PR DESCRIPTION
Fixes #3416 


