### PR TITLE
Fix S2699 FP: Support derivations of ExpectedExceptionBaseAttribute for MsTest

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -105,6 +105,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType Microsoft_VisualBasic_Interaction = new("Microsoft.VisualBasic.Interaction");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_Assert = new("Microsoft.VisualStudio.TestTools.UnitTesting.Assert");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_AssertFailedException = new("Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException");
+        internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_ExpectedExceptionBaseAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.ExpectedExceptionBaseAttribute");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_ExpectedExceptionAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.ExpectedExceptionAttribute");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_IgnoreAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.IgnoreAttribute");
         internal static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestClassAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute");

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/UnitTestHelper.cs
@@ -89,7 +89,9 @@ namespace SonarAnalyzer.Helpers
             method.AnyAttributeDerivesFromOrImplementsAny(KnownTestMethodAttributes);
 
         public static bool HasExpectedExceptionAttribute(this IMethodSymbol method) =>
-            method.GetAttributes().Any(a => a.AttributeClass.IsAny(KnownExpectedExceptionAttributes));
+            method.GetAttributes().Any(a =>
+                a.AttributeClass.IsAny(KnownExpectedExceptionAttributes)
+                || a.AttributeClass.DerivesFrom(KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_ExpectedExceptionBaseAttribute));
 
         public static bool HasAssertionInAttribute(this IMethodSymbol method) =>
             !NoExpectedResultTestMethodReturnTypes.Any(method.ReturnType.Is)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.Custom.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/TestMethodShouldContainAssertion.Custom.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace CustomTests
 {
     using TestFramework;
+    using TestFramework.Attributes;
 
     [TestClass]
     public class Program
@@ -47,6 +48,13 @@ namespace CustomTests
         [TestMethod]
         public void TestMethod7() => // Noncompliant, attribute must be on the method itself
             AttributedType.AttributeOnType();
+
+        [TestMethod]
+        [DerivedExpectedException]
+        public void TestMethod8() // Compliant
+        {
+            var x = 42;
+        }
     }
 }
 
@@ -82,4 +90,5 @@ namespace TestFramework.Attributes
 {
     public class AssertionMethodAttribute : Attribute { }
     public class NotAssertionMethodAttribute : Attribute { } // AssertionMethodAttribute doesn't count as an assertion method attribute
+    public class DerivedExpectedExceptionAttribute : ExpectedExceptionBaseAttribute { protected override void Verify(Exception exception) { } }
 }


### PR DESCRIPTION
Fixes #6497