### PR TITLE
GitHub workflow: Migrate StartProgress to shared action

### DIFF
--- a/.github/workflows/StartProgress.yml
+++ b/.github/workflows/StartProgress.yml
@@ -5,33 +5,12 @@ on:
     types: ["moved"]
 
 jobs:
-  assign_to_self:
+  AssignCardToSender_job:
     runs-on: ubuntu-latest
     if: |
         github.event.changes.column_id.from == 4971951
-        && github.event.project_card.column_id == 4971952
         && github.event.project_card.content_url != null
     steps:
-      # https://github.com/actions/github-script
-      - uses: actions/github-script@v4.0.2
+      - uses: sonarsource/gh-action-lt-backlog/AssignCardToSender@v1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            //
-            async function addAssignee(issue, login) {
-                console.log("Assigning to: " + login);
-                await github.issues.addAssignees({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issue.number,
-                    assignees: [login]
-                });
-            }
-            //
-            const url = context.payload.project_card.content_url;
-            console.log("Processing " + url);
-            var issue = (await github.request(url)).data;
-            if(!issue.assignee){
-                addAssignee(issue, context.payload.sender.login);
-            }
-            console.log(`Done`);


### PR DESCRIPTION
Action: https://github.com/SonarSource/gh-action-lt-backlog/tree/master/AssignCardToSender

Source: https://github.com/SonarSource/gh-action-lt-backlog/blob/master/AssignCardToSender/AssignCardToSender.ts

This PR removes filter for "Target" column. It's just a noise. If I move card from `To do` to `In review`, I should get my face on it too.