### PR TITLE
ITs: Bump System.Data.SqlClient to 4.8.5

### DIFF
--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/IntentionalFindings/IntentionalFindings.csproj
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/IntentionalFindings/IntentionalFindings.csproj
@@ -4,6 +4,6 @@
         <TargetFramework>netcoreapp2.1</TargetFramework>
     </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.5.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
There was a security alert for versions <= 4.8.4

We're not affected as we don't execute this code. This will just remove the FP

ITs are failing due to some issue with master. The change itself worked and projects are built. Rebase will be needed.