### PR TITLE
Remove SonarAnalyzer.Rules.Common namespace

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotInstantiateSharedClasses.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotInstantiateSharedClasses.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FlagsEnumWithoutInitializer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FlagsEnumWithoutInitializer.cs
@@ -23,7 +23,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FlagsEnumZeroMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FlagsEnumZeroMember.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MultipleVariableDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MultipleVariableDeclaration.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MultipleVariableDeclarationCodeFix.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MultipleVariableDeclarationCodeFix.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameter.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyGetterWithThrow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyGetterWithThrow.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyWriteOnly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyWriteOnly.cs
@@ -23,7 +23,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ProvideDeserializationMethodsForOptionalFields.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ProvideDeserializationMethodsForOptionalFields.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicConstantField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicConstantField.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicMethodWithMultidimensionalArray.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicMethodWithMultidimensionalArray.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ShouldImplementExportedInterfaces.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ShouldImplementExportedInterfaces.cs
@@ -23,7 +23,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SingleStatementPerLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SingleStatementPerLine.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringConcatenationInLoop.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringConcatenationInLoop.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchWithoutDefault.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchWithoutDefault.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseShortCircuitingOperator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseShortCircuitingOperator.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseShortCircuitingOperatorCodeFix.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseShortCircuitingOperatorCodeFix.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfNonVoidOneWay.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfNonVoidOneWay.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotInstantiateSharedClassesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotInstantiateSharedClassesBase.cs
@@ -22,7 +22,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class DoNotInstantiateSharedClassesBase : SonarDiagnosticAnalyzer
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FlagsEnumWithoutInitializerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FlagsEnumWithoutInitializerBase.cs
@@ -22,7 +22,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class FlagsEnumWithoutInitializerBase<TSyntaxKind, TEnumMemberDeclarationSyntax> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FlagsEnumZeroMemberBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FlagsEnumZeroMemberBase.cs
@@ -22,7 +22,7 @@ using System;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class FlagsEnumZeroMemberBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MultipleVariableDeclarationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MultipleVariableDeclarationBase.cs
@@ -24,7 +24,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class MultipleVariableDeclarationBase : SonarDiagnosticAnalyzer
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MultipleVariableDeclarationCodeFixBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MultipleVariableDeclarationCodeFixBase.cs
@@ -26,7 +26,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class MultipleVariableDeclarationCodeFixBase : SonarCodeFix
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/OptionalParameterBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/OptionalParameterBase.cs
@@ -24,7 +24,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class OptionalParameterBase : SonarDiagnosticAnalyzer
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertyGetterWithThrowBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertyGetterWithThrowBase.cs
@@ -22,7 +22,7 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class PropertyGetterWithThrowBase : SonarDiagnosticAnalyzer
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertyWriteOnlyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertyWriteOnlyBase.cs
@@ -21,7 +21,7 @@
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class PropertyWriteOnlyBase<TSyntaxKind, TPropertyDeclaration> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ProvideDeserializationMethodsForOptionalFieldsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ProvideDeserializationMethodsForOptionalFieldsBase.cs
@@ -24,7 +24,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class ProvideDeserializationMethodsForOptionalFieldsBase : SonarDiagnosticAnalyzer
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PublicConstantFieldBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PublicConstantFieldBase.cs
@@ -23,7 +23,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class PublicConstantFieldBase : SonarDiagnosticAnalyzer
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PublicMethodWithMultidimensionalArrayBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PublicMethodWithMultidimensionalArrayBase.cs
@@ -23,7 +23,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class PublicMethodWithMultidimensionalArrayBase : SonarDiagnosticAnalyzer
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ShouldImplementExportedInterfacesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ShouldImplementExportedInterfacesBase.cs
@@ -24,7 +24,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class ShouldImplementExportedInterfacesBase<TArgumentSyntax, TAttributeSyntax, TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TArgumentSyntax : SyntaxNode

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SingleStatementPerLineBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SingleStatementPerLineBase.cs
@@ -25,7 +25,7 @@ using Microsoft.CodeAnalysis.Text;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class SingleStatementPerLineBase : SonarDiagnosticAnalyzer
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/StringConcatenationInLoopBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/StringConcatenationInLoopBase.cs
@@ -24,7 +24,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class StringConcatenationInLoopBase : SonarDiagnosticAnalyzer
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SwitchWithoutDefaultBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SwitchWithoutDefaultBase.cs
@@ -23,7 +23,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class SwitchWithoutDefaultBase : SonarDiagnosticAnalyzer
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseShortCircuitingOperatorBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseShortCircuitingOperatorBase.cs
@@ -24,7 +24,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class UseShortCircuitingOperatorBase : SonarDiagnosticAnalyzer
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseShortCircuitingOperatorCodeFixBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseShortCircuitingOperatorCodeFixBase.cs
@@ -26,7 +26,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class UseShortCircuitingOperatorCodeFixBase<TBinaryExpression> : SonarCodeFix
         where TBinaryExpression : SyntaxNode

