### PR TITLE
Refactor SonarAnalysisContext - Migrate RegisterSyntaxNodeAction

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context)
         {
             context.RegisterSymbolAction(ReportPublicExternalMethods, SymbolKind.Method);
-            context.RegisterSyntaxNodeAction(ReportTrivialWrappers, SyntaxKind.MethodDeclaration);
+            context.RegisterSyntaxNodeActionInNonGenerated(ReportTrivialWrappers, SyntaxKind.MethodDeclaration);
         }
 
         private static void ReportPublicExternalMethods(SymbolAnalysisContext c)

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/DiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/DiagnosticAnalyzerContextHelper.cs
@@ -28,15 +28,15 @@ internal static class DiagnosticAnalyzerContextHelper
 {
     private static readonly ConditionalWeakTable<Compilation, ConcurrentDictionary<SyntaxTree, bool>> GeneratedCodeCache = new();
 
-    public static void RegisterSyntaxNodeActionInNonGenerated<TLanguageKindEnum>(this SonarAnalysisContext context,
+    public static void RegisterSyntaxNodeActionInNonGenerated<TLanguageKindEnum>(this SonarAnalysisContext context, // FIXME: Move them
                                                                                  GeneratedCodeRecognizer generatedCodeRecognizer,
                                                                                  Action<SyntaxNodeAnalysisContext> action,
                                                                                  params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct =>
         context.RegisterSyntaxNodeAction(c =>
             {
-                if (SonarAnalysisContext.ShouldAnalyze(context.TryGetValue, context.TryGetValue, generatedCodeRecognizer, c.GetSyntaxTree(), c.Compilation, c.Options))
+                if (c.ShouldAnalyze(generatedCodeRecognizer))
                 {
-                    action(c);
+                    action(c.Context);
                 }
             }, syntaxKinds);
 
@@ -46,9 +46,9 @@ internal static class DiagnosticAnalyzerContextHelper
                                                                                  params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct =>
         context.Context.RegisterSyntaxNodeAction(c =>
             {
-                if (SonarAnalysisContext.ShouldAnalyze(context.Context.TryGetValue, context.Context.TryGetValue, generatedCodeRecognizer, c.GetSyntaxTree(), c.Compilation, c.Options))
+                if (c.ShouldAnalyze(generatedCodeRecognizer))
                 {
-                    action(c);
+                    action(c.Context);
                 }
             }, syntaxKinds);
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/DiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/DiagnosticAnalyzerContextHelper.cs
@@ -91,9 +91,9 @@ internal static class DiagnosticAnalyzerContextHelper
                                                                                      Action<CodeBlockStartAnalysisContext<TLanguageKindEnum>> action) where TLanguageKindEnum : struct =>
         context.RegisterCodeBlockStartAction<TLanguageKindEnum>(c =>
             {
-                if (SonarAnalysisContext.ShouldAnalyze(context.TryGetValue, context.TryGetValue, generatedCodeRecognizer, c.GetSyntaxTree(), c.SemanticModel.Compilation, c.Options))
+                if (c.ShouldAnalyze(generatedCodeRecognizer))
                 {
-                    action(c);
+                    action(c.Context);
                 }
             });
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
@@ -20,7 +20,6 @@
 
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Text;
 using static SonarAnalyzer.Helpers.DiagnosticDescriptorFactory;
@@ -42,7 +41,7 @@ public partial class SonarAnalysisContext
     private static readonly SourceTextValueProvider<bool> ShouldAnalyzeGeneratedCS = CreateAnalyzeGeneratedProvider(LanguageNames.CSharp);
     private static readonly SourceTextValueProvider<bool> ShouldAnalyzeGeneratedVB = CreateAnalyzeGeneratedProvider(LanguageNames.VisualBasic);
     private static readonly SourceTextValueProvider<ProjectConfigReader> ProjectConfigProvider = new(x => new ProjectConfigReader(x));  // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
-    private static readonly ConditionalWeakTable<Compilation, ImmutableHashSet<string>> UnchangedFilesCache = new();
+    private static readonly ConditionalWeakTable<Compilation, ImmutableHashSet<string>> UnchangedFilesCache = new();                    // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
 
     public bool ShouldAnalyzeGenerated(Compilation c, AnalyzerOptions options) =>
         ShouldAnalyzeGenerated(analysisContext.TryGetValue, c, options);
@@ -92,13 +91,6 @@ public partial class SonarAnalysisContext
     //internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
     //    context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
-    // FIXME: Use the other one
-    internal void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-        analysisContext.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), x => action(x.Context)), syntaxKinds);
-
-    //internal void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-    //    context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
-
     /// <summary>
     /// Reads configuration from SonarProjectConfig.xml file and caches the result for scope of this analysis.
     /// </summary>
