### PR TITLE
Refactor SonarAnalysisContext - Migrate RegisterSymbolAction

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
@@ -57,16 +57,8 @@ namespace SonarAnalyzer.Helpers
             }
         }
 
-        public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, Diagnostic diagnostic) =>
+        public static void ReportDiagnosticIfNonGenerated(this SonarSymbolAnalysisContext context, Diagnostic diagnostic) =>
             context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
-
-        public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, IEnumerable<Diagnostic> diagnostics)
-        {
-            foreach (var diagnostic in diagnostics)
-            {
-                context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
-            }
-        }
 
         internal static bool ShouldAnalyze(this SyntaxTree tree, SonarAnalysisContext context, Compilation compilation, AnalyzerOptions options) =>
             SonarAnalysisContext.ShouldAnalyze(context.TryGetValue, context.TryGetValue, CSharpGeneratedCodeRecognizer.Instance, tree, compilation, options);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeAbstract.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeAbstract.cs
@@ -47,13 +47,13 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (!IsRecordWithParameters(symbol) && AbstractTypeShouldBeInterface(symbol))
                     {
-                        Report(symbol, MessageToInterface, c);
+                        Report(c, symbol, MessageToInterface);
                         return;
                     }
 
                     if (AbstractTypeShouldBeConcrete(symbol))
                     {
-                        Report(symbol, MessageToConcreteImplementation, c);
+                        Report(c, symbol, MessageToConcreteImplementation);
                     }
                 },
                 SymbolKind.NamedType);
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static IEnumerable<IMethodSymbol> GetAllOverrideMethods(INamedTypeSymbol symbol) =>
             GetAllMethods(symbol).Where(m => m.IsOverride);
 
-        private static void Report(INamedTypeSymbol symbol, string message, SymbolAnalysisContext context)
+        private static void Report(SonarSymbolAnalysisContext context, INamedTypeSymbol symbol, string message)
         {
             foreach (var declaringSyntaxReference in symbol.DeclaringSyntaxReferences)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithOnlyStaticMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithOnlyStaticMember.cs
@@ -49,12 +49,12 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    CheckClasses(namedType, c);
-                    CheckConstructors(namedType, c);
+                    CheckClasses(c, namedType);
+                    CheckConstructors(c, namedType);
                 },
                 SymbolKind.NamedType);
 
-        private static void CheckClasses(INamedTypeSymbol utilityClass, SymbolAnalysisContext context)
+        private static void CheckClasses(SonarSymbolAnalysisContext context, INamedTypeSymbol utilityClass)
         {
             if (!ClassIsRelevant(utilityClass))
             {
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckConstructors(INamedTypeSymbol utilityClass, SymbolAnalysisContext context)
+        private static void CheckConstructors(SonarSymbolAnalysisContext context, INamedTypeSymbol utilityClass)
         {
             if (!ClassQualifiesForIssue(utilityClass) || !HasMembersAndAllAreStaticExceptConstructors(utilityClass))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableNotDisposed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableNotDisposed.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     }
 
                     var typesDeclarationsAndSemanticModels = namedTypeSymbol.DeclaringSyntaxReferences
-                                                                            .Select(x => CreateNodeAndModel(x, c))
+                                                                            .Select(x => CreateNodeAndModel(c, x))
                                                                             .ToList();
 
                     var trackedNodesAndSymbols = new HashSet<NodeAndSymbol>();
@@ -105,7 +105,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 },
                 SymbolKind.NamedType);
 
-        private static NodeAndModel<SyntaxNode> CreateNodeAndModel(SyntaxReference syntaxReference, SymbolAnalysisContext c) =>
+        private static NodeAndModel<SyntaxNode> CreateNodeAndModel(SonarSymbolAnalysisContext c, SyntaxReference syntaxReference) =>
             new(c.Compilation.GetSemanticModel(syntaxReference.SyntaxTree), syntaxReference.GetSyntax());
 
         private static void TrackInitializedLocalsAndPrivateFields(INamedTypeSymbol namedType,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeNotImplementingDispose.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeNotImplementingDispose.cs
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var disposeMethodsCalledFromDispose = new HashSet<IMethodSymbol>();
                     CollectInvocationsFromDisposeImplementation(disposeMethod, c.Compilation, mightImplementDispose, disposeMethodsCalledFromDispose);
 
-                    ReportDisposeMethods(namedDispose.Except(mightImplementDispose).Where(m => !disposeMethodsCalledFromDispose.Contains(m)), c);
+                    ReportDisposeMethods(c, namedDispose.Except(mightImplementDispose).Where(m => !disposeMethodsCalledFromDispose.Contains(m)));
                 },
                 SymbolKind.NamedType);
 
