### PR TITLE
Fix S2259 FP: SingleOrDefault() and FirstOrDefault() used within EF LINQ queries

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeAnalysisContextExtensions.cs
@@ -30,4 +30,7 @@ public static class SyntaxNodeAnalysisContextExtensions
         context.Node is CompilationUnitSyntax compilationUnitSyntax
         && compilationUnitSyntax.IsTopLevelMain()
         && context.ContainingSymbol.IsGlobalNamespace(); // Needed to avoid the duplicate calls from Roslyn 4.0.0
+
+    public static bool IsInExpressionTree(this SyntaxNodeAnalysisContext context) =>
+        context.Node.IsInExpressionTree(context.SemanticModel);
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -269,19 +269,19 @@ namespace SonarAnalyzer.Extensions
         }
 
         // This is a refactored version of internal Roslyn SyntaxNodeExtensions.IsInExpressionTree
-        public static bool IsInExpressionTree(this SyntaxNode node, SemanticModel semanticModel)
+        public static bool IsInExpressionTree(this SyntaxNode node, SemanticModel model)
         {
             return node.AncestorsAndSelf().Any(x => IsExpressionLambda(x) || IsExpressionSelectOrOrder(x) || IsExpressionQuery(x));
 
             bool IsExpressionLambda(SyntaxNode node) =>
-                node is LambdaExpressionSyntax && semanticModel.GetTypeInfo(node).ConvertedType.DerivesFrom(KnownType.System_Linq_Expressions_Expression);
+                node is LambdaExpressionSyntax && model.GetTypeInfo(node).ConvertedType.DerivesFrom(KnownType.System_Linq_Expressions_Expression);
 
             bool IsExpressionSelectOrOrder(SyntaxNode node) =>
-                node is SelectOrGroupClauseSyntax or OrderingSyntax && TakesExpressionTree(semanticModel.GetSymbolInfo(node));
+                node is SelectOrGroupClauseSyntax or OrderingSyntax && TakesExpressionTree(model.GetSymbolInfo(node));
 
             bool IsExpressionQuery(SyntaxNode node) =>
                 node is QueryClauseSyntax queryClause
-                && semanticModel.GetQueryClauseInfo(queryClause) is var info
+                && model.GetQueryClauseInfo(queryClause) is var info
                 && (TakesExpressionTree(info.CastInfo) || TakesExpressionTree(info.OperationInfo));
 
             static bool TakesExpressionTree(SymbolInfo info)

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpSyntaxHelper.cs
@@ -247,43 +247,6 @@ namespace SonarAnalyzer.Helpers
         public static Location FindIdentifierLocation(this BaseMethodDeclarationSyntax methodDeclaration) =>
             GetIdentifierOrDefault(methodDeclaration)?.GetLocation();
 
-        /// <summary>
-        /// Determines whether the node is being used as part of an expression tree
-        /// i.e. whether it is part of lambda being assigned to System.Linq.Expressions.Expression[TDelegate].
-        /// This could be a local declaration, an assignment, a field, or a property.
-        /// </summary>
-        public static bool IsInExpressionTree(this SyntaxNode node, SemanticModel semanticModel)
-        {
-            // Possible ancestors:
-            // * VariableDeclarationSyntax (for local variable or field),
-            // * PropertyDeclarationSyntax,
-            // * SimpleAssigmentExpression
-            foreach (var n in node.Ancestors())
-            {
-                switch (n.Kind())
-                {
-                    case SyntaxKind.FromClause:
-                    case SyntaxKind.LetClause:
-                    case SyntaxKind.JoinClause:
-                    case SyntaxKind.JoinIntoClause:
-                    case SyntaxKind.WhereClause:
-                    case SyntaxKind.OrderByClause:
-                    case SyntaxKind.SelectClause:
-                    case SyntaxKind.GroupClause:
-                        // For those clauses, we don't know how to differentiate an expression tree from a delegate,
-                        // so we assume we are in the (more restricted) expression tree
-                        return true;
-                    case SyntaxKind.SimpleLambdaExpression:
-                    case SyntaxKind.ParenthesizedLambdaExpression:
-                        return semanticModel.GetTypeInfo(n).ConvertedType?.OriginalDefinition.Is(KnownType.System_Linq_Expressions_Expression_T)
-                            ?? false;
-                    default:
-                        continue;
-                }
-            }
-            return false;
-        }
-
         public static bool HasDefaultLabel(this SwitchStatementSyntax node) =>
             GetDefaultLabelSectionIndex(node) >= 0;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantArgument.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantArgument.cs
@@ -25,6 +25,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
 using StyleCop.Analyzers.Lightup;
 
@@ -45,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 c =>
                 {
                     // Can't use optional arguments in expression trees (CS0584), so skip those
-                    if (c.Node.IsInExpressionTree(c.SemanticModel))
+                    if (c.IsInExpressionTree())
                     {
                         return;
                     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
@@ -25,6 +25,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.CSharp
@@ -63,7 +64,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 return;
             }
 
-            if (invocation.IsInExpressionTree(context.SemanticModel))
+            if (context.IsInExpressionTree())
             {
                 return; // We cannot specify the culture in an expression tree
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 c =>
                 {
                     var declaration = (AnonymousFunctionExpressionSyntax)c.Node;
-                    if (c.SemanticModel.GetSymbolInfo(declaration).Symbol is { } symbol && !IsInLinqExpression(c))
+                    if (c.SemanticModel.GetSymbolInfo(declaration).Symbol is { } symbol && !c.IsInExpressionTree())
                     {
                         Analyze(context, c, declaration.Body, symbol);
                     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 c =>
                 {
                     var declaration = (AnonymousFunctionExpressionSyntax)c.Node;
-                    if (c.SemanticModel.GetSymbolInfo(declaration).Symbol is { } symbol)
+                    if (c.SemanticModel.GetSymbolInfo(declaration).Symbol is { } symbol && !IsInLinqExpression(c))
                     {
                         Analyze(context, c, declaration.Body, symbol);
                     }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -305,6 +305,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_IO_TextWriter = new("System.IO.TextWriter");
         internal static readonly KnownType System_Lazy = new("System.Lazy", "T");
         internal static readonly KnownType System_Linq_Enumerable = new("System.Linq.Enumerable");
+        internal static readonly KnownType System_Linq_Expressions_Expression = new("System.Linq.Expressions.Expression");
         internal static readonly KnownType System_Linq_Expressions_Expression_T = new("System.Linq.Expressions.Expression", "TDelegate");
         internal static readonly KnownType System_Linq_ImmutableArrayExtensions = new("System.Linq.ImmutableArrayExtensions");
         internal static readonly KnownType System_Linq_Queryable = new("System.Linq.Queryable");

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
@@ -82,12 +82,6 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        protected static bool IsInLinqExpression(SyntaxNodeAnalysisContext context) =>
-            ControlFlowGraph.IsAvailable    // GetOperation fails in ITs otherwise
-            && context.SemanticModel.GetOperation(context.Node) is { } operation
-            && new IOperationWrapperSonar(operation).Parent is { Kind: OperationKindEx.Conversion } parentOperation
-            && parentOperation.ToConversion().Type.DerivesFrom(KnownType.System_Linq_Expressions_Expression);
-
         private void AnalyzeRoslyn(SonarAnalysisContext sonarContext, SyntaxNodeAnalysisContext nodeContext, bool isTestProject, bool isScannerRun, SyntaxNode body, ISymbol symbol)
         {
             var checks = AllRules

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
@@ -83,7 +83,8 @@ namespace SonarAnalyzer.Rules
         }
 
         protected static bool IsInLinqExpression(SyntaxNodeAnalysisContext context) =>
-            context.SemanticModel.GetOperation(context.Node) is { } operation
+            ControlFlowGraph.IsAvailable    // GetOperation fails in ITs otherwise
+            && context.SemanticModel.GetOperation(context.Node) is { } operation
             && new IOperationWrapperSonar(operation).Parent is { Kind: OperationKindEx.Conversion } parentOperation
             && parentOperation.ToConversion().Type.DerivesFrom(KnownType.System_Linq_Expressions_Expression);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
@@ -29,6 +29,7 @@ using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.SymbolicExecution;
 using SonarAnalyzer.SymbolicExecution.Roslyn;
+using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.Rules
 {
@@ -80,6 +81,11 @@ namespace SonarAnalyzer.Rules
                 }
             }
         }
+
+        protected static bool IsInLinqExpression(SyntaxNodeAnalysisContext context) =>
+            context.SemanticModel.GetOperation(context.Node) is { } operation
+            && new IOperationWrapperSonar(operation).Parent is { Kind: OperationKindEx.Conversion } parentOperation
+            && parentOperation.ToConversion().Type.DerivesFrom(KnownType.System_Linq_Expressions_Expression);
 
         private void AnalyzeRoslyn(SonarAnalysisContext sonarContext, SyntaxNodeAnalysisContext nodeContext, bool isTestProject, bool isScannerRun, SyntaxNode body, ISymbol symbol)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
@@ -29,7 +29,6 @@ using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 using SonarAnalyzer.SymbolicExecution;
 using SonarAnalyzer.SymbolicExecution.Roslyn;
-using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.Rules
 {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
@@ -62,6 +62,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
 
         private static ITypeSymbol ConvertedType(IOperation operation) =>
             // Some version of Roslyn can send null here with "return default;". It's not reproducible by UTs, as we have "Type" set in that case.
-            operation?.Kind == OperationKindEx.Conversion ? IConversionOperationWrapper.FromOperation(operation).Type : null;
+            operation?.Kind == OperationKindEx.Conversion ? operation.ToConversion().Type : null;
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExceptionCandidate.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExceptionCandidate.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 return null;
             }
 
-            var conversion = IConversionOperationWrapper.FromOperation(operation.Instance);
+            var conversion = operation.Instance.ToConversion();
             return conversion.Operand.Type.DerivesOrImplements(conversion.Type)
                        ? null
                        : new ExceptionState(typeCatalog.SystemInvalidCastException);

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         internal static ISymbol TrackedSymbol(this IOperation operation) =>
             operation?.Kind switch
             {
-                OperationKindEx.Conversion => TrackedSymbol(IConversionOperationWrapper.FromOperation(operation).Operand),
+                OperationKindEx.Conversion => TrackedSymbol(operation.ToConversion().Operand),
                 OperationKindEx.FieldReference when IFieldReferenceOperationWrapper.FromOperation(operation) is var fieldReference && IsStaticOrThis(fieldReference) => fieldReference.Field,
                 OperationKindEx.LocalReference => ILocalReferenceOperationWrapper.FromOperation(operation).Local,
                 OperationKindEx.ParameterReference => IParameterReferenceOperationWrapper.FromOperation(operation).Parameter,
@@ -61,6 +61,9 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         internal static IArrayElementReferenceOperationWrapper ToArrayElementReference(this IOperation operation) =>
             IArrayElementReferenceOperationWrapper.FromOperation(operation);
 
+        internal static IConversionOperationWrapper ToConversion(this IOperation operation) =>
+            IConversionOperationWrapper.FromOperation(operation);
+
         internal static IInvocationOperationWrapper ToInvocation(this IOperation operation) =>
             IInvocationOperationWrapper.FromOperation(operation);
 
@@ -78,7 +81,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         {
             while (operation?.Kind == OperationKindEx.Conversion)
             {
-                operation = IConversionOperationWrapper.FromOperation(operation).Operand;
+                operation = operation.ToConversion().Operand;
             }
             return operation;
         }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Conversion.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Conversion.cs
@@ -26,7 +26,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors;
 internal sealed class Conversion : SimpleProcessor<IConversionOperationWrapper>
 {
     protected override IConversionOperationWrapper Convert(IOperation operation) =>
-        IConversionOperationWrapper.FromOperation(operation);
+        operation.ToConversion();
 
     protected override ProgramState Process(SymbolicContext context, IConversionOperationWrapper conversion) =>
         context.State[conversion.Operand] is { } value

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -243,7 +243,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 OperationKindEx.ObjectCreation => new ExceptionState(operation.Type),
                 OperationKindEx.ParameterReference => new ExceptionState(operation.Type),
                 OperationKindEx.PropertyReference => new ExceptionState(operation.Type),
-                OperationKindEx.Conversion => ThrowExceptionType(IConversionOperationWrapper.FromOperation(operation).Operand),
+                OperationKindEx.Conversion => ThrowExceptionType(operation.ToConversion().Operand),
                 _ => null
             };
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeAnalysisContextExtensions.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace SonarAnalyzer.Extensions;
+
+public static class SyntaxNodeAnalysisContextExtensions
+{
+    public static bool IsInExpressionTree(this SyntaxNodeAnalysisContext context) =>
+        context.Node.IsInExpressionTree(context.SemanticModel);
+}

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeExtensions.cs
@@ -64,15 +64,15 @@ namespace SonarAnalyzer.Extensions
             FindConstantValue(node, semanticModel) as string;
 
         // This is a refactored version of internal Roslyn SyntaxNodeExtensions.IsInExpressionTree
-        public static bool IsInExpressionTree(this SyntaxNode node, SemanticModel semanticModel)
+        public static bool IsInExpressionTree(this SyntaxNode node, SemanticModel model)
         {
             return node.AncestorsAndSelf().Any(x => IsExpressionLambda(x) || IsExpressionQuery(x));
 
             bool IsExpressionLambda(SyntaxNode node) =>
-                node is LambdaExpressionSyntax && semanticModel.GetTypeInfo(node).ConvertedType.DerivesFrom(KnownType.System_Linq_Expressions_Expression);
+                node is LambdaExpressionSyntax && model.GetTypeInfo(node).ConvertedType.DerivesFrom(KnownType.System_Linq_Expressions_Expression);
 
             bool IsExpressionQuery(SyntaxNode node) =>
-                node is OrderingSyntax or QueryClauseSyntax or FunctionAggregationSyntax or ExpressionRangeVariableSyntax && TakesExpressionTree(semanticModel.GetSymbolInfo(node));
+                node is OrderingSyntax or QueryClauseSyntax or FunctionAggregationSyntax or ExpressionRangeVariableSyntax && TakesExpressionTree(model.GetSymbolInfo(node));
 
             static bool TakesExpressionTree(SymbolInfo info)
             {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 c =>
                 {
                     var declaration = (LambdaExpressionSyntax)c.Node;
-                    if (c.SemanticModel.GetSymbolInfo(declaration).Symbol is { } symbol && !IsInLinqExpression(c))
+                    if (c.SemanticModel.GetSymbolInfo(declaration).Symbol is { } symbol && !c.IsInExpressionTree())
                     {
                         Analyze(context, c, declaration, symbol);
                     }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 c =>
                 {
                     var declaration = (LambdaExpressionSyntax)c.Node;
-                    if (c.SemanticModel.GetSymbolInfo(declaration).Symbol is { } symbol)
+                    if (c.SemanticModel.GetSymbolInfo(declaration).Symbol is { } symbol && !IsInLinqExpression(c))
                     {
                         Analyze(context, c, declaration, symbol);
                     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -587,17 +587,17 @@ public class Sample
 {
     public void Main(int[] arr)
     {
-            var withNormalLambda = arr.Where(xNormal => xNormal == 42).OrderBy((xNormal) => xNormal).Select(xNormal => xNormal);
-            var withNormal = from xNormal in arr where xNormal == 42 orderby xNormal select xNormal;
+            var withNormalLambda = arr.Where(xNormal => xNormal == 42).OrderBy((xNormal) => xNormal).Select(xNormal => xNormal.ToString());
+            var withNormal = from xNormal in arr where xNormal == 42 orderby xNormal select xNormal.ToString();
 
-            var withExpressionLambda = arr.AsQueryable().Where(xExpres => xExpres == 42).OrderBy((xExpres) => xExpres).Select(xExpres => xExpres);
-            var withExpression = from xExpres in arr.AsQueryable() where xExpres == 42 orderby xExpres select xExpres;
+            var withExpressionLambda = arr.AsQueryable().Where(xExpres => xExpres == 42).OrderBy((xExpres) => xExpres).Select(xExpres => xExpres.ToString());
+            var withExpression = from xExpres in arr.AsQueryable() where xExpres == 42 orderby xExpres select xExpres.ToString();
     }
 }";
             var (tree, model) = TestHelper.CompileCS(code);
-            var allIdentifiers = tree.GetRoot().DescendantNodes().OfType<CS.IdentifierNameSyntax>().Where(x => x.Parent is not CS.SelectClauseSyntax).ToArray(); // SelectClause doesn't resolve symbol
-            allIdentifiers.Where(x => x.Identifier.ValueText == "xNormal").Should().HaveCount(5).And.OnlyContain(x => !SyntaxNodeExtensionsCS.IsInExpressionTree(x, model));
-            allIdentifiers.Where(x => x.Identifier.ValueText == "xExpres").Should().HaveCount(5).And.OnlyContain(x => SyntaxNodeExtensionsCS.IsInExpressionTree(x, model));
+            var allIdentifiers = tree.GetRoot().DescendantNodes().OfType<CS.IdentifierNameSyntax>().ToArray();
+            allIdentifiers.Where(x => x.Identifier.ValueText == "xNormal").Should().HaveCount(6).And.OnlyContain(x => !SyntaxNodeExtensionsCS.IsInExpressionTree(x, model));
+            allIdentifiers.Where(x => x.Identifier.ValueText == "xExpres").Should().HaveCount(6).And.OnlyContain(x => SyntaxNodeExtensionsCS.IsInExpressionTree(x, model));
         }
 
         [TestMethod]
@@ -606,11 +606,11 @@ public class Sample
             const string code = @"
 Public Class Sample
     Public Sub Main(Arr() As Integer)
-        Dim WithNormalLambda = Arr.Where(Function(xNormal) xNormal = 42).OrderBy(Function(xNormal) xNormal).Select(Function(xNormal) xNormal)
-        Dim WithNormal = From xNormal In Arr Where xNormal = 42 Order By xNormal Select xNormal
+        Dim WithNormalLambda = Arr.Where(Function(xNormal) xNormal = 42).OrderBy(Function(xNormal) xNormal).Select(Function(xNormal) xNormal.ToString())
+        Dim WithNormal = From xNormal In Arr Where xNormal = 42 Order By xNormal Select Result = xNormal.ToString()
 
-        Dim WithExpressionLambda = Arr.AsQueryable().Where(Function(xExpres) xExpres = 42).OrderBy(Function(xExpres) xExpres).Select(Function(xExpres) xExpres)
-        Dim WithExpression = From xExpres In Arr.AsQueryable() Where xExpres = 42 Order By xExpres Select xExpres
+        Dim WithExpressionLambda = Arr.AsQueryable().Where(Function(xExpres) xExpres = 42).OrderBy(Function(xExpres) xExpres).Select(Function(xExpres) xExpres.ToString())
+        Dim WithExpression = From xExpres In Arr.AsQueryable() Where xExpres = 42 Order By xExpres Select Result = xExpres.ToString()
     End Sub
 End Class";
             var (tree, model) = TestHelper.CompileVB(code);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -578,6 +578,47 @@ public class C
             }
         }
 
+        [TestMethod]
+        public void IsInExpressionTree_CS()
+        {
+            const string code = @"
+using System.Linq;
+public class Sample
+{
+    public void Main(int[] arr)
+    {
+            var withNormalLambda = arr.Where(xNormal => xNormal == 42).OrderBy((xNormal) => xNormal).Select(xNormal => xNormal);
+            var withNormal = from xNormal in arr where xNormal == 42 orderby xNormal select xNormal;
+
+            var withExpressionLambda = arr.AsQueryable().Where(xExpres => xExpres == 42).OrderBy((xExpres) => xExpres).Select(xExpres => xExpres);
+            var withExpression = from xExpres in arr.AsQueryable() where xExpres == 42 orderby xExpres select xExpres;
+    }
+}";
+            var (tree, model) = TestHelper.CompileCS(code);
+            var allIdentifiers = tree.GetRoot().DescendantNodes().OfType<CS.IdentifierNameSyntax>().Where(x => x.Parent is not CS.SelectClauseSyntax).ToArray(); // SelectClause doesn't resolve symbol
+            allIdentifiers.Where(x => x.Identifier.ValueText == "xNormal").Should().HaveCount(5).And.OnlyContain(x => !SyntaxNodeExtensionsCS.IsInExpressionTree(x, model));
+            allIdentifiers.Where(x => x.Identifier.ValueText == "xExpres").Should().HaveCount(5).And.OnlyContain(x => SyntaxNodeExtensionsCS.IsInExpressionTree(x, model));
+        }
+
+        [TestMethod]
+        public void IsInExpressionTree_VB()
+        {
+            const string code = @"
+Public Class Sample
+    Public Sub Main(Arr() As Integer)
+        Dim WithNormalLambda = Arr.Where(Function(xNormal) xNormal = 42).OrderBy(Function(xNormal) xNormal).Select(Function(xNormal) xNormal)
+        Dim WithNormal = From xNormal In Arr Where xNormal = 42 Order By xNormal Select xNormal
+
+        Dim WithExpressionLambda = Arr.AsQueryable().Where(Function(xExpres) xExpres = 42).OrderBy(Function(xExpres) xExpres).Select(Function(xExpres) xExpres)
+        Dim WithExpression = From xExpres In Arr.AsQueryable() Where xExpres = 42 Order By xExpres Select xExpres
+    End Sub
+End Class";
+            var (tree, model) = TestHelper.CompileVB(code);
+            var allIdentifiers = tree.GetRoot().DescendantNodes().OfType<VB.IdentifierNameSyntax>().ToArray();
+            allIdentifiers.Where(x => x.Identifier.ValueText == "xNormal").Should().HaveCount(6).And.OnlyContain(x => !SyntaxNodeExtensionsVB.IsInExpressionTree(x, model));
+            allIdentifiers.Where(x => x.Identifier.ValueText == "xExpres").Should().HaveCount(6).And.OnlyContain(x => SyntaxNodeExtensionsVB.IsInExpressionTree(x, model));
+        }
+
         private static SyntaxToken GetFirstTokenOfKind(SyntaxTree syntaxTree, SyntaxKind kind) =>
             syntaxTree.GetRoot().DescendantTokens().First(token => token.IsKind(kind));
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionRunnerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionRunnerTest.cs
@@ -289,8 +289,12 @@ End Sub");
             VerifyClassMainCS(@"
 public void Main()
 {
-    WithExpression(() => 1 + 1);    // Noncompliant FIXME: Should be Compliant, SBinary is not triggered, because this method is not analyzed
+    WithExpression(() => 1 + 1);    // Compliant, SBinary is not triggered, because this method is not analyzed
     WithFunc(() => 1 + 1);          // Noncompliant {{Message for SBinary}} To be sure binary rule triggers
+
+        System.Linq.Expressions.Expression<Func<object[], object>> expr;
+        // Noncompliant@+1 {{Message for SMain}} This is scaffolding issue from the assignment to 'expr'
+        expr = x => x.FirstOrDefault().ToString();      // Compliant
 }
 
 private void WithExpression(System.Linq.Expressions.Expression<Func<int>> arg) { }
@@ -300,8 +304,12 @@ private void WithFunc(Func<int> arg) { }");
         public void Analyze_DoNotRunWhenInsideLinqExpression_VB() =>
             VerifyClassMainVB(@"
 Public Sub Main()
-    WithExpression(Function() 1 + 1)    ' Noncompliant FIXME: Should be Compliant, SBinary is not triggered, because this method is not analyzed
+    WithExpression(Function() 1 + 1)    ' Should be Compliant, SBinary is not triggered, because this method is not analyzed
     WithFunc(Function() 1 + 1)          ' Noncompliant {{Message for SBinary}} To be sure binary rule triggers
+
+    Dim Expr As Linq.Expressions.Expression(Of Func(Of Integer))
+    ' Noncompliant@+1 {{Message for SMain}} This is scaffolding issue from the assignment to 'Expr'
+    Expr = Function() 1 + 1
 End Sub
 
 Private Sub WithExpression(Arg As Linq.Expressions.Expression(Of Func(Of Integer)))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/StringOperationWithoutCulture.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/StringOperationWithoutCulture.cs
@@ -49,11 +49,11 @@ namespace Tests.Diagnostics
         {
             // Make sure we don't report it for Expressions
             Expression<Func<string, bool>> e = s => s.ToUpper() == "TOTO";
-            Func<string, bool> f = s => s.ToUpper() == "TOTO"; // Noncompliant
+            Func<string, bool> f = s => s.ToUpper() == "TOTO";                              // Noncompliant
             var primes = new List<string> { "two", "three", "five", "seven" };
-            var withT = primes.Where(s => s.ToUpper().StartsWith("T")); // Noncompliant
+            var withT = primes.Where(s => s.ToUpper().StartsWith("T"));                     // Noncompliant
             var withTQuery = primes.AsQueryable().Where(s => s.ToUpper().StartsWith("T"));
-            var withoutT = from s in primes where !s.ToUpper().StartsWith("T") select s; // False negative
+            var withoutT = from s in primes where !s.ToUpper().StartsWith("T") select s;    // Noncompliant
             var withoutTQuery = from s in primes.AsQueryable() where !s.ToUpper().StartsWith("T") select s;
 
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -1658,8 +1658,7 @@ public class Repro_6176
 
     public void Nested(object arg)
     {
-        // To fix this, we'd need to bump referenced Roslyn version or shim SyntaxNodeExtensions.IsInExpressionTree for C# and VB, and replace SymbolicExecutionRunnerBase.IsInLinqExpression with that
-        Select(() => Invoke(x => x.FirstOrDefault().ToString()));   // Noncompliant FP - inner expression is nested in outer one
+        Select(() => Invoke(x => x.FirstOrDefault().ToString()));   // Compliant, it's invoked lambda inside an expression tree
     }
 
     private void Select(System.Linq.Expressions.Expression<Func<IEnumerable<object>, object>> expression) { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -1643,8 +1643,8 @@ public class Repro_6176
 {
     public void ExpressionArguments(object arg)
     {
-        Select(x => x.FirstOrDefault().ToString());         // Compliant - custom expression processor, like Entity Framework, can propagate the "null" without executing the actual code
-        Select(() => arg == null ? arg.ToString() : null);  // Compliant, we don't analyze arguments of expression
+        WithExpression(x => x.FirstOrDefault().ToString());         // Compliant - custom expression processor, like Entity Framework, can propagate the "null" without executing the actual code
+        WithExpression(() => arg == null ? arg.ToString() : null);  // Compliant, we don't analyze arguments of expression
 
         System.Linq.Expressions.Expression<Func<IEnumerable<object>, object>> expr;
         expr = x => x.FirstOrDefault().ToString();          // Compliant as well
@@ -1652,17 +1652,17 @@ public class Repro_6176
 
     public void DelegateArguments(object arg)
     {
-        Invoke(x => x.FirstOrDefault().ToString());         // Noncompliant
-        Invoke(() => arg == null ? arg.ToString() : null);  // Noncompliant
+        WithDelegate(x => x.FirstOrDefault().ToString());         // Noncompliant
+        WithDelegate(() => arg == null ? arg.ToString() : null);  // Noncompliant
     }
 
     public void Nested(object arg)
     {
-        Select(() => Invoke(x => x.FirstOrDefault().ToString()));   // Compliant, it's invoked lambda inside an expression tree
+        WithExpression(() => WithDelegate(x => x.FirstOrDefault().ToString()));   // Compliant, it's invoked lambda inside an expression tree
     }
 
-    private void Select(System.Linq.Expressions.Expression<Func<IEnumerable<object>, object>> expression) { }
-    private void Select(System.Linq.Expressions.Expression<Func<object>> expression) { }
-    private object Invoke(Func<IEnumerable<object>, object> expression) => null;
-    private void Invoke(Func<object> expression) { }
+    private void WithExpression(System.Linq.Expressions.Expression<Func<IEnumerable<object>, object>> expression) { }
+    private void WithExpression(System.Linq.Expressions.Expression<Func<object>> expression) { }
+    private object WithDelegate(Func<IEnumerable<object>, object> expression) => null;
+    private void WithDelegate(Func<object> expression) { }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -1643,8 +1643,11 @@ public class Repro_6176
 {
     public void ExpressionArguments(object arg)
     {
-        Select(x => x.FirstOrDefault().ToString());         // Noncompliant FP, should be Compliant - custom expression processor, like Entity Framework, can propagate the "null" without executing the actual code
-        Select(() => arg == null ? arg.ToString() : null);  // Noncompliant FP, should be Compliant, we don't analyze arguments of expression
+        Select(x => x.FirstOrDefault().ToString());         // Compliant - custom expression processor, like Entity Framework, can propagate the "null" without executing the actual code
+        Select(() => arg == null ? arg.ToString() : null);  // Compliant, we don't analyze arguments of expression
+
+        System.Linq.Expressions.Expression<Func<IEnumerable<object>, object>> expr;
+        expr = x => x.FirstOrDefault().ToString();          // Compliant as well
     }
 
     public void DelegateArguments(object arg)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -1637,3 +1637,24 @@ namespace DoesNotReturnIf
         public void FailsWhenFalseAny([DoesNotReturnIf(false)] bool condition1, [DoesNotReturnIf(false)] bool condition2) { }
     }
 }
+
+// https://github.com/SonarSource/sonar-dotnet/issues/6176
+public class Repro_6176
+{
+    public void ExpressionArguments(object arg)
+    {
+        Select(x => x.FirstOrDefault().ToString());         // Noncompliant FP, should be Compliant - custom expression processor, like Entity Framework, can propagate the "null" without executing the actual code
+        Select(() => arg == null ? arg.ToString() : null);  // Noncompliant FP, should be Compliant, we don't analyze arguments of expression
+    }
+
+    public void DelegateArguments(object arg)
+    {
+        Invoke(x => x.FirstOrDefault().ToString());         // Noncompliant
+        Invoke(() => arg == null ? arg.ToString() : null);  // Noncompliant
+    }
+
+    private void Select(System.Linq.Expressions.Expression<Func<IEnumerable<object>, object>> expression) { }
+    private void Select(System.Linq.Expressions.Expression<Func<object>> expression) { }
+    private void Invoke(Func<IEnumerable<object>, object> expression) { }
+    private void Invoke(Func<object> expression) { }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -1656,8 +1656,14 @@ public class Repro_6176
         Invoke(() => arg == null ? arg.ToString() : null);  // Noncompliant
     }
 
+    public void Nested(object arg)
+    {
+        // To fix this, we'd need to bump referenced Roslyn version or shim SyntaxNodeExtensions.IsInExpressionTree for C# and VB, and replace SymbolicExecutionRunnerBase.IsInLinqExpression with that
+        Select(() => Invoke(x => x.FirstOrDefault().ToString()));   // Noncompliant FP - inner expression is nested in outer one
+    }
+
     private void Select(System.Linq.Expressions.Expression<Func<IEnumerable<object>, object>> expression) { }
     private void Select(System.Linq.Expressions.Expression<Func<object>> expression) { }
-    private void Invoke(Func<IEnumerable<object>, object> expression) { }
+    private object Invoke(Func<IEnumerable<object>, object> expression) => null;
     private void Invoke(Func<object> expression) { }
 }


### PR DESCRIPTION
Fixes #6176