### PR TITLE
Refactor SonarAnalysisContext - Migrate RegisterCompilationStartAction

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
@@ -52,8 +52,5 @@ namespace SonarAnalyzer.Helpers
 
         public static void ReportDiagnosticIfNonGenerated(this SonarSymbolAnalysisContext context, Diagnostic diagnostic) =>
             context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
-
-        internal static bool ShouldAnalyze(this SyntaxTree tree, SonarAnalysisContext context, Compilation compilation, AnalyzerOptions options) =>
-            SonarAnalysisContext.ShouldAnalyze(context.TryGetValue, context.TryGetValue, CSharpGeneratedCodeRecognizer.Instance, tree, compilation, options);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Helpers
 {
-    internal static class CSharpDiagnosticAnalyzerContextHelper
+    internal static class CSharpDiagnosticAnalyzerContextHelper     // FIXME: Move and rename
     {
         public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context,
                                                                                Action<SyntaxNodeAnalysisContext> action,
@@ -32,8 +32,9 @@ namespace SonarAnalyzer.Helpers
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this CompilationStartAnalysisContext context, Action<SyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds)
-            where TSyntaxKind : struct =>
+        public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this SonarCompilationStartAnalysisContext context,
+                                                                               Action<SyntaxNodeAnalysisContext> action,
+                                                                               params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
         public static void RegisterSyntaxTreeActionInNonGenerated(this SonarAnalysisContext context, Action<SyntaxTreeAnalysisContext> action) =>
@@ -46,16 +47,8 @@ namespace SonarAnalyzer.Helpers
             where TSyntaxKind : struct =>
             context.RegisterCodeBlockStartActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action);
 
-        public static void ReportDiagnosticIfNonGenerated(this CompilationAnalysisContext context, Diagnostic diagnostic) =>
+        public static void ReportDiagnosticIfNonGenerated(this SonarCompilationAnalysisContext context, Diagnostic diagnostic) =>
             context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
-
-        public static void ReportDiagnosticIfNonGenerated(this CompilationAnalysisContext context, IEnumerable<Diagnostic> diagnostics)
-        {
-            foreach (var diagnostic in diagnostics)
-            {
-                context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
-            }
-        }
 
         public static void ReportDiagnosticIfNonGenerated(this SonarSymbolAnalysisContext context, Diagnostic diagnostic) =>
             context.ReportDiagnosticIfNonGenerated(CSharpGeneratedCodeRecognizer.Instance, diagnostic);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotHardcodeCredentials.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotHardcodeCredentials.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal /*for testing*/ DoNotHardcodeCredentials(IAnalyzerConfiguration configuration) : base(configuration) { }
 
         protected override void InitializeActions(ParameterLoadingAnalysisContext context) =>
