### PR TITLE
Exclude Shim layer code from coverage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -179,7 +179,7 @@ stages:
 
       - powershell: |
           cd analyzers
-          & dotnet test -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|SonarAnalyzer.ShimLayer.CodeGeneration',AltCoverReport=coverage/coverage.xml
+          & dotnet test -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|SonarAnalyzer.ShimLayer.CodeGeneration',AltCoverPathFilter=src/SonarAnalyzer.CFG/ShimLayer,AltCoverReport=coverage/coverage.xml
         displayName: '.Net UTs'
 
       - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -179,7 +179,7 @@ stages:
 
       - powershell: |
           cd analyzers
-          & dotnet test -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover',AltCoverReport=coverage/coverage.xml
+          & dotnet test -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|SonarAnalyzer.ShimLayer.CodeGeneration',AltCoverReport=coverage/coverage.xml
         displayName: '.Net UTs'
 
       - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -179,7 +179,7 @@ stages:
 
       - powershell: |
           cd analyzers
-          & dotnet test -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|SonarAnalyzer.ShimLayer.CodeGeneration',AltCoverPathFilter=src/SonarAnalyzer.CFG/ShimLayer,AltCoverReport=coverage/coverage.xml
+          & dotnet test -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverReport=coverage/coverage.xml
         displayName: '.Net UTs'
 
       - task: PublishPipelineArtifact@1


### PR DESCRIPTION
We will exclude from coverage the `SonarAnalyzer.ShimLayer.CodeGeneration` project and all the files from `src/SonarAnalyzer.CFG/ShimLayer` folder.

I've tested the PT with one file inside the folder and one file outside. The file outside had the coverage computed and the on inside was skipped.