@@ -143,7 +135,7 @@ public partial class SonarAnalysisContext
     public static bool IsUnchanged(TryGetValueDelegate<ProjectConfigReader> tryGetValue, SyntaxTree tree, Compilation compilation, AnalyzerOptions options) =>
         UnchangedFilesCache.GetValue(compilation, _ => CreateUnchangedFilesHashSet(tryGetValue, options)).Contains(tree.FilePath);
 
-    private static ImmutableHashSet<string> CreateUnchangedFilesHashSet(TryGetValueDelegate<ProjectConfigReader> tryGetValue, AnalyzerOptions options) =>
+    private static ImmutableHashSet<string> CreateUnchangedFilesHashSet(TryGetValueDelegate<ProjectConfigReader> tryGetValue, AnalyzerOptions options) =>       // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
         ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, ProjectConfiguration(tryGetValue, options).AnalysisConfig?.UnchangedFiles() ?? Array.Empty<string>());
 
     private static bool IsTestProject(TryGetValueDelegate<ProjectConfigReader> tryGetValue, Compilation compilation, AnalyzerOptions options)   // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
@@ -154,10 +146,10 @@ public partial class SonarAnalysisContext
             : projectType == ProjectType.Test;  // Scanner >= 5.1 does authoritative decision that we follow
     }
 
-    private static SourceTextValueProvider<bool> CreateAnalyzeGeneratedProvider(string language) =>
+    private static SourceTextValueProvider<bool> CreateAnalyzeGeneratedProvider(string language) => //FIXME: Remove, it was migrated to the SonarAnalysisContextBase
         new(x => PropertiesHelper.ReadAnalyzeGeneratedCodeProperty(ParseXmlSettings(x), language));
 
-    private static IEnumerable<XElement> ParseXmlSettings(SourceText sourceText)
+    private static IEnumerable<XElement> ParseXmlSettings(SourceText sourceText)    // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
     {
         try
         {
@@ -170,11 +162,11 @@ public partial class SonarAnalysisContext
         }
     }
 
-    private static bool ShouldAnalyzeGenerated(TryGetValueDelegate<bool> tryGetValue, Compilation c, AnalyzerOptions options) =>
+    private static bool ShouldAnalyzeGenerated(TryGetValueDelegate<bool> tryGetValue, Compilation c, AnalyzerOptions options) =>    // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
         options.SonarLintXml() is { } sonarLintXml
         && tryGetValue(sonarLintXml.GetText(), ShouldAnalyzeGeneratedProvider(c.Language), out var shouldAnalyzeGenerated)
         && shouldAnalyzeGenerated;
 
-    private static SourceTextValueProvider<bool> ShouldAnalyzeGeneratedProvider(string language) =>
+    private static SourceTextValueProvider<bool> ShouldAnalyzeGeneratedProvider(string language) => // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
         language == LanguageNames.CSharp ? ShouldAnalyzeGeneratedCS : ShouldAnalyzeGeneratedVB;
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
@@ -84,13 +84,6 @@ public partial class SonarAnalysisContext
     //public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
     //    context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
 
-    // FIXME: Use the other one
-    internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<CodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), x => action(x.Context)));
-
-    //internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-    //    context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
-
     /// <summary>
     /// Reads configuration from SonarProjectConfig.xml file and caches the result for scope of this analysis.
     /// </summary>

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -70,6 +70,9 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     internal void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
         context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
 