-            context.RegisterCompilationStartAction(
+            context.RegisterPostponedAction(
                 c =>
                 {
                     if (!IsEnabled(c.Options))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithNeutralResourcesLanguageAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithNeutralResourcesLanguageAttribute.cs
@@ -34,8 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterCompilationStartAction(c =>
                 {
                     var hasResx = false;
-
-                    c.RegisterSyntaxNodeAction(cc =>
+                    context.RegisterSyntaxNodeAction(cc =>
                         hasResx = hasResx || IsResxGeneratedFile(cc.SemanticModel, (ClassDeclarationSyntax)cc.Node),
                         SyntaxKind.ClassDeclaration);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldNotHaveConflictingTransparencyAttributes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldNotHaveConflictingTransparencyAttributes.cs
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportOnConflictingTransparencyAttributes(CompilationAnalysisContext compilationContext,
+        private static void ReportOnConflictingTransparencyAttributes(SonarCompilationAnalysisContext compilationContext,
                                                                       Dictionary<SyntaxNode, AttributeSyntax> nodesWithSecuritySafeCritical,
                                                                       Dictionary<SyntaxNode, AttributeSyntax> nodesWithSecurityCritical)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfMissingContractAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfMissingContractAttribute.cs
@@ -86,7 +86,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static TypeDeclarationSyntax GetTypeDeclaration(SonarAnalysisContext context, ISymbol namedType, Compilation compilation, AnalyzerOptions options) =>
             namedType.DeclaringSyntaxReferences
-                     .Where(sr => sr.SyntaxTree.ShouldAnalyze(context, compilation, options))
+                     .Where(sr => context.ShouldAnalyze(CSharpGeneratedCodeRecognizer.Instance, sr.SyntaxTree, compilation, options))
                      .Select(sr => sr.GetSyntax() as TypeDeclarationSyntax)
                      .FirstOrDefault(s => s != null);
     }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
@@ -70,13 +70,6 @@ public partial class SonarAnalysisContext
     internal static bool IsRegisteredActionEnabled(IEnumerable<DiagnosticDescriptor> diagnostics, SyntaxTree tree) =>
         ShouldExecuteRegisteredAction == null || tree == null || ShouldExecuteRegisteredAction(diagnostics, tree);
 
-    // FIXME: Use the other one
-    public void RegisterCompilationStartAction(Action<CompilationStartAnalysisContext> action) =>
-        context.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), x => action(x.Context)));
-
-    //public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
-    //    context.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
-
     /// <summary>
     /// Reads configuration from SonarProjectConfig.xml file and caches the result for scope of this analysis.
     /// </summary>

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
@@ -41,19 +41,9 @@ public partial class SonarAnalysisContext
     private static readonly SourceTextValueProvider<bool> ShouldAnalyzeGeneratedCS = CreateAnalyzeGeneratedProvider(LanguageNames.CSharp);
     private static readonly SourceTextValueProvider<bool> ShouldAnalyzeGeneratedVB = CreateAnalyzeGeneratedProvider(LanguageNames.VisualBasic);
     private static readonly SourceTextValueProvider<ProjectConfigReader> ProjectConfigProvider = new(x => new ProjectConfigReader(x));  // FIXME: Done
-    private static readonly ConditionalWeakTable<Compilation, ImmutableHashSet<string>> UnchangedFilesCache = new();                    // FIXME: Done
 
     public bool ShouldAnalyzeGenerated(Compilation c, AnalyzerOptions options) =>
         ShouldAnalyzeGenerated(context.TryGetValue, c, options);
-
-    public static bool ShouldAnalyze(TryGetValueDelegate<bool> tryGetBool,
-                                     TryGetValueDelegate<ProjectConfigReader> tryGetProjectConfigReader,
-                                     GeneratedCodeRecognizer generatedCodeRecognizer,
-                                     SyntaxTree tree,
-                                     Compilation compilation,
-                                     AnalyzerOptions options) =>
-        !IsUnchanged(tryGetProjectConfigReader, tree, compilation, options)
-        && (ShouldAnalyzeGenerated(tryGetBool, compilation, options) || !tree.IsGenerated(generatedCodeRecognizer, compilation));
 
     public bool IsScannerRun(AnalyzerOptions options) =>
         ProjectConfiguration(options).IsScannerRun;
@@ -110,12 +100,6 @@ public partial class SonarAnalysisContext
                 descriptor.CustomTags.Contains(tag);
         }
     }
-
-    public static bool IsUnchanged(TryGetValueDelegate<ProjectConfigReader> tryGetValue, SyntaxTree tree, Compilation compilation, AnalyzerOptions options) =>
-        UnchangedFilesCache.GetValue(compilation, _ => CreateUnchangedFilesHashSet(tryGetValue, options)).Contains(tree.FilePath);
-
-    private static ImmutableHashSet<string> CreateUnchangedFilesHashSet(TryGetValueDelegate<ProjectConfigReader> tryGetValue, AnalyzerOptions options) =>       // FIXME: Done
-        ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, ProjectConfiguration(tryGetValue, options).AnalysisConfig?.UnchangedFiles() ?? Array.Empty<string>());
 
     private static bool IsTestProject(TryGetValueDelegate<ProjectConfigReader> tryGetValue, Compilation compilation, AnalyzerOptions options)   // FIXME: Done
     {

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -64,17 +64,26 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     public override bool TryGetValue<TValue>(SourceText text, SourceTextValueProvider<TValue> valueProvider, out TValue value) =>
         context.TryGetValue(text, valueProvider, out value);
 
-    internal void RegisterCompilationAction(Action<SonarCompilationAnalysisContext> action) =>
+    public void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
+        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+
+    public void RegisterCompilationAction(Action<SonarCompilationAnalysisContext> action) =>
         context.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
 
-    internal void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-        context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
-
-    internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+    public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
+        context.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
 
     public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
         context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
+
+    public void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
+        context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
+
+    public void RegisterSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
+        context.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
+
+    public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>   // FIXME: Better name
+        c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));
 
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -34,8 +34,8 @@ public abstract class SonarAnalysisContextBase
 
     public abstract bool TryGetValue<TValue>(SourceText text, SourceTextValueProvider<TValue> valueProvider, out TValue value);
 
