### PR TITLE
Added the -release flag in order to run dev-build.ps1

### DIFF
--- a/docs/contributing-plugin.md
+++ b/docs/contributing-plugin.md
@@ -14,7 +14,7 @@
 1. Download sub-modules `git submodule update --init --recursive`
 1. Build the plugin
     * To build the plugin while embedding a local build of the analyzer you can either:
-        * run `.\scripts\build\dev-build.ps1 -build -test -buildJava`
+        * run `.\scripts\build\dev-build.ps1 -build -test -buildJava -release`
 
             The flags `-restore -build -test` need to be run only when you have changed the analyzer. Otherwise you can run only `-buildJava`
 


### PR DESCRIPTION
Added the `-release` flag on the `dev-build.ps1` run instruction, since if the `-buildJava` flag is supplied, it needs the release DLLs.