--- a/analyzers/src/SonarAnalyzer.Common/Rules/WcfNonVoidOneWayBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/WcfNonVoidOneWayBase.cs
@@ -23,7 +23,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using SonarAnalyzer.Helpers;
 
-namespace SonarAnalyzer.Rules.Common
+namespace SonarAnalyzer.Rules
 {
     public abstract class WcfNonVoidOneWayBase<TMethodSyntax, TLanguageKind> : SonarDiagnosticAnalyzer
         where TMethodSyntax : SyntaxNode

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotInstantiateSharedClasses.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotInstantiateSharedClasses.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FlagsEnumWithoutInitializer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FlagsEnumWithoutInitializer.cs
@@ -23,7 +23,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FlagsEnumZeroMember.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FlagsEnumZeroMember.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MultipleVariableDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MultipleVariableDeclaration.cs
@@ -18,19 +18,17 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using SonarAnalyzer.Rules.Common;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {
-    using System.Collections.Generic;
-    using System.Collections.Immutable;
-    using Helpers;
-    using Microsoft.CodeAnalysis.VisualBasic;
-    using Microsoft.CodeAnalysis.VisualBasic.Syntax;
-
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
     public sealed class MultipleVariableDeclaration : MultipleVariableDeclarationBase<SyntaxKind,
         FieldDeclarationSyntax, LocalDeclarationStatementSyntax>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MultipleVariableDeclarationCodeFix.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MultipleVariableDeclarationCodeFix.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameter.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionalParameter.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyGetterWithThrow.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyGetterWithThrow.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyWriteOnly.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyWriteOnly.cs
@@ -23,7 +23,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ProvideDeserializationMethodsForOptionalFields.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ProvideDeserializationMethodsForOptionalFields.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicConstantField.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicConstantField.cs
@@ -26,7 +26,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicMethodWithMultidimensionalArray.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicMethodWithMultidimensionalArray.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ShouldImplementExportedInterfaces.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ShouldImplementExportedInterfaces.cs
@@ -23,7 +23,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SingleStatementPerLine.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SingleStatementPerLine.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringConcatenationInLoop.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringConcatenationInLoop.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchWithoutDefault.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchWithoutDefault.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperator.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperator.cs
@@ -25,7 +25,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperatorCodeFix.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseShortCircuitingOperatorCodeFix.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/WcfNonVoidOneWay.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/WcfNonVoidOneWay.cs
@@ -24,7 +24,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Helpers;
-using SonarAnalyzer.Rules.Common;
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MultipleVariableDeclarationTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/MultipleVariableDeclarationTest.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             builderCS.WithCodeFix<CS.MultipleVariableDeclarationCodeFix>()
                 .AddPaths("MultipleVariableDeclaration.cs")
                 .WithCodeFixedPaths("MultipleVariableDeclaration.Fixed.cs")
-                .WithCodeFixTitle(SonarAnalyzer.Rules.Common.MultipleVariableDeclarationCodeFixBase.Title)
+                .WithCodeFixTitle(SonarAnalyzer.Rules.MultipleVariableDeclarationCodeFixBase.Title)
                 .VerifyCodeFix();
 
         [TestMethod]
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             builderVB.WithCodeFix<VB.MultipleVariableDeclarationCodeFix>()
                 .AddPaths("MultipleVariableDeclaration.vb")
                 .WithCodeFixedPaths("MultipleVariableDeclaration.Fixed.vb")
-                .WithCodeFixTitle(SonarAnalyzer.Rules.Common.MultipleVariableDeclarationCodeFixBase.Title)
+                .WithCodeFixTitle(SonarAnalyzer.Rules.MultipleVariableDeclarationCodeFixBase.Title)
                 .VerifyCodeFix();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/RuleFinder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/RuleFinder.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             {
                 typeof(SonarAnalyzer.Rules.CSharp.FlagsEnumZeroMember),
                 typeof(SonarAnalyzer.Rules.VisualBasic.FlagsEnumZeroMember),
-                typeof(SonarAnalyzer.Rules.Common.FlagsEnumZeroMemberBase<int>)
+                typeof(FlagsEnumZeroMemberBase<int>)
             }
                 .SelectMany(x => x.Assembly.GetExportedTypes())
                 .ToArray();


### PR DESCRIPTION
It was used in 18 out of 141 files. It doesn't bring any value to the codebase