### PR TITLE
Fix S1117 FN: Support list patterns

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
@@ -55,6 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((DeclarationExpressionSyntaxWrapper)c.Node).Designation), SyntaxKindEx.DeclarationExpression);
             context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((RecursivePatternSyntaxWrapper)c.Node).Designation), SyntaxKindEx.RecursivePattern);
+            context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((VarPatternSyntaxWrapper)c.Node).Designation), SyntaxKindEx.VarPattern);
             context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((DeclarationPatternSyntaxWrapper)c.Node).Designation), SyntaxKindEx.DeclarationPattern);
             context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((ListPatternSyntaxWrapper)c.Node).Designation), SyntaxKindEx.ListPattern);
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
@@ -53,8 +53,9 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDeclaration(c, ((UsingStatementSyntax)c.Node).Declaration), SyntaxKind.UsingStatement);
             context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDeclaration(c, ((FixedStatementSyntax)c.Node).Declaration), SyntaxKind.FixedStatement);
 
-            context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((DeclarationPatternSyntaxWrapper)c.Node).Designation), SyntaxKindEx.DeclarationPattern);
             context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((DeclarationExpressionSyntaxWrapper)c.Node).Designation), SyntaxKindEx.DeclarationExpression);
+            context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((RecursivePatternSyntaxWrapper)c.Node).Designation), SyntaxKindEx.RecursivePattern);
+            context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((DeclarationPatternSyntaxWrapper)c.Node).Designation), SyntaxKindEx.DeclarationPattern);
             context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((ListPatternSyntaxWrapper)c.Node).Designation), SyntaxKindEx.ListPattern);
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
@@ -55,6 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((DeclarationPatternSyntaxWrapper)c.Node).Designation), SyntaxKindEx.DeclarationPattern);
             context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((DeclarationExpressionSyntaxWrapper)c.Node).Designation), SyntaxKindEx.DeclarationExpression);
+            context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((ListPatternSyntaxWrapper)c.Node).Designation), SyntaxKindEx.ListPattern);
         }
 
         private static void ProcessVariableDesignation(SyntaxNodeAnalysisContext context, VariableDesignationSyntaxWrapper variableDesignation)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/VariableShadowsField.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/VariableShadowsField.CSharp11.cs
@@ -4,7 +4,7 @@
 
     public void SomeMethod(byte[] byteArray)
     {
-        if (byteArray is [1, 2, 3] somefield) // FN
+        if (byteArray is [1, 2, 3] somefield) // Noncompliant {{Rename 'somefield' which hides the field with the same name.}}
         {
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/VariableShadowsField.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/VariableShadowsField.CSharp9.cs
@@ -8,7 +8,7 @@ record Rec
     public int foo;
     public int bar;
 
-    public void doSomething()
+    public void DoSomething()
     {
         int foo = 0; // Noncompliant
 //          ^^^
@@ -17,5 +17,13 @@ record Rec
         foreach (var bar in new[] { 1, 2 }) // Noncompliant
         {
         }
+    }
+
+    public void PropertyPattern()
+    {
+        _ = new ArgumentException() is
+        {
+            Message: { } bar, // Noncompliant
+        };
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/VariableShadowsField.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/VariableShadowsField.CSharp9.cs
@@ -32,8 +32,8 @@ record Rec
         _ = (1, 2) is (_, _) bar; // Noncompliant
     }
 
-    public void PatternDesignation()
+    public void VarPattern()
     {
-        _ = (1, 2) is (var bar, _); // Noncompliant
+        _ = 1 is var bar; // Noncompliant
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/VariableShadowsField.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/VariableShadowsField.CSharp9.cs
@@ -26,4 +26,14 @@ record Rec
             Message: { } bar, // Noncompliant
         };
     }
+
+    public void PositionalPattern()
+    {
+        _ = (1, 2) is (_, _) bar; // Noncompliant
+    }
+
+    public void PatternDesignation()
+    {
+        _ = (1, 2) is (var bar, _); // Noncompliant
+    }
 }


### PR DESCRIPTION
Fixes #6378

Also adds support for the other [pattern types with a designation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/patterns#patterns)

* property pattern (aka recursive pattern)
* positional pattern (aka recursive pattern)
* var pattern