### PR TITLE
S2068: Support colon in uri password

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -80,15 +80,15 @@ namespace SonarAnalyzer.Rules
             const string Rfc3986_SubDelims = "!$&'()*+,;=";
             const string UriPasswordSpecialCharacters = Rfc3986_Unreserved + Rfc3986_Pct + Rfc3986_SubDelims;
             // See https://tools.ietf.org/html/rfc3986 Userinfo can contain groups: unreserved | pct-encoded | sub-delims
-            var loginGroup = CreateUserInfoGroup("Login", null);
+            var loginGroup = CreateUserInfoGroup("Login");
             var passwordGroup = CreateUserInfoGroup("Password", ":");   // Additional ":" to capture passwords containing it
             uriUserInfoPattern = new Regex(@$"\w+:\/\/{loginGroup}:{passwordGroup}@", RegexOptions.Compiled);
             this.configuration = configuration;
             rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
             CredentialWords = DefaultCredentialWords;   // Property will initialize multiple state variables
 
-            static string CreateUserInfoGroup(string name, string additionalCharacterss) =>
-                $@"(?<{name}>[\w\d{Regex.Escape(UriPasswordSpecialCharacters)}{additionalCharacterss}]+)";
+            static string CreateUserInfoGroup(string name, string additionalCharacters = null) =>
+                $@"(?<{name}>[\w\d{Regex.Escape(UriPasswordSpecialCharacters)}{additionalCharacters}]+)";
         }
 
         protected sealed override void Initialize(ParameterLoadingAnalysisContext context)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DoNotHardcodeCredentials.DefaultValues.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DoNotHardcodeCredentials.DefaultValues.cs
@@ -284,9 +284,10 @@ namespace Tests.Diagnostics
         public void UriWithUserInfo(string pwd, string domain)
         {
             string n1 = "scheme://user:azerty123@domain.com"; // Noncompliant {{Review this hard-coded URI, which may contain a credential.}}
-            string n2 = "scheme://user:With%20%3F%20Encoded@domain.com";              // Noncompliant
-            string n3 = "scheme://user:With!$&'()*+,;=OtherCharacters@domain.com";    // Noncompliant
-            string n4 = "scheme://user:azerty123@" + domain;  // Noncompliant
+            string n2 = "scheme://user:With%20%3F%20Encoded@domain.com";            // Noncompliant
+            string n3 = "scheme://user:With!$&'()*+,;=OtherCharacters@domain.com";  // Noncompliant
+            string n4 = "scheme://user:Pa$$word:With:Colons@domain.com";            // Noncompliant
+            string n5 = "scheme://user:azerty123@" + domain;                        // Noncompliant
 
             string c1 = "scheme://user:" + pwd + "@domain.com";
             string c2 = "scheme://user:@domain.com";


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc3986#section-3.2.1 defines userInfo as
```
userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )
```
therefore `:` is valid part of the password
```
var uri = "scheme://user:Pa$$word:With:Colons@domain.com";            // Noncompliant
```