-    public bool ShouldAnalyze(GeneratedCodeRecognizer generatedCodeRecognizer, SyntaxTree tree, Compilation compilation, AnalyzerOptions options) =>
-        !IsUnchanged(tree, compilation, options)
+    public bool ShouldAnalyze(GeneratedCodeRecognizer generatedCodeRecognizer, SyntaxTree tree, Compilation compilation, AnalyzerOptions options) =>    // FIXME: This thing has confusing name
+        !IsUnchanged(tree, compilation, options)        // FIXME: This needs to go to
         && (ShouldAnalyzeGenerated(compilation, options) || !tree.IsGenerated(generatedCodeRecognizer, compilation));
 
     /// <summary>

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationAnalysisContext.cs
@@ -37,6 +37,14 @@ public sealed class SonarCompilationAnalysisContext : SonarAnalysisContextBase<C
     public void ReportIssue(Diagnostic diagnostic) =>
         ReportIssue(new ReportingContext(Context, diagnostic));
 
+    public void ReportDiagnosticIfNonGenerated(GeneratedCodeRecognizer generatedCodeRecognizer, Diagnostic diagnostic)
+    {
+        if (ShouldAnalyze(generatedCodeRecognizer, diagnostic.Location.SourceTree, Compilation, Options))
+        {
+            ReportIssue(diagnostic);
+        }
+    }
+
     internal IEnumerable<string> WebConfigFiles()
     {
         return ProjectConfiguration().FilesToAnalyze.FindFiles(WebConfigRegex).Where(ShouldProcess);

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
@@ -27,4 +27,10 @@ public sealed class SonarCompilationStartAnalysisContext : SonarAnalysisContextB
     public override AnalyzerOptions Options => Context.Options;
 
     internal SonarCompilationStartAnalysisContext(SonarAnalysisContext analysisContext, CompilationStartAnalysisContext context) : base(analysisContext, context) { }
+
+    public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
+        Context.RegisterSymbolAction(x => action(new(AnalysisContext, x)), symbolKinds);
+
+    public void RegisterCompilationEndAction(Action<SonarCompilationAnalysisContext> action) =>
+        Context.RegisterCompilationEndAction(x => action(new(AnalysisContext, x)));
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSymbolAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSymbolAnalysisContext.cs
@@ -34,7 +34,7 @@ public sealed class SonarSymbolAnalysisContext : SonarAnalysisContextBase<Symbol
 
     public void ReportDiagnosticIfNonGenerated(GeneratedCodeRecognizer generatedCodeRecognizer, Diagnostic diagnostic)
     {
-        if (ShouldAnalyze(generatedCodeRecognizer))
+        if (ShouldAnalyze(generatedCodeRecognizer, diagnostic.Location.SourceTree, Compilation, Options))
         {
             ReportIssue(diagnostic);
         }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxTreeAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxTreeAnalysisContext.cs
@@ -28,4 +28,7 @@ public sealed class SonarSyntaxTreeAnalysisContext : SonarAnalysisContextBase<Sy
 
     internal SonarSyntaxTreeAnalysisContext(SonarAnalysisContext analysisContext, SyntaxTreeAnalysisContext context, Compilation compilation) : base(analysisContext, context) =>
         Compilation = compilation;
+
+    public void ReportIssue(Diagnostic diagnostic) =>
+        ReportIssue(new ReportingContext(Context, diagnostic));
 }

--- a/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/ParameterLoadingDiagnosticAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/ParameterLoadingDiagnosticAnalyzer.cs
@@ -26,17 +26,14 @@ namespace SonarAnalyzer.Helpers
 
         protected sealed override void Initialize(SonarAnalysisContext context)
         {
-            var analysisContext = new ParameterLoadingAnalysisContext(context);
-            Initialize(analysisContext);
+            var parameterContext = new ParameterLoadingAnalysisContext(context);
+            Initialize(parameterContext);
 
             context.RegisterCompilationStartAction(
-                cac =>
+                c =>
                 {
-                    ParameterLoader.SetParameterValues(this, cac.Options);
-                    foreach (var compilationStartActions in analysisContext.CompilationStartActions)
-                    {
-                        compilationStartActions(cac);
-                    }
+                    ParameterLoader.SetParameterValues(this, c.Options);
+                    parameterContext.ExecutePostponedActions(c);
                 });
         }
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/LooseFilePermissionsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/LooseFilePermissionsBase.cs
@@ -25,17 +25,13 @@ namespace SonarAnalyzer.Rules
     {
         protected const string DiagnosticId = "S2612";
         protected const string Everyone = "Everyone";
-
         private const string MessageFormat = "Make sure this permission is safe.";
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
-
         protected readonly DiagnosticDescriptor Rule;
 
         protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
-
         protected abstract void VisitAssignments(SyntaxNodeAnalysisContext context);
-
         protected abstract void VisitInvocations(SyntaxNodeAnalysisContext context);
 
         protected LooseFilePermissionsBase(IAnalyzerConfiguration configuration) : base(configuration) =>
@@ -50,7 +46,6 @@ namespace SonarAnalyzer.Rules
                 }
 
                 c.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, VisitInvocations, Language.SyntaxKind.InvocationExpression);
