### PR TITLE
Refactor SonarAnalysisContext - Migrate ReportIssue for Tree and CodeBlock

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Helpers
         public static void RegisterSyntaxTreeActionInNonGenerated(this ParameterLoadingAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
             context.RegisterSyntaxTreeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterCodeBlockStartActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context, Action<CodeBlockStartAnalysisContext<TSyntaxKind>> action)
+        public static void RegisterCodeBlockStartActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action)
             where TSyntaxKind : struct =>
             context.RegisterCodeBlockStartActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
@@ -37,10 +37,10 @@ namespace SonarAnalyzer.Helpers
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterSyntaxTreeActionInNonGenerated(this SonarAnalysisContext context, Action<SyntaxTreeAnalysisContext> action) =>
+        public static void RegisterSyntaxTreeActionInNonGenerated(this SonarAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
             context.RegisterSyntaxTreeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterSyntaxTreeActionInNonGenerated(this ParameterLoadingAnalysisContext context, Action<SyntaxTreeAnalysisContext> action) =>
+        public static void RegisterSyntaxTreeActionInNonGenerated(this ParameterLoadingAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
             context.RegisterSyntaxTreeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action);
 
         public static void RegisterCodeBlockStartActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context, Action<CodeBlockStartAnalysisContext<TSyntaxKind>> action)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentedOutCode.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentedOutCode.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     }
                 });
 
-        private static void CheckTrivias(SyntaxTreeAnalysisContext context, IEnumerable<SyntaxTrivia> trivias)
+        private static void CheckTrivias(SonarSyntaxTreeAnalysisContext context, IEnumerable<SyntaxTrivia> trivias)
         {
             var shouldReport = true;
             foreach (var trivia in trivias)
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckMultilineComment(SyntaxTreeAnalysisContext context, SyntaxTrivia trivia)
+        private static void CheckMultilineComment(SonarSyntaxTreeAnalysisContext context, SyntaxTrivia trivia)
         {
             var triviaLines = TriviaContent().Split(MetricsBase.LineTerminators, StringSplitOptions.None);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentedOutCode.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentedOutCode.cs
@@ -41,28 +41,28 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     foreach (var token in c.Tree.GetRoot().DescendantTokens())
                     {
-                        CheckTrivias(c, token.LeadingTrivia);
-                        CheckTrivias(c, token.TrailingTrivia);
+                        CheckTrivia(c, token.LeadingTrivia);
+                        CheckTrivia(c, token.TrailingTrivia);
                     }
                 });
 
-        private static void CheckTrivias(SonarSyntaxTreeAnalysisContext context, IEnumerable<SyntaxTrivia> trivias)
+        private static void CheckTrivia(SonarSyntaxTreeAnalysisContext context, IEnumerable<SyntaxTrivia> trivia)
         {
             var shouldReport = true;
-            foreach (var trivia in trivias)
+            foreach (var trivium in trivia)
             {
                 // comment start is checked because of  https://github.com/dotnet/roslyn/issues/10003
-                if (trivia.IsKind(SyntaxKind.MultiLineCommentTrivia) && !trivia.ToFullString().TrimStart().StartsWith("/**", StringComparison.Ordinal))
+                if (trivium.IsKind(SyntaxKind.MultiLineCommentTrivia) && !trivium.ToFullString().TrimStart().StartsWith("/**", StringComparison.Ordinal))
                 {
-                    CheckMultilineComment(context, trivia);
+                    CheckMultilineComment(context, trivium);
                     shouldReport = true;
                 }
                 else if (shouldReport
-                    && trivia.IsKind(SyntaxKind.SingleLineCommentTrivia)
-                    && !trivia.ToFullString().TrimStart().StartsWith("///", StringComparison.Ordinal)
-                    && IsCode(trivia.ToString().Substring(CommentMarkLength)))
+                    && trivium.IsKind(SyntaxKind.SingleLineCommentTrivia)
+                    && !trivium.ToFullString().TrimStart().StartsWith("///", StringComparison.Ordinal)
+                    && IsCode(trivium.ToString().Substring(CommentMarkLength)))
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, trivia.GetLocation()));
+                    context.ReportIssue(Diagnostic.Create(Rule, trivium.GetLocation()));
                     shouldReport = false;
                 }
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeEqualsOverride.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeEqualsOverride.cs
@@ -86,7 +86,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal static bool MethodIsRelevant(ISymbol symbol, ISet<string> methodNames) =>
             methodNames.Contains(symbol.Name) && symbol.IsOverride;
 
