### PR TITLE
Fix S2077: Update false FN in unit tests for EF core

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/ExecutingSqlQueries_EntityFrameworkCoreLatest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/ExecutingSqlQueries_EntityFrameworkCoreLatest.cs
@@ -90,7 +90,7 @@ namespace Tests.Diagnostics
         public void Foo(BloggingContext context, string query)
         {
             var a = context.Blogs.FromSqlRaw($"{query}"); // Noncompliant
-            var b = context.Blogs.FromSqlInterpolated($"{query}"); // Compliant, FN See: https://github.com/SonarSource/sonar-dotnet/issues/5636
+            var b = context.Blogs.FromSqlInterpolated($"{query}"); // Compliant, FromSqlInterpolated is safe https://learn.microsoft.com/ef/core/querying/sql-queries#passing-parameters
         }
     }
 


### PR DESCRIPTION
Part of #3905
All EF core methods defined in [S3649.json](https://github.com/SonarSource/sonar-security/blob/master/config/src/main/resources/config/roslyn.sonaranalyzer.security.cs/sinks/S3649.json) for `Microsoft.EntityFrameworkCore` are supported already. A false FN was fixed.