### PR TITLE
Rename verifiers in SE rules

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ConditionEvaluatesToConstantTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ConditionEvaluatesToConstantTest.cs
@@ -26,26 +26,26 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class ConditionEvaluatesToConstantTest
     {
-        private readonly VerifierBuilder sonarVerifier = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
+        private readonly VerifierBuilder sonar = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
             .WithOnlyDiagnostics(ConditionEvaluatesToConstant.S2583, ConditionEvaluatesToConstant.S2589);
 
         [DataTestMethod]
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void ConditionEvaluatesToConstant_CS(ProjectType projectType) =>
-            sonarVerifier.AddPaths("ConditionEvaluatesToConstant.cs")
+            sonar.AddPaths("ConditionEvaluatesToConstant.cs")
                 .AddReferences(NuGetMetadataReference.MicrosoftExtensionsPrimitives("3.1.7").Concat(TestHelper.ProjectTypeReference(projectType)))
                 .Verify();
 
         [TestMethod]
         public void ConditionEvaluatesToConstant_FromCSharp7() =>
-            sonarVerifier.AddPaths("ConditionEvaluatesToConstant.CSharp7.cs")
+            sonar.AddPaths("ConditionEvaluatesToConstant.CSharp7.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp7)
                 .Verify();
 
         [TestMethod]
         public void ConditionEvaluatesToConstant_FromCSharp8() =>
-            sonarVerifier.AddPaths("ConditionEvaluatesToConstant.CSharp8.cs")
+            sonar.AddPaths("ConditionEvaluatesToConstant.CSharp8.cs")
                 .AddReferences(MetadataReferenceFacade.NETStandard21)
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
@@ -54,19 +54,19 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void ConditionEvaluatesToConstant_FromCSharp9() =>
-            sonarVerifier.AddPaths("ConditionEvaluatesToConstant.CSharp9.cs")
+            sonar.AddPaths("ConditionEvaluatesToConstant.CSharp9.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp9)
                 .Verify();
 
         [TestMethod]
         public void ConditionEvaluatesToConstant_FromCSharp9_TopLevelStatements() =>
-            sonarVerifier.AddPaths("ConditionEvaluatesToConstant.CSharp9.TopLevelStatements.cs")
+            sonar.AddPaths("ConditionEvaluatesToConstant.CSharp9.TopLevelStatements.cs")
                 .WithTopLevelStatements()
                 .Verify();
 
         [TestMethod]
         public void ConditionEvaluatesToConstant_FromCSharp10() =>
-            sonarVerifier.AddPaths("ConditionEvaluatesToConstant.CSharp10.cs")
+            sonar.AddPaths("ConditionEvaluatesToConstant.CSharp10.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .WithConcurrentAnalysis(false)
                 .Verify();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyCollectionsShouldNotBeEnumeratedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyCollectionsShouldNotBeEnumeratedTest.cs
@@ -26,7 +26,7 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class EmptyCollectionsShouldNotBeEnumeratedTest
     {
-        private readonly VerifierBuilder sonarVerifier = new VerifierBuilder<SymbolicExecutionRunner>()
+        private readonly VerifierBuilder sonar = new VerifierBuilder<SymbolicExecutionRunner>()
             .WithOnlyDiagnostics(EmptyCollectionsShouldNotBeEnumerated.S4158)
             .WithBasePath(@"SymbolicExecution\Sonar")
             .WithConcurrentAnalysis(false);
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void EmptyCollectionsShouldNotBeEnumerated_CSharp8(ProjectType projectType) =>
-            sonarVerifier.AddReferences(TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NETStandard21))
+            sonar.AddReferences(TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NETStandard21))
                 .AddPaths("EmptyCollectionsShouldNotBeEnumerated.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
@@ -44,11 +44,11 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void EmptyCollectionsShouldNotBeEnumerated_CSharp9() =>
-            sonarVerifier.AddPaths("EmptyCollectionsShouldNotBeEnumerated.CSharp9.cs").WithTopLevelStatements().Verify();
+            sonar.AddPaths("EmptyCollectionsShouldNotBeEnumerated.CSharp9.cs").WithTopLevelStatements().Verify();
 
         [TestMethod]
         public void EmptyCollectionsShouldNotBeEnumerated_CSharp10() =>
-            sonarVerifier.AddPaths("EmptyCollectionsShouldNotBeEnumerated.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+            sonar.AddPaths("EmptyCollectionsShouldNotBeEnumerated.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
 
 #endif
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyNullableValueAccessTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyNullableValueAccessTest.cs
@@ -26,14 +26,14 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class EmptyNullableValueAccessTest
     {
-        private readonly VerifierBuilder sonarVerifier = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
+        private readonly VerifierBuilder sonar = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
             .WithOnlyDiagnostics(EmptyNullableValueAccess.S3655);
 
         [DataTestMethod]
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void EmptyNullableValueAccess_CSharp8(ProjectType projectType) =>
-            sonarVerifier.AddPaths("EmptyNullableValueAccess.cs")
+            sonar.AddPaths("EmptyNullableValueAccess.cs")
                 .AddReferences(TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NETStandard21))
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
@@ -42,13 +42,13 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void EmptyNullableValueAccess_CSharp9() =>
-            sonarVerifier.AddPaths("EmptyNullableValueAccess.CSharp9.cs")
+            sonar.AddPaths("EmptyNullableValueAccess.CSharp9.cs")
                 .WithTopLevelStatements()
                 .Verify();
 
         [TestMethod]
         public void EmptyNullableValueAccess_CSharp10() =>
-            sonarVerifier.AddPaths("EmptyNullableValueAccess.CSharp10.cs")
+            sonar.AddPaths("EmptyNullableValueAccess.CSharp10.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .Verify();
 
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void EmptyNullableValueAccess_CSharp11() =>
-            sonarVerifier
+            sonar
                 .AddPaths("EmptyNullableValueAccess.CSharp11.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp11)
                 .Verify();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/HashesShouldHaveUnpredictableSaltTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/HashesShouldHaveUnpredictableSaltTest.cs
@@ -28,19 +28,19 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class HashesShouldHaveUnpredictableSaltTest
     {
-        private readonly VerifierBuilder sonarVerifier = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
+        private readonly VerifierBuilder sonar = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
             .WithOnlyDiagnostics(HashesShouldHaveUnpredictableSalt.S2053)
             .AddReferences(MetadataReferenceFacade.SystemSecurityCryptography);
 
         [TestMethod]
         public void HashesShouldHaveUnpredictableSalt_CSharp8() =>
-            sonarVerifier.AddPaths("HashesShouldHaveUnpredictableSalt.cs")
+            sonar.AddPaths("HashesShouldHaveUnpredictableSalt.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
 
         [TestMethod]
         public void HashesShouldHaveUnpredictableSalt_DoesNotRaiseIssuesForTestProject() =>
-            sonarVerifier.AddPaths("HashesShouldHaveUnpredictableSalt.cs")
+            sonar.AddPaths("HashesShouldHaveUnpredictableSalt.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .AddTestReference()
                 .VerifyNoIssueReported();
@@ -49,13 +49,13 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void HashesShouldHaveUnpredictableSalt_CSharp9() =>
-            sonarVerifier.AddPaths("HashesShouldHaveUnpredictableSalt.CSharp9.cs")
+            sonar.AddPaths("HashesShouldHaveUnpredictableSalt.CSharp9.cs")
                 .WithTopLevelStatements()
                 .Verify();
 
         [TestMethod]
         public void HashesShouldHaveUnpredictableSalt_CSharp10() =>
-            sonarVerifier.AddPaths("HashesShouldHaveUnpredictableSalt.CSharp10.cs")
+            sonar.AddPaths("HashesShouldHaveUnpredictableSalt.CSharp10.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InitializationVectorShouldBeRandomTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InitializationVectorShouldBeRandomTest.cs
@@ -26,19 +26,19 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class InitializationVectorShouldBeRandomTest
     {
-        private readonly VerifierBuilder sonarVerifier = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
+        private readonly VerifierBuilder sonar = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
             .WithOnlyDiagnostics(InitializationVectorShouldBeRandom.S3329)
             .AddReferences(MetadataReferenceFacade.SystemSecurityCryptography);
 
         [TestMethod]
         public void InitializationVectorShouldBeRandom_CSharp8() =>
-            sonarVerifier.AddPaths("InitializationVectorShouldBeRandom.cs")
+            sonar.AddPaths("InitializationVectorShouldBeRandom.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
 
         [TestMethod]
         public void InitializationVectorShouldBeRandom_DoesNotRaiseIssuesForTestProject() =>
-            sonarVerifier.AddPaths("InitializationVectorShouldBeRandom.cs")
+            sonar.AddPaths("InitializationVectorShouldBeRandom.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .AddTestReference()
                 .VerifyNoIssueReported();
@@ -47,13 +47,13 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void InitializationVectorShouldBeRandom_CSharp9() =>
-            sonarVerifier.AddPaths("InitializationVectorShouldBeRandom.CSharp9.cs")
+            sonar.AddPaths("InitializationVectorShouldBeRandom.CSharp9.cs")
                 .WithTopLevelStatements()
                 .Verify();
 
         [TestMethod]
         public void InitializationVectorShouldBeRandom_CSharp10() =>
-            sonarVerifier.AddPaths("InitializationVectorShouldBeRandom.CSharp10.cs")
+            sonar.AddPaths("InitializationVectorShouldBeRandom.CSharp10.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InvalidCastToInterfaceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/InvalidCastToInterfaceTest.cs
@@ -26,7 +26,7 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class InvalidCastToInterfaceTest
     {
-        private readonly VerifierBuilder sonarVerifier = new VerifierBuilder<SymbolicExecutionRunner>()
+        private readonly VerifierBuilder sonar = new VerifierBuilder<SymbolicExecutionRunner>()
             .AddAnalyzer(() => new InvalidCastToInterface())
             .WithBasePath(@"SymbolicExecution\Sonar")
             .WithOnlyDiagnostics(InvalidCastToInterfaceSymbolicExecution.S1944);
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void InvalidCastToInterface(ProjectType projectType) =>
-            sonarVerifier.AddPaths("InvalidCastToInterface.cs")
+            sonar.AddPaths("InvalidCastToInterface.cs")
                 .AddReferences(TestHelper.ProjectTypeReference(projectType).Union(MetadataReferenceFacade.NETStandard21))
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
@@ -44,11 +44,11 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void InvalidCastToInterface_CSharp9() =>
-            sonarVerifier.AddPaths("InvalidCastToInterface.CSharp9.cs").WithTopLevelStatements().Verify();
+            sonar.AddPaths("InvalidCastToInterface.CSharp9.cs").WithTopLevelStatements().Verify();
 
         [TestMethod]
         public void InvalidCastToInterface_CSharp10() =>
-            sonarVerifier.AddPaths("InvalidCastToInterface.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+            sonar.AddPaths("InvalidCastToInterface.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
 
 #endif
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/NullPointerDereferenceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/NullPointerDereferenceTest.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class NullPointerDereferenceTest
     {
-        private readonly VerifierBuilder sonarVerifier = new VerifierBuilder()
+        private readonly VerifierBuilder sonar = new VerifierBuilder()
             .AddAnalyzer(() => new CS.SymbolicExecutionRunner(AnalyzerConfiguration.AlwaysEnabledWithSonarCfg))
             .WithBasePath(@"SymbolicExecution\Sonar")
             .WithOnlyDiagnostics(ChecksCS.NullPointerDereference.S2259);
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void NullPointerDereference_Sonar_CS() =>
-            sonarVerifier.AddPaths("NullPointerDereference.cs").WithConcurrentAnalysis(false).Verify();
+            sonar.AddPaths("NullPointerDereference.cs").WithConcurrentAnalysis(false).Verify();
 
         [TestMethod]
         public void NullPointerDereference_Roslyn_CS() =>
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void NullPointerDereference_Sonar_DoesNotRaiseIssuesForTestProject() =>
-            sonarVerifier.AddTestReference().AddPaths("NullPointerDereference.cs").WithConcurrentAnalysis(false).VerifyNoIssueReported();
+            sonar.AddTestReference().AddPaths("NullPointerDereference.cs").WithConcurrentAnalysis(false).VerifyNoIssueReported();
 
         [TestMethod]
         public void NullPointerDereference_Roslyn_DoesNotRaiseIssuesForTestProject() =>
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void NullPointerDereference_Sonar_CSharp6() =>
-            sonarVerifier.AddPaths("NullPointerDereference.CSharp6.cs").WithOptions(ParseOptionsHelper.FromCSharp6).Verify();
+            sonar.AddPaths("NullPointerDereference.CSharp6.cs").WithOptions(ParseOptionsHelper.FromCSharp6).Verify();
 
         [TestMethod]
         public void NullPointerDereference_Roslyn_CSharp6() =>
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void NullPointerDereference_Sonar_CSharp7() =>
-            sonarVerifier.AddPaths("NullPointerDereference.CSharp7.cs").WithOptions(ParseOptionsHelper.FromCSharp7).Verify();
+            sonar.AddPaths("NullPointerDereference.CSharp7.cs").WithOptions(ParseOptionsHelper.FromCSharp7).Verify();
 
         [TestMethod]
         public void NullPointerDereference_Roslyn_CSharp7() =>
@@ -81,7 +81,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void NullPointerDereference_Sonar_CSharp8() =>
-            sonarVerifier.AddPaths("NullPointerDereference.CSharp8.cs").AddReferences(MetadataReferenceFacade.NETStandard21).WithOptions(ParseOptionsHelper.FromCSharp8).Verify();
+            sonar.AddPaths("NullPointerDereference.CSharp8.cs").AddReferences(MetadataReferenceFacade.NETStandard21).WithOptions(ParseOptionsHelper.FromCSharp8).Verify();
 
         [TestMethod]
         public void NullPointerDereference_Roslyn_CSharp8() =>
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void NullPointerDereference_Sonar_CSharp9() =>
-            sonarVerifier.AddPaths("NullPointerDereference.CSharp9.cs").WithTopLevelStatements().Verify();
+            sonar.AddPaths("NullPointerDereference.CSharp9.cs").WithTopLevelStatements().Verify();
 
         [TestMethod]
         public void NullPointerDereference_Roslyn_CSharp9() =>
@@ -103,7 +103,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void NullPointerDereference_Sonar_CSharp10() =>
-            sonarVerifier.AddPaths("NullPointerDereference.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+            sonar.AddPaths("NullPointerDereference.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
 
         [TestMethod]
         public void NullPointerDereference_Roslyn_CSharp10() =>
@@ -117,7 +117,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void NullPointerDereference_Sonar_CSharp11() =>
-            sonarVerifier.AddPaths("NullPointerDereference.CSharp11.cs").WithOptions(ParseOptionsHelper.FromCSharp11).Verify();
+            sonar.AddPaths("NullPointerDereference.CSharp11.cs").WithOptions(ParseOptionsHelper.FromCSharp11).Verify();
 
         [TestMethod]
         public void NullPointerDereference_Roslyn_CSharp11() =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnceTest.cs
@@ -26,14 +26,14 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class ObjectsShouldNotBeDisposedMoreThanOnceTest
     {
-        private readonly VerifierBuilder sonarVerifier = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
+        private readonly VerifierBuilder sonar = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
             .WithOnlyDiagnostics(ObjectsShouldNotBeDisposedMoreThanOnce.S3966);
 
         [DataTestMethod]
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void ObjectsShouldNotBeDisposedMoreThanOnce_CSharp8(ProjectType projectType) =>
-            sonarVerifier.AddPaths("ObjectsShouldNotBeDisposedMoreThanOnce.cs")
+            sonar.AddPaths("ObjectsShouldNotBeDisposedMoreThanOnce.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .AddReferences(TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NETStandard21))
                 .Verify();
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void ObjectsShouldNotBeDisposedMoreThanOnce_CSharp9() =>
-            sonarVerifier.AddPaths("ObjectsShouldNotBeDisposedMoreThanOnce.CSharp9.cs")
+            sonar.AddPaths("ObjectsShouldNotBeDisposedMoreThanOnce.CSharp9.cs")
                 .WithTopLevelStatements()
                 .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNullTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNullTest.cs
@@ -26,14 +26,14 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class PublicMethodArgumentsShouldBeCheckedForNullTest
     {
-        private readonly VerifierBuilder sonarVerifier = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
+        private readonly VerifierBuilder sonar = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
             .WithOnlyDiagnostics(PublicMethodArgumentsShouldBeCheckedForNull.S3900);
 
         [DataTestMethod]
         [DataRow(ProjectType.Product)]
         [DataRow(ProjectType.Test)]
         public void PublicMethodArgumentsShouldBeCheckedForNull_CS(ProjectType projectType) =>
-            sonarVerifier.AddReferences(TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NETStandard21))
+            sonar.AddReferences(TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NETStandard21))
                 .AddPaths("PublicMethodArgumentsShouldBeCheckedForNull.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void PublicMethodArgumentsShouldBeCheckedForNull_CSharp9() =>
-            sonarVerifier.AddPaths("PublicMethodArgumentsShouldBeCheckedForNull.CSharp9.cs")
+            sonar.AddPaths("PublicMethodArgumentsShouldBeCheckedForNull.CSharp9.cs")
                 .AddReferences(NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(Constants.NuGetLatestVersion))
                 .WithOptions(ParseOptionsHelper.FromCSharp9)
                 .Verify();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/RestrictDeserializedTypesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/RestrictDeserializedTypesTest.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class RestrictDeserializedTypesTest
     {
-        private readonly VerifierBuilder sonarVerifier = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
+        private readonly VerifierBuilder sonar = new VerifierBuilder<SymbolicExecutionRunner>().WithBasePath(@"SymbolicExecution\Sonar")
             .AddReferences(AdditionalReferences())
             .WithOnlyDiagnostics(RestrictDeserializedTypes.S5773);
 
@@ -37,27 +37,27 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void RestrictDeserializedTypesFormatters_CSharp8()
         {
             using var _ = new AssertIgnoreScope(); // EnsureStackState fails an assertion in this test file
-            sonarVerifier.AddPaths("RestrictDeserializedTypes.cs")
+            sonar.AddPaths("RestrictDeserializedTypes.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
         }
 
         [TestMethod]
         public void RestrictDeserializedTypes_DoesNotRaiseIssuesForTestProject_CSharp8() =>
-            sonarVerifier.AddPaths("RestrictDeserializedTypes.cs")
+            sonar.AddPaths("RestrictDeserializedTypes.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .AddTestReference()
                 .VerifyNoIssueReported();
 
         [TestMethod]
         public void RestrictDeserializedTypesJavaScriptSerializer_CSharp8() =>
-            sonarVerifier.AddPaths("RestrictDeserializedTypes.JavaScriptSerializer.cs")
+            sonar.AddPaths("RestrictDeserializedTypes.JavaScriptSerializer.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
 
         [TestMethod]
         public void RestrictDeserializedTypesLosFormatter_CSharp8() =>
-            sonarVerifier.AddPaths("RestrictDeserializedTypes.LosFormatter.cs")
+            sonar.AddPaths("RestrictDeserializedTypes.LosFormatter.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
 
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void RestrictDeserializedTypesFormatters_CSharp9() =>
-            sonarVerifier.AddPaths("RestrictDeserializedTypes.CSharp9.cs")
+            sonar.AddPaths("RestrictDeserializedTypes.CSharp9.cs")
                 .WithTopLevelStatements()
                 .Verify();
 


### PR DESCRIPTION
The commit messages contains two changes:
* Align naming in NRE rule - this is the main change
* Align all other affected rules to prepare them for Roslyn migration - this is just mechanical follow up to prepare other rules