### PR TITLE
Rule S2077: support for additional database libraries: IDbCommand.CommandText

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -232,6 +232,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_Data_Common_CommandTrees_DbExpression = new("System.Data.Common.CommandTrees.DbExpression");
         internal static readonly KnownType System_Data_DataSet = new("System.Data.DataSet");
         internal static readonly KnownType System_Data_DataTable = new("System.Data.DataTable");
+        internal static readonly KnownType System_Data_IDbCommand = new("System.Data.IDbCommand");
         internal static readonly KnownType System_Data_Odbc_OdbcCommand = new("System.Data.Odbc.OdbcCommand");
         internal static readonly KnownType System_Data_Odbc_OdbcDataAdapter = new("System.Data.Odbc.OdbcDataAdapter");
         internal static readonly KnownType System_Data_OracleClient_OracleCommand = new("System.Data.OracleClient.OracleCommand");

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/ExecutingSqlQueriesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/ExecutingSqlQueriesBase.cs
@@ -127,7 +127,7 @@ namespace SonarAnalyzer.Rules
 
             var pa = Language.Tracker.PropertyAccess;
             pa.Track(input,
-                pa.MatchProperty(checkOverridenProperties: true, properties),
+                pa.MatchProperty(true, properties),
                 pa.MatchSetter(),
                 c => IsTracked(GetSetValue(c), c),
                 pa.ExceptWhen(pa.AssignedValueIsConstant()));

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/ExecutingSqlQueriesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/ExecutingSqlQueriesBase.cs
@@ -97,13 +97,7 @@ namespace SonarAnalyzer.Rules
 
         private readonly MemberDescriptor[] properties =
             {
-                new(KnownType.System_Data_Odbc_OdbcCommand, "CommandText"),
-                new(KnownType.System_Data_OracleClient_OracleCommand, "CommandText"),
-                new(KnownType.System_Data_SqlClient_SqlCommand, "CommandText"),
-                new(KnownType.System_Data_Sqlite_SqliteCommand, "CommandText"),
-                new(KnownType.System_Data_SqlServerCe_SqlCeCommand, "CommandText"),
-                new(KnownType.Microsoft_Data_Sqlite_SqliteCommand, "CommandText"),
-                new(KnownType.MySql_Data_MySqlClient_MySqlCommand, "CommandText")
+                new(KnownType.System_Data_IDbCommand, "CommandText"),
             };
 
         protected abstract TExpressionSyntax GetArgumentAtIndex(InvocationContext context, int index);
@@ -133,7 +127,7 @@ namespace SonarAnalyzer.Rules
 
             var pa = Language.Tracker.PropertyAccess;
             pa.Track(input,
-                pa.MatchProperty(properties),
+                pa.MatchProperty(checkOverridenProperties: true, properties),
                 pa.MatchSetter(),
                 c => IsTracked(GetSetValue(c), c),
                 pa.ExceptWhen(pa.AssignedValueIsConstant()));

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessTracker.cs
@@ -35,6 +35,9 @@ namespace SonarAnalyzer.Helpers.Trackers
         public Condition MatchProperty(params MemberDescriptor[] properties) =>
             context => MemberDescriptor.MatchesAny(context.PropertyName, context.PropertySymbol, false, Language.NameComparison, properties);
 
+        public Condition MatchProperty(bool checkOverridenProperties, params MemberDescriptor[] properties) =>
+            context => MemberDescriptor.MatchesAny(context.PropertyName, context.PropertySymbol, checkOverridenProperties, Language.NameComparison, properties);
+
         public Condition ExceptWhen(Condition condition) =>
             value => !condition(value);
 

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessTracker.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Helpers.Trackers
         protected abstract bool IsIdentifierWithinMemberAccess(SyntaxNode expression);
 
         public Condition MatchProperty(params MemberDescriptor[] properties) =>
-            context => MemberDescriptor.MatchesAny(context.PropertyName, context.PropertySymbol, false, Language.NameComparison, properties);
+            MatchProperty(false, properties);
 
         public Condition MatchProperty(bool checkOverridenProperties, params MemberDescriptor[] properties) =>
             context => MemberDescriptor.MatchesAny(context.PropertyName, context.PropertySymbol, checkOverridenProperties, Language.NameComparison, properties);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/ExecutingSqlQueries_Net46.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/ExecutingSqlQueries_Net46.cs
@@ -312,15 +312,13 @@ namespace Tests.Diagnostics
             command.CommandText = y;                                                                    // Noncompliant [5]
         }
 
-        public void DbCommand_CommandText(string param)
+        public void DbCommand_CommandText(DbCommand command, string param)
         {
-            var command = DbProviderFactories.GetFactory("someProvider").CreateCommand();
             command.CommandText = string.Format("INSERT INTO Users (name) VALUES (\"{0}\")", param);    // Noncompliant
         }
 
-        public void IDbCommand_CommandText(string param)
+        public void IDbCommand_CommandText(IDbCommand command, string param)
         {
-            IDbCommand command = DbProviderFactories.GetFactory("someProvider").CreateCommand();
             command.CommandText = string.Format("INSERT INTO Users (name) VALUES (\"{0}\")", param);    // Noncompliant
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/ExecutingSqlQueries_Net46.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/ExecutingSqlQueries_Net46.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using System.Data.Common;
 using System.Data.SqlClient;
 using System.Data.Odbc;
 using System.Data.OracleClient;
@@ -309,6 +310,18 @@ namespace Tests.Diagnostics
             string y;
             y = sensitiveQuery;                                                                         // Secondary [5] {{SQL query is assigned to y.}} ^13#1
             command.CommandText = y;                                                                    // Noncompliant [5]
+        }
+
+        public void DbCommand_CommandText(string param)
+        {
+            var command = DbProviderFactories.GetFactory("someProvider").CreateCommand();
+            command.CommandText = string.Format("INSERT INTO Users (name) VALUES (\"{0}\")", param);    // Noncompliant
+        }
+
+        public void IDbCommand_CommandText(string param)
+        {
+            IDbCommand command = DbProviderFactories.GetFactory("someProvider").CreateCommand();
+            command.CommandText = string.Format("INSERT INTO Users (name) VALUES (\"{0}\")", param);    // Noncompliant
         }
     }
 }


### PR DESCRIPTION
Part of #3905

[S3649.json](https://github.com/SonarSource/sonar-security/blob/master/config/src/main/resources/config/roslyn.sonaranalyzer.security.cs/sinks/S3649.json) lists any IDbCommand.CommandText assignments. We only support some specialized commands, like `OracleCommand` but not abstractions like `DbCommand` or `IDbCommand`. We can unify all existing `CommandText` assignments by checking if any `CommandText` implements `IDbCommand.CommandText`.