### PR TITLE
Refactor SonarAnalysisContext - Migrate helper methods

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/ParameterLoadingAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/ParameterLoadingAnalysisContext.cs
@@ -22,7 +22,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace SonarAnalyzer.Helpers;
 
-public sealed class ParameterLoadingAnalysisContext : SonarAnalysisContextBase // FIXME: Refactor: Use Sonar* prefix, change contract not to expose the collection, rename everything to "Postponed" to make it clear, add docs
+public sealed class ParameterLoadingAnalysisContext : SonarAnalysisContextBase
 {
     private readonly List<Action<SonarCompilationStartAnalysisContext>> postponedActions = new();
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
@@ -35,7 +35,7 @@ public partial class SonarAnalysisContext
 {
     public delegate bool TryGetValueDelegate<TValue>(SourceText text, SourceTextValueProvider<TValue> valueProvider, out TValue value);     // FIXME: Remove, new system doesn't need this anymore
 
-    private static readonly SourceTextValueProvider<ProjectConfigReader> ProjectConfigProvider = new(x => new ProjectConfigReader(x));  // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
+    private static readonly SourceTextValueProvider<ProjectConfigReader> ProjectConfigProvider = new(x => new ProjectConfigReader(x));      // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
 
     public bool IsScannerRun(AnalyzerOptions options) =>
         ProjectConfiguration(context.TryGetValue, options).IsScannerRun;
@@ -49,7 +49,7 @@ public partial class SonarAnalysisContext
     public static bool IsTestProject(CompilationAnalysisContext analysisContext) =>
         IsTestProject(analysisContext.TryGetValue, analysisContext.Compilation, analysisContext.Options);
 
-    internal static ProjectConfigReader ProjectConfiguration(TryGetValueDelegate<ProjectConfigReader> tryGetValue, AnalyzerOptions options) // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
+    private static ProjectConfigReader ProjectConfiguration(TryGetValueDelegate<ProjectConfigReader> tryGetValue, AnalyzerOptions options) // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
     {
         if (options.SonarProjectConfig() is { } sonarProjectConfigXml)
         {

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
@@ -20,7 +20,6 @@
 
 using System.IO;
 using Microsoft.CodeAnalysis.Text;
-using static SonarAnalyzer.Helpers.DiagnosticDescriptorFactory;
 
 namespace SonarAnalyzer;
 
@@ -63,25 +62,6 @@ public partial class SonarAnalysisContext
         else
         {
             return ProjectConfigReader.Empty;
-        }
-    }
-
-    internal static bool IsAnalysisScopeMatching(Compilation compilation, bool isTestProject, bool isScannerRun, IEnumerable<DiagnosticDescriptor> diagnostics)
-    {
-        // We don't know the project type without the compilation so let's run the rule
-        return compilation == null || diagnostics.Any(IsMatching);
-
-        bool IsMatching(DiagnosticDescriptor descriptor)
-        {
-            // MMF-2297: Test Code as 1st Class Citizen is not ready on server side yet.
-            // ScannerRun: Only utility rules and rules with TEST-ONLY scope are executed for test projects for now.
-            // SonarLint & Standalone Nuget: Respect the scope as before.
-            return isTestProject
-                ? ContainsTag(TestSourceScopeTag) && !(isScannerRun && ContainsTag(MainSourceScopeTag) && !ContainsTag(UtilityTag))
-                : ContainsTag(MainSourceScopeTag);
-
-            bool ContainsTag(string tag) =>
-                descriptor.CustomTags.Contains(tag);
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
@@ -40,14 +40,8 @@ public partial class SonarAnalysisContext
     public bool IsScannerRun(AnalyzerOptions options) =>                    // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
         ProjectConfiguration(context.TryGetValue, options).IsScannerRun;
 
-    public static bool IsScannerRun(CompilationAnalysisContext context) =>  // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
-        ProjectConfiguration(context.TryGetValue, context.Options).IsScannerRun;
-
     public bool IsTestProject(Compilation c, AnalyzerOptions options) =>    // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
         IsTestProject(context.TryGetValue, c, options);
-
-    public static bool IsTestProject(CompilationAnalysisContext analysisContext) => // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
-        IsTestProject(analysisContext.TryGetValue, analysisContext.Compilation, analysisContext.Options);
 
     private static ProjectConfigReader ProjectConfiguration(TryGetValueDelegate<ProjectConfigReader> tryGetValue, AnalyzerOptions options) // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
     {

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
@@ -38,10 +38,10 @@ public partial class SonarAnalysisContext
     private static readonly SourceTextValueProvider<ProjectConfigReader> ProjectConfigProvider = new(x => new ProjectConfigReader(x));      // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
 
     public bool IsScannerRun(AnalyzerOptions options) =>                    // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
-        ProjectConfiguration(context.TryGetValue, options).IsScannerRun;
+        ProjectConfiguration(analysisContext.TryGetValue, options).IsScannerRun;
 
     public bool IsTestProject(Compilation c, AnalyzerOptions options) =>    // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
-        IsTestProject(context.TryGetValue, c, options);
+        IsTestProject(analysisContext.TryGetValue, c, options);
 
     private static ProjectConfigReader ProjectConfiguration(TryGetValueDelegate<ProjectConfigReader> tryGetValue, AnalyzerOptions options) // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
     {

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
@@ -39,7 +39,7 @@ public partial class SonarAnalysisContext
     private static readonly SourceTextValueProvider<ProjectConfigReader> ProjectConfigProvider = new(x => new ProjectConfigReader(x));  // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
 
     public bool IsScannerRun(AnalyzerOptions options) =>
-        ProjectConfiguration(options).IsScannerRun;
+        ProjectConfiguration(context.TryGetValue, options).IsScannerRun;
 
     public static bool IsScannerRun(CompilationAnalysisContext context) =>
         ProjectConfiguration(context.TryGetValue, context.Options).IsScannerRun;
@@ -49,12 +49,6 @@ public partial class SonarAnalysisContext
 
     public static bool IsTestProject(CompilationAnalysisContext analysisContext) =>
         IsTestProject(analysisContext.TryGetValue, analysisContext.Compilation, analysisContext.Options);
-
-    /// <summary>
-    /// Reads configuration from SonarProjectConfig.xml file and caches the result for scope of this analysis.
-    /// </summary>
-    internal ProjectConfigReader ProjectConfiguration(AnalyzerOptions options) =>   // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
-        ProjectConfiguration(analysisContext.TryGetValue, options);
 
     internal static ProjectConfigReader ProjectConfiguration(TryGetValueDelegate<ProjectConfigReader> tryGetValue, AnalyzerOptions options) // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
     {

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
@@ -50,9 +50,6 @@ public partial class SonarAnalysisContext
     public static bool IsTestProject(CompilationAnalysisContext analysisContext) =>
         IsTestProject(analysisContext.TryGetValue, analysisContext.Compilation, analysisContext.Options);
 
-    internal static bool IsRegisteredActionEnabled(IEnumerable<DiagnosticDescriptor> diagnostics, SyntaxTree tree) =>
-        ShouldExecuteRegisteredAction == null || tree == null || ShouldExecuteRegisteredAction(diagnostics, tree);
-
     /// <summary>
     /// Reads configuration from SonarProjectConfig.xml file and caches the result for scope of this analysis.
     /// </summary>

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.ScrapYard.cs
@@ -33,20 +33,20 @@ namespace SonarAnalyzer;
 /// </summary>
 public partial class SonarAnalysisContext
 {
-    public delegate bool TryGetValueDelegate<TValue>(SourceText text, SourceTextValueProvider<TValue> valueProvider, out TValue value);     // FIXME: Remove, new system doesn't need this anymore
+    private delegate bool TryGetValueDelegate<TValue>(SourceText text, SourceTextValueProvider<TValue> valueProvider, out TValue value);     // FIXME: Remove, new system doesn't need this anymore
 
     private static readonly SourceTextValueProvider<ProjectConfigReader> ProjectConfigProvider = new(x => new ProjectConfigReader(x));      // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
 
-    public bool IsScannerRun(AnalyzerOptions options) =>
+    public bool IsScannerRun(AnalyzerOptions options) =>                    // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
         ProjectConfiguration(context.TryGetValue, options).IsScannerRun;
 
-    public static bool IsScannerRun(CompilationAnalysisContext context) =>
+    public static bool IsScannerRun(CompilationAnalysisContext context) =>  // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
         ProjectConfiguration(context.TryGetValue, context.Options).IsScannerRun;
 
-    public bool IsTestProject(Compilation c, AnalyzerOptions options) =>
-        IsTestProject(analysisContext.TryGetValue, c, options);
+    public bool IsTestProject(Compilation c, AnalyzerOptions options) =>    // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
+        IsTestProject(context.TryGetValue, c, options);
 
-    public static bool IsTestProject(CompilationAnalysisContext analysisContext) =>
+    public static bool IsTestProject(CompilationAnalysisContext analysisContext) => // FIXME: Remove, it was migrated to the SonarAnalysisContextBase
         IsTestProject(analysisContext.TryGetValue, analysisContext.Compilation, analysisContext.Options);
 
     private static ProjectConfigReader ProjectConfiguration(TryGetValueDelegate<ProjectConfigReader> tryGetValue, AnalyzerOptions options) // FIXME: Remove, it was migrated to the SonarAnalysisContextBase

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -85,6 +85,9 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
         c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));
 
+    internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
+        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {
         // For each action registered on context we need to do some pre-processing before actually calling the rule.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -95,7 +95,7 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
         // Second, we call an external delegate (set by SonarLint for VS) to ensure the rule should be run (usually
         // the decision is made on based on whether the project contains the analyzer as NuGet).
         var isTestProject = IsTestProject(context.Compilation, context.Options);
-        if (IsAnalysisScopeMatching(context.Compilation, isTestProject, IsScannerRun(context.Options), supportedDiagnostics) && LegacyIsRegisteredActionEnabled(supportedDiagnostics, context.Tree))
+        if (supportedDiagnostics.Any(x => x.HasMatchingScope(context.Compilation, isTestProject, IsScannerRun(context.Options))) && LegacyIsRegisteredActionEnabled(supportedDiagnostics, context.Tree))
         {
             action(context);
         }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -68,22 +68,22 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
         ShouldExecuteRegisteredAction == null || tree == null || ShouldExecuteRegisteredAction(diagnostics, tree);
 
     public void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+        analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
     public void RegisterCompilationAction(Action<SonarCompilationAnalysisContext> action) =>
-        context.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
+        analysisContext.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
 
     public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
-        context.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
+        analysisContext.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
 
     public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
-        context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
+        analysisContext.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
 
     public void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-        context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
+        analysisContext.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
 
     public void RegisterSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
-        context.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
+        analysisContext.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
 
     public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
         c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -85,9 +85,6 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
         c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));
 
-    internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
-
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {
         // For each action registered on context we need to do some pre-processing before actually calling the rule.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -92,10 +92,10 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     {
         // For each action registered on context we need to do some pre-processing before actually calling the rule.
         // First, we need to ensure the rule does apply to the current scope (main vs test source).
-        // Second, we call an external delegate (set by SonarLint for VS) to ensure the rule should be run (usually
+        // Second, we call an external delegate (set by legacy SonarLint for VS) to ensure the rule should be run (usually
         // the decision is made on based on whether the project contains the analyzer as NuGet).
-        var isTestProject = IsTestProject(context.Compilation, context.Options);
-        if (supportedDiagnostics.Any(x => x.HasMatchingScope(context.Compilation, isTestProject, IsScannerRun(context.Options))) && LegacyIsRegisteredActionEnabled(supportedDiagnostics, context.Tree))
+        if (supportedDiagnostics.Any(x => x.HasMatchingScope(context.Compilation, context.IsTestProject(), context.IsScannerRun()))
+            && LegacyIsRegisteredActionEnabled(supportedDiagnostics, context.Tree))
         {
             action(context);
         }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -64,6 +64,9 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     public override bool TryGetValue<TValue>(SourceText text, SourceTextValueProvider<TValue> valueProvider, out TValue value) =>
         analysisContext.TryGetValue(text, valueProvider, out value);
 
+    internal static bool LegacyIsRegisteredActionEnabled(IEnumerable<DiagnosticDescriptor> diagnostics, SyntaxTree tree) =>
+        ShouldExecuteRegisteredAction == null || tree == null || ShouldExecuteRegisteredAction(diagnostics, tree);
+
     public void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
         context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
@@ -92,7 +95,7 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
         // Second, we call an external delegate (set by SonarLint for VS) to ensure the rule should be run (usually
         // the decision is made on based on whether the project contains the analyzer as NuGet).
         var isTestProject = IsTestProject(context.Compilation, context.Options);
-        if (IsAnalysisScopeMatching(context.Compilation, isTestProject, IsScannerRun(context.Options), supportedDiagnostics) && IsRegisteredActionEnabled(supportedDiagnostics, context.Tree))
+        if (IsAnalysisScopeMatching(context.Compilation, isTestProject, IsScannerRun(context.Options), supportedDiagnostics) && LegacyIsRegisteredActionEnabled(supportedDiagnostics, context.Tree))
         {
             action(context);
         }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -32,9 +32,10 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     /// control whether or not the action should be executed.
     /// </summary>
     /// <remarks>
-    /// Currently this delegate is set by SonarLint (4.0+) when the project has the NuGet package installed to avoid
+    /// This delegate is set by old SonarLint (from v4.0 to v5.5) when the project has the NuGet package installed to avoid
     /// duplicated analysis and issues. When both the NuGet and the VSIX are available, NuGet will take precedence and VSIX
     /// will be inhibited.
+    /// This delegate was removed from SonarLint v6.0.
     /// </remarks>
     public static Func<IEnumerable<DiagnosticDescriptor>, SyntaxTree, bool> ShouldExecuteRegisteredAction { get; set; }
 
@@ -64,6 +65,9 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     public override bool TryGetValue<TValue>(SourceText text, SourceTextValueProvider<TValue> valueProvider, out TValue value) =>
         analysisContext.TryGetValue(text, valueProvider, out value);
 
+    /// <summary>
+    /// Legacy API for backward compatibility with SonarLint v4.0 - v5.5. See <see cref="ShouldExecuteRegisteredAction"/>.
+    /// </summary>
     internal static bool LegacyIsRegisteredActionEnabled(IEnumerable<DiagnosticDescriptor> diagnostics, SyntaxTree tree) =>
         ShouldExecuteRegisteredAction == null || tree == null || ShouldExecuteRegisteredAction(diagnostics, tree);
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -65,22 +65,22 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
         analysisContext.TryGetValue(text, valueProvider, out value);
 
     public void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
     public void RegisterCompilationAction(Action<SonarCompilationAnalysisContext> action) =>
-        analysisContext.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
+        context.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
 
     public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
-        analysisContext.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
+        context.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
 
     public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
-        analysisContext.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
+        context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
 
     public void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-        analysisContext.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
+        context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
 
     public void RegisterSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
-        analysisContext.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
+        context.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
 
     public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
         c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -121,20 +121,19 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
 
     private protected void ReportIssue(ReportingContext reportingContext)
     {
-        if (!SonarAnalysisContext.IsAnalysisScopeMatching(reportingContext.Compilation, IsTestProject(), ProjectConfiguration().IsScannerRun, new[] { reportingContext.Diagnostic.Descriptor }))
+        if (!reportingContext.Diagnostic.Descriptor.HasMatchingScope(reportingContext.Compilation, IsTestProject(), ProjectConfiguration().IsScannerRun))
         {
             return;
         }
 
-        if (reportingContext is { Compilation: { } compilation, Diagnostic.Location: { Kind: LocationKind.SourceFile, SourceTree: { } syntaxTree } }
-            && !compilation.ContainsSyntaxTree(syntaxTree))
+        if (reportingContext is { Compilation: { } compilation, Diagnostic.Location: { Kind: LocationKind.SourceFile, SourceTree: { } tree } } && !compilation.ContainsSyntaxTree(tree))
         {
             Debug.Fail("Primary location should be part of the compilation. An AD0001 is raised if this is not the case.");
             return;
         }
 
         // This is the current way SonarLint will handle how and what to report.
-        if (SonarAnalysisContext.ReportDiagnostic != null)
+        if (SonarAnalysisContext.ReportDiagnostic is not null)
         {
             Debug.Assert(SonarAnalysisContext.ShouldDiagnosticBeReported == null, "Not expecting SonarLint to set both the old and the new delegates.");
             SonarAnalysisContext.ReportDiagnostic(reportingContext);

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -108,9 +108,12 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
     public ProjectConfigReader ProjectConfiguration() =>
         ProjectConfiguration(Options);
 
+    public bool IsScannerRun() =>
+        ProjectConfiguration().IsScannerRun;
+
     public bool IsTestProject()
     {
-        var projectType = ProjectConfiguration(Options).ProjectType;
+        var projectType = ProjectConfiguration().ProjectType;
         return projectType == ProjectType.Unknown
             ? Compilation.IsTest()              // SonarLint, NuGet or Scanner <= 5.0
             : projectType == ProjectType.Test;  // Scanner >= 5.1 does authoritative decision that we follow

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -129,7 +129,8 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
             return;
         }
 
-        if (reportingContext is { Compilation: { } compilation, Diagnostic.Location: { Kind: LocationKind.SourceFile, SourceTree: { } tree } } && !compilation.ContainsSyntaxTree(tree))
+        if (reportingContext is { Compilation: { } compilation, Diagnostic.Location: { Kind: LocationKind.SourceFile, SourceTree: { } tree } }
+            && !compilation.ContainsSyntaxTree(tree))
         {
             Debug.Fail("Primary location should be part of the compilation. An AD0001 is raised if this is not the case.");
             return;

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -41,7 +41,7 @@ public abstract class SonarAnalysisContextBase
     /// <summary>
     /// Reads configuration from SonarProjectConfig.xml file and caches the result for scope of this analysis.
     /// </summary>
-    protected ProjectConfigReader ProjectConfiguration(AnalyzerOptions options)
+    public ProjectConfigReader ProjectConfiguration(AnalyzerOptions options)
     {
         if (options.SonarProjectConfig() is { } sonarProjectConfig)
         {

--- a/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/ParameterLoadingDiagnosticAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/ParameterLoadingDiagnosticAnalyzer.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Helpers
 {
-    public abstract class ParameterLoadingDiagnosticAnalyzer : SonarDiagnosticAnalyzer
+    public abstract class ParameterLoadingDiagnosticAnalyzer : SonarDiagnosticAnalyzer  // FIXME: Rename To Sonar*
     {
         protected abstract void Initialize(ParameterLoadingAnalysisContext context);
 

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/DiagnosticDescriptorExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/DiagnosticDescriptorExtensions.cs
@@ -50,6 +50,4 @@ public static class DiagnosticDescriptorExtensions
 
     private static bool IsLocationValid(Location location, Compilation compilation) =>
         location.Kind != LocationKind.SourceFile || compilation.ContainsSyntaxTree(location.SourceTree);
-
-
 }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
@@ -56,9 +56,6 @@ namespace SonarAnalyzer.Helpers
         public static void ReportIssue(this SyntaxTreeAnalysisContext context, Diagnostic diagnostic) =>
             ReportIssue(new ReportingContext(context, diagnostic), null, null);
 
-        public static void ReportIssue(this CompilationAnalysisContext context, Diagnostic diagnostic) =>
-            ReportIssue(new ReportingContext(context, diagnostic), SonarAnalysisContext.IsTestProject(context), SonarAnalysisContext.IsScannerRun(context));
-
         /// <param name="verifyScopeContext">Provide value for this argument only if the class has more than one SupportedDiagnostics.</param>
         public static void ReportIssue(this SymbolAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext = null) =>
             ReportIssue(new ReportingContext(context, diagnostic), verifyScopeContext?.IsTestProject(context.Compilation, context.Options), verifyScopeContext?.IsScannerRun(context.Options));

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
@@ -57,10 +57,6 @@ namespace SonarAnalyzer.Helpers
             ReportIssue(new ReportingContext(context, diagnostic), null, null);
 
         /// <param name="verifyScopeContext">Provide value for this argument only if the class has more than one SupportedDiagnostics.</param>
-        public static void ReportIssue(this SymbolAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext = null) =>
-            ReportIssue(new ReportingContext(context, diagnostic), verifyScopeContext?.IsTestProject(context.Compilation, context.Options), verifyScopeContext?.IsScannerRun(context.Options));
-
-        /// <param name="verifyScopeContext">Provide value for this argument only if the class has more than one SupportedDiagnostics.</param>
         public static void ReportIssue(this CodeBlockAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext = null) =>
             ReportIssue(new ReportingContext(context, diagnostic), verifyScopeContext?.IsTestProject(context.SemanticModel.Compilation, context.Options),
                 verifyScopeContext?.IsScannerRun(context.Options));

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/SonarCodeFix.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/SonarCodeFix.cs
@@ -34,13 +34,13 @@ public abstract class SonarCodeFix : CodeFixProvider
         var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
         /// This only disables code-fixes when different versions are loaded
-        /// In case of analyzers, <see cref="SonarAnalysisContext.IsRegisteredActionEnabled"/> is sufficient, because Roslyn only
+        /// In case of analyzers, <see cref="SonarAnalysisContext.LegacyIsRegisteredActionEnabled"/> is sufficient, because Roslyn only
         /// creates a single instance from each assembly-version, so we can disable the VSIX analyzers
         /// In case of code fix providers Roslyn creates multiple instances of the code fix providers. Which means that
         /// we can only disable one of them if they are created from different assembly-versions.
         /// If the VSIX and the NuGet has the same version, then code fixes show up multiple times, this ticket will fix
         /// this problem: https://github.com/dotnet/roslyn/issues/4030
-        if (SonarAnalysisContext.IsRegisteredActionEnabled(Enumerable.Empty<DiagnosticDescriptor>(), syntaxRoot.SyntaxTree))
+        if (SonarAnalysisContext.LegacyIsRegisteredActionEnabled(Enumerable.Empty<DiagnosticDescriptor>(), syntaxRoot.SyntaxTree))
         {
             await RegisterCodeFixesAsync(syntaxRoot, context).ConfigureAwait(false);
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/EmptyMethodBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/EmptyMethodBase.cs
@@ -35,8 +35,7 @@ namespace SonarAnalyzer.Rules
                 {
                     if (c.ShouldAnalyze(GeneratedCodeRecognizer))
                     {
-                        var isTestProject = context.IsTestProject(c.Compilation, c.Options);
-                        CheckMethod(c.Context, isTestProject);
+                        CheckMethod(c.Context, c.IsTestProject());
                     }
                 },
                 SyntaxKinds.ToArray());

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules
 
         // We need to rewrite this https://github.com/SonarSource/sonar-dotnet/issues/4824
         protected static bool IsEnabled(SyntaxNodeAnalysisContext context, bool isTestProject, bool isScannerRun, DiagnosticDescriptor descriptor) =>
-            SonarAnalysisContext.IsAnalysisScopeMatching(context.Compilation, isTestProject, isScannerRun, new[] { descriptor })
+            descriptor.HasMatchingScope(context.Compilation, isTestProject, isScannerRun)
             && descriptor.GetEffectiveSeverity(context.Compilation.Options) != ReportDiagnostic.Suppress;
 
         protected void Analyze<TNode>(SonarAnalysisContext analysisContext, SyntaxNodeAnalysisContext context, Func<TNode, SyntaxNode> getBody) where TNode : SyntaxNode

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.ShouldAnalyze.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.ShouldAnalyze.cs
@@ -53,7 +53,7 @@ public partial class SonarAnalysisContextTest
     [TestMethod]
     public void ShouldAnalyze_Scanner_UnchangedFiles_ContainsTreeFile()
     {
-        var options = CreateOptions(new[] { "snippet0.cs" });
+        var options = CreateOptions(new[] { OtherFileName + "cs" });
 
         ShouldAnalyze(options).Should().BeFalse("File is known to be Unchanged in Incremental PR analysis");
     }
@@ -61,7 +61,7 @@ public partial class SonarAnalysisContextTest
     [TestMethod]
     public void ShouldAnalyze_Scanner_UnchangedFiles_ContainsOtherFile()
     {
-        var options = CreateOptions(new[] { "OtherFile.cs", "SomethingElse.cs" });
+        var options = CreateOptions(new[] { "ThisIsNotInCompilation.cs", "SomethingElse.cs" });
 
         ShouldAnalyze(options).Should().BeTrue();
     }
@@ -69,7 +69,7 @@ public partial class SonarAnalysisContextTest
     private static bool ShouldAnalyze(AnalyzerOptions options)
     {
         var compilation = CreateDummyCompilation(AnalyzerLanguage.CSharp);
-        return CreateSut().ShouldAnalyze(CSharpGeneratedCodeRecognizer.Instance, compilation.SyntaxTrees.First(), compilation, options);
+        return CreateSut().ShouldAnalyze(CSharpGeneratedCodeRecognizer.Instance, compilation.SyntaxTrees.Single(x => x.FilePath.Contains(OtherFileName)), compilation, options);
     }
 
     private AnalyzerOptions CreateOptions(string[] unchangedFiles)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.ShouldAnalyze.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.ShouldAnalyze.cs
@@ -68,8 +68,8 @@ public partial class SonarAnalysisContextTest
 
     private static bool ShouldAnalyze(AnalyzerOptions options)
     {
-        var compilation = CreateDummyCompilation(AnalyzerLanguage.CSharp);
-        return CreateSut().ShouldAnalyze(CSharpGeneratedCodeRecognizer.Instance, compilation.SyntaxTrees.Single(x => x.FilePath.Contains(OtherFileName)), compilation, options);
+        var (compilation, tree) = CreateDummyCompilation(AnalyzerLanguage.CSharp, OtherFileName);
+        return CreateSut().ShouldAnalyze(CSharpGeneratedCodeRecognizer.Instance, tree, compilation, options);
     }
 
     private AnalyzerOptions CreateOptions(string[] unchangedFiles)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.ShouldAnalyze.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.ShouldAnalyze.cs
@@ -53,7 +53,7 @@ public partial class SonarAnalysisContextTest
     [TestMethod]
     public void ShouldAnalyze_Scanner_UnchangedFiles_ContainsTreeFile()
     {
-        var options = CreateOptions(new[] { OtherFileName + "cs" });
+        var options = CreateOptions(new[] { OtherFileName + ".cs" });
 
         ShouldAnalyze(options).Should().BeFalse("File is known to be Unchanged in Incremental PR analysis");
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.cs
@@ -29,10 +29,6 @@ namespace SonarAnalyzer.UnitTest;
 [TestClass]
 public partial class SonarAnalysisContextTest
 {
-    private const string MainTag = "MainSourceScope";
-    private const string TestTag = "TestSourceScope";
-    private const string UtilityTag = "Utility";
-
     public TestContext TestContext { get; set; }
 
     private sealed class TestSetup
@@ -339,81 +335,6 @@ public partial class SonarAnalysisContextTest
            .Should()
            .Throw<InvalidOperationException>()
            .WithMessage("File SonarProjectConfig.xml has been added as an AdditionalFile but could not be read and parsed.");
-    }
-
-    [TestMethod]
-    public void IsAnalysisScopeMatching_NoCompilation_IsMatching() =>
-        SonarAnalysisContext.IsAnalysisScopeMatching(null, true, false, null).Should().BeTrue();
-
-    [DataTestMethod]
-    [DataRow(true, ProjectType.Product, MainTag)]
-    [DataRow(true, ProjectType.Product, MainTag, UtilityTag)]
-    [DataRow(true, ProjectType.Product, MainTag, TestTag)]
-    [DataRow(true, ProjectType.Product, MainTag, TestTag, UtilityTag)]
-    [DataRow(true, ProjectType.Test, TestTag)]
-    [DataRow(true, ProjectType.Test, TestTag, UtilityTag)]
-    [DataRow(true, ProjectType.Test, MainTag, TestTag)]
-    [DataRow(true, ProjectType.Test, MainTag, TestTag, UtilityTag)]
-    [DataRow(false, ProjectType.Product, TestTag)]
-    [DataRow(false, ProjectType.Product, TestTag, TestTag)]
-    [DataRow(false, ProjectType.Test, MainTag)]
-    [DataRow(false, ProjectType.Test, MainTag, MainTag)]
-    public void IsAnalysisScopeMatching_SingleDiagnostic_WithOneOrMoreScopes_SonarLint(bool expectedResult, ProjectType projectType, params string[] ruleTags)
-    {
-        var compilation = new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation;
-        var diagnostic = TestHelper.CreateDescriptor("Sxxx", ruleTags);
-        SonarAnalysisContext.IsAnalysisScopeMatching(compilation, projectType == ProjectType.Test, false, new[] { diagnostic }).Should().Be(expectedResult);
-    }
-
-    [DataTestMethod]
-    [DataRow(true, ProjectType.Product, MainTag)]
-    [DataRow(true, ProjectType.Product, MainTag, UtilityTag)]
-    [DataRow(true, ProjectType.Product, MainTag, TestTag)]
-    [DataRow(true, ProjectType.Product, MainTag, TestTag, UtilityTag)]
-    [DataRow(true, ProjectType.Test, TestTag)]
-    [DataRow(true, ProjectType.Test, TestTag, UtilityTag)]
-    [DataRow(true, ProjectType.Test, MainTag, TestTag, UtilityTag)]     // Utility rules with scope Test&Main do run on test code under scanner context.
-    [DataRow(false, ProjectType.Test, MainTag, TestTag)]                // Rules with scope Test&Main do not run on test code under scanner context for now.
-    [DataRow(false, ProjectType.Product, TestTag)]
-    [DataRow(false, ProjectType.Product, TestTag, UtilityTag)]
-    [DataRow(false, ProjectType.Product, TestTag, TestTag)]
-    [DataRow(false, ProjectType.Test, MainTag)]
-    [DataRow(false, ProjectType.Test, MainTag, UtilityTag)]
-    [DataRow(false, ProjectType.Test, MainTag, MainTag)]
-    public void IsAnalysisScopeMatching_SingleDiagnostic_WithOneOrMoreScopes_Scanner(bool expectedResult, ProjectType projectType, params string[] ruleTags)
-    {
-        var compilation = new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation;
-        var diagnostic = TestHelper.CreateDescriptor("Sxxx", ruleTags);
-        SonarAnalysisContext.IsAnalysisScopeMatching(compilation, projectType == ProjectType.Test, true, new[] { diagnostic }).Should().Be(expectedResult);
-    }
-
-    [DataTestMethod]
-    [DataRow(true, ProjectType.Product, MainTag, MainTag)]
-    [DataRow(true, ProjectType.Product, MainTag, MainTag)]
-    [DataRow(true, ProjectType.Product, MainTag, TestTag)]
-    [DataRow(true, ProjectType.Test, TestTag, TestTag)]
-    [DataRow(true, ProjectType.Test, TestTag, MainTag)]
-    [DataRow(false, ProjectType.Product, TestTag, TestTag)]
-    [DataRow(false, ProjectType.Test, MainTag, MainTag)]
-    public void IsAnalysisScopeMatching_MultipleDiagnostics_WithSingleScope_SonarLint(bool expectedResult, ProjectType projectType, params string[] rulesTag)
-    {
-        var compilation = new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation;
-        var diagnostics = rulesTag.Select(x => TestHelper.CreateDescriptor("Sxxx", x));
-        SonarAnalysisContext.IsAnalysisScopeMatching(compilation, projectType == ProjectType.Test, false, diagnostics).Should().Be(expectedResult);
-    }
-
-    [DataTestMethod]
-    [DataRow(true, ProjectType.Product, MainTag, MainTag)]
-    [DataRow(true, ProjectType.Product, MainTag, TestTag)]
-    [DataRow(true, ProjectType.Test, TestTag, TestTag)]
-    [DataRow(true, ProjectType.Test, TestTag, MainTag)]    // Rules with scope Test&Main will run to let the Test diagnostics to be detected. ReportDiagnostic should filter Main issues out.
-    [DataRow(false, ProjectType.Product, TestTag, TestTag)]
-    [DataRow(false, ProjectType.Test, MainTag, MainTag)]
-    public void IsAnalysisScopeMatching_MultipleDiagnostics_WithSingleScope_Scanner(bool expectedResult, ProjectType projectType, params string[] rulesTag)
-    {
-        var compilation = new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation;
-        var diagnostics = rulesTag.Select(x => TestHelper.CreateDescriptor("Sxxx", x));
-        SonarAnalysisContext.IsAnalysisScopeMatching(compilation, projectType == ProjectType.Test, true, diagnostics).Should().Be(expectedResult);
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.cs
@@ -322,7 +322,7 @@ public partial class SonarAnalysisContextTest
         sut.Invoking(x => x.ProjectConfiguration(options))
            .Should()
            .Throw<InvalidOperationException>()
-           .WithMessage("File SonarProjectConfig.xml has been added as an AdditionalFile but could not be read and parsed.");
+           .WithMessage("File 'SonarProjectConfig.xml' has been added as an AdditionalFile but could not be read and parsed.");
     }
 
     [TestMethod]
@@ -335,7 +335,7 @@ public partial class SonarAnalysisContextTest
         sut.Invoking(x => x.ProjectConfiguration(options))
            .Should()
            .Throw<InvalidOperationException>()
-           .WithMessage("File SonarProjectConfig.xml has been added as an AdditionalFile but could not be read and parsed.");
+           .WithMessage("File 'SonarProjectConfig.xml' has been added as an AdditionalFile but could not be read and parsed.");
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/DiagnosticDescriptorExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/DiagnosticDescriptorExtensionsTest.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2022 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.Extensions;
+
+using static SonarAnalyzer.Helpers.DiagnosticDescriptorFactory;
+
+namespace SonarAnalyzer.UnitTest.Extensions;
+
+[TestClass]
+public class DiagnosticDescriptorExtensionsTest
+{
+    private const string MainTag = "MainSourceScope";
+    private const string TestTag = "TestSourceScope";
+    private const string UtilityTag = "Utility";
+
+    [TestMethod]
+    public void HasMatchingScope_NoCompilation_IsMatching() =>
+        TestHelper.CreateDescriptor("Sxxx").HasMatchingScope(null, true, false).Should().BeTrue();
+
+    [DataTestMethod]
+    [DataRow(true, ProjectType.Product, MainTag)]
+    [DataRow(true, ProjectType.Product, MainTag, UtilityTag)]
+    [DataRow(true, ProjectType.Product, MainTag, TestTag)]
+    [DataRow(true, ProjectType.Product, MainTag, TestTag, UtilityTag)]
+    [DataRow(true, ProjectType.Test, TestTag)]
+    [DataRow(true, ProjectType.Test, TestTag, UtilityTag)]
+    [DataRow(true, ProjectType.Test, MainTag, TestTag)]
+    [DataRow(true, ProjectType.Test, MainTag, TestTag, UtilityTag)]
+    [DataRow(false, ProjectType.Product, TestTag)]
+    [DataRow(false, ProjectType.Product, TestTag, TestTag)]
+    [DataRow(false, ProjectType.Test, MainTag)]
+    [DataRow(false, ProjectType.Test, MainTag, MainTag)]
+    public void HasMatchingScope_SingleDiagnostic_WithOneOrMoreScopes_SonarLint(bool expectedResult, ProjectType projectType, params string[] ruleTags)
+    {
+        var compilation = new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation;
+        var diagnostic = TestHelper.CreateDescriptor("Sxxx", ruleTags);
+        diagnostic.HasMatchingScope(compilation, projectType == ProjectType.Test, false).Should().Be(expectedResult);
+    }
+
+    [DataTestMethod]
+    [DataRow(true, ProjectType.Product, MainTag)]
+    [DataRow(true, ProjectType.Product, MainTag, UtilityTag)]
+    [DataRow(true, ProjectType.Product, MainTag, TestTag)]
+    [DataRow(true, ProjectType.Product, MainTag, TestTag, UtilityTag)]
+    [DataRow(true, ProjectType.Test, TestTag)]
+    [DataRow(true, ProjectType.Test, TestTag, UtilityTag)]
+    [DataRow(true, ProjectType.Test, MainTag, TestTag, UtilityTag)]     // Utility rules with scope Test&Main do run on test code under scanner context.
+    [DataRow(false, ProjectType.Test, MainTag, TestTag)]                // Rules with scope Test&Main do not run on test code under scanner context for now.
+    [DataRow(false, ProjectType.Product, TestTag)]
+    [DataRow(false, ProjectType.Product, TestTag, UtilityTag)]
+    [DataRow(false, ProjectType.Product, TestTag, TestTag)]
+    [DataRow(false, ProjectType.Test, MainTag)]
+    [DataRow(false, ProjectType.Test, MainTag, UtilityTag)]
+    [DataRow(false, ProjectType.Test, MainTag, MainTag)]
+    public void HasMatchingScope_SingleDiagnostic_WithOneOrMoreScopes_Scanner(bool expectedResult, ProjectType projectType, params string[] ruleTags)
+    {
+        var compilation = new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation;
+        var diagnostic = TestHelper.CreateDescriptor("Sxxx", ruleTags);
+        diagnostic.HasMatchingScope(compilation, projectType == ProjectType.Test, true).Should().Be(expectedResult);
+    }
+
+    [DataTestMethod]
+    [DataRow(true, ProjectType.Product, MainTag, MainTag)]
+    [DataRow(true, ProjectType.Product, MainTag, MainTag)]
+    [DataRow(true, ProjectType.Product, MainTag, TestTag)]
+    [DataRow(true, ProjectType.Test, TestTag, TestTag)]
+    [DataRow(true, ProjectType.Test, TestTag, MainTag)]
+    [DataRow(false, ProjectType.Product, TestTag, TestTag)]
+    [DataRow(false, ProjectType.Test, MainTag, MainTag)]
+    public void HasMatchingScope_MultipleDiagnostics_WithSingleScope_SonarLint(bool expectedResult, ProjectType projectType, params string[] rulesTag)
+    {
+        var compilation = new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation;
+        var diagnostics = rulesTag.Select(x => TestHelper.CreateDescriptor("Sxxx", x));
+        diagnostics.Any(x => x.HasMatchingScope(compilation, projectType == ProjectType.Test, false)).Should().Be(expectedResult);
+    }
+
+    [DataTestMethod]
+    [DataRow(true, ProjectType.Product, MainTag, MainTag)]
+    [DataRow(true, ProjectType.Product, MainTag, TestTag)]
+    [DataRow(true, ProjectType.Test, TestTag, TestTag)]
+    [DataRow(true, ProjectType.Test, TestTag, MainTag)]    // Rules with scope Test&Main will run to let the Test diagnostics to be detected. ReportDiagnostic should filter Main issues out.
+    [DataRow(false, ProjectType.Product, TestTag, TestTag)]
+    [DataRow(false, ProjectType.Test, MainTag, MainTag)]
+    public void HasMatchingScope_MultipleDiagnostics_WithSingleScope_Scanner(bool expectedResult, ProjectType projectType, params string[] rulesTag)
+    {
+        var compilation = new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation;
+        var diagnostics = rulesTag.Select(x => TestHelper.CreateDescriptor("Sxxx", x));
+        diagnostics.Any(x => x.HasMatchingScope(compilation, projectType == ProjectType.Test, true)).Should().Be(expectedResult);
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/DiagnosticDescriptorExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/DiagnosticDescriptorExtensionsTest.cs
@@ -30,10 +30,11 @@ public class DiagnosticDescriptorExtensionsTest
     private const string MainTag = "MainSourceScope";
     private const string TestTag = "TestSourceScope";
     private const string UtilityTag = "Utility";
+    private const string DummyID = "Sxxx";
 
     [TestMethod]
     public void HasMatchingScope_NoCompilation_IsMatching() =>
-        TestHelper.CreateDescriptor("Sxxx").HasMatchingScope(null, true, false).Should().BeTrue();
+        TestHelper.CreateDescriptor(DummyID).HasMatchingScope(null, true, false).Should().BeTrue();
 
     [DataTestMethod]
     [DataRow(true, ProjectType.Product, MainTag)]
@@ -51,7 +52,7 @@ public class DiagnosticDescriptorExtensionsTest
     public void HasMatchingScope_SingleDiagnostic_WithOneOrMoreScopes_SonarLint(bool expectedResult, ProjectType projectType, params string[] ruleTags)
     {
         var compilation = new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation;
-        var diagnostic = TestHelper.CreateDescriptor("Sxxx", ruleTags);
+        var diagnostic = TestHelper.CreateDescriptor(DummyID, ruleTags);
         diagnostic.HasMatchingScope(compilation, projectType == ProjectType.Test, false).Should().Be(expectedResult);
     }
 
@@ -73,7 +74,7 @@ public class DiagnosticDescriptorExtensionsTest
     public void HasMatchingScope_SingleDiagnostic_WithOneOrMoreScopes_Scanner(bool expectedResult, ProjectType projectType, params string[] ruleTags)
     {
         var compilation = new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation;
-        var diagnostic = TestHelper.CreateDescriptor("Sxxx", ruleTags);
+        var diagnostic = TestHelper.CreateDescriptor(DummyID, ruleTags);
         diagnostic.HasMatchingScope(compilation, projectType == ProjectType.Test, true).Should().Be(expectedResult);
     }
 
@@ -88,7 +89,7 @@ public class DiagnosticDescriptorExtensionsTest
     public void HasMatchingScope_MultipleDiagnostics_WithSingleScope_SonarLint(bool expectedResult, ProjectType projectType, params string[] rulesTag)
     {
         var compilation = new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation;
-        var diagnostics = rulesTag.Select(x => TestHelper.CreateDescriptor("Sxxx", x));
+        var diagnostics = rulesTag.Select(x => TestHelper.CreateDescriptor(DummyID, x));
         diagnostics.Any(x => x.HasMatchingScope(compilation, projectType == ProjectType.Test, false)).Should().Be(expectedResult);
     }
 
@@ -102,7 +103,7 @@ public class DiagnosticDescriptorExtensionsTest
     public void HasMatchingScope_MultipleDiagnostics_WithSingleScope_Scanner(bool expectedResult, ProjectType projectType, params string[] rulesTag)
     {
         var compilation = new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation;
-        var diagnostics = rulesTag.Select(x => TestHelper.CreateDescriptor("Sxxx", x));
+        var diagnostics = rulesTag.Select(x => TestHelper.CreateDescriptor(DummyID, x));
         diagnostics.Any(x => x.HasMatchingScope(compilation, projectType == ProjectType.Test, true)).Should().Be(expectedResult);
     }
 }


### PR DESCRIPTION
Part of #6540

Review per commit should show how individual steps were made:
* Move `IsAnalysisScopeMatching` into an extension
* Move `IsRegisteredActionEnabled` - renamed to `LegacyIsRegisteredActionEnabled`
* Remove `ShouldAnalyzeGenerated` - rewrote UTs to match the new state and test all scenarios properly