-        private static bool TryGetLocationFromInvocationInsideMethod(SyntaxNodeAnalysisContext context, ISymbol symbol, out Location location)
+        private static bool TryGetLocationFromInvocationInsideMethod(SonarSyntaxNodeAnalysisContext context, ISymbol symbol, out Location location)
         {
             location = null;
             var invocation = (InvocationExpressionSyntax)context.Node;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GuardConditionOnEqualsOverride.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GuardConditionOnEqualsOverride.cs
@@ -43,10 +43,10 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    cb.RegisterSyntaxNodeAction(c => { CheckInvocationInsideMethod(c, methodSymbol); }, SyntaxKind.InvocationExpression);
+                    cb.RegisterSyntaxNodeAction(c => CheckInvocationInsideMethod(c, methodSymbol), SyntaxKind.InvocationExpression);
                 });
 
-        private static void CheckInvocationInsideMethod(SyntaxNodeAnalysisContext context, ISymbol symbol)
+        private static void CheckInvocationInsideMethod(SonarSyntaxNodeAnalysisContext context, ISymbol symbol)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if (!(context.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol invokedMethod)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/IssueSuppression.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/IssueSuppression.cs
@@ -60,13 +60,13 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     foreach (var token in c.Tree.GetRoot().DescendantTokens())
                     {
-                        CheckTrivias(token.LeadingTrivia, c);
-                        CheckTrivias(token.TrailingTrivia, c);
+                        CheckTrivias(c, token.LeadingTrivia);
+                        CheckTrivias(c, token.TrailingTrivia);
                     }
                 });
         }
 
-        private static void CheckTrivias(SyntaxTriviaList triviaList, SyntaxTreeAnalysisContext c)
+        private static void CheckTrivias(SonarSyntaxTreeAnalysisContext c, SyntaxTriviaList triviaList)
         {
             var pragmaWarnings = triviaList
                 .Where(t => t.HasStructure)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableUnused.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     SyntaxKindEx.DeclarationPattern,
                     SyntaxKindEx.ListPattern);
                 cbc.RegisterSyntaxNodeAction(collector.CollectUsages, SyntaxKind.IdentifierName);
-                cbc.RegisterCodeBlockEndAction(collector.GetReportUnusedVariablesAction(Rule));
+                cbc.RegisterCodeBlockEndAction(c => collector.ReportUnusedVariables(c, Rule));
             });
 
         private sealed class UnusedLocalsCollector : UnusedLocalsCollectorBase<SyntaxNode>

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/DiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/DiagnosticAnalyzerContextHelper.cs
@@ -78,12 +78,12 @@ internal static class DiagnosticAnalyzerContextHelper   // FIXME: Rename and mov
 
     public static void RegisterCodeBlockStartActionInNonGenerated<TLanguageKindEnum>(this SonarAnalysisContext context,
                                                                                      GeneratedCodeRecognizer generatedCodeRecognizer,
-                                                                                     Action<CodeBlockStartAnalysisContext<TLanguageKindEnum>> action) where TLanguageKindEnum : struct =>
+                                                                                     Action<SonarCodeBlockStartAnalysisContext<TLanguageKindEnum>> action) where TLanguageKindEnum : struct =>
         context.RegisterCodeBlockStartAction<TLanguageKindEnum>(c =>
             {
                 if (c.ShouldAnalyze(generatedCodeRecognizer))   // FIXME: Unify
                 {
-                    action(c.Context);
+                    action(c);
                 }
             });
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/DiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/DiagnosticAnalyzerContextHelper.cs
@@ -51,18 +51,18 @@ internal static class DiagnosticAnalyzerContextHelper   // FIXME: Rename and mov
                                                                                  params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct =>
         context.AnalysisContext.RegisterSyntaxNodeActionInNonGenerated(generatedCodeRecognizer, action, syntaxKinds);
 
