### PR TITLE
Fix S2302 FN: Issue is not raised when the name of one of the method parameters is a raw string literal

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NameOfShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NameOfShouldBeUsed.cs
@@ -26,7 +26,9 @@ namespace SonarAnalyzer.Rules.CSharp
         private static readonly HashSet<SyntaxKind> StringTokenTypes = new HashSet<SyntaxKind>
         {
             SyntaxKind.InterpolatedStringTextToken,
-            SyntaxKind.StringLiteralToken
+            SyntaxKind.StringLiteralToken,
+            SyntaxKindEx.SingleLineRawStringLiteralToken,
+            SyntaxKindEx.MultiLineRawStringLiteralToken
         };
 
         protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/NameOfShouldBeUsedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/NameOfShouldBeUsedBase.cs
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.Rules
         /// Iterates over the string tokens (either from simple strings or from interpolated strings)
         /// and returns pairs where
         /// - the key is the string SyntaxToken which contains the verbatim parameter name
-        /// - the value is the name of the parameter which is present in the string token
+        /// - the value is the name of the parameter which is present in the string token.
         /// </summary>
         private Dictionary<SyntaxToken, string> GetStringTokenAndParamNamePairs(IEnumerable<SyntaxToken> tokens, IEnumerable<string> parameterNames)
         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NameOfShouldBeUsed.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NameOfShouldBeUsed.CSharp11.cs
@@ -6,11 +6,14 @@ namespace Tests.Diagnostics
     {
         public void Method_With_RawStringLiterals(int arg1)
         {
-            // Repro for https://github.com/SonarSource/sonar-dotnet/issues/6441
             if (arg1 < 0)
-                throw new Exception("""arg1"""); // FN
-            else if (arg1 > 100)
-                throw new ArgumentException("""Bad parameter name""", """arg1"""); // FN
+                throw new Exception("""arg1"""); // Noncompliant
+            else if (arg1 < 100)
+                throw new ArgumentException("""Bad parameter name""", """arg1"""); // Noncompliant
+            else if (arg1 < 1000)
+                throw new ArgumentOutOfRangeException("""
+                    arg1
+                    """); // Noncompliant@-2
         }
 
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NameOfShouldBeUsed.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NameOfShouldBeUsed.CSharp11.cs
@@ -4,16 +4,23 @@ namespace Tests.Diagnostics
 {
     class Program
     {
-        public void Method_With_RawStringLiterals(int arg1)
+        public void Method_With_RawStringLiterals(int arg1, string argument)
         {
             if (arg1 < 0)
                 throw new Exception("""arg1"""); // Noncompliant
-            else if (arg1 < 100)
+            else if (arg1 < 1)
                 throw new ArgumentException("""Bad parameter name""", """arg1"""); // Noncompliant
-            else if (arg1 < 1000)
+            else if (arg1 < 2)
                 throw new ArgumentOutOfRangeException("""
                     arg1
                     """); // Noncompliant@-2
+            else if (arg1 < 3)
+                throw new Exception($"""argument {argument}"""); // Noncompliant
+//                                      ^^^^^^^^^
+            else if (arg1 < 4)
+                throw new Exception($"""arg1 {arg1}"""); // Compliant (parameter length 4, minimum allowed to raise 5)
+            else
+                throw new Exception($"""{nameof(argument)} should not be used with value {argument}"""); // Compliant
         }
 
 


### PR DESCRIPTION
Fixes #6441
