### PR TITLE
Remove explicit org.slf4j dependency and update java dependencies

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -50,12 +50,12 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <version>${junit.version}</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.23.1</version>
+      <version>${assertj.core.version}</version>
     </dependency>
     <dependency>
       <groupId>io.github.classgraph</groupId>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -62,11 +62,6 @@
       <artifactId>classgraph</artifactId>
       <version>4.8.87</version>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>2.0.5</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -50,17 +50,17 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.6.1</version>
+      <version>3.23.1</version>
     </dependency>
     <dependency>
       <groupId>io.github.classgraph</groupId>
       <artifactId>classgraph</artifactId>
-      <version>4.8.87</version>
+      <version>4.8.151</version>
     </dependency>
   </dependencies>
 

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -11,9 +11,9 @@
 
   <groupId>com.sonarsource.it</groupId>
   <artifactId>it-dotnet-plugin</artifactId>
-
   <name>SonarSource :: C# :: ITs :: Plugin</name>
   <inceptionYear>2011</inceptionYear>
+
   <organization>
     <name>SonarSource</name>
     <url>http://www.sonarsource.com</url>

--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,12 @@
   <description>Code Analyzers for .NET</description>
   <url>https://github.com/SonarSource/sonar-dotnet</url>
   <inceptionYear>2014</inceptionYear>
+
   <organization>
     <name>SonarSource</name>
     <url>http://www.sonarsource.com</url>
   </organization>
+
   <licenses>
     <license>
       <name>GNU LGPL 3</name>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
     <sonar.api.impl.version>9.7.1.62043</sonar.api.impl.version>
     <jdk.min.version>11</jdk.min.version>
     <maven.compiler.release>${jdk.min.version}</maven.compiler.release>
+
+    <!-- Test dependencies -->
+    <logback.classic.version>1.4.5</logback.classic.version>
+    <junit.version>4.13.2</junit.version>
+    <assertj.core.version>3.23.1</assertj.core.version>
   </properties>
 
   <profiles>

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.4.4</version>
+      <version>1.4.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -80,13 +80,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.23.0</version>
+      <version>3.23.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -16,10 +16,12 @@
   <description>Code Analyzer for C#</description>
   <url>http://redirect.sonarsource.com/plugins/csharp.html</url>
   <inceptionYear>2014</inceptionYear>
+
   <organization>
     <name>SonarSource</name>
     <url>http://www.sonarsource.com</url>
   </organization>
+
   <licenses>
     <license>
       <name>GNU LGPL 3</name>

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -76,19 +76,19 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.4.5</version>
+      <version>${logback.classic.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.23.1</version>
+      <version>${assertj.core.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-dotnet-shared-library/pom.xml
+++ b/sonar-dotnet-shared-library/pom.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/sonar-dotnet-shared-library/pom.xml
+++ b/sonar-dotnet-shared-library/pom.xml
@@ -74,13 +74,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.23.0</version>
+      <version>3.23.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-dotnet-shared-library/pom.xml
+++ b/sonar-dotnet-shared-library/pom.xml
@@ -75,13 +75,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.23.1</version>
+      <version>${assertj.core.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.4.4</version>
+      <version>1.4.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -80,13 +80,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.23.0</version>
+      <version>3.23.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -76,19 +76,19 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.4.5</version>
+      <version>${logback.classic.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.23.1</version>
+      <version>${assertj.core.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -16,10 +16,12 @@
   <description>Code Analyzer for VB.NET</description>
   <url>http://redirect.sonarsource.com/plugins/vbnet.html</url>
   <inceptionYear>2012</inceptionYear>
+
   <organization>
     <name>SonarSource</name>
     <url>http://www.sonarsource.com</url>
   </organization>
+
   <licenses>
     <license>
       <name>GNU LGPL 3</name>


### PR DESCRIPTION
`org.slf4j` dependency is added by `logback-classic` and we don't need to explicitly set it.

If we change the version by hand we can get to errors like:
```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/C:/Users/../.m2/repository/ch/qos/logback/logback-classic/1.2.0/logback-classic-1.2.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```