-    public static void RegisterSyntaxTreeActionInNonGenerated(this SonarAnalysisContext context, GeneratedCodeRecognizer generatedCodeRecognizer, Action<SyntaxTreeAnalysisContext> action) =>
+    public static void RegisterSyntaxTreeActionInNonGenerated(this SonarAnalysisContext context, GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxTreeAnalysisContext> action) =>
         context.RegisterSyntaxTreeAction(c =>
             {
                 if (c.ShouldAnalyze(generatedCodeRecognizer))   // FIXME: Unify
                 {
-                    action(c.Context);
+                    action(c);
                 }
             });
 
     public static void RegisterSyntaxTreeActionInNonGenerated(this ParameterLoadingAnalysisContext context,
                                                               GeneratedCodeRecognizer generatedCodeRecognizer,
-                                                              Action<SyntaxTreeAnalysisContext> action)
+                                                              Action<SonarSyntaxTreeAnalysisContext> action)
     {
         // This is tricky. SyntaxTree actions do not have compilation. So we register them in CompilationStart.
         // ParametrizedAnalyzer postpones CompilationStartActions to enforce that parameters are already set when the postponed action is executed.
@@ -70,7 +70,7 @@ internal static class DiagnosticAnalyzerContextHelper   // FIXME: Rename and mov
         {
             if (c.ShouldAnalyze(generatedCodeRecognizer))
             {
-                action(c.Context);
+                action(c);
             }
         });
         context.RegisterPostponedAction(startContext => wrappedAction(startContext.Context));

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -72,22 +72,22 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
         ShouldExecuteRegisteredAction == null || tree == null || ShouldExecuteRegisteredAction(diagnostics, tree);
 
     public void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
     public void RegisterCompilationAction(Action<SonarCompilationAnalysisContext> action) =>
-        analysisContext.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
+        context.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
 
     public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
-        analysisContext.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
+        context.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
 
     public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
-        analysisContext.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
+        context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
 
     public void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-        analysisContext.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
+        context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
 
     public void RegisterSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
-        analysisContext.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
+        context.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
 
     public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
         c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -72,22 +72,22 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
         ShouldExecuteRegisteredAction == null || tree == null || ShouldExecuteRegisteredAction(diagnostics, tree);
 
     public void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+        analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
     public void RegisterCompilationAction(Action<SonarCompilationAnalysisContext> action) =>
-        context.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
+        analysisContext.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
 
     public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
-        context.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
+        analysisContext.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
 
     public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
-        context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
+        analysisContext.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
 
     public void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-        context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
+        analysisContext.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
 
     public void RegisterSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
-        context.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
+        analysisContext.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
 
     public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
         c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -92,6 +92,9 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
         c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));
 
+    internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
+        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {
         // For each action registered on context we need to do some pre-processing before actually calling the rule.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -92,9 +92,6 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
         c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));
 
