### PR TITLE
Extract JsonWalker

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Json/JsonWalker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Json/JsonWalker.cs
@@ -1,0 +1,67 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.Json.Parsing;
+
+namespace SonarAnalyzer.Json
+{
+    public abstract class JsonWalker
+    {
+        public void Visit(JsonNode node)
+        {
+            switch (node.Kind)
+            {
+                case Kind.Object:
+                    VisitObject(node);
+                    break;
+                case Kind.List:
+                    VisitList(node);
+                    break;
+                case Kind.Value:
+                    VisitValue(node);
+                    break;
+            }
+        }
+
+        protected virtual void VisitObject(JsonNode node)
+        {
+            foreach (var key in node.Keys)
+            {
+                VisitObject(key, node[key]);
+            }
+        }
+
+        protected virtual void VisitObject(string key, JsonNode value) =>
+            Visit(value);
+
+        protected virtual void VisitList(JsonNode node)
+        {
+            foreach (var item in node)
+            {
+                Visit(item);
+            }
+        }
+
+        protected virtual void VisitValue(JsonNode node)
+        {
+            // Override me
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/Json/JsonWalker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Json/JsonWalker.cs
@@ -24,7 +24,7 @@ namespace SonarAnalyzer.Json
 {
     public abstract class JsonWalker
     {
-        public void Visit(JsonNode node)
+        public virtual void Visit(JsonNode node)
         {
             switch (node.Kind)
             {

--- a/analyzers/src/SonarAnalyzer.Common/Json/JsonWalker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Json/JsonWalker.cs
@@ -22,8 +22,10 @@ using SonarAnalyzer.Json.Parsing;
 
 namespace SonarAnalyzer.Json
 {
-    public abstract class JsonWalker
+    public class JsonWalker
     {
+        protected JsonWalker() { }
+
         public virtual void Visit(JsonNode node)
         {
             switch (node.Kind)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -284,6 +284,5 @@ namespace SonarAnalyzer.Rules
                 }
             }
         }
-
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -160,55 +160,8 @@ namespace SonarAnalyzer.Rules
             {
                 if (JsonNode.FromString(File.ReadAllText(path)) is { } json)
                 {
-                    CheckAppSettings(c, path, json);
-                }
-            }
-        }
-
-        private void CheckAppSettings(CompilationAnalysisContext c, string path, JsonNode json)
-        {
-            var queue = new Queue<JsonNode>();
-            queue.Enqueue(json);
-            while (queue.Any())
-            {
-                var node = queue.Dequeue();
-                switch (node.Kind)
-                {
-                    case Kind.Object:
-                        foreach (var key in node.Keys)
-                        {
-                            ProcessKeyValue(key, node[key]);
-                        }
-                        break;
-                    case Kind.List:
-                        foreach (var item in node)
-                        {
-                            queue.Enqueue(item);
-                        }
-                        break;
-                    case Kind.Value:
-                        CheckKeyValue(null, node);
-                        break;
-                }
-            }
-
-            void ProcessKeyValue(string key, JsonNode value)
-            {
-                if (value.Kind == Kind.Value)
-                {
-                    CheckKeyValue(key, value);
-                }
-                else
-                {
-                    queue.Enqueue(value);
-                }
-            }
-
-            void CheckKeyValue(string key, JsonNode value)
-            {
-                if (value.Value is string str && IssueMessage(key, str) is { } valueMessage)
-                {
-                    c.ReportIssue(Diagnostic.Create(rule, value.ToLocation(path), valueMessage));
+                    var walker = new CredentialWordsJsonWalker(this, c, path);
+                    walker.Visit(json);
                 }
             }
         }
@@ -294,5 +247,43 @@ namespace SonarAnalyzer.Rules
                     }
                 };
         }
+
+        private sealed class CredentialWordsJsonWalker : JsonWalker
+        {
+            private readonly DoNotHardcodeCredentialsBase<TSyntaxKind> analyzer;
+            private readonly CompilationAnalysisContext context;
+            private readonly string path;
+
+            public CredentialWordsJsonWalker(DoNotHardcodeCredentialsBase<TSyntaxKind> analyzer, CompilationAnalysisContext context, string path)
+            {
+                this.analyzer = analyzer;
+                this.context = context;
+                this.path = path;
+            }
+
+            protected override void VisitObject(string key, JsonNode value)
+            {
+                if (value.Kind == Kind.Value)
+                {
+                    CheckKeyValue(key, value);
+                }
+                else
+                {
+                    base.VisitObject(key, value);
+                }
+            }
+
+            protected override void VisitValue(JsonNode node) =>
+                CheckKeyValue(null, node);
+
+            private void CheckKeyValue(string key, JsonNode value)
+            {
+                if (value.Value is string str && analyzer.IssueMessage(key, str) is { } valueMessage)
+                {
+                    context.ReportIssue(Diagnostic.Create(analyzer.rule, value.ToLocation(path), valueMessage));
+                }
+            }
+        }
+
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Json/JsonWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Json/JsonWalkerTest.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.Json;
+
+namespace SonarAnalyzer.UnitTest.Common
+{
+    [TestClass]
+    public class JsonWalkerTest
+    {
+        [TestMethod]
+        public void VisitsAllNodes()
+        {
+            const string json = @"
+{
+    ""OuterKey"": ""OuterValue"",
+    ""OuterBool"": true,
+    ""NestedArray"": [
+        ""Array1"",
+        ""Array2"",
+        ""Array3""
+    ]
+}";
+            var sut = new JsonWalkerCollector();
+            sut.Visit(JsonNode.FromString(json));
+            sut.VisitedKeys.Should().BeEquivalentTo("OuterKey", "OuterBool", "NestedArray");
+            sut.VisitedValues.Should().BeEquivalentTo("OuterValue", true, "Array1", "Array2", "Array3");
+        }
+
+        private class JsonWalkerCollector : JsonWalker
+        {
+            public readonly List<string> VisitedKeys = new();
+            public readonly List<object> VisitedValues = new();
+
+            protected override void VisitObject(string key, JsonNode value)
+            {
+                VisitedKeys.Add(key);
+                base.VisitObject(key, value);
+            }
+
+            protected override void VisitValue(JsonNode node)
+            {
+                VisitedValues.Add(node.Value);
+                base.VisitValue(node);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow up of #6187 and https://github.com/SonarSource/sonar-dotnet/pull/6187#discussion_r992050938

`Squash S206-appsettings` doesn't need a review

## Original discussion:

@pavel-mikula-sonarsource 
>Extract as reusable walker?

@martin-strecker-sonarsource 
>Sounds like a good idea to me. You could provide `IEnumerable<JsonNode> Descendants()` and `IEnumerable<KeyValuePair<string?, object>> DescendantValues()` extension methods for `JsonNode` on top of it.
>
>It's also easier to test the visitor for things like nested lists and the like.

@pavel-mikula-sonarsource 
>The walker is not as easy at it seemed. I'll leave it like this for now and we can discuss it here and do it in another PR.
The key problem is, that I need to visit `"value"`, but I do not want to visit `"value"` inside object `"key": "value"`. And node doesn't know it's parent.
I don't have a good idea for this stop mechanism without going into recursive descent and enqueuing in the `base.VisitObject`.
>
>How would `Descendants' and `DescendantValues` actually work together?


