### PR TITLE
Run .Net code analysis only if the UTs pass

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,7 +211,7 @@ stages:
         clean: all
       # This job runs the .Net code analysis and uploads to SonarCloud the test results and coverage reports generated
       # in previous jobs.
-      condition: always()
+      condition: eq(dependencies.runUnitTestsDotNet.result, 'Succeeded')
       dependsOn:
       - runUnitTestsDotNet
       steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,21 +183,18 @@ stages:
         displayName: '.Net UTs'
 
       - task: PublishPipelineArtifact@1
-        condition: always()
         displayName: 'Save coverage files'
         inputs:
           path: '$(UnitTestProjectPath)\coverage'
           artifact: $(CoverageArtifactName)
 
       - task: PublishPipelineArtifact@1
-        condition: always()
         displayName: 'Save test results files'
         inputs:
           path: '$(UnitTestResultsPath)'
           artifact: $(TestResultsArtifactName)
 
       - task: PublishTestResults@2
-        condition: always()
         displayName: 'Publish test results'
         inputs:
           testRunner: VSTest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -195,6 +195,7 @@ stages:
           artifact: $(TestResultsArtifactName)
 
       - task: PublishTestResults@2
+        condition: always()
         displayName: 'Publish test results'
         inputs:
           testRunner: VSTest


### PR DESCRIPTION
The new behavior can be observed here: https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=55839&view=results

There are 2 different changes:
- `.Net Analysis` job is not executed if .Net unit tests fail.
- Coverage and test results artifacts are not published if running the unit tests fails. The reason is that the uploaded artifacts cannot be overwritten and all the subsequent build retries will fail.