### PR TITLE
Bump sonar-analyzer-commons to 2.0.0.1075

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -54,7 +55,7 @@
     <artifactsToDownload>${project.groupId}:SonarAnalyzer.CSharp:nupkg,${project.groupId}:SonarAnalyzer.VisualBasic:nupkg</artifactsToDownload>
     <!-- We are ignoring java doc warnings - this is because we are using JDK 11. Ideally we should not do that. -->
     <doclint>none</doclint>
-    <sonar.analyzer.commons>1.28.0.1058</sonar.analyzer.commons>
+    <sonar.analyzer.commons>2.0.0.1075</sonar.analyzer.commons>
     <sonar.version>9.11.0.290</sonar.version>
     <sonar.api.impl.version>9.6.1.59531</sonar.api.impl.version>
   </properties>


### PR DESCRIPTION
C# Jar size went from 5 532 287 bytes -> 5 508 320 bytes

We're still within boundaries
https://github.com/SonarSource/sonar-dotnet/blob/d2590e5c855787cfcd9b351f546023485a953294/sonar-csharp-plugin/pom.xml#L217-L220