@@ -107,15 +107,13 @@ namespace SonarAnalyzer.Rules.CSharp
             disposeMethodsCalledFromDispose.Add(invokedMethod);
         }
 
-        private static void ReportDisposeMethods(IEnumerable<IMethodSymbol> disposeMethods,
-                                                 SymbolAnalysisContext context)
+        private static void ReportDisposeMethods(SonarSymbolAnalysisContext context, IEnumerable<IMethodSymbol> disposeMethods)
         {
             foreach (var disposeMethod in disposeMethods)
             {
                 foreach (var location in disposeMethod.Locations)
                 {
-                    var diagnostic = Rule.CreateDiagnostic(context.Compilation, location, disposeMethod.PartialImplementationPart?.Locations ?? Enumerable.Empty<Location>());
-                    context.ReportDiagnosticIfNonGenerated(diagnostic);
+                    context.ReportDiagnosticIfNonGenerated(Rule.CreateDiagnostic(context.Compilation, location, disposeMethod.PartialImplementationPart?.Locations ?? Enumerable.Empty<Location>()));
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShadowsOuterStaticMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShadowsOuterStaticMember.cs
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 },
                 SymbolKind.NamedType);
 
-        private static void CheckNamedType(SymbolAnalysisContext context, IReadOnlyList<ISymbol> outerMembersOfSameName, INamedTypeSymbol namedType)
+        private static void CheckNamedType(SonarSymbolAnalysisContext context, IReadOnlyList<ISymbol> outerMembersOfSameName, INamedTypeSymbol namedType)
         {
             if (outerMembersOfSameName.Any(x => x is INamedTypeSymbol { TypeKind: TypeKind.Class or TypeKind.Struct or TypeKind.Delegate or TypeKind.Enum or TypeKind.Interface }))
             {
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckMember(SymbolAnalysisContext context, IReadOnlyList<ISymbol> outerMembersOfSameName, ISymbol member)
+        private static void CheckMember(SonarSymbolAnalysisContext context, IReadOnlyList<ISymbol> outerMembersOfSameName, ISymbol member)
         {
             if (outerMembersOfSameName.Any(x => (x.IsStatic && !x.IsAbstract && !x.IsVirtual) || x is IFieldSymbol { IsConst: true })
                 && member.FirstDeclaringReferenceIdentifier() is { } identifier

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(ReportTrivialWrappers, SyntaxKind.MethodDeclaration);
         }
 
-        private static void ReportPublicExternalMethods(SymbolAnalysisContext c)
+        private static void ReportPublicExternalMethods(SonarSymbolAnalysisContext c)
         {
             var methodSymbol = (IMethodSymbol)c.Symbol;
             if (methodSymbol.IsExtern

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSymbolAction(RaiseOnUninvokedEventDeclaration, SymbolKind.NamedType);
 
-        private void RaiseOnUninvokedEventDeclaration(SymbolAnalysisContext context)
+        private void RaiseOnUninvokedEventDeclaration(SonarSymbolAnalysisContext context)
         {
             var namedType = (INamedTypeSymbol)context.Symbol;
             if (!namedType.IsClassOrStruct() || namedType.ContainingType != null)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(AnalyzeLocalFunctionStatements, SyntaxKindEx.LocalFunctionStatement);
         }
 
-        private static void AnalyzeNamedTypes(SymbolAnalysisContext context)
+        private static void AnalyzeNamedTypes(SonarSymbolAnalysisContext context)
         {
             var namedType = (INamedTypeSymbol)context.Symbol;
             if (!namedType.IsClassOrStruct() || namedType.ContainingType != null)

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/DiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/DiagnosticAnalyzerContextHelper.cs
@@ -97,37 +97,11 @@ internal static class DiagnosticAnalyzerContextHelper
                 }
             });
 
-    public static void ReportDiagnosticIfNonGenerated(this CompilationAnalysisContext context, GeneratedCodeRecognizer generatedCodeRecognizer, Diagnostic diagnostic)
+    public static void ReportDiagnosticIfNonGenerated(this CompilationAnalysisContext context, GeneratedCodeRecognizer generatedCodeRecognizer, Diagnostic diagnostic)  // FIXME: Move
     {
         if (SonarAnalysisContext.ShouldAnalyze(context.TryGetValue, context.TryGetValue, generatedCodeRecognizer, diagnostic.Location.SourceTree, context.Compilation, context.Options))
         {
             context.ReportIssue(diagnostic);
-        }
-    }
-
-    public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, GeneratedCodeRecognizer generatedCodeRecognizer, Diagnostic diagnostic)
-    {
-        if (SonarAnalysisContext.ShouldAnalyze(AnalyzeGeneratedNoCache, ProjectConfigReaderNoCache, generatedCodeRecognizer, diagnostic.Location.SourceTree, context.Compilation, context.Options))
-        {
-            context.ReportIssue(diagnostic);
-        }
-
-        bool AnalyzeGeneratedNoCache(SourceText text, SourceTextValueProvider<bool> valueProvider, out bool value)
-        {
-            value = PropertiesHelper.ReadAnalyzeGeneratedCodeProperty(PropertiesHelper.GetSettings(context.Options), context.Compilation.Language);
-            return true;
-        }
-
-        bool ProjectConfigReaderNoCache(SourceText text, SourceTextValueProvider<ProjectConfigReader> valueProvider, out ProjectConfigReader value)
-        {
-            value = SonarAnalysisContext.ProjectConfiguration(CreateProjectConfigReader, context.Options);
-            return true;
-        }
-
-        bool CreateProjectConfigReader(SourceText text, SourceTextValueProvider<ProjectConfigReader> valueProvider, out ProjectConfigReader value)
-        {
-            value = new ProjectConfigReader(text); // Recreating manually, SourceTextValueProvider doesn't have public API to use
-            return true;
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
@@ -77,13 +77,6 @@ public partial class SonarAnalysisContext
     //public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
     //    context.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
 
-    // FIXME: Use the other one
-    public void RegisterSymbolAction(Action<SymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
-        analysisContext.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), x => action(x.Context)), symbolKinds);
-
-    //public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
-    //    context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
-
     /// <summary>
     /// Reads configuration from SonarProjectConfig.xml file and caches the result for scope of this analysis.
     /// </summary>

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -76,6 +76,9 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
         context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
+    public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
+        context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
+
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {
         // For each action registered on context we need to do some pre-processing before actually calling the rule.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -73,11 +73,8 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
         analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
-    internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
-
     public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
-        context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
+        analysisContext.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
 
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -73,6 +73,9 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
         analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
+    internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
+        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {
         // For each action registered on context we need to do some pre-processing before actually calling the rule.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSymbolAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSymbolAnalysisContext.cs
@@ -31,4 +31,12 @@ public sealed class SonarSymbolAnalysisContext : SonarAnalysisContextBase<Symbol
 
     public void ReportIssue(Diagnostic diagnostic) =>
         ReportIssue(new ReportingContext(Context, diagnostic));
+
+    public void ReportDiagnosticIfNonGenerated(GeneratedCodeRecognizer generatedCodeRecognizer, Diagnostic diagnostic)
+    {
+        if (ShouldAnalyze(generatedCodeRecognizer))
+        {
+            ReportIssue(diagnostic);
+        }
+    }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ClassNotInstantiatableBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ClassNotInstantiatableBase.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules
                     IsAnyConstructorToCurrentType(descendants.DescendantNodes, namedType, descendants.Model)
                     || IsAnyNestedTypeExtendingCurrentType(descendants.DescendantNodes, namedType, descendants.Model));
 
-        private void CheckClassWithOnlyUnusedPrivateConstructors(SymbolAnalysisContext context)
+        private void CheckClassWithOnlyUnusedPrivateConstructors(SonarSymbolAnalysisContext context)
         {
             var namedType = (INamedTypeSymbol)context.Symbol;
             if (!IsNonStaticClassWithNoAttributes(namedType) || DerivesFromSafeHandle(namedType))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DisablingRequestValidationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DisablingRequestValidationBase.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules
             context.RegisterCompilationAction(CheckWebConfig);
         }
 
-        private void CheckController(SymbolAnalysisContext context)
+        private void CheckController(SonarSymbolAnalysisContext context)
         {
             if (!IsEnabled(context.Options))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertiesAccessCorrectFieldBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertiesAccessCorrectFieldBase.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules
             ? invokedMethod
             : null;
 
-        private void CheckType(SymbolAnalysisContext context)
+        private void CheckType(SonarSymbolAnalysisContext context)
         {
             var symbol = (INamedTypeSymbol)context.Symbol;
             if (!symbol.TypeKind.Equals(TypeKind.Class)
@@ -86,11 +86,11 @@ namespace SonarAnalyzer.Rules
                 {
                     if (!data.IgnoreGetter)
                     {
-                        CheckExpectedFieldIsUsed(data.PropertySymbol.GetMethod, expectedField, data.ReadFields, context);
+                        CheckExpectedFieldIsUsed(context, data.PropertySymbol.GetMethod, expectedField, data.ReadFields);
                     }
                     if (!data.IgnoreSetter)
                     {
-                        CheckExpectedFieldIsUsed(data.PropertySymbol.SetMethod, expectedField, data.UpdatedFields, context);
+                        CheckExpectedFieldIsUsed(context, data.PropertySymbol.SetMethod, expectedField, data.UpdatedFields);
                     }
                 }
             }
@@ -113,7 +113,7 @@ namespace SonarAnalyzer.Rules
                   .OfType<IPropertySymbol>()
                   .Where(ImplementsExplicitGetterOrSetter);
 
-        private void CheckExpectedFieldIsUsed(IMethodSymbol methodSymbol, IFieldSymbol expectedField, ImmutableArray<FieldData> actualFields, SymbolAnalysisContext context)
+        private void CheckExpectedFieldIsUsed(SonarSymbolAnalysisContext context, IMethodSymbol methodSymbol, IFieldSymbol expectedField, ImmutableArray<FieldData> actualFields)
         {
             var expectedFieldIsUsed = actualFields.Any(a => a.Field.Equals(expectedField));
             if (!expectedFieldIsUsed || !actualFields.Any())

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Helpers
             where TSyntaxKind : struct =>
             context.RegisterCodeBlockStartActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-        public static void ReportDiagnosticIfNonGenerated(this SymbolAnalysisContext context, Diagnostic diagnostic) =>
+        public static void ReportDiagnosticIfNonGenerated(this SonarSymbolAnalysisContext context, Diagnostic diagnostic) =>
             context.ReportDiagnosticIfNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/DiagnosticAnalyzerContextHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/DiagnosticAnalyzerContextHelperTest.cs
@@ -356,7 +356,8 @@ $@"namespace PartiallyGenerated
         var wasReported = false;
         var location = context.Tree.GetRoot().GetLocation();
         var symbol = Mock.Of<ISymbol>(x => x.Locations == ImmutableArray.Create(location));
-        var sut = new SymbolAnalysisContext(symbol, context.Model.Compilation, context.Options, _ => wasReported = true, _ => true, default);
+        var symbolContext = new SymbolAnalysisContext(symbol, context.Model.Compilation, context.Options, _ => wasReported = true, _ => true, default);
+        var sut = new SonarSymbolAnalysisContext(new SonarAnalysisContext(context, DummyMainDescriptor), symbolContext);
         sut.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, Mock.Of<Diagnostic>(x => x.Id == "Sxxx" && x.Location == location));
 
         wasReported.Should().Be(expected);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/DiagnosticAnalyzerContextHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/DiagnosticAnalyzerContextHelperTest.cs
@@ -358,7 +358,7 @@ $@"namespace PartiallyGenerated
         var symbol = Mock.Of<ISymbol>(x => x.Locations == ImmutableArray.Create(location));
         var symbolContext = new SymbolAnalysisContext(symbol, context.Model.Compilation, context.Options, _ => wasReported = true, _ => true, default);
         var sut = new SonarSymbolAnalysisContext(new SonarAnalysisContext(context, DummyMainDescriptor), symbolContext);
-        sut.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, Mock.Of<Diagnostic>(x => x.Id == "Sxxx" && x.Location == location));
+        sut.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, Mock.Of<Diagnostic>(x => x.Id == "Sxxx" && x.Location == location && x.Descriptor == DummyMainDescriptor[0]));
 
         wasReported.Should().Be(expected);
     }


### PR DESCRIPTION
Part of #6540

* Migrate `RegisterSymbolAction` to the new Sonar-signature
