### PR TITLE
Fix S1854 FP: Rule should not raise if empty interpolated string is assigned to the variable

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
@@ -18,21 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.CFG.LiveVariableAnalysis;
 using SonarAnalyzer.CFG.Sonar;
-using SonarAnalyzer.Common;
-using SonarAnalyzer.Extensions;
-using SonarAnalyzer.Helpers;
 using SonarAnalyzer.LiveVariableAnalysis.CSharp;
-using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.Rules.CSharp
 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
@@ -189,6 +189,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                 private bool IsAllowedStringInitialization(ExpressionSyntax expression) =>
                     (expression.IsKind(SyntaxKind.StringLiteralExpression) && AllowedStringValues.Contains(((LiteralExpressionSyntax)expression).Token.ValueText))
+                    || (expression.IsKind(SyntaxKind.InterpolatedStringExpression) && ((InterpolatedStringExpressionSyntax)expression).Contents.Count == 0)
                     || expression.IsStringEmpty(SemanticModel);
             }
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.CSharp11.cs
@@ -83,14 +83,14 @@ void InterpolatedRawStringLiterals(string param)
         """;      // Noncompliant@-3
 
     string empty = "";
-    string x = $"""{empty}"""; // Noncompliant FP (string is still empty, should be compliant)
+    string x = $"""{empty}"""; // Noncompliant  string interpolation values are intentionally not evaluated
     x = $"""{empty}Test""";
     Foo(x);
 
     string emptyMultiline = """
 
         """;
-    string q = $"""{emptyMultiline}"""; // Noncompliant FP (string is still empty, should be compliant)
+    string q = $"""{emptyMultiline}"""; // Noncompliant  string interpolation values are intentionally not evaluated
     q = $"""{emptyMultiline}Test""";
     Foo(q);
 
@@ -114,9 +114,20 @@ void NewlinesInStringInterpolation(string param)
 
     string empty = "";
     string x = $"{empty +
-        empty}"; // Noncompliant@-1 FP (string is still empty, should be compliant)
+        empty}"; // Noncompliant@-1 string interpolation values are intentionally not evaluated
     x = "Test";
     Foo(x);
+}
+
+void IgnoredValues()
+{
+    string emptyMultilineRawStringLiteral = $$"""
+
+        """; // Compliant
+    emptyMultilineRawStringLiteral = "other";
+
+    // Variables should be used in order the rule to trigger
+    Console.WriteLine("", emptyMultilineRawStringLiteral);
 }
 
 static void Foo(object x){ }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.CSharp11.cs
@@ -126,8 +126,8 @@ void IgnoredValues()
         """; // Compliant
     emptyMultilineRawStringLiteral = "other";
 
-    // Variables should be used in order the rule to trigger
-    Console.WriteLine("", emptyMultilineRawStringLiteral);
+    Foo(emptyMultilineRawStringLiteral);
 }
 
+// This method is used because the variables should be used in order for the rule to trigger.
 static void Foo(object x){ }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.RoslynCfg.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.RoslynCfg.cs
@@ -64,8 +64,14 @@ namespace Tests.Diagnostics
             var fromCast = (string)null;            // Compliant
             fromCast = "other";
 
+            var emptyStringLiteral = ""; // Compliant
+            emptyStringLiteral = "other";
+
+            var emptyInterpolatedStringLiteral = $""; // Compliant
+            emptyInterpolatedStringLiteral = "other";
+
             // Variables should be used in order the rule to trigger
-            Console.WriteLine("", stringEmpty, stringNull, boolFalse, boolTrue, objectNull, intZero, intOne, intMinusOne, intPlusOne, fromLocalConstant, fromClassConstant, fromConstantEmpty, fromCast);
+            Console.WriteLine("", stringEmpty, stringNull, boolFalse, boolTrue, objectNull, intZero, intOne, intMinusOne, intPlusOne, fromLocalConstant, fromClassConstant, fromConstantEmpty, fromCast, emptyStringLiteral, emptyInterpolatedStringLiteral);
         }
 
         private void NonignoredValues()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.SonarCfg.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/DeadStores.SonarCfg.cs
@@ -48,8 +48,14 @@ namespace Tests.Diagnostics
             var intPlusOne = +1; // Compliant
             intPlusOne = 42;
 
+            var emptyStringLiteral = ""; // Compliant
+            emptyStringLiteral = "other";
+
+            var emptyInterpolatedStringLiteral = $""; // Compliant
+            emptyInterpolatedStringLiteral = "other";
+
             // Variables should be used in order the rule to trigger
-            Console.WriteLine("", stringEmpty, stringNull, boolFalse, boolTrue,
+            Console.WriteLine("", emptyStringLiteral, emptyInterpolatedStringLiteral, stringEmpty, stringNull, boolFalse, boolTrue,
                 objectNull, intZero, intOne, intMinusOne, intPlusOne);
         }
 


### PR DESCRIPTION
This rule also documents that the behaviour reported in the following two issues is not a false positive as we intentionally not evaluate string interpolations.
- https://github.com/SonarSource/sonar-dotnet/issues/6301
- https://github.com/SonarSource/sonar-dotnet/issues/6302 
 
Fixes #6301 
Fixes #6302
