### PR TITLE
S106: Refactor DiagnosticDescriptor Rule inheritance.

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConsoleLogging.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConsoleLogging.cs
@@ -33,8 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S2228";
         private const string MessageFormat = "Remove this logging statement.";
 
-        private static readonly DiagnosticDescriptor rule =
+        protected override DiagnosticDescriptor Rule =>
             DescriptorFactory.Create(DiagnosticId, MessageFormat);
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotWriteToStandardOutput.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotWriteToStandardOutput.cs
@@ -31,7 +31,12 @@ namespace SonarAnalyzer.Rules.CSharp
     // This base class is only there to avoid duplication between the implementation of S106 and S2228
     public abstract class DoNotWriteToStandardOutputBase : SonarDiagnosticAnalyzer
     {
+        protected abstract DiagnosticDescriptor Rule { get; }
+
         private static readonly ISet<string> BannedConsoleMembers = new HashSet<string> { "WriteLine", "Write" };
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(Rule);
 
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(
@@ -51,7 +56,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         !c.Node.IsInDebugBlock() &&
                         !CSharpDebugOnlyCodeHelper.IsCallerInConditionalDebug(methodCall, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], methodCall.Expression.GetLocation()));
+                        c.ReportIssue(Diagnostic.Create(Rule, methodCall.Expression.GetLocation()));
                     }
                 },
                 SyntaxKind.InvocationExpression);
@@ -63,7 +68,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string DiagnosticId = "S106";
         private const string MessageFormat = "Remove this logging statement.";
 
-        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        protected override DiagnosticDescriptor Rule =>
+            DescriptorFactory.Create(DiagnosticId, MessageFormat);
     }
 }


### PR DESCRIPTION
The abstract `Rule` property approach is the more common way how we do it in the code base.