### PR TITLE
Rename external pipeline variable group

### DIFF
--- a/azure-pipelines-external.yml
+++ b/azure-pipelines-external.yml
@@ -1,7 +1,7 @@
 pool: '.Net Bubble - GCP'
 
 variables:
-  - group: sonar-dotnet-variables
+  - group: sonar-dotnet-variables-external
   - group: sonarsource-build-variables
   - name: MsBuildPath
     value: 'C:\Program Files\Microsoft Visual Studio\2022\Preview\Msbuild\Current\Bin\msbuild.exe'


### PR DESCRIPTION
The production group is named `sonar-dotnet-variables-tmp`, we need to change that. 

To make the room for the rename, we need to first rename the external pipeline to something specific.

The external pipeline doesn't work anyway right now (too behind latest changes). I've raised the point on How we work already about it.

I've already renamed it on the [AZP side](https://dev.azure.com/sonarsource/DotNetTeam%20Project/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=4&path=sonar-dotnet-variables-external).

Next steps will be to rename the production one.