### PR TITLE
Fix AssertIgnoreScope for .NET 7

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/RestrictDeserializedTypesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/RestrictDeserializedTypesTest.cs
@@ -20,6 +20,7 @@
 
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.SymbolicExecution.Sonar.Analyzers;
+using SonarAnalyzer.UnitTest.Helpers;
 
 namespace SonarAnalyzer.UnitTest.Rules
 {
@@ -30,12 +31,15 @@ namespace SonarAnalyzer.UnitTest.Rules
 
 #if NETFRAMEWORK // These serializers are available only when targeting .Net Framework
         [TestMethod]
-        public void RestrictDeserializedTypesFormatters() =>
+        public void RestrictDeserializedTypesFormatters()
+        {
+            using var _ = new AssertIgnoreScope(); // EnsureStackState fails an assertion in this test file
             OldVerifier.VerifyAnalyzer(@"TestCases\SymbolicExecution\Sonar\RestrictDeserializedTypes.cs",
                 new SymbolicExecutionRunner(),
                 ParseOptionsHelper.FromCSharp8,
                 AdditionalReferencesNetFx(),
                 onlyDiagnostics: OnlyDiagnostics);
+        }
 
         [TestMethod]
         public void RestrictDeserializedTypes_DoesNotRaiseIssuesForTestProject() =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/AssertIgnoreScope.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/AssertIgnoreScope.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
             listener = Trace.Listeners.OfType<DefaultTraceListener>().FirstOrDefault();
             if (listener != null)
             {
-                listener.AssertUiEnabled = false;
+                Trace.Listeners.Remove(listener);
             }
         }
 
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
         {
             if (listener != null)
             {
-                listener.AssertUiEnabled = true;
+                Trace.Listeners.Add(listener);
             }
         }
     }


### PR DESCRIPTION
`WhenReportDiagnosticActionNotNull_AllowToControlWhetherOrNotToReport` UT is failing in Debug mode since updating to .NET 7. Root cause is the impression mechanism for Debug.Assert exception is no longer working on .Net 7 as before. A more radical approach (removing the default listener) fixes the problem,