+    internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
+        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {
         // For each action registered on context we need to do some pre-processing before actually calling the rule.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -68,10 +68,10 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
         analysisContext.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
 
     internal void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-        context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
+        analysisContext.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
 
     internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+        analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -67,6 +67,9 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     internal void RegisterCompilationAction(Action<SonarCompilationAnalysisContext> action) =>
         analysisContext.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
 
+    internal void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
+        context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
+
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {
         // For each action registered on context we need to do some pre-processing before actually calling the rule.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -19,15 +19,24 @@
  */
 
 using System.IO;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Text;
 
 namespace SonarAnalyzer;
 
 public abstract class SonarAnalysisContextBase
 {
+    private static readonly Lazy<SourceTextValueProvider<bool>> ShouldAnalyzeGeneratedCS = new(() => CreateAnalyzeGeneratedProvider(LanguageNames.CSharp));
+    private static readonly Lazy<SourceTextValueProvider<bool>> ShouldAnalyzeGeneratedVB = new(() => CreateAnalyzeGeneratedProvider(LanguageNames.VisualBasic));
     private static readonly SourceTextValueProvider<ProjectConfigReader> ProjectConfigProvider = new(x => new ProjectConfigReader(x));
+    private static readonly ConditionalWeakTable<Compilation, ImmutableHashSet<string>> UnchangedFilesCache = new();
 
     public abstract bool TryGetValue<TValue>(SourceText text, SourceTextValueProvider<TValue> valueProvider, out TValue value);
+
+    public bool ShouldAnalyze(GeneratedCodeRecognizer generatedCodeRecognizer, SyntaxTree tree, Compilation compilation, AnalyzerOptions options) =>
+        !IsUnchanged(tree, compilation, options)
+        && (ShouldAnalyzeGenerated(compilation, options) || !tree.IsGenerated(generatedCodeRecognizer, compilation));
 
     /// <summary>
     /// Reads configuration from SonarProjectConfig.xml file and caches the result for scope of this analysis.
@@ -45,6 +54,35 @@ public abstract class SonarAnalysisContextBase
         else
         {
             return ProjectConfigReader.Empty;
+        }
+    }
+
+    private bool IsUnchanged(SyntaxTree tree, Compilation compilation, AnalyzerOptions options) =>
+        UnchangedFilesCache.GetValue(compilation, _ => CreateUnchangedFilesHashSet(options)).Contains(tree.FilePath);
+
+    private ImmutableHashSet<string> CreateUnchangedFilesHashSet(AnalyzerOptions options) =>
+        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, ProjectConfiguration(options).AnalysisConfig?.UnchangedFiles() ?? Array.Empty<string>());
+
+    private bool ShouldAnalyzeGenerated(Compilation compilation, AnalyzerOptions options) =>
+        options.SonarLintXml() is { } sonarLintXml
+        && TryGetValue(sonarLintXml.GetText(), ShouldAnalyzeGeneratedProvider(compilation.Language), out var shouldAnalyzeGenerated)
+        && shouldAnalyzeGenerated;
+
+    private static SourceTextValueProvider<bool> ShouldAnalyzeGeneratedProvider(string language) =>
+        language == LanguageNames.CSharp ? ShouldAnalyzeGeneratedCS.Value : ShouldAnalyzeGeneratedVB.Value;
+
+    private static SourceTextValueProvider<bool> CreateAnalyzeGeneratedProvider(string language) =>
+        new(x => PropertiesHelper.ReadAnalyzeGeneratedCodeProperty(ParseXmlSettings(x), language));
+
+    private static IEnumerable<XElement> ParseXmlSettings(SourceText sourceText)    // FIXME: This should not be here
+    {
+        try
+        {
+            return XDocument.Parse(sourceText.ToString()).Descendants("Setting");
+        }
+        catch
+        {
+            return Enumerable.Empty<XElement>();    // Can not log the exception, so ignore it
         }
     }
 }
@@ -77,6 +115,9 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
             ? Compilation.IsTest()              // SonarLint, NuGet or Scanner <= 5.0
             : projectType == ProjectType.Test;  // Scanner >= 5.1 does authoritative decision that we follow
     }
+
+    public bool ShouldAnalyze(GeneratedCodeRecognizer generatedCodeRecognizer) =>
+        ShouldAnalyze(generatedCodeRecognizer, Tree, Compilation, Options);
 
     private protected void ReportIssue(ReportingContext reportingContext)
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/EmptyMethodBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/EmptyMethodBase.cs
@@ -33,10 +33,10 @@ namespace SonarAnalyzer.Rules
             context.RegisterSyntaxNodeAction(
                 c =>
                 {
-                    if (SonarAnalysisContext.ShouldAnalyze(context.TryGetValue, context.TryGetValue, GeneratedCodeRecognizer, c.GetSyntaxTree(), c.Compilation, c.Options))
+                    if (c.ShouldAnalyze(GeneratedCodeRecognizer))
                     {
                         var isTestProject = context.IsTestProject(c.Compilation, c.Options);
-                        CheckMethod(c, isTestProject);
+                        CheckMethod(c.Context, isTestProject);
                     }
                 },
                 SyntaxKinds.ToArray());

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/CodeFixProviderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/CodeFixProviderTest.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -52,8 +51,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
                 context.RegisterSyntaxNodeAction(c =>
                 {
                     // Duplicate issues from different analyzer versions, see https://github.com/SonarSource/sonar-dotnet/issues/1109
-                    c.ReportDiagnostic(Diagnostic.Create(this.rule, c.Node.GetLocation()));
-                    c.ReportDiagnostic(Diagnostic.Create(this.rule, c.Node.GetLocation()));
+                    c.ReportIssue(Diagnostic.Create(rule, c.Context.Node.GetLocation()));
+                    c.ReportIssue(Diagnostic.Create(rule, c.Context.Node.GetLocation()));
                 }, SyntaxKind.NamespaceDeclaration);
             }
         }


### PR DESCRIPTION
Part of #6540

* Migrate `RegisterSyntaxNodeAction` to the new Sonar-signature
* Migrate `RegisterCodeBlockStartAction` to the new Sonar-signature