### PR TITLE
Revert S4502 C#11 changes to opt for performance

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
@@ -21,10 +21,8 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
-using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Helpers;
 
 namespace SonarAnalyzer.Rules.CSharp

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DisablingCSRFProtection.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DisablingCSRFProtection.CSharp11.cs
@@ -7,15 +7,11 @@ namespace Net6Poc.DisablingCSRFProtection
 {
     internal class TestCases
     {
-        [GenericIgnoreAntiforgeryToken<int>] // FN
+        [GenericIgnoreAntiforgeryToken<int>] // FN - for performance reasons attribute inheritance is not supported
         public void A() { }
 
-        [NonGenericAttribute] // FN
         public void B() { }
-
-        public void C() { }
     }
-    public class NonGenericAttribute : IgnoreAntiforgeryTokenAttribute { }
 
     public class GenericIgnoreAntiforgeryToken<T> : IgnoreAntiforgeryTokenAttribute { }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DisablingCSRFProtection.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DisablingCSRFProtection.CSharp11.cs
@@ -7,7 +7,7 @@ namespace Net6Poc.DisablingCSRFProtection
 {
     internal class TestCases
     {
-        [GenericIgnoreAntiforgeryToken<int>] // FN - for performance reasons attribute inheritance is not supported
+        [GenericIgnoreAntiforgeryToken<int>] // FN - for performance reasons inheritance is not supported
         public void A() { }
 
         public void B() { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DisablingCSRFProtection.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DisablingCSRFProtection.CSharp11.cs
@@ -7,10 +7,10 @@ namespace Net6Poc.DisablingCSRFProtection
 {
     internal class TestCases
     {
-        [GenericIgnoreAntiforgeryToken<int>] // Noncompliant
+        [GenericIgnoreAntiforgeryToken<int>] // FN
         public void A() { }
 
-        [NonGenericAttribute] // Noncompliant
+        [NonGenericAttribute] // FN
         public void B() { }
 
         public void C() { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DisablingCSRFProtection.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DisablingCSRFProtection.cs
@@ -54,7 +54,7 @@ namespace TestCases
 
     internal class Inheritance 
     {
-        [DerivedAttribute] // FN - for performance reasons attribute inheritance is not supported
+        [DerivedAttribute] // FN - for performance reasons inheritance is not supported
         public void B() { }
     }
     public class DerivedAttribute : IgnoreAntiforgeryTokenAttribute { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DisablingCSRFProtection.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DisablingCSRFProtection.cs
@@ -51,4 +51,13 @@ namespace TestCases
         [HttpPost, AutoValidateAntiforgeryToken]
         public IActionResult ChangeEmail_AttributesOnTheSameLine_Compliant(string model) => View(path);
     }
+
+    internal class Inheritance 
+    {
+        [DerivedAttribute] // FN - for performance reasons attribute inheritance is not supported
+        public void B() { }
+    }
+    public class DerivedAttribute : IgnoreAntiforgeryTokenAttribute { }
+
+
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DisablingCSRFProtection.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Hotspots/DisablingCSRFProtection.cs
@@ -11,7 +11,7 @@ namespace TestCases
         public static void ConfigureServices(IServiceCollection services)
         {
             services.AddControllersWithViews(options => options.Filters.Add(new IgnoreAntiforgeryTokenAttribute())); // Noncompliant
-            services.AddControllersWithViews(options => options.Filters.Add(new IATA())); // Noncompliant
+            services.AddControllersWithViews(options => options.Filters.Add(new IATA())); // FN - for performance reasons type alias is not supported
             services.AddControllersWithViews(options => options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute()));
             services.AddControllersWithViews(options => options.Filters.Add(new ValidateAntiForgeryTokenAttribute()));
             services.AddControllers(options => options.Filters.Add(new IgnoreAntiforgeryTokenAttribute())); // Noncompliant


### PR DESCRIPTION
This reverts #6314 in favor of performance.

Also fixed some comments to document this decision.