### PR TITLE
GitHub workflow: Create Milestone creates card on Kanban

### DIFF
--- a/.github/workflows/CreateMilestone.yml
+++ b/.github/workflows/CreateMilestone.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: sonarsource/gh-action-lt-backlog/CreateRspecIssue@v1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          column-id: 4971951
+          column-id: 4971951  # Kanban "To Do" column

--- a/.github/workflows/CreateMilestone.yml
+++ b/.github/workflows/CreateMilestone.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: sonarsource/gh-action-lt-backlog/CreateRspecIssue@v1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
+          column-id: 4971951


### PR DESCRIPTION
One action doesn't trigger another. So we also need to crate cards on Kanban from this action.

Action was already modified here: 
https://github.com/SonarSource/gh-action-lt-backlog/pull/5

All we need to do is to provide a value for the new parameter with target column-id of our `To Do` column. Column ID can be found as part of the column URL.