### PR TITLE
Fix flaky UT AllElements_Performance_DeepNesting

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/ITupleOperationWrapperExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/ITupleOperationWrapperExtensionsTests.cs
@@ -39,8 +39,8 @@ namespace SonarAnalyzer.UnitTest.Extensions
         {
             // NET48 does not support deeply nested tuples and fails with CS8078: An expression is too long or complex to compile
             var deeplyNestedTuple = DeeplyNestedTuple(500); // (1, (2,... , 500))..)
-            // Actual execution time is about 0.5ms.
-            AssertAllElementsExecutionTimeBeLessThan(deeplyNestedTuple, 5.Milliseconds());
+            // Actual execution time is about 0.5 - 10.0 ms.
+            AssertAllElementsExecutionTimeBeLessThan(deeplyNestedTuple, 15.Milliseconds());
 
             static string DeeplyNestedTuple(int depth)
             {


### PR DESCRIPTION
I've recently seen this UT failing randomly on the CI. Last few times with messages:

>Execution of the action should be less than 0.005s, but it required more than 0.009s and 947.9µs.
>Execution of the action should be less than 0.005s, but it required more than 0.012s and 363.9µs.