-    internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
-
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {
         // For each action registered on context we need to do some pre-processing before actually calling the rule.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -122,7 +122,7 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
     public bool ShouldAnalyze(GeneratedCodeRecognizer generatedCodeRecognizer) =>
         ShouldAnalyze(generatedCodeRecognizer, Tree, Compilation, Options);
 
-    private protected void ReportIssue(ReportingContext reportingContext)
+    private protected void ReportIssue(ReportingContext reportingContext)   // FIXME: Change design to make this public on one place
     {
         if (!reportingContext.Diagnostic.Descriptor.HasMatchingScope(reportingContext.Compilation, IsTestProject(), ProjectConfiguration().IsScannerRun))
         {

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCodeBlockAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCodeBlockAnalysisContext.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer;
 
-public sealed class SonarCodeBlockStartAnalysisContext<TSyntaxKind> : SonarAnalysisContextBase<CodeBlockStartAnalysisContext<TSyntaxKind>> where TSyntaxKind : struct
+public sealed class SonarCodeBlockAnalysisContext : SonarAnalysisContextBase<CodeBlockAnalysisContext>
 {
     public override SyntaxTree Tree => Context.GetSyntaxTree();
     public override Compilation Compilation => Context.SemanticModel.Compilation;
@@ -29,12 +29,8 @@ public sealed class SonarCodeBlockStartAnalysisContext<TSyntaxKind> : SonarAnaly
     public ISymbol OwningSymbol => Context.OwningSymbol;
     public SemanticModel SemanticModel => Context.SemanticModel;
 
-    internal SonarCodeBlockStartAnalysisContext(SonarAnalysisContext analysisContext, CodeBlockStartAnalysisContext<TSyntaxKind> context) : base(analysisContext, context) { }
+    internal SonarCodeBlockAnalysisContext(SonarAnalysisContext analysisContext, CodeBlockAnalysisContext context) : base(analysisContext, context) { }
 
-    public void RegisterSyntaxNodeAction(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] symbolKinds) =>
-        Context.RegisterSyntaxNodeAction(x => action(new(AnalysisContext, x)), symbolKinds);
-
-    public void RegisterCodeBlockEndAction(Action<SonarCodeBlockAnalysisContext> action) =>
-        Context.RegisterCodeBlockEndAction(x => action(new(AnalysisContext, x)));
-
+    public void ReportIssue(Diagnostic diagnostic) =>
+        ReportIssue(new ReportingContext(Context, diagnostic));
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCodeBlockStartAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCodeBlockStartAnalysisContext.cs
@@ -36,5 +36,4 @@ public sealed class SonarCodeBlockStartAnalysisContext<TSyntaxKind> : SonarAnaly
 
     public void RegisterCodeBlockEndAction(Action<SonarCodeBlockAnalysisContext> action) =>
         Context.RegisterCodeBlockEndAction(x => action(new(AnalysisContext, x)));
-
 }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
@@ -52,10 +52,6 @@ namespace SonarAnalyzer.Helpers
         public static void ReportIssue(this SyntaxNodeAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext = null) =>
             ReportIssue(new ReportingContext(context, diagnostic), verifyScopeContext?.IsTestProject(context.Compilation, context.Options), verifyScopeContext?.IsScannerRun(context.Options));
 
-        /// <param name="verifyScopeContext">Provide value for this argument only if the class has more than one SupportedDiagnostics.</param>
-        public static void ReportIssue(this CodeBlockAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext = null) =>
-            ReportIssue(new ReportingContext(context, diagnostic), verifyScopeContext?.IsTestProject(context.SemanticModel.Compilation, context.Options), verifyScopeContext?.IsScannerRun(context.Options));
-
         private static void ReportIssue(ReportingContext reportingContext, bool? isTestProject, bool? isScannerRun) // FIXME: REMOVE, already migrated
         {
             if (isTestProject.HasValue && !reportingContext.Diagnostic.Descriptor.HasMatchingScope(reportingContext.Compilation, isTestProject.Value, isScannerRun ?? true))

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisContextExtensions.cs
@@ -52,14 +52,9 @@ namespace SonarAnalyzer.Helpers
         public static void ReportIssue(this SyntaxNodeAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext = null) =>
             ReportIssue(new ReportingContext(context, diagnostic), verifyScopeContext?.IsTestProject(context.Compilation, context.Options), verifyScopeContext?.IsScannerRun(context.Options));
 
-        // SyntaxTreeAnalysisContext doesn't have a Compilation => verifyScopeContext is never needed, because IsAnalysisScopeMatching returns always true.
-        public static void ReportIssue(this SyntaxTreeAnalysisContext context, Diagnostic diagnostic) =>
-            ReportIssue(new ReportingContext(context, diagnostic), null, null);
-
         /// <param name="verifyScopeContext">Provide value for this argument only if the class has more than one SupportedDiagnostics.</param>
         public static void ReportIssue(this CodeBlockAnalysisContext context, Diagnostic diagnostic, SonarAnalysisContext verifyScopeContext = null) =>
-            ReportIssue(new ReportingContext(context, diagnostic), verifyScopeContext?.IsTestProject(context.SemanticModel.Compilation, context.Options),
-                verifyScopeContext?.IsScannerRun(context.Options));
+            ReportIssue(new ReportingContext(context, diagnostic), verifyScopeContext?.IsTestProject(context.SemanticModel.Compilation, context.Options), verifyScopeContext?.IsScannerRun(context.Options));
 
         private static void ReportIssue(ReportingContext reportingContext, bool? isTestProject, bool? isScannerRun) // FIXME: REMOVE, already migrated
         {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Helpers
         public static void RegisterSyntaxTreeActionInNonGenerated(this ParameterLoadingAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
             context.RegisterSyntaxTreeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterCodeBlockStartActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context, Action<CodeBlockStartAnalysisContext<TSyntaxKind>> action)
+        public static void RegisterCodeBlockStartActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action)
             where TSyntaxKind : struct =>
             context.RegisterCodeBlockStartActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
@@ -37,10 +37,10 @@ namespace SonarAnalyzer.Helpers
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterSyntaxTreeActionInNonGenerated(this SonarAnalysisContext context, Action<SyntaxTreeAnalysisContext> action) =>
+        public static void RegisterSyntaxTreeActionInNonGenerated(this SonarAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
             context.RegisterSyntaxTreeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterSyntaxTreeActionInNonGenerated(this ParameterLoadingAnalysisContext context, Action<SyntaxTreeAnalysisContext> action) =>
+        public static void RegisterSyntaxTreeActionInNonGenerated(this ParameterLoadingAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
             context.RegisterSyntaxTreeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
         public static void RegisterCodeBlockStartActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context, Action<CodeBlockStartAnalysisContext<TSyntaxKind>> action)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CommentLineEnd.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CommentLineEnd.cs
@@ -45,12 +45,12 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 {
                     foreach (var token in c.Tree.GetRoot().DescendantTokens())
                     {
-                        CheckTokenComments(token, c);
+                        CheckTokenComments(c, token);
                     }
                 });
         }
 
-        private void CheckTokenComments(SyntaxToken token, SyntaxTreeAnalysisContext context)
+        private void CheckTokenComments(SonarSyntaxTreeAnalysisContext context, SyntaxToken token)
         {
             var tokenLine = token.GetLocation().GetLineSpan().StartLinePosition.Line;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/VariableUnused.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/VariableUnused.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
                 cbc.RegisterSyntaxNodeAction(collector.CollectDeclarations, SyntaxKind.LocalDeclarationStatement);
                 cbc.RegisterSyntaxNodeAction(collector.CollectUsages, SyntaxKind.IdentifierName);
-                cbc.RegisterCodeBlockEndAction(collector.GetReportUnusedVariablesAction(Rule));
+                cbc.RegisterCodeBlockEndAction(c => collector.ReportUnusedVariables(c, Rule));
             });
 
         private class UnusedLocalsCollector : UnusedLocalsCollectorBase<LocalDeclarationStatementSyntax>


### PR DESCRIPTION
Part of #6540

* Migrate `ReportIssue` for `SyntaxTreeAnalysisContext`
* Migrate `ReportIssue` for `CodeBlockAnalysisContext`