### PR TITLE
Rename pipeline variable group

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ trigger:
 pool: '.Net Bubble - GCP'
 
 variables:
-  - group: sonar-dotnet-variables-tmp
+  - group: sonar-dotnet-variables
   - group: sonarsource-build-variables
   # To make sure we don`t use MsBuild 17.
   - name: MsBuildPath


### PR DESCRIPTION
Follow up of #6197 

`sonar-dotnet-variables-tmp` was duplicated as `sonar-dotnet-variables`
`sonar-dotnet-variables-tmp` will be deleted once this is merged