### PR TITLE
GitHub workflow: Create Milestone

### DIFF
--- a/.github/workflows/CreateMilestone.yml
+++ b/.github/workflows/CreateMilestone.yml
@@ -1,0 +1,14 @@
+name: Create Milestone
+
+on:
+  milestone:
+    types: ["created"]
+
+jobs:
+  CreateRspecIssue_job:
+    name: Create RSPEC Issue
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sonarsource/gh-action-lt-backlog/CreateRspecIssue@v1
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Automatically create `Update RSPEC before x.y release` and milestone it, once a milestone is created.

Tested here: [CreateMilestone.yml](https://github.com/pavel-mikula-sonarsource/GitHubActionPlayground/blob/master/.github/workflows/CreateMilestone.yml), `@master` and `@v1` are identical now.
Source milestone: [6.2.4](https://github.com/pavel-mikula-sonarsource/GitHubActionPlayground/milestone/31)
Action log: [Job run log](https://github.com/pavel-mikula-sonarsource/GitHubActionPlayground/actions/runs/3393178582/jobs/5640215197)
Produced issue: https://github.com/pavel-mikula-sonarsource/GitHubActionPlayground/issues/35

---

How it really works:
[Source of the action](https://github.com/SonarSource/gh-action-lt-backlog/blob/master/CreateRspecIssue/index.ts)
[Boring intermediate base class](https://github.com/SonarSource/gh-action-lt-backlog/blob/master/lib/OctokitAction.ts)
[Real base class](https://github.com/SonarSource/gh-action-lt-backlog/blob/master/lib/Action.ts)