### PR TITLE
Documentation: Add markdown file with description of the verifier doc comment syntax

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs
@@ -27,8 +27,8 @@ using SonarAnalyzer.Common;
 namespace SonarAnalyzer.UnitTest.TestFramework
 {
     /// <summary>
-    /// Click <see href="https://github.com/SonarSource/sonar-dotnet/blob/master/docs/verifier-syntax.md">here</see> to see the
-    /// description of the supported syntax elements in code comments.
+    /// See <see href="https://github.com/SonarSource/sonar-dotnet/blob/master/docs/verifier-syntax.md">docs/verifier-syntax.md</see>
+    /// for a comprehensive documentation of the verifier syntax.
     /// </summary>
     public static class IssueLocationCollector
     {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs
@@ -27,62 +27,8 @@ using SonarAnalyzer.Common;
 namespace SonarAnalyzer.UnitTest.TestFramework
 {
     /// <summary>
-    /// This class will look for specific patterns inside the unit test files being analyzed when testing a rule.
-    /// Here's a summary and examples of the different patterns that can be used to mark part of the code as noncompliant.
-    /// These patterns must appear after a single line comment (the supported comment tokens: "//" for C#, "'" for VB.NET and "<!--" for XML).
-    ///
-    /// Simple 'Noncompliant' comment. Will mark the current line as expecting the primary location of an issue.
-    /// <code>
-    ///     private void MyMethod() // Noncompliant
-    /// </code>
-    ///
-    /// 'Secondary' location comment. Must be used together with a main primary location to mark the expected line of a
-    /// secondary location.
-    /// <code>
-    ///     if (myCondition) // Noncompliant
-    ///     {
-    ///       var a = null; // Secondary
-    ///     }
-    /// </code>
-    ///
-    /// Using offsets. Using @[+-][0-9]+ after a 'Noncompliant' or 'Secondary' comment will mark the expected location to be
-    /// offset by the given number of lines.
-    /// <code>
-    ///  private void MyMethod() // Noncompliant@+2 - issue is actually expected 2 lines after this comment
-    /// </code>
-    ///
-    /// Checking the issue message. The message raised by the issue can be checked using the {{expected message}} pattern.
-    /// <code>
-    ///     private void MyMethod() // Noncompliant {{Remove this unused private method}}
-    /// </code>
-    ///
-    /// Checking the precise/exact location of an issue. Only one precise location or column location can be present
-    /// at one time. Precise location is used by adding '^^^^' comment under the location where the issue is expected.
-    /// The alternative column location pattern can be used by following the 'Noncompliant' or 'Secondary' comment
-    /// with '^X#Y' where 'X' is the expected start column and Y the length of the issue.
-    /// <code>
-    ///     private void MyMethod() // Noncompliant
-    /// //  ^^^^^^^
-    /// </code>
-    /// <code>
-    ///     private void MyMethod() // Noncompliant ^4#7
-    /// </code>
-    ///
-    /// Multiple issues per line. To declare that multiple issues are expected, each issue must be assigned an id. All
-    /// secondary locations associated with an issue must have the same id. Note that it is not possible to have multiple
-    /// precise/column locations on a single line.
-    /// <code>
-    ///     var a = null; // Noncompliant [myId2]
-    ///     if (myCondition) // Noncompliant [myId1, myId3]
-    ///     {
-    ///       a = null; // Secondary [myId1, myId2]
-    ///     }
-    /// </code>
-    ///
-    /// Note that most of the previous patterns can be used together when needed.
-    /// <code>
-    ///     private void MyMethod() // Noncompliant@+1 ^4#7 [MyIssueId] {{Remove this unused private method}}
-    /// </code>
+    /// Click <see href="https://github.com/SonarSource/sonar-dotnet/blob/master/docs/verifier-syntax.md">here</see> to see the
+    /// description of the supported syntax elements in code comments.
     /// </summary>
     public static class IssueLocationCollector
     {

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -47,11 +47,39 @@ In general, it is best to run commands from the Visual Studio Developer Command 
         - SonarScanner for .NET folder and to the Scanner CLI ([SonarScanner download](https://github.com/SonarSource/sonar-scanner-msbuild/releases))
 1. Open `analyzers/SonarAnalyzer.sln`
 
-## Running Tests
+## Tests
 
-### Unit Tests
+### Running Unit Tests
 
 You can run the Unit Tests via the Test Explorer of Visual Studio or using `.\scripts\build\dev-build.ps1 -test`
+
+### Writing Unit Tests
+
+Rule tests are written in source files and setup like this:
+
+```cs
+public class MyAnalyzerTest
+{
+    private readonly VerifierBuilder verifier = new VerifierBuilder<MyAnalyzer>();
+
+    [TestMethod]
+    public void MyAnalyzer_CSharp10()
+    {
+        verifier
+            .AddPaths("MyAnalyzer.CSharp10.cs") // searched in analyzers\tests\SonarAnalyzer.UnitTest\TestCases\
+            .AddReferences(MetadataReferenceFacade.SystemData);
+            .WithOptions(ParseOptionsHelper.FromCSharp10)
+            .Verify();
+    }
+}
+```
+
+In the test files [special annotations](verifier-syntax.md) are used to describe the non-compliant code.
+
+```cs
+    private void MyMethod() // Noncompliant {{Remove this unused private method}}
+    //           ^^^^^^^^
+```
 
 ### Integration Tests
 

--- a/docs/verifier-syntax.md
+++ b/docs/verifier-syntax.md
@@ -1,0 +1,75 @@
+## Unit test comment syntax
+
+The rule unit tests use source files with special annotations in code comments to specifiy uncompliant code.
+
+These annotation patterns must appear after a single line comment (the supported comment tokens: `//` for C#, `'` for VB.NET and `<!--` for XML).
+
+### Simple `Noncompliant` comment
+
+Will mark the current line as expecting the primary location of an issue.
+
+```cs
+    private void MyMethod() // Noncompliant
+```
+
+### `Secondary` location comment.
+
+Must be used together with a main primary location to mark the expected line of a secondary location.
+
+```cs
+    if (myCondition) // Noncompliant
+    {
+      var a = null; // Secondary
+    }
+```
+
+### Using offsets
+
+Using `@[+-][0-9]+` after a `Noncompliant` or `Secondary` comment will mark the expected location to be offset by the given number of lines.
+
+```cs
+ private void MyMethod() // Noncompliant@+2 - issue is actually expected 2 lines after this comment
+```
+
+### Checking the issue message
+
+The message raised by the issue can be checked using the `{{expected message}}` pattern.
+
+```cs
+    private void MyMethod() // Noncompliant {{Remove this unused private method}}
+```
+
+### Checking the precise/exact location of an issue
+
+Only one precise location or column location can be present at one time. Precise location is used by adding `^^^^` comment under the location where the issue is expected. The alternative column location pattern can be used by following the `Noncompliant` or `Secondary` comment with `^X#Y` where `X` is the expected start column and Y the length of the issue.
+
+```cs
+    private void MyMethod() // Noncompliant
+//  ^^^^^^^
+```
+
+```cs
+    private void MyMethod() // Noncompliant ^4#7
+```
+
+### Multiple issues per line
+
+To declare that multiple issues are expected, each issue must be assigned an id. All secondary locations associated with an issue must have the same id. Note that it is not possible to have multiple precise/column locations on a single line.
+
+```cs
+    var a = null; // Noncompliant [myId2]
+    if (myCondition) // Noncompliant [myId1, myId3]
+    {
+      a = null; // Secondary [myId1, myId2]
+    }
+```
+
+Note that most of the previous patterns can be used together when needed.
+
+```cs
+    private void MyMethod() // Noncompliant@+1 ^4#7 [MyIssueId] {{Remove this unused private method}}
+
+    private void MyMethod(int i2, int i2)
+//                        ^^^^^^             {{Message for issue 1}}
+//                                ^^^^^^ @-1 {{Message for issue 2}}
+```

--- a/docs/verifier-syntax.md
+++ b/docs/verifier-syntax.md
@@ -1,26 +1,15 @@
 ## Unit test comment syntax
 
-The rule unit tests use source files with special annotations in code comments to specifiy uncompliant code.
+The rule unit tests use source files with special annotations in code comments to specify noncompliant code.
 
 These annotation patterns must appear after a single line comment (the supported comment tokens: `//` for C#, `'` for VB.NET and `<!--` for XML).
 
-### Simple `Noncompliant` comment
+### `Noncompliant` primary location comment
 
-Will mark the current line as expecting the primary location of an issue.
-
-```cs
-    private void MyMethod() // Noncompliant
-```
-
-### `Secondary` location comment
-
-Must be used together with a main primary location to mark the expected line of a secondary location.
+Use `Noncompliant` to mark the current line as the primary location of an expected issue.
 
 ```cs
-    if (myCondition) // Noncompliant
-    {
-      var a = null; // Secondary
-    }
+    private void MyMethod() // Noncompliant
 ```
 
 ### Using offsets
@@ -28,7 +17,7 @@ Must be used together with a main primary location to mark the expected line of 
 Using `@[+-][0-9]+` after a `Noncompliant` or `Secondary` comment will mark the expected location to be offset by the given number of lines.
 
 ```cs
-    private void MyMethod() // Noncompliant@+2 - issue is actually expected 2 lines after this comment
+    private void MyMethod() // Noncompliant@+2 - issue is actually expected 2 lines after this comment
 ```
 
 ### Checking the issue message
@@ -36,7 +25,7 @@ Using `@[+-][0-9]+` after a `Noncompliant` or `Secondary` comment will mark the 
 The message raised by the issue can be checked using the `{{expected message}}` pattern.
 
 ```cs
-    private void MyMethod() // Noncompliant {{Remove this unused private method}}
+    private void MyMethod() // Noncompliant {{Remove this unused private method}}
 ```
 
 ### Checking the precise/exact location of an issue
@@ -44,44 +33,59 @@ The message raised by the issue can be checked using the `{{expected message}}` 
 Only one precise location or column location can be present at one time. Precise location is used by adding `^^^^` comment under the location where the issue is expected. The alternative column location pattern can be used by following the `Noncompliant` or `Secondary` comment with `^X#Y` where `X` is the expected start column and Y the length of the issue.
 
 ```cs
-    private void MyMethod() // Noncompliant
-//  ^^^^^^^
+    private void MyMethod() // Noncompliant
+//  ^^^^^^^
 
-    private void MyMethod() // Noncompliant ^4#7
+    private void MyMethod() // Noncompliant ^4#7
+```
+
+### `Secondary` location comment
+
+`Secondary` is used to mark the expected line of a [secondary location](https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/src/SonarAnalyzer.Common/Common/SecondaryLocation.cs) and must be used together with a primary location.
+
+```cs
+    if (myCondition) // Noncompliant
+    {
+      var a = null; // Secondary
+    }
 ```
 
 ### Multiple issues per line
 
-To declare that multiple issues are expected, each issue must be assigned an id. All secondary locations associated with an issue must have the same id. Note that it is not possible to have multiple precise/column locations on a single line.
+To declare that multiple issues are expected, each issue must be assigned an `[ID]`. All secondary locations associated with an issue must have the same ID. Use offsets to define multiple precise locations on a single line.
 
 ```cs
-    var a = null;    // Noncompliant [myId2]
-    if (myCondition) // Noncompliant [myId1, myId3]
-    {
-      a = null;      // Secondary [myId1, myId2]
-    }
+    var a = null;    // Noncompliant [myId2]
+    if (myCondition) // Noncompliant [myId1, myId3]
+    {
+      a = null;      // Secondary [myId1, myId2]
+    }
+
+    private void MyMethod(int i1, int i2) { }
+    //                    ^^^^^^
+    //                            ^^^^^^ @-1
 ```
 
 ### Compilation Errors
 
-Will mark the line as the location of a compilation error. This is useful to test a code snippet that cannot be compiled, as it is usually the case inside an IDE/Editor. To increase readability, the error code as well as some comments can be specified. These are ignored by the verification process.
+`Error` will mark the line as the location of a compilation error. This is useful to test code snippets that cannot be compiled, as it is usually the case inside an IDE/Editor. To increase comprehensibility, the error code as well as some comments can be specified. These are ignored by the verification process.
 
 ```csharp
-    string x = 2; // Error
-    string x = 2; // Error [CS0029]
-    string x = 2; // Error [CS0029] - cannot implicitly convert int to string
+    string x = 2; // Error
+    string x = 2; // Error [CS0029]
+    string x = 2; // Error [CS0029] - cannot implicitly convert int to string
 ```
 
-### Examples
+### Combining multiple patterns
 
 Note that most of the previous patterns can be used together when needed.
 
 ```cs
-    private void MyMethod() // Noncompliant@+1 ^4#7 [MyIssueId] {{Remove this unused private method}}
+    private void MyMethod() // Noncompliant@+1 ^4#7 [MyIssueId] {{Remove this unused private method}}
 
-    private void MyMethod(int i1, int i2) { }
-    //                    ^^^^^^             {{Message for issue 1}}
-    //                            ^^^^^^ @-1 {{Message for issue 2}}
+    private void MyMethod(int i1, int i2) { }
+    //                    ^^^^^^             {{Message for issue 1}}
+    //                            ^^^^^^ @-1 {{Message for issue 2}}
 ```
 
-The code comment syntax logic is implementied by the `IssueLocationCollector` class.
+The code comment syntax logic is implemented by the [`IssueLocationCollector`](https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs) class.

--- a/docs/verifier-syntax.md
+++ b/docs/verifier-syntax.md
@@ -12,7 +12,7 @@ Will mark the current line as expecting the primary location of an issue.
     private void MyMethod() // Noncompliant
 ```
 
-### `Secondary` location comment.
+### `Secondary` location comment
 
 Must be used together with a main primary location to mark the expected line of a secondary location.
 

--- a/docs/verifier-syntax.md
+++ b/docs/verifier-syntax.md
@@ -46,9 +46,7 @@ Only one precise location or column location can be present at one time. Precise
 ```cs
     private void MyMethod() // Noncompliant
 //  ^^^^^^^
-```
 
-```cs
     private void MyMethod() // Noncompliant ^4#7
 ```
 

--- a/docs/verifier-syntax.md
+++ b/docs/verifier-syntax.md
@@ -28,7 +28,7 @@ Must be used together with a main primary location to mark the expected line of 
 Using `@[+-][0-9]+` after a `Noncompliant` or `Secondary` comment will mark the expected location to be offset by the given number of lines.
 
 ```cs
- private void MyMethod() // Noncompliant@+2 - issue is actually expected 2 lines after this comment
+    private void MyMethod() // Noncompliant@+2 - issue is actually expected 2 lines after this comment
 ```
 
 ### Checking the issue message

--- a/docs/verifier-syntax.md
+++ b/docs/verifier-syntax.md
@@ -9,7 +9,7 @@ These annotation patterns must appear after a single line comment (the supported
 Use `Noncompliant` to mark the current line as the primary location of an expected issue.
 
 ```cs
-    private void MyMethod() // Noncompliant
+    private void MyMethod() { } // Noncompliant
 ```
 
 ### Using offsets
@@ -17,7 +17,7 @@ Use `Noncompliant` to mark the current line as the primary location of an expect
 Using `@[+-][0-9]+` after a `Noncompliant` or `Secondary` comment will mark the expected location to be offset by the given number of lines.
 
 ```cs
-    private void MyMethod() // Noncompliant@+2 - issue is actually expected 2 lines after this comment
+    private void MyMethod() { } // Noncompliant@+2 - issue is actually expected 2 lines after this comment
 ```
 
 ### Checking the issue message
@@ -25,7 +25,7 @@ Using `@[+-][0-9]+` after a `Noncompliant` or `Secondary` comment will mark the 
 The message raised by the issue can be checked using the `{{expected message}}` pattern.
 
 ```cs
-    private void MyMethod() // Noncompliant {{Remove this unused private method}}
+    private void MyMethod() { } // Noncompliant {{Remove this unused private method}}
 ```
 
 ### Checking the precise/exact location of an issue
@@ -33,10 +33,10 @@ The message raised by the issue can be checked using the `{{expected message}}` 
 Only one precise location or column location can be present at one time. Precise location is used by adding `^^^^` comment under the location where the issue is expected. The alternative column location pattern can be used by following the `Noncompliant` or `Secondary` comment with `^X#Y` where `X` is the expected start column and Y the length of the issue.
 
 ```cs
-    private void MyMethod() // Noncompliant
+    private void MyMethod() { } // Noncompliant
 //  ^^^^^^^
 
-    private void MyMethod() // Noncompliant ^4#7
+    private void MyMethod() { } // Noncompliant ^4#7
 ```
 
 ### `Secondary` location comment
@@ -81,7 +81,7 @@ To declare that multiple issues are expected, each issue must be assigned an `[I
 Note that most of the previous patterns can be used together when needed.
 
 ```cs
-    private void MyMethod() // Noncompliant@+1 ^4#7 [MyIssueId] {{Remove this unused private method}}
+    private void MyMethod() { } // Noncompliant@+1 ^4#7 [MyIssueId] {{Remove this unused private method}}
 
     private void MyMethod(int i1, int i2) { }
     //                    ^^^^^^             {{Message for issue 1}}

--- a/docs/verifier-syntax.md
+++ b/docs/verifier-syntax.md
@@ -55,19 +55,33 @@ Only one precise location or column location can be present at one time. Precise
 To declare that multiple issues are expected, each issue must be assigned an id. All secondary locations associated with an issue must have the same id. Note that it is not possible to have multiple precise/column locations on a single line.
 
 ```cs
-    var a = null; // Noncompliant [myId2]
+    var a = null;    // Noncompliant [myId2]
     if (myCondition) // Noncompliant [myId1, myId3]
     {
-      a = null; // Secondary [myId1, myId2]
+      a = null;      // Secondary [myId1, myId2]
     }
 ```
+
+### Compilation Errors
+
+Will mark the line as the location of a compilation error. This is useful to test a code snippet that cannot be compiled, as it is usually the case inside an IDE/Editor. To increase readability, the error code as well as some comments can be specified. These are ignored by the verification process.
+
+```csharp
+    string x = 2; // Error
+    string x = 2; // Error [CS0029]
+    string x = 2; // Error [CS0029] - cannot implicitly convert int to string
+```
+
+### Examples
 
 Note that most of the previous patterns can be used together when needed.
 
 ```cs
     private void MyMethod() // Noncompliant@+1 ^4#7 [MyIssueId] {{Remove this unused private method}}
 
-    private void MyMethod(int i2, int i2)
-//                        ^^^^^^             {{Message for issue 1}}
-//                                ^^^^^^ @-1 {{Message for issue 2}}
+    private void MyMethod(int i1, int i2) { }
+    //                    ^^^^^^             {{Message for issue 1}}
+    //                            ^^^^^^ @-1 {{Message for issue 2}}
 ```
+
+The code comment syntax logic is implementied by the `IssueLocationCollector` class.


### PR DESCRIPTION
[Preview](https://github.com/SonarSource/sonar-dotnet/blob/Martin/docs_VerifierSyntax/docs/verifier-syntax.md)

based on https://github.com/gregory-paidis-sonarsource/random/blob/main/issue_location_collector.md and on the comment from here:
https://github.com/SonarSource/sonar-dotnet/blob/d795ff77dc05911a1ae06ab151568dd229b08e74/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/IssueLocationCollector.cs#L29-L86