-
                 c.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, VisitAssignments, Language.SyntaxKind.IdentifierName);
             });
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules
 
         protected override void Initialize(ParameterLoadingAnalysisContext context)
         {
-            context.RegisterCompilationStartAction(
+            context.RegisterPostponedAction(
                 c =>
                 {
                     var attributesOverTheLimit = new Dictionary<SyntaxNode, Attributes>();
@@ -116,7 +116,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void ReportOnCollectedAttributes(CompilationAnalysisContext context, IDictionary<SyntaxNode, Attributes> attributesOverTheLimit)
+        private void ReportOnCollectedAttributes(SonarCompilationAnalysisContext context, IDictionary<SyntaxNode, Attributes> attributesOverTheLimit)
         {
             foreach (var invalidAttributes in attributesOverTheLimit.Values)
             {

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/MethodDeclarationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/MethodDeclarationTracker.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Helpers.Trackers
                     }
                 });
 
-            void TrackMethodDeclaration(SymbolAnalysisContext c)
+            void TrackMethodDeclaration(SonarSymbolAnalysisContext c)
             {
                 if (!IsTrackedMethod((IMethodSymbol)c.Symbol, c.Compilation))
                 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Helpers
 {
-    public static class VisualBasicDiagnosticAnalyzerContextHelper
+    public static class VisualBasicDiagnosticAnalyzerContextHelper  // FIXME: Move and rename
     {
         public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context,
                                                                                Action<SyntaxNodeAnalysisContext> action,
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Helpers
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this CompilationStartAnalysisContext context,
+        public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this SonarCompilationStartAnalysisContext context,
                                                                                Action<SyntaxNodeAnalysisContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DoNotHardcodeCredentials.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DoNotHardcodeCredentials.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         internal /*for testing*/ DoNotHardcodeCredentials(IAnalyzerConfiguration configuration) : base(configuration) { }
 
         protected override void InitializeActions(ParameterLoadingAnalysisContext context) =>
-            context.RegisterCompilationStartAction(
+            context.RegisterPostponedAction(
                 c =>
                 {
                     if (!IsEnabled(c.Options))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/DiagnosticAnalyzerContextHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/DiagnosticAnalyzerContextHelperTest.cs
@@ -330,7 +330,7 @@ $@"namespace PartiallyGenerated
         var context = new DummyAnalysisContext(TestContext, unchangedFileName);
         var sut = new ParameterLoadingAnalysisContext(new(context, DummyMainDescriptor));
         sut.RegisterSyntaxTreeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, context.DelegateAction);
-        sut.CompilationStartActions.Single()(MockCompilationStartAnalysisContext(context));  // Manual invocation, because ParameterLoadingAnalysisContext stores actions separately
+        sut.ExecutePostponedActions(new(sut.Context, MockCompilationStartAnalysisContext(context)));  // Manual invocation, because ParameterLoadingAnalysisContext stores actions separately
 
         context.AssertDelegateInvoked(expected);
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.ShouldAnalyze.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.ShouldAnalyze.cs
@@ -69,9 +69,7 @@ public partial class SonarAnalysisContextTest
     private static bool ShouldAnalyze(AnalyzerOptions options)
     {
         var compilation = CreateDummyCompilation(AnalyzerLanguage.CSharp);
-        var context = CreateSut();
-
-        return SonarAnalysisContext.ShouldAnalyze(context.TryGetValue, context.TryGetValue, CSharpGeneratedCodeRecognizer.Instance, compilation.SyntaxTrees.First(), compilation, options);
+        return CreateSut().ShouldAnalyze(CSharpGeneratedCodeRecognizer.Instance, compilation.SyntaxTrees.First(), compilation, options);
     }
 
     private AnalyzerOptions CreateOptions(string[] unchangedFiles)


### PR DESCRIPTION
Part of #6540

* Migrate `RegisterCompilationStartAction` to the new Sonar-signature
