### PR TITLE
Refactor SonarAnalysisContext - Migrate ReportIssue for SyntaxNodeAnalysisContext

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeAnalysisContextExtensions.cs
@@ -20,13 +20,13 @@
 
 namespace SonarAnalyzer.Extensions;
 
-public static class SyntaxNodeAnalysisContextExtensions
+public static class SyntaxNodeAnalysisContextExtensions // FIXME: Doesn't need to be extension anymore
 {
-    public static bool IsTopLevelMain(this SyntaxNodeAnalysisContext context) =>
+    public static bool IsTopLevelMain(this SonarSyntaxNodeAnalysisContext context) =>
         context.Node is CompilationUnitSyntax compilationUnitSyntax
         && compilationUnitSyntax.IsTopLevelMain()
         && context.ContainingSymbol.IsGlobalNamespace(); // Needed to avoid the duplicate calls from Roslyn 4.0.0
 
-    public static bool IsInExpressionTree(this SyntaxNodeAnalysisContext context) =>
+    public static bool IsInExpressionTree(this SonarSyntaxNodeAnalysisContext context) =>
         context.Node.IsInExpressionTree(context.SemanticModel);
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
@@ -23,17 +23,17 @@ namespace SonarAnalyzer.Helpers
     internal static class CSharpDiagnosticAnalyzerContextHelper     // FIXME: Move and rename
     {
         public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context,
-                                                                               Action<SyntaxNodeAnalysisContext> action,
+                                                                               Action<SonarSyntaxNodeAnalysisContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
         public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this ParameterLoadingAnalysisContext context,
-                                                                               Action<SyntaxNodeAnalysisContext> action,
+                                                                               Action<SonarSyntaxNodeAnalysisContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
         public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this SonarCompilationStartAnalysisContext context,
-                                                                               Action<SyntaxNodeAnalysisContext> action,
+                                                                               Action<SonarSyntaxNodeAnalysisContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AllBranchesShouldNotHaveSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AllBranchesShouldNotHaveSameImplementation.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ElseClause);
         }
 
-        private static void Analyze(SyntaxNodeAnalysisContext context, SwitchExpressionSyntaxWrapper switchExpression)
+        private static void Analyze(SonarSyntaxNodeAnalysisContext context, SwitchExpressionSyntaxWrapper switchExpression)
         {
             var arms = switchExpression.Arms;
             if (arms.Count < 2)
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (switchExpression.HasDiscardPattern() &&
                 arms.Skip(1).All(arm => SyntaxFactory.AreEquivalent(arm.Expression, firstArm.Expression)))
             {
-                context.ReportDiagnostic(Diagnostic.Create(rule, switchExpression.SwitchKeyword.GetLocation(), StatementsMessage));
+                context.ReportIssue(Diagnostic.Create(rule, switchExpression.SwitchKeyword.GetLocation(), StatementsMessage));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ArrayCovariance.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ArrayCovariance.cs
@@ -37,13 +37,13 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(RaiseOnArrayCovarianceInCastExpression, SyntaxKind.CastExpression);
         }
 
-        private static void RaiseOnArrayCovarianceInSimpleAssignmentExpression(SyntaxNodeAnalysisContext context)
+        private static void RaiseOnArrayCovarianceInSimpleAssignmentExpression(SonarSyntaxNodeAnalysisContext context)
         {
             var assignment = (AssignmentExpressionSyntax)context.Node;
             VerifyExpression(assignment.Right, context.SemanticModel.GetTypeInfo(assignment.Left).Type, context);
         }
 
-        private static void RaiseOnArrayCovarianceInVariableDeclaration(SyntaxNodeAnalysisContext context)
+        private static void RaiseOnArrayCovarianceInVariableDeclaration(SonarSyntaxNodeAnalysisContext context)
         {
             var variableDeclaration = (VariableDeclarationSyntax)context.Node;
             var baseType = context.SemanticModel.GetTypeInfo(variableDeclaration.Type).Type;
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void RaiseOnArrayCovarianceInInvocationExpression(SyntaxNodeAnalysisContext context)
+        private static void RaiseOnArrayCovarianceInInvocationExpression(SonarSyntaxNodeAnalysisContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             var methodParameterLookup = new CSharpMethodParameterLookup(invocation, context.SemanticModel);
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void RaiseOnArrayCovarianceInCastExpression(SyntaxNodeAnalysisContext context)
+        private static void RaiseOnArrayCovarianceInCastExpression(SonarSyntaxNodeAnalysisContext context)
         {
             var castExpression = (CastExpressionSyntax)context.Node;
             var baseType = context.SemanticModel.GetTypeInfo(castExpression.Type).Type;
@@ -78,7 +78,7 @@ namespace SonarAnalyzer.Rules.CSharp
             VerifyExpression(castExpression.Expression, baseType, context);
         }
 
-        private static void VerifyExpression(SyntaxNode node, ITypeSymbol baseType, SyntaxNodeAnalysisContext context)
+        private static void VerifyExpression(SyntaxNode node, ITypeSymbol baseType, SonarSyntaxNodeAnalysisContext context)
         {
             foreach (var pair in GetPossibleTypes(node, context.SemanticModel).Where(pair => AreCovariantArrayTypes(pair.Symbol, baseType)))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BinaryOperationWithIdenticalExpressions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BinaryOperationWithIdenticalExpressions.cs
@@ -64,12 +64,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKindsToCheckAssignment);
 
             context.RegisterSyntaxNodeActionInNonGenerated(
-                c => ReportOnObjectEqualsMatches((InvocationExpressionSyntax)c.Node, c),
+                c => ReportOnObjectEqualsMatches(c, (InvocationExpressionSyntax)c.Node),
                 SyntaxKind.InvocationExpression);
         }
 
-        private static void ReportOnObjectEqualsMatches(InvocationExpressionSyntax invocation,
-            SyntaxNodeAnalysisContext context)
+        private static void ReportOnObjectEqualsMatches(SonarSyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation)
         {
             var methodSymbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
 
@@ -110,7 +109,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static SyntaxNode RemoveParentheses(SyntaxNode node) =>
             node is ExpressionSyntax expression ? expression.RemoveParentheses() : node;
 
-        private static void ReportIfOperatorExpressionsMatch(SyntaxNodeAnalysisContext context, ExpressionSyntax left, ExpressionSyntax right, SyntaxToken operatorToken)
+        private static void ReportIfOperatorExpressionsMatch(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax left, ExpressionSyntax right, SyntaxToken operatorToken)
         {
             if (CSharpEquivalenceChecker.AreEquivalent(left.RemoveParentheses(), right.RemoveParentheses()))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BooleanLiteralUnnecessary.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BooleanLiteralUnnecessary.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(CheckForLoopCondition, SyntaxKind.ForStatement);
         }
 
-        private void CheckForLoopCondition(SyntaxNodeAnalysisContext context)
+        private void CheckForLoopCondition(SonarSyntaxNodeAnalysisContext context)
         {
             var forLoop = (ForStatementSyntax)context.Node;
 
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void CheckLogicalNot(SyntaxNodeAnalysisContext context)
+        private void CheckLogicalNot(SonarSyntaxNodeAnalysisContext context)
         {
             var logicalNot = (PrefixUnaryExpressionSyntax)context.Node;
             var logicalNotOperand = logicalNot.Operand.RemoveParentheses();
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 node.IsKind(SyntaxKind.TrueLiteralExpression) || node.IsKind(SyntaxKind.FalseLiteralExpression);
         }
 
-        private void CheckConditional(SyntaxNodeAnalysisContext context)
+        private void CheckConditional(SonarSyntaxNodeAnalysisContext context)
         {
             var conditional = (ConditionalExpressionSyntax)context.Node;
             var whenTrue = conditional.WhenTrue;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CallToAsyncMethodShouldNotBeBlocking.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CallToAsyncMethodShouldNotBeBlocking.cs
@@ -75,7 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(ReportOnViolation, SyntaxKind.SimpleMemberAccessExpression);
 
-        private static void ReportOnViolation(SyntaxNodeAnalysisContext context)
+        private static void ReportOnViolation(SonarSyntaxNodeAnalysisContext context)
         {
             var simpleMemberAccess = (MemberAccessExpressionSyntax)context.Node;
             var memberAccessNameName = simpleMemberAccess.GetName();
@@ -114,7 +114,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.ReportIssue(Diagnostic.Create(context.IsAzureFunction() ? RuleS6422 : RuleS4462, simpleMemberAccess.GetLocation(), MemberNameToMessageArguments[memberAccessNameName]));
         }
 
-        private static bool IsAwaited(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax simpleMemberAccess)
+        private static bool IsAwaited(SonarSyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax simpleMemberAccess)
         {
             return context.SemanticModel.GetSymbolInfo(simpleMemberAccess.Expression).Symbol is { } accessedSymbol
                    && simpleMemberAccess.FirstAncestorOrSelf<StatementSyntax>() is { } currentStatement

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CallerInformationParametersShouldBeLast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CallerInformationParametersShouldBeLast.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ConstructorDeclaration,
                 SyntaxKindEx.LocalFunctionStatement);
 
-        private static void ReportOnViolation(SyntaxNodeAnalysisContext context)
+        private static void ReportOnViolation(SonarSyntaxNodeAnalysisContext context)
         {
             var methodDeclaration = context.Node;
             var parameterList = LocalFunctionStatementSyntaxWrapper.IsInstance(methodDeclaration)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CastConcreteTypeToInterface.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CastConcreteTypeToInterface.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var castExpression = (CastExpressionSyntax)c.Node;
                     var castedTo = c.SemanticModel.GetTypeInfo(castExpression.Type).Type;
                     var castedFrom = c.SemanticModel.GetTypeInfo(castExpression.Expression).Type;
-                    CheckForIssue(castedTo, castedFrom, c);
+                    CheckForIssue(c, castedTo, castedFrom);
                 },
                 SyntaxKind.CastExpression);
 
@@ -49,13 +49,12 @@ namespace SonarAnalyzer.Rules.CSharp
                     var castExpression = (BinaryExpressionSyntax)c.Node;
                     var castedTo = c.SemanticModel.GetTypeInfo(castExpression.Right).Type;
                     var castedFrom = c.SemanticModel.GetTypeInfo(castExpression.Left).Type;
-                    CheckForIssue(castedTo, castedFrom, c);
+                    CheckForIssue(c, castedTo, castedFrom);
                 },
                 SyntaxKind.AsExpression);
         }
 
-        public static void CheckForIssue(ITypeSymbol castedTo, ITypeSymbol castedFrom,
-            SyntaxNodeAnalysisContext context)
+        public static void CheckForIssue(SonarSyntaxNodeAnalysisContext context, ITypeSymbol castedTo, ITypeSymbol castedFrom)
         {
             if (!castedFrom.Is(TypeKind.Interface) ||
                 !castedFrom.DeclaringSyntaxReferences.Any() ||

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CastShouldNotBeDuplicated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CastShouldNotBeDuplicated.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(CasePatternSwitchLabel, SyntaxKindEx.CasePatternSwitchLabel);
         }
 
-        private static void CasePatternSwitchLabel(SyntaxNodeAnalysisContext analysisContext)
+        private static void CasePatternSwitchLabel(SonarSyntaxNodeAnalysisContext analysisContext)
         {
             var casePatternSwitch = (CasePatternSwitchLabelSyntaxWrapper)analysisContext.Node;
             if (casePatternSwitch.SyntaxNode.GetFirstNonParenthesizedParent().GetFirstNonParenthesizedParent() is not SwitchStatementSyntax parentSwitchStatement)
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                      parentSwitchStatement);
         }
 
-        private static void SwitchExpressionArm(SyntaxNodeAnalysisContext analysisContext)
+        private static void SwitchExpressionArm(SonarSyntaxNodeAnalysisContext analysisContext)
         {
             var isSwitchExpression = (SwitchExpressionArmSyntaxWrapper)analysisContext.Node;
             var parent = isSwitchExpression.SyntaxNode.GetFirstNonParenthesizedParent();
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                      isSwitchExpression);
         }
 
-        private static void IsPatternExpression(SyntaxNodeAnalysisContext analysisContext)
+        private static void IsPatternExpression(SonarSyntaxNodeAnalysisContext analysisContext)
         {
             var isPatternExpression = (IsPatternExpressionSyntaxWrapper)analysisContext.Node;
             if (isPatternExpression.SyntaxNode.GetFirstNonParenthesizedParent() is not IfStatementSyntax parentIfStatement)
@@ -83,7 +83,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                      parentIfStatement.Statement);
         }
 
-        private static void IsExpression(SyntaxNodeAnalysisContext analysisContext)
+        private static void IsExpression(SonarSyntaxNodeAnalysisContext analysisContext)
         {
             var isExpression = (BinaryExpressionSyntax)analysisContext.Node;
 
@@ -98,7 +98,7 @@ namespace SonarAnalyzer.Rules.CSharp
             ReportPatternAtMainVariable(analysisContext, isExpression.Left, isExpression.GetLocation(), parentIfStatement.Statement, castType, ReplaceWithAsAndNullCheckMessage);
         }
 
-        private static List<Location> GetDuplicatedCastLocations(SyntaxNodeAnalysisContext analysisContext, SyntaxNode parentStatement, TypeSyntax castType, SyntaxNode typedVariable)
+        private static List<Location> GetDuplicatedCastLocations(SonarSyntaxNodeAnalysisContext analysisContext, SyntaxNode parentStatement, TypeSyntax castType, SyntaxNode typedVariable)
         {
             var typeExpressionSymbol = analysisContext.SemanticModel.GetSymbolInfo(typedVariable).Symbol
                                        ?? analysisContext.SemanticModel.GetDeclaredSymbol(typedVariable);
@@ -115,7 +115,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 Equals(analysisContext.SemanticModel.GetSymbolInfo(castExpression.Expression).Symbol, typeExpressionSymbol);
         }
 
-        private static void ProcessPatternExpression(SyntaxNodeAnalysisContext analysisContext,
+        private static void ProcessPatternExpression(SonarSyntaxNodeAnalysisContext analysisContext,
                                                      SyntaxNode isPattern,
                                                      SyntaxNode mainVariableExpression,
                                                      SyntaxNode parentStatement)
@@ -209,7 +209,7 @@ namespace SonarAnalyzer.Rules.CSharp
             return null;
         }
 
-        private static void ReportPatternAtMainVariable(SyntaxNodeAnalysisContext context,
+        private static void ReportPatternAtMainVariable(SonarSyntaxNodeAnalysisContext context,
                                                         SyntaxNode variableExpression,
                                                         Location mainLocation,
                                                         SyntaxNode parentStatement,
@@ -224,7 +224,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportPatternAtCastLocation(SyntaxNodeAnalysisContext context,
+        private static void ReportPatternAtCastLocation(SonarSyntaxNodeAnalysisContext context,
                                                         SyntaxNode variableExpression,
                                                         Location patternLocation,
                                                         SyntaxNode parentStatement,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CheckArgumentException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CheckArgumentException.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(CheckForIssue, SyntaxKind.ObjectCreationExpression, SyntaxKindEx.ImplicitObjectCreationExpression);
 
-        private static void CheckForIssue(SyntaxNodeAnalysisContext analysisContext)
+        private static void CheckForIssue(SonarSyntaxNodeAnalysisContext analysisContext)
         {
             var objectCreation = ObjectCreationFactory.Create(analysisContext.Node);
             var methodSymbol = objectCreation.MethodSymbol(analysisContext.SemanticModel);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassAndMethodName.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassAndMethodName.cs
@@ -108,14 +108,14 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
                 {
                     var identifier = GetDeclarationIdentifier(c.Node);
-                    CheckMemberName(c.Node, identifier, c);
+                    CheckMemberName(c, identifier);
                 },
                 SyntaxKind.MethodDeclaration,
                 SyntaxKind.PropertyDeclaration,
                 SyntaxKindEx.LocalFunctionStatement);
         }
 
-        private static void CheckTypeName(SyntaxNodeAnalysisContext context, bool isTest)
+        private static void CheckTypeName(SonarSyntaxNodeAnalysisContext context, bool isTest)
         {
             var typeDeclaration = (BaseTypeDeclarationSyntax)context.Node;
             var identifier = typeDeclaration.Identifier;
@@ -159,9 +159,9 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckMemberName(SyntaxNode member, SyntaxToken identifier, SyntaxNodeAnalysisContext context)
+        private static void CheckMemberName(SonarSyntaxNodeAnalysisContext context, SyntaxToken identifier)
         {
-            var symbol = context.SemanticModel.GetDeclaredSymbol(member);
+            var symbol = context.SemanticModel.GetDeclaredSymbol(context.Node);
             if (symbol == null)
             {
                 return;
@@ -179,7 +179,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (identifier.ValueText.StartsWith("_", StringComparison.Ordinal)
                 || identifier.ValueText.EndsWith("_", StringComparison.Ordinal))
             {
-                context.ReportIssue(Diagnostic.Create(MethodNameRule, identifier.GetLocation(), member.GetDeclarationTypeName(), identifier.ValueText, MessageFormatUnderscore));
+                context.ReportIssue(Diagnostic.Create(MethodNameRule, identifier.GetLocation(), context.Node.GetDeclarationTypeName(), identifier.ValueText, MessageFormatUnderscore));
                 return;
             }
 
@@ -191,7 +191,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (!IsMemberNameValid(identifier.ValueText, out var suggestion))
             {
                 var messageEnding = string.Format(MessageFormatNonUnderscore, suggestion);
-                context.ReportIssue(Diagnostic.Create(MethodNameRule, identifier.GetLocation(), member.GetDeclarationTypeName(), identifier.ValueText, messageEnding));
+                context.ReportIssue(Diagnostic.Create(MethodNameRule, identifier.GetLocation(), context.Node.GetDeclarationTypeName(), identifier.ValueText, messageEnding));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsLogFailures.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsLogFailures.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 if (c.AzureFunctionMethod() is { } entryPoint
                     && HasLoggerInScope(entryPoint))
                 {
-                    var walker = new LoggerCallWalker(c.SemanticModel, c.CancellationToken);
+                    var walker = new LoggerCallWalker(c.SemanticModel, c.Cancel);
                     walker.SafeVisit(catchClause.Block);
                     // Exception handling in the filter clause preserves log scopes and is therefore recommended
                     // See https://blog.stephencleary.com/2020/06/a-new-pattern-for-exception-logging.html

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsReuseClients.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsReuseClients.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.CSharp
             },
             SyntaxKind.ObjectCreationExpression, SyntaxKindEx.ImplicitObjectCreationExpression);
 
-        private static bool IsAssignedForReuse(SyntaxNodeAnalysisContext context) =>
+        private static bool IsAssignedForReuse(SonarSyntaxNodeAnalysisContext context) =>
             !IsInVariableDeclaration(context.Node)
             && (IsInFieldOrPropertyInitializer(context.Node) || IsAssignedToStaticFieldOrProperty(context));
 
@@ -75,11 +75,11 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool IsInFieldOrPropertyInitializer(SyntaxNode node) =>
             node.Ancestors().Any(x => x.IsAnyKind(SyntaxKind.FieldDeclaration, SyntaxKind.PropertyDeclaration));
 
-        private static bool IsAssignedToStaticFieldOrProperty(SyntaxNodeAnalysisContext context) =>
+        private static bool IsAssignedToStaticFieldOrProperty(SonarSyntaxNodeAnalysisContext context) =>
             context.Node.Parent.WalkUpParentheses() is AssignmentExpressionSyntax assignment
-                && context.SemanticModel.GetSymbolInfo(assignment.Left, context.CancellationToken).Symbol is { IsStatic: true, Kind: SymbolKind.Field or SymbolKind.Property };
+                && context.SemanticModel.GetSymbolInfo(assignment.Left, context.Cancel).Symbol is { IsStatic: true, Kind: SymbolKind.Field or SymbolKind.Property };
 
-        private static bool IsResuableClient(SyntaxNodeAnalysisContext context)
+        private static bool IsResuableClient(SonarSyntaxNodeAnalysisContext context)
         {
             var objectCreation = ObjectCreationFactory.Create(context.Node);
             return ReusableClients.Any(x => objectCreation.IsKnownType(x, context.SemanticModel));

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsStateless.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsStateless.cs
@@ -69,7 +69,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.Argument);
         }
 
-        private static void CheckTarget(SyntaxNodeAnalysisContext context, ExpressionSyntax target)
+        private static void CheckTarget(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax target)
         {
             if (context.IsAzureFunction()
                 && context.SemanticModel.GetSymbolInfo((target as ElementAccessExpressionSyntax)?.Expression ?? target).Symbol is { } symbol

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
@@ -232,8 +232,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 : invocation.ArgumentList.Arguments.Skip(1).ToList();
         }
 
-        private static void CheckForCastSimplification(SonarSyntaxNodeAnalysisContext context, IMethodSymbol outerMethodSymbol, InvocationExpressionSyntax outerInvocation,
-            IMethodSymbol innerMethodSymbol, InvocationExpressionSyntax innerInvocation)
+        private static void CheckForCastSimplification(SonarSyntaxNodeAnalysisContext context,
+                                                       IMethodSymbol outerMethodSymbol,
+                                                       InvocationExpressionSyntax outerInvocation,
+                                                       IMethodSymbol innerMethodSymbol,
+                                                       InvocationExpressionSyntax innerInvocation)
         {
             if (MethodNamesForTypeCheckingWithSelect.Contains(outerMethodSymbol.Name) &&
                 innerMethodSymbol.Name == SelectMethodName &&
@@ -393,8 +396,11 @@ namespace SonarAnalyzer.Rules.CSharp
             return true;
         }
 
-        private static bool CheckForSimplifiable(SonarSyntaxNodeAnalysisContext context, IMethodSymbol outerMethodSymbol, InvocationExpressionSyntax outerInvocation,
-            IMethodSymbol innerMethodSymbol, InvocationExpressionSyntax innerInvocation)
+        private static bool CheckForSimplifiable(SonarSyntaxNodeAnalysisContext context,
+                                                 IMethodSymbol outerMethodSymbol,
+                                                 InvocationExpressionSyntax outerInvocation,
+                                                 IMethodSymbol innerMethodSymbol,
+                                                 InvocationExpressionSyntax innerInvocation)
         {
             if (MethodIsNotUsingPredicate(outerMethodSymbol, outerInvocation) &&
                 innerMethodSymbol.Name == WhereMethodName &&

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalSimplification.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalSimplification.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(CheckNotPattern, SyntaxKindEx.NotPattern);
         }
 
-        private static void CheckNotPattern(SyntaxNodeAnalysisContext context)
+        private static void CheckNotPattern(SonarSyntaxNodeAnalysisContext context)
         {
             var wrapper = (UnaryPatternSyntaxWrapper)context.Node;
             if (wrapper.Pattern.IsNot()
@@ -78,7 +78,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckCoalesceExpression(SyntaxNodeAnalysisContext context)
+        private static void CheckCoalesceExpression(SonarSyntaxNodeAnalysisContext context)
         {
             if (context.Node.GetFirstNonParenthesizedParent() is AssignmentExpressionSyntax assignment
                 && !assignment.Parent.IsKind(SyntaxKind.ObjectInitializerExpression)
@@ -92,7 +92,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckIfStatement(SyntaxNodeAnalysisContext context)
+        private static void CheckIfStatement(SonarSyntaxNodeAnalysisContext context)
         {
             var ifStatement = (IfStatementSyntax)context.Node;
             if (ifStatement.Parent is ElseClauseSyntax)
@@ -122,7 +122,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckConditionalExpression(SyntaxNodeAnalysisContext context)
+        private static void CheckConditionalExpression(SonarSyntaxNodeAnalysisContext context)
         {
             var conditional = (ConditionalExpressionSyntax)context.Node;
             var condition = conditional.Condition.RemoveParentheses();
@@ -183,7 +183,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool IsNullAndValueType(ITypeSymbol typeNull, ITypeSymbol typeValue) =>
             typeNull == null && typeValue is {IsValueType: true};
 
-        private static bool CanBeSimplified(SyntaxNodeAnalysisContext context,
+        private static bool CanBeSimplified(SonarSyntaxNodeAnalysisContext context,
                                             StatementSyntax statement1,
                                             StatementSyntax statement2,
                                             SyntaxNode comparedToNull,
@@ -343,7 +343,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static ImmutableDictionary<string, string> BuildCodeFixProperties(SyntaxNodeAnalysisContext c, string simplifiedOperator = null)
+        private static ImmutableDictionary<string, string> BuildCodeFixProperties(SonarSyntaxNodeAnalysisContext c, string simplifiedOperator = null)
         {
             var ret = new Dictionary<string, string> { {IsCoalesceAssignmentSupportedKey, c.Compilation.IsCoalesceAssignmentSupported().ToString() }};
             if (simplifiedOperator != null)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameImplementation.cs
@@ -85,7 +85,7 @@ namespace SonarAnalyzer.Rules.CSharp
                       .Union(switchSection.Statements.OfType<BlockSyntax>().SelectMany(block => block.Statements))
                       .Union(switchSection.Statements.Where(s => !s.IsKind(SyntaxKind.Block)));
 
-        private static void CheckStatement(SyntaxNodeAnalysisContext context, SyntaxNode statement, IEnumerable<StatementSyntax> precedingStatements)
+        private static void CheckStatement(SonarSyntaxNodeAnalysisContext context, SyntaxNode statement, IEnumerable<StatementSyntax> precedingStatements)
         {
             if (statement.ChildNodes().Count() < 2)
             {
@@ -99,7 +99,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportSyntaxNode(SyntaxNodeAnalysisContext context, SyntaxNode node, SyntaxNode precedingNode, string errorMessageDiscriminator) =>
+        private static void ReportSyntaxNode(SonarSyntaxNodeAnalysisContext context, SyntaxNode node, SyntaxNode precedingNode, string errorMessageDiscriminator) =>
             context.ReportIssue(Rule.CreateDiagnostic(context.Compilation,
                 node.GetLocation(),
                 additionalLocations: new[] { precedingNode.GetLocation() },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.SwitchStatement);
         }
 
-        private static void CheckMatchingExpressionsInSucceedingStatements<T>(SyntaxNodeAnalysisContext context, Func<T, ExpressionSyntax> expression) where T : StatementSyntax
+        private static void CheckMatchingExpressionsInSucceedingStatements<T>(SonarSyntaxNodeAnalysisContext context, Func<T, ExpressionSyntax> expression) where T : StatementSyntax
         {
             var currentStatement = (T)context.Node;
             if (currentStatement.GetPrecedingStatement() is T previousStatement)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorArgumentValueShouldExist.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorArgumentValueShouldExist.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 .Select(x => x.Identifier.ValueText);
         }
 
-        protected override void ReportIssue(SyntaxNodeAnalysisContext c, AttributeData constructorArgumentAttribute)
+        protected override void ReportIssue(SonarSyntaxNodeAnalysisContext c, AttributeData constructorArgumentAttribute)
         {
             var attributeSyntax =
                 (AttributeSyntax)constructorArgumentAttribute.ApplicationSyntaxReference.GetSyntax();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorOverridableCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorOverridableCall.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.InvocationExpression);
         }
 
-        private static void CheckOverridableCallInConstructor(SyntaxNodeAnalysisContext context)
+        private static void CheckOverridableCallInConstructor(SonarSyntaxNodeAnalysisContext context)
         {
             var invocationExpression = (InvocationExpressionSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ControlCharacterInString.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ControlCharacterInString.cs
@@ -102,7 +102,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.InterpolatedStringText);
         }
 
-        private static void CheckControlCharacter(SyntaxNodeAnalysisContext c, string text, int displayPosIncrement)
+        private static void CheckControlCharacter(SonarSyntaxNodeAnalysisContext c, string text, int displayPosIncrement)
         {
             if (IsInescapableString(c.Node) || IsInescepableInterpolatedString(c.Node.Parent) || IsInescapableUtf8String(c.Node))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.RoslynCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.RoslynCfg.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             private readonly RoslynLiveVariableAnalysis lva;
 
-            public RoslynChecker(SyntaxNodeAnalysisContext context, RoslynLiveVariableAnalysis lva) : base(context, lva) =>
+            public RoslynChecker(SonarSyntaxNodeAnalysisContext context, RoslynLiveVariableAnalysis lva) : base(context, lva) =>
                 this.lva = lva;
 
             protected override State CreateState(BasicBlock block) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.SonarCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.SonarCfg.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             private readonly SyntaxNode node;
 
-            public SonarChecker(SyntaxNodeAnalysisContext context, SonarCSharpLiveVariableAnalysis lva, SyntaxNode node) : base(context, lva) =>
+            public SonarChecker(SonarSyntaxNodeAnalysisContext context, SonarCSharpLiveVariableAnalysis lva, SyntaxNode node) : base(context, lva) =>
                 this.node = node;
 
             protected override State CreateState(Block block) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DebugAssertHasNoSideEffects.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DebugAssertHasNoSideEffects.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     var invokedMethodSyntax = c.Node as InvocationExpressionSyntax;
 
-                    if (IsDebugAssert(invokedMethodSyntax, c)
+                    if (IsDebugAssert(c, invokedMethodSyntax)
                         && ContainsCallsWithSideEffects(invokedMethodSyntax))
                     {
                         c.ReportIssue(Diagnostic.Create(rule, invokedMethodSyntax.ArgumentList.GetLocation()));
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
             return memberBinding?.Name?.Identifier.ValueText;
         }
 
-        private static bool IsDebugAssert(InvocationExpressionSyntax invocation, SyntaxNodeAnalysisContext context) =>
+        private static bool IsDebugAssert(SonarSyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation) =>
             invocation.Expression is MemberAccessExpressionSyntax memberAccess
             && memberAccess.Name.Identifier.ValueText == nameof(System.Diagnostics.Debug.Assert)
             && context.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol symbol

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeclareEventHandlersCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeclareEventHandlersCorrectly.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                SyntaxKind.EventDeclaration);
         }
 
-        private static void AnalyzeEventType(SyntaxNodeAnalysisContext analysisContext, TypeSyntax typeSyntax, ISymbol eventSymbol)
+        private static void AnalyzeEventType(SonarSyntaxNodeAnalysisContext analysisContext, TypeSyntax typeSyntax, ISymbol eventSymbol)
         {
             if (!eventSymbol.IsOverride
                 && eventSymbol.GetInterfaceMember() is null

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableReturnedFromUsing.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableReturnedFromUsing.cs
@@ -84,7 +84,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.LocalDeclarationStatement);
         }
 
-        private static void CheckReturns(SyntaxNodeAnalysisContext c, SyntaxToken usingKeyword, SyntaxNode body, HashSet<ISymbol> declaredSymbols)
+        private static void CheckReturns(SonarSyntaxNodeAnalysisContext c, SyntaxToken usingKeyword, SyntaxNode body, HashSet<ISymbol> declaredSymbols)
         {
             if (declaredSymbols.Count == 0)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCheckZeroSizeCollection.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCheckZeroSizeCollection.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(AnalyzePropertyPatternClause, SyntaxKindEx.PropertyPatternClause);
         }
 
-        private void AnalyzePropertyPatternClause(SyntaxNodeAnalysisContext c)
+        private void AnalyzePropertyPatternClause(SonarSyntaxNodeAnalysisContext c)
         {
             var propertyPatternClause = (PropertyPatternClauseSyntaxWrapper)c.Node;
 
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void AnalyzePatterns(SyntaxNodeAnalysisContext c, ExpressionSyntax expression, SyntaxNode pattern)
+        private void AnalyzePatterns(SonarSyntaxNodeAnalysisContext c, ExpressionSyntax expression, SyntaxNode pattern)
         {
             var objectToPatternMap = new Dictionary<ExpressionSyntax, SyntaxNode>();
             PatternExpressionObjectToPatternMapping.MapObjectToPattern(expression, pattern, objectToPatternMap);
@@ -66,13 +66,13 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void AnalyzeIsPatternExpression(SyntaxNodeAnalysisContext c)
+        private void AnalyzeIsPatternExpression(SonarSyntaxNodeAnalysisContext c)
         {
             var isPatternExpression = (IsPatternExpressionSyntaxWrapper)c.Node;
             AnalyzePatterns(c, isPatternExpression.Expression, isPatternExpression.Pattern);
         }
 
-        private void AnalyzeSwitchExpression(SyntaxNodeAnalysisContext c)
+        private void AnalyzeSwitchExpression(SonarSyntaxNodeAnalysisContext c)
         {
             var switchExpression = (SwitchExpressionSyntaxWrapper)c.Node;
 
@@ -82,7 +82,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void AnalyzeSwitchStatement(SyntaxNodeAnalysisContext c)
+        private void AnalyzeSwitchStatement(SonarSyntaxNodeAnalysisContext c)
         {
             var switchStatement = (SwitchStatementSyntax)c.Node;
             foreach (var section in switchStatement.Sections)
@@ -94,7 +94,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void CheckPatternCondition(SyntaxNodeAnalysisContext context, SyntaxNode expression, SyntaxNode pattern)
+        private void CheckPatternCondition(SonarSyntaxNodeAnalysisContext context, SyntaxNode expression, SyntaxNode pattern)
         {
             if (pattern.DescendantNodesAndSelf().FirstOrDefault(x => x.IsKind(SyntaxKindEx.RelationalPattern)) is { } relationalPatternNode
                 && ((RelationalPatternSyntaxWrapper)relationalPatternNode) is var relationalPattern

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotExposeListT.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotExposeListT.cs
@@ -49,14 +49,14 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (baseMethodDeclaration is MethodDeclarationSyntax methodDeclaration)
                     {
-                        ReportIfListT(methodDeclaration.ReturnType, c, methodType);
+                        ReportIfListT(c, methodDeclaration.ReturnType, methodType);
                     }
 
                     baseMethodDeclaration
                         .ParameterList?
                         .Parameters
                         .ToList()
-                        .ForEach(p => ReportIfListT(p.Type, c, methodType));
+                        .ForEach(p => ReportIfListT(c, p.Type, methodType));
                 },
                 SyntaxKind.MethodDeclaration,
                 SyntaxKind.ConstructorDeclaration);
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && !propertySymbol.IsOverride
                         && !HasXmlElementAttribute(propertySymbol))
                     {
-                        ReportIfListT(propertyDeclaration.Type, c, "property");
+                        ReportIfListT(c, propertyDeclaration.Type, "property");
                     }
                 },
                 SyntaxKind.PropertyDeclaration);
@@ -94,13 +94,13 @@ namespace SonarAnalyzer.Rules.CSharp
                         && fieldSymbol.IsPubliclyAccessible()
                         && !HasXmlElementAttribute(fieldSymbol))
                     {
-                        ReportIfListT(fieldDeclaration.Declaration.Type, c, "field");
+                        ReportIfListT(c, fieldDeclaration.Declaration.Type, "field");
                     }
                 },
                 SyntaxKind.FieldDeclaration);
         }
 
-        private static void ReportIfListT(TypeSyntax typeSyntax, SyntaxNodeAnalysisContext context, string memberType)
+        private static void ReportIfListT(SonarSyntaxNodeAnalysisContext context, TypeSyntax typeSyntax, string memberType)
         {
             if (typeSyntax != null && typeSyntax.IsKnownType(KnownType.System_Collections_Generic_List_T, context.SemanticModel))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotOverloadOperatorEqual.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotOverloadOperatorEqual.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(CheckForIssue, SyntaxKind.OperatorDeclaration);
 
-        private static void CheckForIssue(SyntaxNodeAnalysisContext analysisContext)
+        private static void CheckForIssue(SonarSyntaxNodeAnalysisContext analysisContext)
         {
             var declaration = (OperatorDeclarationSyntax)analysisContext.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotTestThisWithIsOperator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotTestThisWithIsOperator.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(AnalyzeSwitchStatement, SyntaxKind.SwitchStatement);
         }
 
-        private static void AnalyzeIsExpression(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeIsExpression(SonarSyntaxNodeAnalysisContext context)
         {
             if (IsThisExpressionSyntax(((BinaryExpressionSyntax)context.Node).Left))
             {
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void AnalyzeIsPatternExpression(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeIsPatternExpression(SonarSyntaxNodeAnalysisContext context)
         {
             if (IsThisExpressionSyntax(((IsPatternExpressionSyntaxWrapper)context.Node).Expression) && ContainsTypeCheckInPattern(context.Node))
             {
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void AnalyzeSwitchStatement(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeSwitchStatement(SonarSyntaxNodeAnalysisContext context)
         {
             var switchStatement = (SwitchStatementSyntax)context.Node;
             if (IsThisExpressionSyntax(switchStatement.Expression))
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void AnalyzeSwitchExpression(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeSwitchExpression(SonarSyntaxNodeAnalysisContext context)
         {
             var switchExpression = (SwitchExpressionSyntaxWrapper)context.Node;
             if (IsThisExpressionSyntax(switchExpression.GoverningExpression))
@@ -122,10 +122,10 @@ namespace SonarAnalyzer.Rules.CSharp
                                                                   SyntaxKindEx.Subpattern))
                                                  .IsKind(SyntaxKindEx.Subpattern);
 
-        private static void ReportDiagnostic(SyntaxNodeAnalysisContext context, SyntaxNode node) =>
+        private static void ReportDiagnostic(SonarSyntaxNodeAnalysisContext context, SyntaxNode node) =>
             context.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
 
-        private static void ReportDiagnostic(SyntaxNodeAnalysisContext context, SyntaxNode node, IList<SecondaryLocation> secondaryLocations)
+        private static void ReportDiagnostic(SonarSyntaxNodeAnalysisContext context, SyntaxNode node, IList<SecondaryLocation> secondaryLocations)
         {
             if (secondaryLocations.Any())
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyMethod.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKindEx.LocalFunctionStatement
             };
 
-        protected override void CheckMethod(SyntaxNodeAnalysisContext context, bool isTestProject)
+        protected override void CheckMethod(SonarSyntaxNodeAnalysisContext context, bool isTestProject)
         {
             if (LocalFunctionStatementSyntaxWrapper.IsInstance(context.Node))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.LogicalOrExpression);
         }
 
-        private static void CheckLogicalExpression(SyntaxNodeAnalysisContext context)
+        private static void CheckLogicalExpression(SonarSyntaxNodeAnalysisContext context)
         {
             var binaryExpression = (BinaryExpressionSyntax)context.Node;
             var left = TryGetBinaryExpression(binaryExpression.Left);
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static string GetMessageEqualityPart(bool isEquality) =>
             isEquality ? "equality" : "inequality";
 
-        private static void CheckEquality(SyntaxNodeAnalysisContext context)
+        private static void CheckEquality(SonarSyntaxNodeAnalysisContext context)
         {
             var equals = (BinaryExpressionSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnModulus.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnModulus.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(VisitEquality, SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression);
 
-        private static void VisitEquality(SyntaxNodeAnalysisContext c)
+        private static void VisitEquality(SonarSyntaxNodeAnalysisContext c)
         {
             var equalsExpression = (BinaryExpressionSyntax)c.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionShouldNotBeThrownFromUnexpectedMethods.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionShouldNotBeThrownFromUnexpectedMethods.cs
@@ -74,7 +74,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ConversionOperatorDeclaration);
         }
 
-        private static void CheckForIssue<TSyntax>(SyntaxNodeAnalysisContext analysisContext, Func<TSyntax, bool> isTrackedSyntax, ImmutableArray<KnownType> allowedThrowTypes)
+        private static void CheckForIssue<TSyntax>(SonarSyntaxNodeAnalysisContext analysisContext, Func<TSyntax, bool> isTrackedSyntax, ImmutableArray<KnownType> allowedThrowTypes)
             where TSyntax : SyntaxNode
         {
             var syntax = (TSyntax)analysisContext.Node;
@@ -118,8 +118,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool IsModuleInitializer(IMethodSymbol methodSymbol) =>
             methodSymbol.AnyAttributeDerivesFrom(KnownType.System_Runtime_CompilerServices_ModuleInitializerAttribute);
 
-        private static void ReportOnInvalidThrow(SyntaxNodeAnalysisContext analysisContext,
-            SyntaxNode node, ImmutableArray<KnownType> allowedTypes)
+        private static void ReportOnInvalidThrow(SonarSyntaxNodeAnalysisContext analysisContext, SyntaxNode node, ImmutableArray<KnownType> allowedTypes)
         {
             if (node.ArrowExpressionBody() is { } expressionBody
                 && GetLocationToReport(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShadowsParentField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShadowsParentField.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         foreach (var diagnostics in fieldDeclaration.Declaration.Variables.SelectMany(x => CheckFields(c.SemanticModel, x)))
                         {
-                            c.ReportIssue(diagnostics, context);
+                            c.ReportIssue(diagnostics);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionComplexity.cs
@@ -86,12 +86,12 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKindEx.InitAccessorDeclaration);
         }
 
-        private void CheckComplexity<TSyntax>(SyntaxNodeAnalysisContext context, Func<TSyntax, Location> getLocation, string declarationType, bool onlyGlobalStatements = false)
+        private void CheckComplexity<TSyntax>(SonarSyntaxNodeAnalysisContext context, Func<TSyntax, Location> getLocation, string declarationType, bool onlyGlobalStatements = false)
             where TSyntax : SyntaxNode =>
             CheckComplexity(context, getLocation, n => n, declarationType, onlyGlobalStatements);
 
         private void CheckComplexity<TSyntax>(
-            SyntaxNodeAnalysisContext context,
+            SonarSyntaxNodeAnalysisContext context,
             Func<TSyntax, Location> getLocation,
             Func<TSyntax, SyntaxNode> getNodeToCheck,
             string declarationType,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericReadonlyFieldPropertyAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericReadonlyFieldPropertyAssignment.cs
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PostIncrementExpression);
         }
 
-        private static void ProcessPropertyChange(SyntaxNodeAnalysisContext context, SemanticModel semanticModel, ExpressionSyntax expression)
+        private static void ProcessPropertyChange(SonarSyntaxNodeAnalysisContext context, SemanticModel semanticModel, ExpressionSyntax expression)
         {
             if (TupleExpressionSyntaxWrapper.IsInstance(expression))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterInOut.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterInOut.cs
@@ -32,13 +32,13 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override void Initialize(SonarAnalysisContext context)
         {
-            context.RegisterSyntaxNodeActionInNonGenerated(c => CheckInterfaceVariance((InterfaceDeclarationSyntax)c.Node, c), SyntaxKind.InterfaceDeclaration);
-            context.RegisterSyntaxNodeActionInNonGenerated(c => CheckDelegateVariance((DelegateDeclarationSyntax)c.Node, c), SyntaxKind.DelegateDeclaration);
+            context.RegisterSyntaxNodeActionInNonGenerated(c => CheckInterfaceVariance(c, (InterfaceDeclarationSyntax)c.Node), SyntaxKind.InterfaceDeclaration);
+            context.RegisterSyntaxNodeActionInNonGenerated(c => CheckDelegateVariance(c, (DelegateDeclarationSyntax)c.Node), SyntaxKind.DelegateDeclaration);
         }
 
         #region Top level
 
-        private static void CheckInterfaceVariance(InterfaceDeclarationSyntax declaration, SyntaxNodeAnalysisContext context)
+        private static void CheckInterfaceVariance(SonarSyntaxNodeAnalysisContext context, InterfaceDeclarationSyntax declaration)
         {
             var interfaceType = context.SemanticModel.GetDeclaredSymbol(declaration);
             if (interfaceType == null)
@@ -54,11 +54,11 @@ namespace SonarAnalyzer.Rules.CSharp
 
                 if (canBeIn ^ canBeOut)
                 {
-                    ReportIssue(typeParameter, canBeIn ? VarianceKind.In : VarianceKind.Out, context);
+                    ReportIssue(context, typeParameter, canBeIn ? VarianceKind.In : VarianceKind.Out);
                 }
             }
         }
-        private static void CheckDelegateVariance(DelegateDeclarationSyntax declaration, SyntaxNodeAnalysisContext context)
+        private static void CheckDelegateVariance(SonarSyntaxNodeAnalysisContext context, DelegateDeclarationSyntax declaration)
         {
             var declaredSymbol = context.SemanticModel.GetDeclaredSymbol(declaration);
             if (declaredSymbol == null)
@@ -90,7 +90,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                 if (canBeIn ^ canBeOut)
                 {
-                    ReportIssue(typeParameter, canBeIn ? VarianceKind.In : VarianceKind.Out, context);
+                    ReportIssue(context, typeParameter, canBeIn ? VarianceKind.In : VarianceKind.Out);
                 }
             }
         }
@@ -170,7 +170,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #endregion
 
-        private static void ReportIssue(ITypeParameterSymbol typeParameter, VarianceKind variance, SyntaxNodeAnalysisContext context)
+        private static void ReportIssue(SonarSyntaxNodeAnalysisContext context, ITypeParameterSymbol typeParameter, VarianceKind variance)
         {
             if (!typeParameter.DeclaringSyntaxReferences.Any())
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeMutable.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeMutable.cs
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static SecondaryLocation CreateSecondaryLocation(SimpleNameSyntax identifierSyntax) =>
             new SecondaryLocation(identifierSyntax.GetLocation(), string.Format(SecondaryMessageFormat, identifierSyntax.Identifier.Text));
 
-        private static IEnumerable<IdentifierNameSyntax> GetAllFirstMutableFieldsUsed(SyntaxNodeAnalysisContext context,
+        private static IEnumerable<IdentifierNameSyntax> GetAllFirstMutableFieldsUsed(SonarSyntaxNodeAnalysisContext context,
                                                                                       ICollection<IFieldSymbol> fieldsOfClass,
                                                                                       IEnumerable<IdentifierNameSyntax> identifiers)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetTypeWithIsAssignableFrom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetTypeWithIsAssignableFrom.cs
@@ -92,7 +92,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKindEx.IsPatternExpression);
         }
 
-        private static void CheckAsOperatorComparedToNull(SyntaxNodeAnalysisContext context, ExpressionSyntax sideA, ExpressionSyntax sideB)
+        private static void CheckAsOperatorComparedToNull(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax sideA, ExpressionSyntax sideB)
         {
             if (sideA.RemoveParentheses().IsKind(SyntaxKind.AsExpression) && sideB.RemoveParentheses().IsKind(SyntaxKind.NullLiteralExpression))
             {
@@ -100,7 +100,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckGetTypeAndTypeOfEquality(SyntaxNodeAnalysisContext context, ExpressionSyntax sideA, ExpressionSyntax sideB)
+        private static void CheckGetTypeAndTypeOfEquality(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax sideA, ExpressionSyntax sideB)
         {
             if (sideA.ToStringContains("GetType")
                 && sideB is TypeOfExpressionSyntax sideBTypeOf
@@ -113,7 +113,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckForIsInstanceOfType(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax memberAccess, IMethodSymbol methodSymbol)
+        private static void CheckForIsInstanceOfType(SonarSyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax memberAccess, IMethodSymbol methodSymbol)
         {
             if (methodSymbol.Name == "IsInstanceOfType" && memberAccess.Expression is TypeOfExpressionSyntax)
             {
@@ -121,7 +121,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckForIsAssignableFrom(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax memberAccess, IMethodSymbol methodSymbol, ExpressionSyntax argument)
+        private static void CheckForIsAssignableFrom(SonarSyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax memberAccess, IMethodSymbol methodSymbol, ExpressionSyntax argument)
         {
             if (methodSymbol.Name == nameof(Type.IsAssignableFrom) && (argument as InvocationExpressionSyntax).IsGetTypeCall(context.SemanticModel))
             {
@@ -144,7 +144,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 _ => null
             };
 
-        private static void ReportDiagnostic(SyntaxNodeAnalysisContext context, string messageArg, bool useIsOperator = false, bool shouldRemoveGetType = false)
+        private static void ReportDiagnostic(SonarSyntaxNodeAnalysisContext context, string messageArg, bool useIsOperator = false, bool shouldRemoveGetType = false)
         {
             var properties = ImmutableDictionary<string, string>.Empty
                 .Add(UseIsOperatorKey, useIsOperator.ToString())

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
@@ -125,7 +125,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 context.RegisterSyntaxNodeActionInNonGenerated(VisitAssignments, SyntaxKind.SimpleAssignmentExpression);
             });
 
-        private void VisitObjectCreation(SyntaxNodeAnalysisContext context)
+        private void VisitObjectCreation(SonarSyntaxNodeAnalysisContext context)
         {
             var objectCreation = ObjectCreationFactory.Create(context.Node);
 
@@ -139,7 +139,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void VisitInvocationExpression(SyntaxNodeAnalysisContext context)
+        private void VisitInvocationExpression(SonarSyntaxNodeAnalysisContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if (telnetRegexForIdentifier.IsMatch(invocation.Expression.ToString()))
@@ -148,7 +148,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void VisitAssignments(SyntaxNodeAnalysisContext context)
+        private static void VisitAssignments(SonarSyntaxNodeAnalysisContext context)
         {
             var assignment = (AssignmentExpressionSyntax)context.Node;
             if (assignment.Left is MemberAccessExpressionSyntax memberAccess
@@ -160,7 +160,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void VisitStringExpressions(SyntaxNodeAnalysisContext c)
+        private void VisitStringExpressions(SonarSyntaxNodeAnalysisContext c)
         {
             if (GetUnsafeProtocol(c.Node, c.SemanticModel) is { } unsafeProtocol)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                                                    ImplicitObjectCreationExpression);
                 });
 
-        private static void CheckIgnoreAntiforgeryTokenAttribute(SyntaxNodeAnalysisContext c)
+        private static void CheckIgnoreAntiforgeryTokenAttribute(SonarSyntaxNodeAnalysisContext c)
         {
             var shouldReport = c.Node switch
             {
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportDiagnostic(SyntaxNodeAnalysisContext context) =>
+        private static void ReportDiagnostic(SonarSyntaxNodeAnalysisContext context) =>
             context.ReportIssue(Diagnostic.Create(Rule, context.Node.GetLocation()));
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/InsecureDeserialization.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/InsecureDeserialization.cs
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKindEx.RecordStructDeclaration,
             SyntaxKind.StructDeclaration);
 
-        private static void ReportOnInsecureDeserializations(SyntaxNodeAnalysisContext context, TypeDeclarationSyntax declaration, ITypeSymbol typeSymbol)
+        private static void ReportOnInsecureDeserializations(SonarSyntaxNodeAnalysisContext context, TypeDeclarationSyntax declaration, ITypeSymbol typeSymbol)
         {
             var implementsISerializable = ImplementsISerializable(typeSymbol);
             var implementsIDeserializationCallback = ImplementsIDeserializationCallback(typeSymbol);
@@ -83,7 +83,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             }
 
-            static void ReportIssue(SyntaxNodeAnalysisContext context, ConstructorInfo constructor) =>
+            static void ReportIssue(SonarSyntaxNodeAnalysisContext context, ConstructorInfo constructor) =>
                 context.ReportIssue(Diagnostic.Create(Rule, constructor.GetReportLocation()));
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/LooseFilePermissions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/LooseFilePermissions.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         internal LooseFilePermissions(IAnalyzerConfiguration configuration) : base(configuration) { }
 
-        protected override void VisitAssignments(SyntaxNodeAnalysisContext context)
+        protected override void VisitAssignments(SonarSyntaxNodeAnalysisContext context)
         {
             var node = context.Node;
             if (IsFileAccessPermissions(node, context.SemanticModel) && !node.IsPartOfBinaryNegationOrCondition())
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        protected override void VisitInvocations(SyntaxNodeAnalysisContext context)
+        protected override void VisitInvocations(SonarSyntaxNodeAnalysisContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if ((IsSetAccessRule(invocation, context.SemanticModel) || IsAddAccessRule(invocation, context.SemanticModel))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/PermissiveCors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/PermissiveCors.cs
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 tracker.MatchConstructor(KnownType.Microsoft_AspNetCore_Cors_Infrastructure_CorsPolicyBuilder),
                 c => ContainsStar(ObjectCreationFactory.Create(c.Node), c.SemanticModel));
 
-        private void VisitAttribute(SyntaxNodeAnalysisContext context)
+        private void VisitAttribute(SonarSyntaxNodeAnalysisContext context)
         {
             var attribute = (AttributeSyntax)context.Node;
             if (attribute.IsKnownType(KnownType.System_Web_Http_Cors_EnableCorsAttribute, context.SemanticModel)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/IfChainWithoutElse.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/IfChainWithoutElse.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
            ifSyntax.Parent.IsKind(SyntaxKind.ElseClause)
            && (ifSyntax.Else == null || IsEmptyBlock(ifSyntax.Else));
 
-        protected override Location IssueLocation(SyntaxNodeAnalysisContext context, IfStatementSyntax ifSyntax)
+        protected override Location IssueLocation(SonarSyntaxNodeAnalysisContext context, IfStatementSyntax ifSyntax)
         {
             var parentElse = (ElseClauseSyntax)ifSyntax.Parent;
             var diff = ifSyntax.IfKeyword.Span.End - parentElse.ElseKeyword.SpanStart;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementSerializationMethodsCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementSerializationMethodsCorrectly.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
             base.Initialize(context);
         }
 
-        private void ReportOnAttributes(SyntaxNodeAnalysisContext context, IEnumerable<AttributeSyntax> attributes, string memberType)
+        private void ReportOnAttributes(SonarSyntaxNodeAnalysisContext context, IEnumerable<AttributeSyntax> attributes, string memberType)
         {
             foreach (var attribute in attributes)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/IndentSingleLineFollowingConditional.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/IndentSingleLineFollowingConditional.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(CheckElse, SyntaxKind.ElseClause);
         }
 
-        private static void CheckWhile(SyntaxNodeAnalysisContext context)
+        private static void CheckWhile(SonarSyntaxNodeAnalysisContext context)
         {
             var whileStatement = (WhileStatementSyntax)context.Node;
             if (!IsStatementIndentationOk(whileStatement, whileStatement.Statement))
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckDo(SyntaxNodeAnalysisContext context)
+        private static void CheckDo(SonarSyntaxNodeAnalysisContext context)
         {
             var doStatement = (DoStatementSyntax)context.Node;
             if (!IsStatementIndentationOk(doStatement, doStatement.Statement))
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckFor(SyntaxNodeAnalysisContext context)
+        private static void CheckFor(SonarSyntaxNodeAnalysisContext context)
         {
             var forStatement = (ForStatementSyntax)context.Node;
             if (!IsStatementIndentationOk(forStatement, forStatement.Statement))
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckForEach(SyntaxNodeAnalysisContext context)
+        private static void CheckForEach(SonarSyntaxNodeAnalysisContext context)
         {
             var forEachStatement = (ForEachStatementSyntax)context.Node;
             if (!IsStatementIndentationOk(forEachStatement, forEachStatement.Statement))
@@ -84,7 +84,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckIf(SyntaxNodeAnalysisContext context)
+        private static void CheckIf(SonarSyntaxNodeAnalysisContext context)
         {
             var ifStatement = (IfStatementSyntax)context.Node;
 
@@ -115,7 +115,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckElse(SyntaxNodeAnalysisContext context)
+        private static void CheckElse(SonarSyntaxNodeAnalysisContext context)
         {
             var elseClause = (ElseClauseSyntax)context.Node;
             if (!IsStatementIndentationOk(elseClause, elseClause.Statement))
@@ -129,7 +129,7 @@ namespace SonarAnalyzer.Rules.CSharp
             conditionallyExecutedNode is BlockSyntax ||
             VisualIndentComparer.IsSecondIndentLonger(controlNode, conditionallyExecutedNode);
 
-        private static void ReportIssue(SyntaxNodeAnalysisContext context, Location primaryLocation,
+        private static void ReportIssue(SonarSyntaxNodeAnalysisContext context, Location primaryLocation,
             SyntaxNode secondaryLocationNode, string conditionLabelText) =>
                context.ReportIssue(Rule.CreateDiagnostic(context.Compilation, primaryLocation, new[] { GetFirstLineOfNode(secondaryLocationNode) }, conditionLabelText));
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
@@ -75,7 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PropertyDeclaration);
         }
 
-        private void CheckForNoExitMethod(SyntaxNodeAnalysisContext c, CSharpSyntaxNode body, SyntaxToken identifier)
+        private void CheckForNoExitMethod(SonarSyntaxNodeAnalysisContext c, CSharpSyntaxNode body, SyntaxToken identifier)
         {
             if (body != null && c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol symbol)
             {
@@ -96,22 +96,22 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private sealed class RecursionContext<TControlFlowGraph>
         {
+            private readonly SonarSyntaxNodeAnalysisContext analysisContext;
             private readonly string messageArg;
-            private readonly SyntaxNodeAnalysisContext analysisContext;
             private readonly Location issueLocation;
 
             public TControlFlowGraph ControlFlowGraph { get; }
             public ISymbol AnalyzedSymbol { get; }
             public SemanticModel SemanticModel => analysisContext.SemanticModel;
 
-            public RecursionContext(TControlFlowGraph controlFlowGraph,
+            public RecursionContext(SonarSyntaxNodeAnalysisContext analysisContext,
+                                    TControlFlowGraph controlFlowGraph,
                                     ISymbol analyzedSymbol,
                                     Location issueLocation,
-                                    SyntaxNodeAnalysisContext analysisContext,
                                     string messageArg)
             {
-                this.messageArg = messageArg;
                 this.analysisContext = analysisContext;
+                this.messageArg = messageArg;
                 this.issueLocation = issueLocation;
                 ControlFlowGraph = controlFlowGraph;
                 AnalyzedSymbol = analyzedSymbol;
@@ -123,8 +123,8 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private interface IChecker
         {
-            void CheckForNoExitProperty(SyntaxNodeAnalysisContext c, PropertyDeclarationSyntax property, IPropertySymbol propertySymbol);
-            void CheckForNoExitMethod(SyntaxNodeAnalysisContext c, CSharpSyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol);
+            void CheckForNoExitProperty(SonarSyntaxNodeAnalysisContext c, PropertyDeclarationSyntax property, IPropertySymbol propertySymbol);
+            void CheckForNoExitMethod(SonarSyntaxNodeAnalysisContext c, CSharpSyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfaceMethodsShouldBeCallableByChildTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfaceMethodsShouldBeCallableByChildTypes.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.EventDeclaration);
         }
 
-        private static void ReportOnIssue<TMemberSyntax>(SyntaxNodeAnalysisContext analysisContext,
+        private static void ReportOnIssue<TMemberSyntax>(SonarSyntaxNodeAnalysisContext analysisContext,
                                                          Func<TMemberSyntax, ExplicitInterfaceSpecifierSyntax> getExplicitInterfaceSpecifier,
                                                          Func<TMemberSyntax, SyntaxToken> getIdentifierName,
                                                          Func<TMemberSyntax, TMemberSyntax, bool> areMembersEquivalent)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterface.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterface.cs
@@ -74,16 +74,14 @@ namespace SonarAnalyzer.Rules.CSharp
                             var interfaceType = c.SemanticModel.GetTypeInfo(cast.Type).Type as INamedTypeSymbol;
                             var expressionType = c.SemanticModel.GetTypeInfo(cast.Expression).Type as INamedTypeSymbol;
 
-                            CheckTypesForInvalidCast(interfaceType, expressionType, interfaceImplementerMappings,
-                                cast.Type.GetLocation(), c);
+                            CheckTypesForInvalidCast(c, interfaceType, expressionType, interfaceImplementerMappings, cast.Type.GetLocation());
                         },
                         SyntaxKind.CastExpression);
                 });
         }
 
-        private static void CheckTypesForInvalidCast(INamedTypeSymbol interfaceType, INamedTypeSymbol expressionType,
-            Dictionary<INamedTypeSymbol, HashSet<INamedTypeSymbol>> interfaceImplementerMappings, Location issueLocation,
-            SyntaxNodeAnalysisContext context)
+        private static void CheckTypesForInvalidCast(SonarSyntaxNodeAnalysisContext context, INamedTypeSymbol interfaceType, INamedTypeSymbol expressionType,
+            Dictionary<INamedTypeSymbol, HashSet<INamedTypeSymbol>> interfaceImplementerMappings, Location issueLocation)
         {
             if (interfaceType == null ||
                 expressionType == null ||
@@ -108,7 +106,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 !interfaceImplementerMappings[interfaceType.OriginalDefinition].Any(t => t.DerivesOrImplements(expressionType.OriginalDefinition)) &&
                 !expressionType.IsSealed)
             {
-                ReportIssue(interfaceType, expressionType, issueLocation, context);
+                ReportIssue(context, interfaceType, expressionType, issueLocation);
             }
         }
 
@@ -117,8 +115,7 @@ namespace SonarAnalyzer.Rules.CSharp
             interfaceImplementerMappings.ContainsKey(type) &&
             interfaceImplementerMappings[type].Any(t => t.IsClassOrStruct());
 
-        private static void ReportIssue(ISymbol interfaceType, ITypeSymbol expressionType, Location issueLocation,
-            SyntaxNodeAnalysisContext context)
+        private static void ReportIssue(SonarSyntaxNodeAnalysisContext context, ISymbol interfaceType, ITypeSymbol expressionType, Location issueLocation)
         {
             var interfaceTypeName = interfaceType.ToMinimalDisplayString(context.SemanticModel, issueLocation.SourceSpan.Start);
             var expressionTypeName = expressionType.ToMinimalDisplayString(context.SemanticModel, issueLocation.SourceSpan.Start);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 c =>
                 {
                     var invocation = (InvocationExpressionSyntax)c.Node;
-                    CheckCall(invocation, invocation.ArgumentList, c);
+                    CheckCall(c, invocation, invocation.ArgumentList);
                 },
                 SyntaxKind.InvocationExpression);
 
@@ -43,12 +43,12 @@ namespace SonarAnalyzer.Rules.CSharp
                 c =>
                 {
                     var objectCreation = (ObjectCreationExpressionSyntax)c.Node;
-                    CheckCall(objectCreation, objectCreation.ArgumentList, c);
+                    CheckCall(c, objectCreation, objectCreation.ArgumentList);
                 },
                 SyntaxKind.ObjectCreationExpression);
         }
 
-        private static void CheckCall(SyntaxNode node, ArgumentListSyntax argumentList, SyntaxNodeAnalysisContext context)
+        private static void CheckCall(SonarSyntaxNodeAnalysisContext context, SyntaxNode node, ArgumentListSyntax argumentList)
         {
             if (argumentList == null
                 || argumentList.Arguments.Count == 0

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LiteralsShouldNotBePassedAsLocalizedParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LiteralsShouldNotBePassedAsLocalizedParameters.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(AnalyzeAssignments, SyntaxKind.SimpleAssignmentExpression);
         }
 
-        private static void AnalyzeInvocations(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeInvocations(SonarSyntaxNodeAnalysisContext context)
         {
             var invocationSyntax = (InvocationExpressionSyntax)context.Node;
             if (!(context.SemanticModel.GetSymbolInfo(invocationSyntax).Symbol is IMethodSymbol methodSymbol)
@@ -80,7 +80,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void AnalyzeAssignments(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeAssignments(SonarSyntaxNodeAnalysisContext context)
         {
             var assignmentSyntax = (AssignmentExpressionSyntax)context.Node;
             if (CSharpDebugOnlyCodeHelper.IsCallerInConditionalDebug(assignmentSyntax, context.SemanticModel))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LoopsAndLinq.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LoopsAndLinq.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     }
                     else
                     {
-                        CheckIfCanBeSimplifiedUsingSelect(forEachStatementSyntax, c);
+                        CheckIfCanBeSimplifiedUsingSelect(c, forEachStatementSyntax);
                     }
                 },
                 SyntaxKind.ForEachStatement);
@@ -92,7 +92,7 @@ namespace SonarAnalyzer.Rules.CSharp
         ///  - the property is used more than once
         ///  - the property is the right side of a variable declaration.
         /// </remarks>
-        private static void CheckIfCanBeSimplifiedUsingSelect(ForEachStatementSyntax forEachStatementSyntax, SyntaxNodeAnalysisContext c)
+        private static void CheckIfCanBeSimplifiedUsingSelect(SonarSyntaxNodeAnalysisContext c, ForEachStatementSyntax forEachStatementSyntax)
         {
             var declaredSymbol = new Lazy<ILocalSymbol>(() => c.SemanticModel.GetDeclaredSymbol(forEachStatementSyntax));
             var expressionTypeIsOrImplementsIEnumerable = new Lazy<bool>(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializedToDefault.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializedToDefault.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(CheckAutoProperty, SyntaxKind.PropertyDeclaration);
         }
 
-        private static void CheckAutoProperty(SyntaxNodeAnalysisContext context)
+        private static void CheckAutoProperty(SonarSyntaxNodeAnalysisContext context)
         {
             var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
 
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckEvent(SyntaxNodeAnalysisContext context)
+        private static void CheckEvent(SonarSyntaxNodeAnalysisContext context)
         {
             var field = (EventFieldDeclarationSyntax)context.Node;
 
@@ -78,7 +78,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckField(SyntaxNodeAnalysisContext context)
+        private static void CheckField(SonarSyntaxNodeAnalysisContext context)
         {
             var field = (FieldDeclarationSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldBeStatic.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldBeStatic.cs
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 ? methodDeclaration.Body?.DescendantNodes()
                 : methodDeclaration.ExpressionBody.DescendantNodes();
 
-        private static void CheckIssue<TDeclarationSyntax>(SyntaxNodeAnalysisContext context,
+        private static void CheckIssue<TDeclarationSyntax>(SonarSyntaxNodeAnalysisContext context,
                                                            Func<TDeclarationSyntax, IEnumerable<SyntaxNode>> getDescendants,
                                                            Func<TDeclarationSyntax, SyntaxToken> getIdentifier,
                                                            string memberKind)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldNotHaveConflictingTransparencyAttributes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldNotHaveConflictingTransparencyAttributes.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     csac.RegisterCompilationEndAction(cac => ReportOnConflictingTransparencyAttributes(cac, nodesWithSecuritySafeCritical, nodesWithSecurityCritical));
                 });
 
-        private static void CollectSecurityAttributes(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext,
+        private static void CollectSecurityAttributes(SonarSyntaxNodeAnalysisContext syntaxNodeAnalysisContext,
                                                       Dictionary<SyntaxNode, AttributeSyntax> nodesWithSecuritySafeCritical,
                                                       Dictionary<SyntaxNode, AttributeSyntax> nodesWithSecurityCritical)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverloadsShouldBeGrouped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverloadsShouldBeGrouped.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKindEx.RecordStructDeclaration,
         };
 
-        protected override MemberInfo CreateMemberInfo(SyntaxNodeAnalysisContext c, MemberDeclarationSyntax member) =>
+        protected override MemberInfo CreateMemberInfo(SonarSyntaxNodeAnalysisContext c, MemberDeclarationSyntax member) =>
             member switch
             {
                 ConstructorDeclarationSyntax constructor => new MemberInfo(c, member, constructor.Identifier, constructor.IsStatic(), false, true),

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideChangedDefaultValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideChangedDefaultValue.cs
@@ -57,16 +57,14 @@ namespace SonarAnalyzer.Rules.CSharp
 
                         var parameterSyntax = method.ParameterList.Parameters[i];
 
-                        ReportParameterIfNeeded(overridingParameter, overriddenParameter, parameterSyntax,
-                            isExplicitImplementation: methodSymbol.ExplicitInterfaceImplementations.Any(),
-                            context: c);
+                        ReportParameterIfNeeded(c, overridingParameter, overriddenParameter, parameterSyntax, methodSymbol.ExplicitInterfaceImplementations.Any());
                     }
                 },
                 SyntaxKind.MethodDeclaration);
         }
 
-        private static void ReportParameterIfNeeded(IParameterSymbol overridingParameter, IParameterSymbol overriddenParameter,
-            ParameterSyntax parameterSyntax, bool isExplicitImplementation, SyntaxNodeAnalysisContext context)
+        private static void ReportParameterIfNeeded(SonarSyntaxNodeAnalysisContext context, IParameterSymbol overridingParameter, IParameterSymbol overriddenParameter,
+            ParameterSyntax parameterSyntax, bool isExplicitImplementation)
         {
             if (isExplicitImplementation)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ConstructorDeclaration,
                 SyntaxKindEx.LocalFunctionStatement);
 
-        private static MethodContext CreateContext(SyntaxNodeAnalysisContext c)
+        private static MethodContext CreateContext(SonarSyntaxNodeAnalysisContext c)
         {
             if (c.Node is BaseMethodDeclarationSyntax method)
             {
@@ -156,8 +156,8 @@ namespace SonarAnalyzer.Rules.CSharp
             }
             else
             {
-                return body.CreateCfg(declaration.Context.SemanticModel, declaration.Context.CancellationToken) is { } cfg
-                    ? new LvaResult(cfg, declaration.Context.CancellationToken)
+                return body.CreateCfg(declaration.Context.SemanticModel, declaration.Context.Cancel) is { } cfg
+                    ? new LvaResult(cfg, declaration.Context.Cancel)
                     : null;
             }
         }
@@ -254,19 +254,19 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private class MethodContext
         {
-            public readonly SyntaxNodeAnalysisContext Context;
+            public readonly SonarSyntaxNodeAnalysisContext Context;
             public readonly IMethodSymbol Symbol;
             public readonly ParameterListSyntax ParameterList;
             public readonly BlockSyntax Body;
             public readonly ArrowExpressionClauseSyntax ExpressionBody;
 
-            public MethodContext(SyntaxNodeAnalysisContext context, BaseMethodDeclarationSyntax declaration)
+            public MethodContext(SonarSyntaxNodeAnalysisContext context, BaseMethodDeclarationSyntax declaration)
                 : this(context, declaration.ParameterList, declaration.Body, declaration.ExpressionBody()) { }
 
-            public MethodContext(SyntaxNodeAnalysisContext context, LocalFunctionStatementSyntaxWrapper declaration)
+            public MethodContext(SonarSyntaxNodeAnalysisContext context, LocalFunctionStatementSyntaxWrapper declaration)
                 : this(context, declaration.ParameterList, declaration.Body, declaration.ExpressionBody) { }
 
-            private MethodContext(SyntaxNodeAnalysisContext context, ParameterListSyntax parameterList, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody)
+            private MethodContext(SonarSyntaxNodeAnalysisContext context, ParameterListSyntax parameterList, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody)
             {
                 Context = context;
                 Symbol = context.SemanticModel.GetDeclaredSymbol(context.Node) as IMethodSymbol;
@@ -283,7 +283,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             public LvaResult(MethodContext declaration, IControlFlowGraph cfg)
             {
-                var lva = new SonarCSharpLiveVariableAnalysis(cfg, declaration.Symbol, declaration.Context.SemanticModel, declaration.Context.CancellationToken);
+                var lva = new SonarCSharpLiveVariableAnalysis(cfg, declaration.Symbol, declaration.Context.SemanticModel, declaration.Context.Cancel);
                 LiveInEntryBlock = lva.LiveIn(cfg.EntryBlock).OfType<IParameterSymbol>().ToImmutableArray();
                 CapturedVariables = lva.CapturedVariables;
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveIdenticalImplementations.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveIdenticalImplementations.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override SyntaxToken GetMethodIdentifier(IMethodDeclaration method) =>
             method.Identifier;
 
-        protected override bool IsExcludedFromBeingExamined(SyntaxNodeAnalysisContext context) =>
+        protected override bool IsExcludedFromBeingExamined(SonarSyntaxNodeAnalysisContext context) =>
             base.IsExcludedFromBeingExamined(context)
             && !context.IsTopLevelMain();
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MultilineBlocksWithoutBrace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MultilineBlocksWithoutBrace.cs
@@ -50,7 +50,7 @@ public sealed class MultilineBlocksWithoutBrace : SonarDiagnosticAnalyzer
             SyntaxKind.IfStatement);
     }
 
-    private static void CheckLoop(SyntaxNodeAnalysisContext context, StatementSyntax statement)
+    private static void CheckLoop(SonarSyntaxNodeAnalysisContext context, StatementSyntax statement)
     {
         if (!IsNestedStatement(statement))
         {
@@ -58,7 +58,7 @@ public sealed class MultilineBlocksWithoutBrace : SonarDiagnosticAnalyzer
         }
     }
 
-    private static void CheckIf(SyntaxNodeAnalysisContext context, IfStatementSyntax ifStatement)
+    private static void CheckIf(SonarSyntaxNodeAnalysisContext context, IfStatementSyntax ifStatement)
     {
         if (!ifStatement.GetPrecedingIfsInConditionChain().Any()
             && !IsNestedStatement(ifStatement.Statement)
@@ -85,7 +85,7 @@ public sealed class MultilineBlocksWithoutBrace : SonarDiagnosticAnalyzer
         return statement;
     }
 
-    private static void CheckStatement(SyntaxNodeAnalysisContext context, StatementSyntax first, string executed, string execute)
+    private static void CheckStatement(SonarSyntaxNodeAnalysisContext context, StatementSyntax first, string executed, string execute)
     {
         if (IsNotEmpty(first)
             && SecondStatement(context.Node, first) is { } second

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NameOfShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NameOfShouldBeUsed.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 : paramGroups.Select(g => g.First().Identifier.ValueText);
         }
 
-        protected override bool LeastLanguageVersionMatches(SyntaxNodeAnalysisContext context) =>
+        protected override bool LeastLanguageVersionMatches(SonarSyntaxNodeAnalysisContext context) =>
             context.Compilation.IsAtLeastLanguageVersion(LanguageVersion.CSharp6);
 
         protected override bool IsArgumentExceptionCallingNameOf(SyntaxNode node, IEnumerable<string> arguments) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportTrivialWrappers(SyntaxNodeAnalysisContext c)
+        private static void ReportTrivialWrappers(SonarSyntaxNodeAnalysisContext c)
         {
             var methodDeclaration = (MethodDeclarationSyntax)c.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NoExceptionsInFinally.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NoExceptionsInFinally.cs
@@ -32,10 +32,10 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private sealed class ThrowInFinallyWalker : SafeCSharpSyntaxWalker
         {
-            private readonly SyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeAnalysisContext context;
             private readonly DiagnosticDescriptor rule;
 
-            public ThrowInFinallyWalker(SyntaxNodeAnalysisContext context, DiagnosticDescriptor rule)
+            public ThrowInFinallyWalker(SonarSyntaxNodeAnalysisContext context, DiagnosticDescriptor rule)
             {
                 this.context = context;
                 this.rule = rule;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NonFlagsEnumInBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NonFlagsEnumInBitwiseOperation.cs
@@ -36,19 +36,19 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
-                c => CheckExpressionWithOperator<BinaryExpressionSyntax>(b => b.OperatorToken, c),
+                c => CheckExpressionWithOperator<BinaryExpressionSyntax>(c, b => b.OperatorToken),
                 SyntaxKind.BitwiseOrExpression,
                 SyntaxKind.BitwiseAndExpression,
                 SyntaxKind.ExclusiveOrExpression);
 
             context.RegisterSyntaxNodeActionInNonGenerated(
-                c => CheckExpressionWithOperator<AssignmentExpressionSyntax>(a => a.OperatorToken, c),
+                c => CheckExpressionWithOperator<AssignmentExpressionSyntax>(c, a => a.OperatorToken),
                 SyntaxKind.AndAssignmentExpression,
                 SyntaxKind.OrAssignmentExpression,
                 SyntaxKind.ExclusiveOrAssignmentExpression);
         }
 
-        private static void CheckExpressionWithOperator<T>(Func<T, SyntaxToken> operatorSelector, SyntaxNodeAnalysisContext context)
+        private static void CheckExpressionWithOperator<T>(SonarSyntaxNodeAnalysisContext context, Func<T, SyntaxToken> operatorSelector)
             where T : SyntaxNode
         {
             if (context.SemanticModel.GetSymbolInfo(context.Node).Symbol is not IMethodSymbol { MethodKind: MethodKind.BuiltinOperator, ReturnType.TypeKind: TypeKind.Enum } operation

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterNamesShouldNotDuplicateMethodNames.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterNamesShouldNotDuplicateMethodNames.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKindEx.LocalFunctionStatement);
         }
 
-        private static void CheckMethodParameters(SyntaxNodeAnalysisContext context, SyntaxToken identifier, ParameterListSyntax parameterList)
+        private static void CheckMethodParameters(SonarSyntaxNodeAnalysisContext context, SyntaxToken identifier, ParameterListSyntax parameterList)
         {
             var methodName = identifier.ToString();
             foreach (var parameter in parameterList.Parameters.Select(p => p.Identifier))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }, SyntaxKind.ObjectCreationExpression);
         }
 
-        private void AnalyzeArguments(SyntaxNodeAnalysisContext analysisContext, ArgumentListSyntax argumentList,
+        private void AnalyzeArguments(SonarSyntaxNodeAnalysisContext analysisContext, ArgumentListSyntax argumentList,
             Func<Location> getLocation)
         {
             if (argumentList == null)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PartialMethodNoImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PartialMethodNoImplementation.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(CheckForCandidatePartialInvocation, SyntaxKind.InvocationExpression);
         }
 
-        private static void CheckForCandidatePartialDeclaration(SyntaxNodeAnalysisContext context)
+        private static void CheckForCandidatePartialDeclaration(SonarSyntaxNodeAnalysisContext context)
         {
             var declaration = (MethodDeclarationSyntax)context.Node;
             var partialKeyword = declaration.Modifiers.FirstOrDefault(m => m.IsKind(SyntaxKind.PartialKeyword));
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckForCandidatePartialInvocation(SyntaxNodeAnalysisContext context)
+        private static void CheckForCandidatePartialInvocation(SonarSyntaxNodeAnalysisContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PreferJaggedArraysOverMultidimensional.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PreferJaggedArraysOverMultidimensional.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PropertyDeclaration);
         }
 
-        private static void AnalyzeNode<TSyntax>(SyntaxNodeAnalysisContext context,
+        private static void AnalyzeNode<TSyntax>(SonarSyntaxNodeAnalysisContext context,
             Func<SemanticModel, TSyntax, ITypeSymbol> getTypeSymbol, Func<TSyntax, Location> getLocation)
             where TSyntax : SyntaxNode
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundancyInConstructorDestructorDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundancyInConstructorDestructorDeclaration.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(CheckDestructorDeclaration, SyntaxKind.DestructorDeclaration);
         }
 
-        private static void CheckDestructorDeclaration(SyntaxNodeAnalysisContext context)
+        private static void CheckDestructorDeclaration(SonarSyntaxNodeAnalysisContext context)
         {
             var destructorDeclaration = (DestructorDeclarationSyntax)context.Node;
 
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckConstructorDeclaration(SyntaxNodeAnalysisContext context)
+        private static void CheckConstructorDeclaration(SonarSyntaxNodeAnalysisContext context)
         {
             var constructorDeclaration = (ConstructorDeclarationSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantCast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantCast.cs
@@ -57,8 +57,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.InvocationExpression);
         }
 
-        private static void CheckCastExpression(SyntaxNodeAnalysisContext context, ExpressionSyntax expression,
-            ExpressionSyntax type, Location location)
+        private static void CheckCastExpression(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax expression, ExpressionSyntax type, Location location)
         {
             if (expression.IsKind(SyntaxKindEx.DefaultLiteralExpression))
             {
@@ -84,7 +83,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckExtensionMethodInvocation(SyntaxNodeAnalysisContext context)
+        private static void CheckExtensionMethodInvocation(SonarSyntaxNodeAnalysisContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if (GetEnumerableExtensionSymbol(invocation, context.SemanticModel) is { } methodSymbol)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(UselessConditionSwitchExpression, SyntaxKindEx.SwitchExpression);
         }
 
-        private static void UselessConditionIfStatement(SyntaxNodeAnalysisContext c)
+        private static void UselessConditionIfStatement(SonarSyntaxNodeAnalysisContext c)
         {
             var ifStatement = (IfStatementSyntax)c.Node;
 
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void UselessConditionSwitchExpression(SyntaxNodeAnalysisContext c)
+        private static void UselessConditionSwitchExpression(SonarSyntaxNodeAnalysisContext c)
         {
             var switchExpression = (SwitchExpressionSyntaxWrapper)c.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantDeclaration.cs
@@ -73,15 +73,15 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKind.OutKeyword
         };
 
-        private static void VisitParenthesizedLambdaExpression(SyntaxNodeAnalysisContext context)
+        private static void VisitParenthesizedLambdaExpression(SonarSyntaxNodeAnalysisContext context)
         {
             var lambda = (ParenthesizedLambdaExpressionSyntax)context.Node;
 
-            CheckUnusedParameters(lambda, context);
-            CheckTypeSpecifications(lambda, context);
+            CheckUnusedParameters(context, lambda);
+            CheckTypeSpecifications(context, lambda);
         }
 
-        private static void CheckTypeSpecifications(ParenthesizedLambdaExpressionSyntax lambda, SyntaxNodeAnalysisContext context)
+        private static void CheckTypeSpecifications(SonarSyntaxNodeAnalysisContext context, ParenthesizedLambdaExpressionSyntax lambda)
         {
             if (!IsParameterListModifiable(lambda))
             {
@@ -113,7 +113,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckUnusedParameters(ParenthesizedLambdaExpressionSyntax lambda, SyntaxNodeAnalysisContext context)
+        private static void CheckUnusedParameters(SonarSyntaxNodeAnalysisContext context, ParenthesizedLambdaExpressionSyntax lambda)
         {
             if (context.Compilation.IsLambdaDiscardParameterSupported())
             {
@@ -156,7 +156,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #region Nullable constructor call
 
-        private static void ReportRedundantNullableConstructorCall(SyntaxNodeAnalysisContext context)
+        private static void ReportRedundantNullableConstructorCall(SonarSyntaxNodeAnalysisContext context)
         {
             var objectCreation = ObjectCreationFactory.Create(context.Node);
             if (!IsNullableCreation(objectCreation, context.SemanticModel))
@@ -196,14 +196,14 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #region Array (creation, size, type)
 
-        private static void ReportRedundancyInArrayCreation(SyntaxNodeAnalysisContext context)
+        private static void ReportRedundancyInArrayCreation(SonarSyntaxNodeAnalysisContext context)
         {
             var array = (ArrayCreationExpressionSyntax)context.Node;
             ReportRedundantArraySizeSpecifier(context, array);
             ReportRedundantArrayTypeSpecifier(context, array);
         }
 
-        private static void ReportRedundantArraySizeSpecifier(SyntaxNodeAnalysisContext context, ArrayCreationExpressionSyntax array)
+        private static void ReportRedundantArraySizeSpecifier(SonarSyntaxNodeAnalysisContext context, ArrayCreationExpressionSyntax array)
         {
             if (array.Initializer == null || array.Type == null)
             {
@@ -223,7 +223,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportRedundantArrayTypeSpecifier(SyntaxNodeAnalysisContext context, ArrayCreationExpressionSyntax array)
+        private static void ReportRedundantArrayTypeSpecifier(SonarSyntaxNodeAnalysisContext context, ArrayCreationExpressionSyntax array)
         {
             if (array.Initializer == null
                 || !array.Initializer.Expressions.Any()
@@ -264,7 +264,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #region Object initializer
 
-        private static void ReportOnRedundantObjectInitializer(SyntaxNodeAnalysisContext context)
+        private static void ReportOnRedundantObjectInitializer(SonarSyntaxNodeAnalysisContext context)
         {
             var objectCreation = ObjectCreationFactory.Create(context.Node);
 
@@ -280,7 +280,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #region Explicit delegate creation
 
-        private static void ReportOnExplicitDelegateCreation(SyntaxNodeAnalysisContext context)
+        private static void ReportOnExplicitDelegateCreation(SonarSyntaxNodeAnalysisContext context)
         {
             var objectCreation = ObjectCreationFactory.Create(context.Node);
             var argumentExpression = objectCreation.ArgumentList?.Arguments.FirstOrDefault()?.Expression;
@@ -361,7 +361,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #region Parameter list
 
-        private static void ReportOnRedundantParameterList(SyntaxNodeAnalysisContext context)
+        private static void ReportOnRedundantParameterList(SonarSyntaxNodeAnalysisContext context)
         {
             var anonymousMethod = (AnonymousMethodExpressionSyntax)context.Node;
             if (anonymousMethod.ParameterList == null)
@@ -426,7 +426,7 @@ namespace SonarAnalyzer.Rules.CSharp
                    && methodSymbol.ToDisplayString() == newMethodSymbol.ToDisplayString();
         }
 
-        private static void ReportIssueOnRedundantObjectCreation(SyntaxNodeAnalysisContext context, SyntaxNode node, string message, RedundancyType redundancyType)
+        private static void ReportIssueOnRedundantObjectCreation(SonarSyntaxNodeAnalysisContext context, SyntaxNode node, string message, RedundancyType redundancyType)
         {
             var location = node is ObjectCreationExpressionSyntax objectCreation
                 ? objectCreation.CreateLocation(objectCreation.Type)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKindEx.RecordClassDeclaration,
             SyntaxKindEx.RecordStructDeclaration);
 
-        private static void ReportRedundantBaseType(SyntaxNodeAnalysisContext context, BaseTypeDeclarationSyntax typeDeclaration, KnownType redundantType, string message)
+        private static void ReportRedundantBaseType(SonarSyntaxNodeAnalysisContext context, BaseTypeDeclarationSyntax typeDeclaration, KnownType redundantType, string message)
         {
             var baseTypeSyntax = typeDeclaration.BaseList.Types.First().Type;
             if (context.SemanticModel.GetSymbolInfo(baseTypeSyntax).Symbol is ITypeSymbol baseTypeSymbol
@@ -75,7 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportRedundantInterfaces(SyntaxNodeAnalysisContext context, BaseTypeDeclarationSyntax typeDeclaration)
+        private static void ReportRedundantInterfaces(SonarSyntaxNodeAnalysisContext context, BaseTypeDeclarationSyntax typeDeclaration)
         {
             var declaredType = context.SemanticModel.GetDeclaredSymbol(typeDeclaration);
             if (declaredType is null)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
@@ -35,11 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
-                c =>
-                {
-                    var declaration = (BaseMethodDeclarationSyntax)c.Node;
-                    CheckForRedundantJumps(declaration.Body, c);
-                },
+                c => CheckForRedundantJumps(c, ((BaseMethodDeclarationSyntax)c.Node).Body),
                 SyntaxKind.MethodDeclaration,
                 SyntaxKind.ConstructorDeclaration,
                 SyntaxKind.DestructorDeclaration,
@@ -47,19 +43,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.OperatorDeclaration);
 
             context.RegisterSyntaxNodeActionInNonGenerated(
-                c =>
-                {
-                    var declaration = (LocalFunctionStatementSyntaxWrapper)c.Node;
-                    CheckForRedundantJumps(declaration.Body, c);
-                },
+                c => CheckForRedundantJumps(c, ((LocalFunctionStatementSyntaxWrapper)c.Node).Body),
                 SyntaxKindEx.LocalFunctionStatement);
 
             context.RegisterSyntaxNodeActionInNonGenerated(
-                c =>
-                {
-                    var declaration = (AccessorDeclarationSyntax)c.Node;
-                    CheckForRedundantJumps(declaration.Body, c);
-                },
+                c => CheckForRedundantJumps(c, ((AccessorDeclarationSyntax)c.Node).Body),
                 SyntaxKind.GetAccessorDeclaration,
                 SyntaxKind.SetAccessorDeclaration,
                 SyntaxKindEx.InitAccessorDeclaration,
@@ -67,17 +55,13 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.RemoveAccessorDeclaration);
 
             context.RegisterSyntaxNodeActionInNonGenerated(
-                c =>
-                {
-                    var declaration = (AnonymousFunctionExpressionSyntax)c.Node;
-                    CheckForRedundantJumps(declaration.Body, c);
-                },
+                c => CheckForRedundantJumps(c, ((AnonymousFunctionExpressionSyntax)c.Node).Body),
                 SyntaxKind.AnonymousMethodExpression,
                 SyntaxKind.SimpleLambdaExpression,
                 SyntaxKind.ParenthesizedLambdaExpression);
         }
 
-        private static void CheckForRedundantJumps(CSharpSyntaxNode node, SyntaxNodeAnalysisContext context)
+        private static void CheckForRedundantJumps(SonarSyntaxNodeAnalysisContext context, CSharpSyntaxNode node)
         {
             if (!CSharpControlFlowGraph.TryGet(node, context.SemanticModel, out var cfg))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantModifier.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantModifier.cs
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.UncheckedStatement);
         }
 
-        private static void CheckForUnnecessaryUnsafeBlocks(SyntaxNodeAnalysisContext context)
+        private static void CheckForUnnecessaryUnsafeBlocks(SonarSyntaxNodeAnalysisContext context)
         {
             var typeDeclaration = (TypeDeclarationSyntax)context.Node;
             if (typeDeclaration.Parent is TypeDeclarationSyntax || context.IsRedundantPositionalRecordContext())
@@ -91,7 +91,7 @@ namespace SonarAnalyzer.Rules.CSharp
             CheckForUnnecessaryUnsafeBlocksBelow(context, typeDeclaration);
         }
 
-        private static void CheckForUnnecessaryUnsafeBlocksBelow(SyntaxNodeAnalysisContext context, TypeDeclarationSyntax typeDeclaration)
+        private static void CheckForUnnecessaryUnsafeBlocksBelow(SonarSyntaxNodeAnalysisContext context, TypeDeclarationSyntax typeDeclaration)
         {
             var unsafeKeyword = FindUnsafeKeyword(typeDeclaration);
             if (unsafeKeyword == default)
@@ -111,7 +111,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckForUnnecessaryUnsafeBlocksInMember(SyntaxNodeAnalysisContext context, MemberDeclarationSyntax member)
+        private static void CheckForUnnecessaryUnsafeBlocksInMember(SonarSyntaxNodeAnalysisContext context, MemberDeclarationSyntax member)
         {
             var unsafeKeyword = FindUnsafeKeyword(member);
             if (unsafeKeyword != default)
@@ -175,7 +175,7 @@ namespace SonarAnalyzer.Rules.CSharp
             && (type.TypeKind == TypeKind.Pointer
                 || (type.TypeKind == TypeKind.Array && IsUnsafe(((IArrayTypeSymbol)type).ElementType)));
 
-        private static void MarkAllUnsafeBlockInside(SyntaxNodeAnalysisContext context, SyntaxNode container)
+        private static void MarkAllUnsafeBlockInside(SonarSyntaxNodeAnalysisContext context, SyntaxNode container)
         {
             foreach (var @unsafe in container.DescendantNodes().SelectMany(x => x.ChildTokens()).Where(x => x.IsKind(SyntaxKind.UnsafeKeyword)))
             {
@@ -183,13 +183,13 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportOnUnsafeBlock(SyntaxNodeAnalysisContext context, Location issueLocation) =>
+        private static void ReportOnUnsafeBlock(SonarSyntaxNodeAnalysisContext context, Location issueLocation) =>
             context.ReportIssue(Diagnostic.Create(Rule, issueLocation, "unsafe", "redundant"));
 
         private static SyntaxToken FindUnsafeKeyword(MemberDeclarationSyntax memberDeclaration) =>
             Modifiers(memberDeclaration).FirstOrDefault(x => x.IsKind(SyntaxKind.UnsafeKeyword));
 
-        private static void CheckTypeDeclarationForRedundantPartial(SyntaxNodeAnalysisContext context)
+        private static void CheckTypeDeclarationForRedundantPartial(SonarSyntaxNodeAnalysisContext context)
         {
             var typeDeclaration = (TypeDeclarationSyntax)context.Node;
             if (!context.IsRedundantPositionalRecordContext()
@@ -212,7 +212,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 _ => default
             };
 
-        private static void CheckSealedMemberInSealedClass(SyntaxNodeAnalysisContext context)
+        private static void CheckSealedMemberInSealedClass(SonarSyntaxNodeAnalysisContext context)
         {
             if (Modifiers((MemberDeclarationSyntax)context.Node) is var modifiers
                 && modifiers.Any(SyntaxKind.SealedKeyword)
@@ -250,11 +250,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PreIncrementExpression
             };
 
-            private readonly SyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeAnalysisContext context;
             private bool isCurrentContextChecked;
             private bool currentContextHasIntegralOperation;
 
-            public CheckedWalker(SyntaxNodeAnalysisContext context)
+            public CheckedWalker(SonarSyntaxNodeAnalysisContext context)
             {
                 this.context = context;
                 isCurrentContextChecked = context.Node switch

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
@@ -93,7 +93,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override bool AreEquivalent(SyntaxNode node1, SyntaxNode node2) => CSharpEquivalenceChecker.AreEquivalent(node1, node2);
 
-        private static void CheckAndPattern(SyntaxNodeAnalysisContext context)
+        private static void CheckAndPattern(SonarSyntaxNodeAnalysisContext context)
         {
             var binaryPatternNode = (BinaryPatternSyntaxWrapper)context.Node;
             var left = binaryPatternNode.Left.SyntaxNode.RemoveParentheses();
@@ -122,7 +122,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && !isPatternWrapper.IsNull();
         }
 
-        private static void CheckOrPattern(SyntaxNodeAnalysisContext context)
+        private static void CheckOrPattern(SonarSyntaxNodeAnalysisContext context)
         {
             var binaryPatternNode = (BinaryPatternSyntaxWrapper)context.Node;
             var left = binaryPatternNode.Left.SyntaxNode.RemoveParentheses();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullableTypeComparison.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullableTypeComparison.cs
@@ -37,15 +37,14 @@ namespace SonarAnalyzer.Rules.CSharp
                 c =>
                 {
                     var binary = (BinaryExpressionSyntax)c.Node;
-                    CheckGetTypeAndTypeOfEquality(binary.Left, binary.Right, binary.GetLocation(), c);
-                    CheckGetTypeAndTypeOfEquality(binary.Right, binary.Left, binary.GetLocation(), c);
+                    CheckGetTypeAndTypeOfEquality(c, binary.Left, binary.Right, binary.GetLocation());
+                    CheckGetTypeAndTypeOfEquality(c, binary.Right, binary.Left, binary.GetLocation());
                 },
                 SyntaxKind.EqualsExpression,
                 SyntaxKind.NotEqualsExpression);
         }
 
-        private static void CheckGetTypeAndTypeOfEquality(ExpressionSyntax sideA, ExpressionSyntax sideB, Location location,
-            SyntaxNodeAnalysisContext context)
+        private static void CheckGetTypeAndTypeOfEquality(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax sideA, ExpressionSyntax sideB, Location location)
         {
             if (!(sideA as InvocationExpressionSyntax).IsGetTypeCall(context.SemanticModel))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToArrayCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToArrayCall.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 },
                 SyntaxKind.InvocationExpression);
 
-        private static MemberAccessExpressionSyntax GetRedundantMemberAccess(SyntaxNodeAnalysisContext context, string targetMethodName, KnownType targetKnownType)
+        private static MemberAccessExpressionSyntax GetRedundantMemberAccess(SonarSyntaxNodeAnalysisContext context, string targetMethodName, KnownType targetKnownType)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToStringCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToStringCall.cs
@@ -117,23 +117,23 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.InvocationExpression);
         }
 
-        private static void CheckLeftExpressionForRemovableToStringCall(SyntaxNodeAnalysisContext context,
+        private static void CheckLeftExpressionForRemovableToStringCall(SonarSyntaxNodeAnalysisContext context,
             BinaryExpressionSyntax binary)
         {
             CheckExpressionForRemovableToStringCall(context, binary.Left, binary.Right, 0);
         }
-        private static void CheckRightExpressionForRemovableToStringCall(SyntaxNodeAnalysisContext context,
+        private static void CheckRightExpressionForRemovableToStringCall(SonarSyntaxNodeAnalysisContext context,
             BinaryExpressionSyntax binary)
         {
             CheckExpressionForRemovableToStringCall(context, binary.Right, binary.Left, 1);
         }
-        private static void CheckRightExpressionForRemovableToStringCall(SyntaxNodeAnalysisContext context,
+        private static void CheckRightExpressionForRemovableToStringCall(SonarSyntaxNodeAnalysisContext context,
             AssignmentExpressionSyntax assignment)
         {
             CheckExpressionForRemovableToStringCall(context, assignment.Right, assignment.Left, 1);
         }
 
-        private static void CheckExpressionForRemovableToStringCall(SyntaxNodeAnalysisContext context,
+        private static void CheckExpressionForRemovableToStringCall(SonarSyntaxNodeAnalysisContext context,
             ExpressionSyntax expressionWithToStringCall, ExpressionSyntax otherOperandOfAddition, int checkedSideIndex)
         {
             if (!IsArgumentlessToStringCallNotOnBaseExpression(expressionWithToStringCall, context.SemanticModel, out var location, out var methodSymbol) ||

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PropertyDeclaration,
                 SyntaxKind.OperatorDeclaration);
 
-        private static void ReportIfReturnsNullOrDefault(SyntaxNodeAnalysisContext context)
+        private static void ReportIfReturnsNullOrDefault(SonarSyntaxNodeAnalysisContext context)
         {
             if (GetExpressionBody(context.Node) is { } expressionBody)
             {
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static bool IsReturningCollection(SyntaxNodeAnalysisContext context)
+        private static bool IsReturningCollection(SonarSyntaxNodeAnalysisContext context)
         {
             var symbol = context.SemanticModel.GetDeclaredSymbol(context.Node);
             var methodSymbol = (symbol as IPropertySymbol)?.GetMethod ?? symbol as IMethodSymbol;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnValueIgnored.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnValueIgnored.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.SimpleLambdaExpression);
         }
 
-        private static void CheckExpressionForPureMethod(SyntaxNodeAnalysisContext context, ExpressionSyntax expression)
+        private static void CheckExpressionForPureMethod(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax expression)
         {
             if (expression is InvocationExpressionSyntax invocation
                 && context.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol { ReturnsVoid: false } invokedMethodSymbol

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
@@ -34,11 +34,10 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override void Initialize(SonarAnalysisContext context)
         {
-            context.RegisterSyntaxNodeActionInNonGenerated(FindPossibleViolations,
-                SyntaxKind.ConstructorDeclaration);
+            context.RegisterSyntaxNodeActionInNonGenerated(FindPossibleViolations, SyntaxKind.ConstructorDeclaration);
         }
 
-        private void FindPossibleViolations(SyntaxNodeAnalysisContext c)
+        private void FindPossibleViolations(SonarSyntaxNodeAnalysisContext c)
         {
             var constructorSyntax = (ConstructorDeclarationSyntax)c.Node;
             var reportLocation = constructorSyntax?.Identifier.GetLocation();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(FindPossibleViolations, SyntaxKind.ConstructorDeclaration);
         }
 
-        private void FindPossibleViolations(SonarSyntaxNodeAnalysisContext c)
+        private static void FindPossibleViolations(SonarSyntaxNodeAnalysisContext c)
         {
             var constructorSyntax = (ConstructorDeclarationSyntax)c.Node;
             var reportLocation = constructorSyntax?.Identifier.GetLocation();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SetLocaleForDataTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SetLocaleForDataTypes.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     compilationStartContext.RegisterCompilationEndAction(c => ProcessCollectedSymbols(c, symbolsWhereTypeIsCreated, symbolsWhereLocaleIsSet));
                 });
 
-        private static void ProcessObjectCreations(SyntaxNodeAnalysisContext c, IDictionary<ISymbol, SyntaxNode> symbolsWhereTypeIsCreated)
+        private static void ProcessObjectCreations(SonarSyntaxNodeAnalysisContext c, IDictionary<ISymbol, SyntaxNode> symbolsWhereTypeIsCreated)
         {
             if (GetSymbolFromConstructorInvocation(c.Node, c.SemanticModel) is ITypeSymbol objectType
                 && objectType.IsAny(CheckedTypes)
@@ -71,7 +71,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ProcessSimpleAssignments(SyntaxNodeAnalysisContext c, ISet<ISymbol> symbolsWhereLocaleIsSet)
+        private static void ProcessSimpleAssignments(SonarSyntaxNodeAnalysisContext c, ISet<ISymbol> symbolsWhereLocaleIsSet)
         {
             var assignmentExpression = (AssignmentExpressionSyntax)c.Node;
             var variableSymbols = assignmentExpression.AssignmentTargets()

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SillyBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SillyBitwiseOperation.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ExclusiveOrAssignmentExpression);
         }
 
-        private void CheckAssignment(SyntaxNodeAnalysisContext context, int constValueToLookFor)
+        private void CheckAssignment(SonarSyntaxNodeAnalysisContext context, int constValueToLookFor)
         {
             var assignment = (AssignmentExpressionSyntax)context.Node;
             if (FindIntConstant(context.SemanticModel, assignment.Right) is { } constValue
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void CheckBinary(SyntaxNodeAnalysisContext context, int constValueToLookFor)
+        private void CheckBinary(SonarSyntaxNodeAnalysisContext context, int constValueToLookFor)
         {
             var binary = (BinaryExpressionSyntax)context.Node;
             CheckBinary(context, binary.Left, binary.OperatorToken, binary.Right, constValueToLookFor);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SqlKeywordsDelimitedBySpace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SqlKeywordsDelimitedBySpace.cs
@@ -97,9 +97,9 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private sealed class StringConcatenationWalker : SafeCSharpSyntaxWalker
         {
-            private readonly SyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeAnalysisContext context;
 
-            public StringConcatenationWalker(SyntaxNodeAnalysisContext context) =>
+            public StringConcatenationWalker(SonarSyntaxNodeAnalysisContext context) =>
                 this.context = context;
 
             public override void VisitInterpolatedStringExpression(InterpolatedStringExpressionSyntax node)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInGenericClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInGenericClass.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKindEx.RecordStructDeclaration,
                 SyntaxKind.StructDeclaration);
 
-        private static void CheckMember(SyntaxNodeAnalysisContext context, SyntaxNode root, Location location, string[] typeParameterNames)
+        private static void CheckMember(SonarSyntaxNodeAnalysisContext context, SyntaxNode root, Location location, string[] typeParameterNames)
         {
             if (!HasGenericType(context, root, typeParameterNames))
             {
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static bool HasGenericType(SyntaxNodeAnalysisContext context, SyntaxNode root, string[] typeParameterNames) =>
+        private static bool HasGenericType(SonarSyntaxNodeAnalysisContext context, SyntaxNode root, string[] typeParameterNames) =>
             root.DescendantNodesAndSelf()
                 .OfType<IdentifierNameSyntax>()
                 .Any(x => typeParameterNames.Contains(x.Identifier.Value) && context.SemanticModel.GetSymbolInfo(x).Symbol is { Kind: SymbolKind.TypeParameter });

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticSealedClassProtectedMembers.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticSealedClassProtectedMembers.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKind.EventFieldDeclaration);
         }
 
-        private static void ReportDiagnostics(SyntaxNodeAnalysisContext context, SyntaxNode declaration, IEnumerable<SyntaxToken> modifiers)
+        private static void ReportDiagnostics(SonarSyntaxNodeAnalysisContext context, SyntaxNode declaration, IEnumerable<SyntaxToken> modifiers)
         {
             var symbol = context.SemanticModel.GetDeclaredSymbol(declaration);
             if (symbol == null || symbol.IsOverride || !symbol.ContainingType.IsSealed)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringFormatValidator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringFormatValidator.cs
@@ -80,7 +80,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(CheckForFormatStringIssues, SyntaxKind.InvocationExpression);
 
-        private static void CheckForFormatStringIssues(SyntaxNodeAnalysisContext analysisContext)
+        private static void CheckForFormatStringIssues(SonarSyntaxNodeAnalysisContext analysisContext)
         {
             var invocation = (InvocationExpressionSyntax)analysisContext.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringLiteralShouldNotBeDuplicated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringLiteralShouldNotBeDuplicated.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 .Any(p => p.Identifier.ValueText == literalExpression.Token.ValueText)
             ?? false;
 
-        protected override bool IsInnerInstance(SyntaxNodeAnalysisContext context) =>
+        protected override bool IsInnerInstance(SonarSyntaxNodeAnalysisContext context) =>
             context.Node.Ancestors().Any(x =>
                 x.IsAnyKind(TypeDeclarationSyntaxKinds)
                 || (x.IsKind(SyntaxKind.CompilationUnit) && x.ChildNodes().Any(y => y.IsKind(SyntaxKind.GlobalStatement))));
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override SyntaxToken LiteralToken(LiteralExpressionSyntax literal) =>
             literal.Token;
 
-        protected override bool IsNamedTypeOrTopLevelMain(SyntaxNodeAnalysisContext context) =>
+        protected override bool IsNamedTypeOrTopLevelMain(SonarSyntaxNodeAnalysisContext context) =>
             IsNamedType(context) || context.IsTopLevelMain();
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.InvocationExpression);
         }
 
-        private static void ReportOnViolation(SyntaxNodeAnalysisContext context)
+        private static void ReportOnViolation(SonarSyntaxNodeAnalysisContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(AnalyzeMethod, SyntaxKind.MethodDeclaration, SyntaxKindEx.LocalFunctionStatement);
 
-        private static void AnalyzeMethod(SyntaxNodeAnalysisContext c)
+        private static void AnalyzeMethod(SonarSyntaxNodeAnalysisContext c)
         {
             if (HasAttributes(c.Node) && c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol methodSymbol)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
                  SyntaxKindEx.ThrowExpression);
         }
 
-        private static void ReportDiagnostic(SyntaxNodeAnalysisContext c, ExpressionSyntax newExceptionExpression, SyntaxNode throwExpression)
+        private static void ReportDiagnostic(SonarSyntaxNodeAnalysisContext c, ExpressionSyntax newExceptionExpression, SyntaxNode throwExpression)
         {
             if (c.SemanticModel.GetTypeInfo(newExceptionExpression).Type.Is(KnownType.System_NotImplementedException))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeExaminationOnSystemType.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeExaminationOnSystemType.cs
@@ -41,13 +41,13 @@ namespace SonarAnalyzer.Rules.CSharp
                    if (invocation.Expression.ToStringContainsEitherOr(nameof(Type.IsInstanceOfType), nameof(Type.GetType))
                        && c.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol)
                    {
-                       CheckGetTypeCallOnType(invocation, methodSymbol, c);
-                       CheckIsInstanceOfTypeCallWithTypeArgument(invocation, methodSymbol, c);
+                       CheckGetTypeCallOnType(c, invocation, methodSymbol);
+                       CheckIsInstanceOfTypeCallWithTypeArgument(c, invocation, methodSymbol);
                    }
                },
                SyntaxKind.InvocationExpression);
 
-        private static void CheckIsInstanceOfTypeCallWithTypeArgument(InvocationExpressionSyntax invocation, ISymbol methodSymbol, SyntaxNodeAnalysisContext context)
+        private static void CheckIsInstanceOfTypeCallWithTypeArgument(SonarSyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation, ISymbol methodSymbol)
         {
             if (methodSymbol.Name != nameof(Type.IsInstanceOfType) || !methodSymbol.ContainingType.Is(KnownType.System_Type))
             {
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.ReportIssue(Diagnostic.Create(Rule, argument.GetLocation(), message));
         }
 
-        private static void CheckGetTypeCallOnType(InvocationExpressionSyntax invocation, IMethodSymbol invokedMethod, SyntaxNodeAnalysisContext context)
+        private static void CheckGetTypeCallOnType(SonarSyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation, IMethodSymbol invokedMethod)
         {
             if (!(invocation.Expression is MemberAccessExpressionSyntax memberCall)
                 || IsException(memberCall, context.SemanticModel)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
@@ -60,7 +60,7 @@ public sealed class UnchangedLocalVariablesShouldBeConst : SonarDiagnosticAnalyz
                         && IsInitializedWithCompatibleConstant(v, c.SemanticModel, declaredType)
                         && !HasMutableUsagesInMethod(c.SemanticModel, v))
                     .ToList()
-                    .ForEach(x => Report(x, c));
+                    .ForEach(x => Report(c, x));
             },
             SyntaxKind.LocalDeclarationStatement);
 
@@ -164,7 +164,7 @@ public sealed class UnchangedLocalVariablesShouldBeConst : SonarDiagnosticAnalyz
         declaratorSyntax is { Initializer.Value: { } initializer }
             && initializer.DescendantNodesAndSelf().Any(x => x.IsKind(SyntaxKind.Interpolation));
 
-    private static void Report(VariableDeclaratorSyntax declaratorSyntax, SyntaxNodeAnalysisContext c) =>
+    private static void Report(SonarSyntaxNodeAnalysisContext c, VariableDeclaratorSyntax declaratorSyntax) =>
         c.ReportIssue(Diagnostic.Create(Rule,
             declaratorSyntax.Identifier.GetLocation(),
             declaratorSyntax.Identifier.ValueText,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnconditionalJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnconditionalJumpStatement.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKind.DoStatement
         };
 
-        protected override LoopWalkerBase<StatementSyntax, SyntaxKind> GetWalker(SyntaxNodeAnalysisContext context)
+        protected override LoopWalkerBase<StatementSyntax, SyntaxKind> GetWalker(SonarSyntaxNodeAnalysisContext context)
             => new LoopWalker(context, LoopStatements);
 
         private class LoopWalker : LoopWalkerBase<StatementSyntax, SyntaxKind>
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
-            public LoopWalker(SyntaxNodeAnalysisContext context, ISet<SyntaxKind> loopStatements) : base(context, loopStatements) { }
+            public LoopWalker(SonarSyntaxNodeAnalysisContext context, ISet<SyntaxKind> loopStatements) : base(context, loopStatements) { }
 
             public override void Visit()
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryUsings.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryUsings.cs
@@ -69,7 +69,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckUnnecessaryUsings(SyntaxNodeAnalysisContext context, IEnumerable<UsingDirectiveSyntax> usingDirectives, ISet<INamespaceSymbol> necessaryNamespaces)
+        private static void CheckUnnecessaryUsings(SonarSyntaxNodeAnalysisContext context, IEnumerable<UsingDirectiveSyntax> usingDirectives, ISet<INamespaceSymbol> necessaryNamespaces)
         {
             foreach (var usingDirective in usingDirectives)
             {
@@ -91,12 +91,12 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             public readonly HashSet<INamespaceSymbol> NecessaryNamespaces = new();
 
-            private readonly SyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeAnalysisContext context;
             private readonly IImmutableSet<EquivalentNameSyntax> usingDirectivesFromParent;
             private readonly INamespaceSymbol currentNamespace;
             private bool linqQueryVisited;
 
-            public CSharpRemovableUsingWalker(SyntaxNodeAnalysisContext context, IImmutableSet<EquivalentNameSyntax> usingDirectivesFromParent, INamespaceSymbol currentNamespace)
+            public CSharpRemovableUsingWalker(SonarSyntaxNodeAnalysisContext context, IImmutableSet<EquivalentNameSyntax> usingDirectivesFromParent, INamespaceSymbol currentNamespace)
             {
                 this.context = context;
                 this.usingDirectivesFromParent = usingDirectivesFromParent;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void AnalyzeLocalFunctionStatements(SyntaxNodeAnalysisContext context)
+        private static void AnalyzeLocalFunctionStatements(SonarSyntaxNodeAnalysisContext context)
         {
             var localFunctionSyntax = (LocalFunctionStatementSyntaxWrapper)context.Node;
             var topMostContainingMethod = localFunctionSyntax.IsTopLevel()

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericEventHandlerInstances.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericEventHandlerInstances.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
                }, SyntaxKind.EventDeclaration);
         }
 
-        private static void AnalyzeEventType(SyntaxNodeAnalysisContext analysisContext, SyntaxNode eventNode,
+        private static void AnalyzeEventType(SonarSyntaxNodeAnalysisContext analysisContext, SyntaxNode eventNode,
             Func<Location> getLocationToReportOn)
         {
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKindEx.RecordStructDeclaration);
         }
 
-        private static void VerifyMethodDeclaration(SyntaxNodeAnalysisContext context)
+        private static void VerifyMethodDeclaration(SonarSyntaxNodeAnalysisContext context)
         {
             var methodDeclaration = (BaseMethodDeclarationSyntax)context.Node;
             var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodDeclaration);
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void VerifyPropertyDeclaration(SyntaxNodeAnalysisContext context)
+        private static void VerifyPropertyDeclaration(SonarSyntaxNodeAnalysisContext context)
         {
             var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
             var propertySymbol = context.SemanticModel.GetDeclaredSymbol(propertyDeclaration);
@@ -107,7 +107,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void VerifyRecordDeclaration(SyntaxNodeAnalysisContext context)
+        private static void VerifyRecordDeclaration(SonarSyntaxNodeAnalysisContext context)
         {
             var declaration = (RecordDeclarationSyntaxWrapper)context.Node;
             if (!context.IsRedundantPositionalRecordContext() && HasStringUriParams(declaration.ParameterList, context.SemanticModel))
@@ -120,7 +120,7 @@ namespace SonarAnalyzer.Rules.CSharp
             parameterList != null
             && parameterList.Parameters.Any(x => NameContainsUri(x.Identifier.Text) && model.GetDeclaredSymbol(x).IsType(KnownType.System_String));
 
-        private static void VerifyInvocationAndCreation(SyntaxNodeAnalysisContext context)
+        private static void VerifyInvocationAndCreation(SonarSyntaxNodeAnalysisContext context)
         {
             if (context.SemanticModel.GetSymbolInfo(context.Node).Symbol is IMethodSymbol invokedMethodSymbol
                 && !invokedMethodSymbol.IsInType(KnownType.System_Uri)
@@ -131,7 +131,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void VerifyReturnType(SyntaxNodeAnalysisContext context, BaseMethodDeclarationSyntax methodDeclaration, IMethodSymbol methodSymbol)
+        private static void VerifyReturnType(SonarSyntaxNodeAnalysisContext context, BaseMethodDeclarationSyntax methodDeclaration, IMethodSymbol methodSymbol)
         {
             if ((methodDeclaration as MethodDeclarationSyntax)?.ReturnType?.GetLocation() is { } returnTypeLocation
                 && methodSymbol.ReturnType.Is(KnownType.System_String)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ValuesUselesslyIncremented.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ValuesUselesslyIncremented.cs
@@ -39,13 +39,13 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (symbol is ILocalSymbol || symbol is IParameterSymbol { RefKind: RefKind.None })
                     {
-                        VisitParent(increment, c);
+                        VisitParent(c, increment);
                     }
                 },
                 SyntaxKind.PostIncrementExpression,
                 SyntaxKind.PostDecrementExpression);
 
-        private static void VisitParent(PostfixUnaryExpressionSyntax increment, SyntaxNodeAnalysisContext context)
+        private static void VisitParent(SonarSyntaxNodeAnalysisContext context, PostfixUnaryExpressionSyntax increment)
         {
             switch (increment.Parent)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterSyntaxNodeActionInNonGenerated(c => ProcessVariableDesignation(c, ((ListPatternSyntaxWrapper)c.Node).Designation), SyntaxKindEx.ListPattern);
         }
 
-        private static void ProcessVariableDesignation(SyntaxNodeAnalysisContext context, VariableDesignationSyntaxWrapper variableDesignation)
+        private static void ProcessVariableDesignation(SonarSyntaxNodeAnalysisContext context, VariableDesignationSyntaxWrapper variableDesignation)
         {
             if (variableDesignation.AllVariables() is { Length: > 0 } variables
                 && context.ContainingSymbol.ContainingType is { } containingType
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ProcessVariableDeclaration(SyntaxNodeAnalysisContext context, VariableDeclarationSyntax variableDeclaration)
+        private static void ProcessVariableDeclaration(SonarSyntaxNodeAnalysisContext context, VariableDeclarationSyntax variableDeclaration)
         {
             if (variableDeclaration is { Variables: { Count: > 0 } variables }
                 && context.ContainingSymbol.ContainingType is { } containingType
@@ -86,7 +86,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportOnVariableMatchingField(SyntaxNodeAnalysisContext context, IEnumerable<ISymbol> members, SyntaxToken identifier)
+        private static void ReportOnVariableMatchingField(SonarSyntaxNodeAnalysisContext context, IEnumerable<ISymbol> members, SyntaxToken identifier)
         {
             if (members.FirstOrDefault(m => m.Name == identifier.ValueText) is { } matchingMember)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
@@ -84,7 +84,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     ccc.RegisterSyntaxNodeActionInNonGenerated(VerifyXmlReaderInvocations, SyntaxKind.InvocationExpression);
                 });
 
-        private void VerifyXmlReaderInvocations(SyntaxNodeAnalysisContext context)
+        private void VerifyXmlReaderInvocations(SonarSyntaxNodeAnalysisContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if (!invocation.IsMemberAccessOnKnownType("Create", KnownType.System_Xml_XmlReader, context.SemanticModel))
@@ -105,7 +105,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void VerifyXPathDocumentConstructor(SyntaxNodeAnalysisContext context, IObjectCreation objectCreation)
+        private void VerifyXPathDocumentConstructor(SonarSyntaxNodeAnalysisContext context, IObjectCreation objectCreation)
         {
             if (!context.SemanticModel.GetTypeInfo(objectCreation.Expression).Type.Is(KnownType.System_Xml_XPath_XPathDocument)
                 // If a XmlReader is provided in the constructor, XPathDocument will be as safe as the received reader.
@@ -117,7 +117,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (!IsXPathDocumentSecureByDefault(versionProvider.GetDotNetFrameworkVersion(context.Compilation)))
             {
-                context.ReportDiagnostic(Diagnostic.Create(Rule, objectCreation.Expression.GetLocation()));
+                context.ReportIssue(Diagnostic.Create(Rule, objectCreation.Expression.GetLocation()));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ConditionEvaluatesToConstant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ConditionEvaluatesToConstant.cs
@@ -89,13 +89,13 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S2583, S2589);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
-            new AnalysisContext(explodedGraph, context);
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+            new AnalysisContext(context, explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext
         {
+            private readonly SonarSyntaxNodeAnalysisContext context;
             private readonly SonarExplodedGraph explodedGraph;
-            private readonly SyntaxNodeAnalysisContext context;
 
             private readonly HashSet<SyntaxNode> conditionTrue = new HashSet<SyntaxNode>();
             private readonly HashSet<SyntaxNode> conditionFalse = new HashSet<SyntaxNode>();
@@ -105,10 +105,10 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
             private bool hasYieldStatement;
 
-            public AnalysisContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
+            public AnalysisContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph)
             {
-                this.explodedGraph = explodedGraph;
                 this.context = context;
+                this.explodedGraph = explodedGraph;
 
                 explodedGraph.InstructionProcessed += InstructionProcessed;
                 explodedGraph.ConditionEvaluated += ConditionEvaluatedHandler;

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -74,7 +74,8 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S4158);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) => new AnalysisContext(explodedGraph);
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+            new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyNullableValueAccess.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyNullableValueAccess.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S3655);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/HashesShouldHaveUnpredictableSalt.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/HashesShouldHaveUnpredictableSalt.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S2053);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(explodedGraph);
 
         internal sealed class LocationContext

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InitializationVectorShouldBeRandom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InitializationVectorShouldBeRandom.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(S3329);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : DefaultAnalysisContext<Location>

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InvalidCastToInterfaceSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InvalidCastToInterfaceSymbolicExecution.cs
@@ -31,19 +31,19 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S1944);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
-            new AnalysisContext(explodedGraph, context);
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+            new AnalysisContext(context, explodedGraph);
 
         internal sealed class NullableCastCheck : ExplodedGraphCheck
         {
-            private readonly SyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeAnalysisContext context;
 
             public NullableCastCheck(SonarExplodedGraph explodedGraph)
                 : base(explodedGraph)
             {
             }
 
-            public NullableCastCheck(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
+            public NullableCastCheck(SonarExplodedGraph explodedGraph, SonarSyntaxNodeAnalysisContext context)
                 : this(explodedGraph)
             {
                 this.context = context;
@@ -90,7 +90,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
         {
             public bool SupportsPartialResults => true;
 
-            public AnalysisContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+            public AnalysisContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
                 explodedGraph.AddExplodedGraphCheck(new NullableCastCheck(explodedGraph, context));
 
             public void Dispose()

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/NullPointerDereference.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/NullPointerDereference.cs
@@ -32,8 +32,8 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S2259);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
-            new AnalysisContext(explodedGraph, context);
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+            new AnalysisContext(context, explodedGraph);
 
         internal sealed class NullPointerCheck : ExplodedGraphCheck
         {
@@ -192,11 +192,11 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext
         {
-            private readonly SyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeAnalysisContext context;
             private readonly HashSet<IdentifierNameSyntax> nullIdentifiers = new();
             private readonly NullPointerCheck nullPointerCheck;
 
-            public AnalysisContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context)
+            public AnalysisContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph)
             {
                 this.context = context;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ObjectsShouldNotBeDisposedMoreThanOnce.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ObjectsShouldNotBeDisposedMoreThanOnce.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S3966);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/RestrictDeserializedTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/RestrictDeserializedTypes.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(S5773);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ISymbolicExecutionAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ISymbolicExecutionAnalyzer.cs
@@ -24,6 +24,6 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar
     {
         IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; }
 
-        ISymbolicExecutionAnalysisContext CreateContext(SonarExplodedGraph explodedGraph, SyntaxNodeAnalysisContext context);
+        ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/DiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/DiagnosticAnalyzerContextHelper.cs
@@ -29,25 +29,25 @@ internal static class DiagnosticAnalyzerContextHelper   // FIXME: Rename and mov
 
     public static void RegisterSyntaxNodeActionInNonGenerated<TLanguageKindEnum>(this SonarAnalysisContext context, // FIXME: Move them
                                                                                  GeneratedCodeRecognizer generatedCodeRecognizer,
-                                                                                 Action<SyntaxNodeAnalysisContext> action,
+                                                                                 Action<SonarSyntaxNodeAnalysisContext> action,
                                                                                  params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct =>
         context.RegisterSyntaxNodeAction(c =>
             {
                 if (c.ShouldAnalyze(generatedCodeRecognizer))   // FIXME: Unify
                 {
-                    action(c.Context);
+                    action(c);
                 }
             }, syntaxKinds);
 
     public static void RegisterSyntaxNodeActionInNonGenerated<TLanguageKindEnum>(this ParameterLoadingAnalysisContext context,
                                                                                  GeneratedCodeRecognizer generatedCodeRecognizer,
-                                                                                 Action<SyntaxNodeAnalysisContext> action,
+                                                                                 Action<SonarSyntaxNodeAnalysisContext> action,
                                                                                  params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct =>
         context.Context.RegisterSyntaxNodeActionInNonGenerated(generatedCodeRecognizer, action, syntaxKinds);
 
     public static void RegisterSyntaxNodeActionInNonGenerated<TLanguageKindEnum>(this SonarCompilationStartAnalysisContext context,
                                                                                  GeneratedCodeRecognizer generatedCodeRecognizer,
-                                                                                 Action<SyntaxNodeAnalysisContext> action,
+                                                                                 Action<SonarSyntaxNodeAnalysisContext> action,
                                                                                  params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct =>
         context.AnalysisContext.RegisterSyntaxNodeActionInNonGenerated(generatedCodeRecognizer, action, syntaxKinds);
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -72,22 +72,22 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
         ShouldExecuteRegisteredAction == null || tree == null || ShouldExecuteRegisteredAction(diagnostics, tree);
 
     public void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
     public void RegisterCompilationAction(Action<SonarCompilationAnalysisContext> action) =>
-        analysisContext.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
+        context.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
 
     public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
-        analysisContext.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
+        context.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
 
     public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
-        analysisContext.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
+        context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
 
     public void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-        analysisContext.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
+        context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
 
     public void RegisterSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
-        analysisContext.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
+        context.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
 
     public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
         c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -72,22 +72,22 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
         ShouldExecuteRegisteredAction == null || tree == null || ShouldExecuteRegisteredAction(diagnostics, tree);
 
     public void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+        analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
     public void RegisterCompilationAction(Action<SonarCompilationAnalysisContext> action) =>
-        context.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
+        analysisContext.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
 
     public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
-        context.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
+        analysisContext.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
 
     public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
-        context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
+        analysisContext.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
 
     public void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-        context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
+        analysisContext.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
 
     public void RegisterSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
-        context.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
+        analysisContext.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
 
     public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
         c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -92,6 +92,9 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
         c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));
 
+    internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
+        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {
         // For each action registered on context we need to do some pre-processing before actually calling the rule.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -92,9 +92,6 @@ public sealed partial /*FIXME: REMOVE partial */ class SonarAnalysisContext : So
     public Action<CompilationStartAnalysisContext> WrapSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
         c => c.RegisterSyntaxTreeAction(treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action));
 
-    internal void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
-
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action) where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {
         // For each action registered on context we need to do some pre-processing before actually calling the rule.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -92,6 +92,7 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
     public abstract SyntaxTree Tree { get; }
     public abstract Compilation Compilation { get; }
     public abstract AnalyzerOptions Options { get; }
+    public abstract CancellationToken Cancel { get; }
 
     public SonarAnalysisContext AnalysisContext { get; }
     public TContext Context { get; }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCodeBlockAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCodeBlockAnalysisContext.cs
@@ -25,6 +25,7 @@ public sealed class SonarCodeBlockAnalysisContext : SonarAnalysisContextBase<Cod
     public override SyntaxTree Tree => Context.GetSyntaxTree();
     public override Compilation Compilation => Context.SemanticModel.Compilation;
     public override AnalyzerOptions Options => Context.Options;
+    public override CancellationToken Cancel => Context.CancellationToken;
     public SyntaxNode CodeBlock => Context.CodeBlock;
     public ISymbol OwningSymbol => Context.OwningSymbol;
     public SemanticModel SemanticModel => Context.SemanticModel;

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCodeBlockStartAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCodeBlockStartAnalysisContext.cs
@@ -25,6 +25,7 @@ public sealed class SonarCodeBlockStartAnalysisContext<TSyntaxKind> : SonarAnaly
     public override SyntaxTree Tree => Context.GetSyntaxTree();
     public override Compilation Compilation => Context.SemanticModel.Compilation;
     public override AnalyzerOptions Options => Context.Options;
+    public override CancellationToken Cancel => Context.CancellationToken;
     public SyntaxNode CodeBlock => Context.CodeBlock;
     public ISymbol OwningSymbol => Context.OwningSymbol;
     public SemanticModel SemanticModel => Context.SemanticModel;

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationAnalysisContext.cs
@@ -31,6 +31,7 @@ public sealed class SonarCompilationAnalysisContext : SonarAnalysisContextBase<C
     public override SyntaxTree Tree => Context.GetFirstSyntaxTree();
     public override Compilation Compilation => Context.Compilation;
     public override AnalyzerOptions Options => Context.Options;
+    public override CancellationToken Cancel => Context.CancellationToken;
 
     internal SonarCompilationAnalysisContext(SonarAnalysisContext analysisContext, CompilationAnalysisContext context) : base(analysisContext, context) { }
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
@@ -25,6 +25,7 @@ public sealed class SonarCompilationStartAnalysisContext : SonarAnalysisContextB
     public override SyntaxTree Tree => Context.GetFirstSyntaxTree();
     public override Compilation Compilation => Context.Compilation;
     public override AnalyzerOptions Options => Context.Options;
+    public override CancellationToken Cancel => Context.CancellationToken;
 
     internal SonarCompilationStartAnalysisContext(SonarAnalysisContext analysisContext, CompilationStartAnalysisContext context) : base(analysisContext, context) { }
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSymbolAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSymbolAnalysisContext.cs
@@ -25,6 +25,7 @@ public sealed class SonarSymbolAnalysisContext : SonarAnalysisContextBase<Symbol
     public override SyntaxTree Tree => Context.GetFirstSyntaxTree();
     public override Compilation Compilation => Context.Compilation;
     public override AnalyzerOptions Options => Context.Options;
+    public override CancellationToken Cancel => Context.CancellationToken;
     public ISymbol Symbol => Context.Symbol;
 
     internal SonarSymbolAnalysisContext(SonarAnalysisContext analysisContext, SymbolAnalysisContext context) : base(analysisContext, context) { }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxNodeAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxNodeAnalysisContext.cs
@@ -25,6 +25,7 @@ public sealed class SonarSyntaxNodeAnalysisContext : SonarAnalysisContextBase<Sy
     public override SyntaxTree Tree => Context.GetSyntaxTree();
     public override Compilation Compilation => Context.Compilation;
     public override AnalyzerOptions Options => Context.Options;
+    public override CancellationToken Cancel => Context.CancellationToken;
     public SyntaxNode Node => Context.Node;
     public SemanticModel SemanticModel => Context.SemanticModel;
     public ISymbol ContainingSymbol => Context.ContainingSymbol;

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxTreeAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxTreeAnalysisContext.cs
@@ -25,6 +25,7 @@ public sealed class SonarSyntaxTreeAnalysisContext : SonarAnalysisContextBase<Sy
     public override SyntaxTree Tree => Context.Tree;
     public override Compilation Compilation { get; }    // SyntaxTreeAnalysisContext doesn't hold a Compilation reference
     public override AnalyzerOptions Options => Context.Options;
+    public override CancellationToken Cancel => Context.CancellationToken;
 
     internal SonarSyntaxTreeAnalysisContext(SonarAnalysisContext analysisContext, SyntaxTreeAnalysisContext context, Compilation compilation) : base(analysisContext, context) =>
         Compilation = compilation;

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/DiagnosticDescriptorExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/DiagnosticDescriptorExtensions.cs
@@ -24,7 +24,7 @@ namespace SonarAnalyzer.Extensions;
 
 public static class DiagnosticDescriptorExtensions
 {
-    public static bool HasMatchingScope(this DiagnosticDescriptor descriptor, Compilation compilation, bool isTestProject, bool isScannerRun)
+    public static bool HasMatchingScope(this DiagnosticDescriptor descriptor, Compilation compilation, bool isTestProject, bool isScannerRun)   // FIXME: Pass context instead?
     {
         if (compilation is null)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxNodeAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxNodeAnalysisContextExtensions.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Extensions
 {
-    internal static class SyntaxNodeAnalysisContextExtensions
+    internal static class SyntaxNodeAnalysisContextExtensions// FIXME: Doesn't need to be extension anymore
     {
         /// <summary>
         /// Roslyn invokes the analyzer twice for positional records. The first invocation is for the class declaration and the second for the ctor represented by the positional parameter list.
@@ -33,13 +33,13 @@ namespace SonarAnalyzer.Extensions
         /// record R(int i);
         /// </example>
         /// <seealso href="https://github.com/dotnet/roslyn/issues/53136"/>
-        internal static bool IsRedundantPositionalRecordContext(this SyntaxNodeAnalysisContext context) =>
+        internal static bool IsRedundantPositionalRecordContext(this SonarSyntaxNodeAnalysisContext context) =>
             context.ContainingSymbol.Kind == SymbolKind.Method;
 
-        public static bool IsAzureFunction(this SyntaxNodeAnalysisContext context) =>
+        public static bool IsAzureFunction(this SonarSyntaxNodeAnalysisContext context) =>
             context.AzureFunctionMethod() is not null;
 
-        public static IMethodSymbol AzureFunctionMethod(this SyntaxNodeAnalysisContext context) =>
+        public static IMethodSymbol AzureFunctionMethod(this SonarSyntaxNodeAnalysisContext context) =>
             context.ContainingSymbol is IMethodSymbol method && method.HasAttribute(KnownType.Microsoft_Azure_WebJobs_FunctionNameAttribute)
                 ? method
                 : null;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AllBranchesShouldNotHaveSameImplementationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AllBranchesShouldNotHaveSameImplementationBase.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules
 
             protected abstract Location GetLocation(TIfSyntax topLevelIf);
 
-            public Action<SyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
+            public Action<SonarSyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
                 context =>
                 {
                     var elseSyntax = (TElseSyntax)context.Node;
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules
 
             protected abstract Location GetLocation(TTernaryStatement ternaryStatement);
 
-            public Action<SyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
+            public Action<SonarSyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
                 context =>
                 {
                     var ternaryStatement = (TTernaryStatement)context.Node;
@@ -87,7 +87,7 @@ namespace SonarAnalyzer.Rules
 
                     if (whenTrue.IsEquivalentTo(whenFalse, topLevel: false))
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(rule, GetLocation(ternaryStatement), TernaryMessage));
+                        context.ReportIssue(Diagnostic.Create(rule, GetLocation(ternaryStatement), TernaryMessage));
                     }
                 };
         }
@@ -104,7 +104,7 @@ namespace SonarAnalyzer.Rules
 
             protected abstract Location GetLocation(TSwitchStatement switchStatement);
 
-            public Action<SyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
+            public Action<SonarSyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
                 context =>
                 {
                     var switchStatement = (TSwitchStatement)context.Node;
@@ -115,7 +115,7 @@ namespace SonarAnalyzer.Rules
                         HasDefaultLabel(switchStatement) &&
                         sections.Skip(1).All(section => AreEquivalent(section, sections[0])))
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(rule, GetLocation(switchStatement), StatementsMessage));
+                        context.ReportIssue(Diagnostic.Create(rule, GetLocation(switchStatement), StatementsMessage));
                     }
                 };
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/BooleanCheckInvertedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/BooleanCheckInvertedBase.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract bool IsIgnoredNullableOperation(TBinaryExpression expression, SemanticModel semanticModel);
 
-        protected Action<SyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule)
+        protected Action<SonarSyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule)
         {
             return c =>
             {
@@ -46,8 +46,7 @@ namespace SonarAnalyzer.Rules
 
                 if (IsLogicalNot(expression, out var logicalNot))
                 {
-                    c.ReportIssue(
-                        Diagnostic.Create(rule, logicalNot.GetLocation(), GetSuggestedReplacement(expression)));
+                    c.ReportIssue(Diagnostic.Create(rule, logicalNot.GetLocation(), GetSuggestedReplacement(expression)));
                 }
             };
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CatchRethrowBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CatchRethrowBase.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract SyntaxNode GetDeclarationType(TCatchClause catchClause);
 
-        protected void RaiseOnInvalidCatch(SyntaxNodeAnalysisContext context)
+        protected void RaiseOnInvalidCatch(SonarSyntaxNodeAnalysisContext context)
         {
             var catches = GetCatches(context.Node);
             var caughtExceptionTypes = new Lazy<List<INamedTypeSymbol>>(() =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules
 
         protected CertificateValidationCheckBase() : base(DiagnosticId) { }
 
-        protected void CheckAssignmentSyntax(SyntaxNodeAnalysisContext c)
+        protected void CheckAssignmentSyntax(SonarSyntaxNodeAnalysisContext c)
         {
             SplitAssignment((TAssignmentExpressionSyntax)c.Node, out var leftIdentifier, out var right);
             if (leftIdentifier != null && right != null
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        protected void CheckConstructorParameterSyntax(SyntaxNodeAnalysisContext c)
+        protected void CheckConstructorParameterSyntax(SonarSyntaxNodeAnalysisContext c)
         {
             if (c.SemanticModel.GetSymbolInfo(c.Node).Symbol is IMethodSymbol ctor)
             {
@@ -290,7 +290,7 @@ namespace SonarAnalyzer.Rules
             return lst;
         }
 
-        private ImmutableArray<TInvocationExpressionSyntax> FindInvocationList(SyntaxNodeAnalysisContext c, SyntaxNode root, IMethodSymbol method)
+        private ImmutableArray<TInvocationExpressionSyntax> FindInvocationList(SonarSyntaxNodeAnalysisContext c, SyntaxNode root, IMethodSymbol method)
         {
             if (root == null || method == null)
             {
@@ -312,10 +312,10 @@ namespace SonarAnalyzer.Rules
 
         protected readonly struct InspectionContext
         {
-            public readonly SyntaxNodeAnalysisContext Context;
+            public readonly SonarSyntaxNodeAnalysisContext Context;
             public readonly HashSet<SyntaxNode> VisitedMethods;
 
-            public InspectionContext(SyntaxNodeAnalysisContext context)
+            public InspectionContext(SonarSyntaxNodeAnalysisContext context)
             {
                 Context = context;
                 VisitedMethods = new HashSet<SyntaxNode>();

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CognitiveComplexityBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CognitiveComplexityBase.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules
         protected CognitiveComplexityBase() =>
             rule = Language.CreateDescriptor(DiagnosticId, MessageFormat, isEnabledByDefault: false);
 
-        protected void CheckComplexity<TSyntax>(SyntaxNodeAnalysisContext context,
+        protected void CheckComplexity<TSyntax>(SonarSyntaxNodeAnalysisContext context,
                                                 Func<TSyntax, SyntaxNode> nodeSelector,
                                                 Func<TSyntax, Location> getLocationToReport,
                                                 Func<SyntaxNode, CognitiveComplexity> getComplexity,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CollectionEmptinessCheckingBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CollectionEmptinessCheckingBase.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules
                 },
                 Language.SyntaxKind.ComparisonKinds);
 
-        private void CheckExpression(SyntaxNodeAnalysisContext context, SyntaxNode expression, int constant, ComparisonKind comparison)
+        private void CheckExpression(SonarSyntaxNodeAnalysisContext context, SyntaxNode expression, int constant, ComparisonKind comparison)
         {
             if (comparison.Compare(constant).IsEmptyOrNotEmpty()
                 && TryGetCountCall(expression, context.SemanticModel, out var location, out var typeArgument))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ConstructorArgumentValueShouldExistBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ConstructorArgumentValueShouldExistBase.cs
@@ -36,8 +36,7 @@ namespace SonarAnalyzer.Rules
                 : null;
         }
 
-        protected void CheckConstructorArgumentProperty(
-            SyntaxNodeAnalysisContext c, SyntaxNode propertyDeclaration, IPropertySymbol propertySymbol)
+        protected void CheckConstructorArgumentProperty(SonarSyntaxNodeAnalysisContext c, SyntaxNode propertyDeclaration, IPropertySymbol propertySymbol)
         {
             if (propertySymbol == null)
             {
@@ -58,6 +57,6 @@ namespace SonarAnalyzer.Rules
         }
 
         protected abstract IEnumerable<string> GetAllParentClassConstructorArgumentNames(SyntaxNode propertyDeclaration);
-        protected abstract void ReportIssue(SyntaxNodeAnalysisContext c, AttributeData constructorArgumentAttribute);
+        protected abstract void ReportIssue(SonarSyntaxNodeAnalysisContext c, AttributeData constructorArgumentAttribute);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallInsecureSecurityAlgorithmBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallInsecureSecurityAlgorithmBase.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, CheckInvocation, Language.SyntaxKind.InvocationExpression);
         }
 
-        private void CheckInvocation(SyntaxNodeAnalysisContext context)
+        private void CheckInvocation(SonarSyntaxNodeAnalysisContext context)
         {
             var invocation = (TInvocationExpressionSyntax)context.Node;
 
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void CheckObjectCreation(SyntaxNodeAnalysisContext context)
+        private void CheckObjectCreation(SonarSyntaxNodeAnalysisContext context)
         {
             var objectCreation = context.Node;
 
@@ -102,7 +102,7 @@ namespace SonarAnalyzer.Rules
             return FactoryParameterNames.Any(alg => alg.Equals(StringLiteralValue(Arguments(argumentList).First()), StringComparison.Ordinal));
         }
 
-        private void ReportAllDiagnostics(SyntaxNodeAnalysisContext context, Location location)
+        private void ReportAllDiagnostics(SonarSyntaxNodeAnalysisContext context, Location location)
         {
             foreach (var supportedDiagnostic in SupportedDiagnostics)
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallMethodsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallMethodsBase.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, AnalyzeInvocation, Language.SyntaxKind.InvocationExpression);
 
-        private void AnalyzeInvocation(SyntaxNodeAnalysisContext analysisContext)
+        private void AnalyzeInvocation(SonarSyntaxNodeAnalysisContext analysisContext)
         {
             if ((TInvocationExpressionSyntax)analysisContext.Node is var invocation
                 && Language.Syntax.InvocationIdentifier(invocation) is { } identifier

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCheckZeroSizeCollectionBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCheckZeroSizeCollectionBase.cs
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Rules
                 },
                 Language.SyntaxKind.ComparisonKinds);
 
-        protected void CheckExpression(SyntaxNodeAnalysisContext context, SyntaxNode issue, SyntaxNode expression, int constant, ComparisonKind comparison)
+        protected void CheckExpression(SonarSyntaxNodeAnalysisContext context, SyntaxNode issue, SyntaxNode expression, int constant, ComparisonKind comparison)
         {
             expression = Language.Syntax.RemoveConditionalAccess(expression);
             var result = comparison.Compare(constant);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotOverwriteCollectionElementsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotOverwriteCollectionElementsBase.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules
 
         protected DoNotOverwriteCollectionElementsBase() : base(DiagnosticId) { }
 
-        protected void AnalysisAction(SyntaxNodeAnalysisContext context)
+        protected void AnalysisAction(SonarSyntaxNodeAnalysisContext context)
         {
             var statement = (TStatementSyntax)context.Node;
             var collectionIdentifier = GetCollectionIdentifier(statement);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/EmptyMethodBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/EmptyMethodBase.cs
@@ -35,13 +35,13 @@ namespace SonarAnalyzer.Rules
                 {
                     if (c.ShouldAnalyze(GeneratedCodeRecognizer))
                     {
-                        CheckMethod(c.Context, c.IsTestProject());
+                        CheckMethod(c, c.IsTestProject());
                     }
                 },
                 SyntaxKinds.ToArray());
 
         protected abstract GeneratedCodeRecognizer GeneratedCodeRecognizer { get; }
         protected abstract TLanguageKindEnum[] SyntaxKinds { get; }
-        protected abstract void CheckMethod(SyntaxNodeAnalysisContext context, bool isTestProject);
+        protected abstract void CheckMethod(SonarSyntaxNodeAnalysisContext context, bool isTestProject);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FunctionComplexityBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FunctionComplexityBase.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract override void Initialize(ParameterLoadingAnalysisContext context);
 
-        protected void CheckComplexity<TSyntax>(SyntaxNodeAnalysisContext context, Func<TSyntax, SyntaxNode> nodeSelector, Func<TSyntax, Location> location,
+        protected void CheckComplexity<TSyntax>(SonarSyntaxNodeAnalysisContext context, Func<TSyntax, SyntaxNode> nodeSelector, Func<TSyntax, Location> location,
             string declarationType)
             where TSyntax : SyntaxNode
         {
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        protected void CheckComplexity<TSyntax>(SyntaxNodeAnalysisContext context, Func<TSyntax, Location> location,
+        protected void CheckComplexity<TSyntax>(SonarSyntaxNodeAnalysisContext context, Func<TSyntax, Location> location,
             string declarationType)
             where TSyntax : SyntaxNode
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -229,7 +229,7 @@ namespace SonarAnalyzer.Rules
             protected CredentialWordsFinderBase(DoNotHardcodeCredentialsBase<TSyntaxKind> analyzer) =>
                 this.analyzer = analyzer;
 
-            public Action<SyntaxNodeAnalysisContext> AnalysisAction() =>
+            public Action<SonarSyntaxNodeAnalysisContext> AnalysisAction() =>
                 context =>
                 {
                     var declarator = (TSyntaxNode)context.Node;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/HardcodedIpAddressBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/HardcodedIpAddressBase.cs
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules
             && !IsIgnoredVariableName(node)
             && !HasAttributes(node);
 
-        private void CheckForHardcodedIpAddressesInStringLiteral(SyntaxNodeAnalysisContext context)
+        private void CheckForHardcodedIpAddressesInStringLiteral(SonarSyntaxNodeAnalysisContext context)
         {
             if (IsEnabled(context.Options)
                 && (TLiteralExpression)context.Node is var stringLiteral
@@ -90,7 +90,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void CheckForHardcodedIpAddressesInStringInterpolation(SyntaxNodeAnalysisContext context)
+        private void CheckForHardcodedIpAddressesInStringInterpolation(SonarSyntaxNodeAnalysisContext context)
         {
             if (IsEnabled(context.Options)
                 && Language.Syntax.TryGetGetInterpolatedTextValue(context.Node, context.SemanticModel, out var stringContent)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/LooseFilePermissionsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/LooseFilePermissionsBase.cs
@@ -31,8 +31,8 @@ namespace SonarAnalyzer.Rules
         protected readonly DiagnosticDescriptor Rule;
 
         protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
-        protected abstract void VisitAssignments(SyntaxNodeAnalysisContext context);
-        protected abstract void VisitInvocations(SyntaxNodeAnalysisContext context);
+        protected abstract void VisitAssignments(SonarSyntaxNodeAnalysisContext context);
+        protected abstract void VisitInvocations(SonarSyntaxNodeAnalysisContext context);
 
         protected LooseFilePermissionsBase(IAnalyzerConfiguration configuration) : base(configuration) =>
             Rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
@@ -88,7 +88,7 @@ namespace SonarAnalyzer.Rules
             attributeName.Equals(RequestSizeLimit, Language.NameComparison)
             || attributeName.Equals(RequestSizeLimitAttribute, Language.NameComparison);
 
-        private void CollectAttributesOverTheLimit(SyntaxNodeAnalysisContext context, IDictionary<SyntaxNode, Attributes> attributesOverTheLimit)
+        private void CollectAttributesOverTheLimit(SonarSyntaxNodeAnalysisContext context, IDictionary<SyntaxNode, Attributes> attributesOverTheLimit)
         {
             if (!IsEnabled(context.Options))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/IfChainWithoutElseBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/IfChainWithoutElseBase.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules
         protected abstract string ElseClause { get; }
 
         protected abstract bool IsElseIfWithoutElse(TIfSyntax ifSyntax);
-        protected abstract Location IssueLocation(SyntaxNodeAnalysisContext context, TIfSyntax ifSyntax);
+        protected abstract Location IssueLocation(SonarSyntaxNodeAnalysisContext context, TIfSyntax ifSyntax);
 
         protected override string MessageFormat => "Add the missing '{0}' clause with either the appropriate action or a suitable comment as to why no action is taken.";
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/InsecureTemporaryFilesCreationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/InsecureTemporaryFilesCreationBase.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, Visit, Language.SyntaxKind.SimpleMemberAccessExpression);
 
-        private void Visit(SyntaxNodeAnalysisContext context)
+        private void Visit(SonarSyntaxNodeAnalysisContext context)
         {
             var memberAccess = (TMemberAccessSyntax)context.Node;
             if (IsMemberAccessOnKnownType(memberAccess, VulnerableApiName, KnownType.System_IO_Path, context.SemanticModel))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MarkWindowsFormsMainWithStaThreadBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MarkWindowsFormsMainWithStaThreadBase.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, Action, SyntaxKinds);
 
-        private void Action(SyntaxNodeAnalysisContext c)
+        private void Action(SonarSyntaxNodeAnalysisContext c)
         {
             var methodDeclaration = (TMethodSyntax)c.Node;
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MethodOverloadsShouldBeGroupedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MethodOverloadsShouldBeGroupedBase.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules
         protected abstract TSyntaxKind[] SyntaxKinds { get; }
 
         protected abstract IEnumerable<TMemberDeclarationSyntax> GetMemberDeclarations(SyntaxNode node);
-        protected abstract MemberInfo CreateMemberInfo(SyntaxNodeAnalysisContext c, TMemberDeclarationSyntax member);
+        protected abstract MemberInfo CreateMemberInfo(SonarSyntaxNodeAnalysisContext c, TMemberDeclarationSyntax member);
 
         protected override string MessageFormat => "All '{0}' method overloads should be adjacent.";
 
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules
             },
             SyntaxKinds);
 
-        protected List<MemberInfo>[] GetMisplacedOverloads(SyntaxNodeAnalysisContext c, IEnumerable<TMemberDeclarationSyntax> members)
+        protected List<MemberInfo>[] GetMisplacedOverloads(SonarSyntaxNodeAnalysisContext c, IEnumerable<TMemberDeclarationSyntax> members)
         {
             var misplacedOverloads = new Dictionary<MemberInfo, List<MemberInfo>>();
             var membersGroupedByInterface = MembersGroupedByInterface(c, members);
@@ -104,7 +104,7 @@ namespace SonarAnalyzer.Rules
         /// Returned ImmutableArray of interfaces for each member is used to determine whether overloads of the same interface should be grouped by name.
         /// If all methods of the class implement single interface, we want the overloads to be placed together within interface group.
         /// </summary>
-        private static Dictionary<TMemberDeclarationSyntax, ImmutableArray<INamedTypeSymbol>> MembersGroupedByInterface(SyntaxNodeAnalysisContext c, IEnumerable<TMemberDeclarationSyntax> members)
+        private static Dictionary<TMemberDeclarationSyntax, ImmutableArray<INamedTypeSymbol>> MembersGroupedByInterface(SonarSyntaxNodeAnalysisContext c, IEnumerable<TMemberDeclarationSyntax> members)
         {
             var ret = new Dictionary<TMemberDeclarationSyntax, ImmutableArray<INamedTypeSymbol>>();
             ImmutableArray<INamedTypeSymbol> currentInterfaces, previousInterfaces = ImmutableArray<INamedTypeSymbol>.Empty;
@@ -163,7 +163,7 @@ namespace SonarAnalyzer.Rules
             public TMemberDeclarationSyntax Member { get; }
             public SyntaxToken NameSyntax { get; }
 
-            public MemberInfo(SyntaxNodeAnalysisContext context, TMemberDeclarationSyntax member, SyntaxToken nameSyntax, bool isStatic, bool isAbstract, bool isCaseSensitive)
+            public MemberInfo(SonarSyntaxNodeAnalysisContext context, TMemberDeclarationSyntax member, SyntaxToken nameSyntax, bool isStatic, bool isAbstract, bool isCaseSensitive)
             {
                 Member = member;
                 accessibility = context.SemanticModel.GetDeclaredSymbol(member)?.DeclaredAccessibility.ToString();

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MethodsShouldNotHaveIdenticalImplementationsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MethodsShouldNotHaveIdenticalImplementationsBase.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules
                 },
                 SyntaxKinds);
 
-        protected virtual bool IsExcludedFromBeingExamined(SyntaxNodeAnalysisContext context) =>
+        protected virtual bool IsExcludedFromBeingExamined(SonarSyntaxNodeAnalysisContext context) =>
             context.ContainingSymbol.Kind != SymbolKind.NamedType;
 
         protected static bool HaveSameParameters<TSyntax>(SeparatedSyntaxList<TSyntax>? leftParameters, SeparatedSyntaxList<TSyntax>? rightParameters)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MultipleVariableDeclarationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MultipleVariableDeclarationBase.cs
@@ -38,7 +38,7 @@ public abstract class MultipleVariableDeclarationBase<TSyntaxKind> : SonarDiagno
             Language.GeneratedCodeRecognizer,
             c =>
             {
-                CheckAndReportVariables(Language.Syntax.LocalDeclarationIdentifiers(c.Node), c, Rule);
+                CheckAndReportVariables(c, Rule, Language.Syntax.LocalDeclarationIdentifiers(c.Node));
             },
             Language.SyntaxKind.LocalDeclaration);
 
@@ -46,12 +46,12 @@ public abstract class MultipleVariableDeclarationBase<TSyntaxKind> : SonarDiagno
             Language.GeneratedCodeRecognizer,
             c =>
             {
-                CheckAndReportVariables(Language.Syntax.FieldDeclarationIdentifiers(c.Node), c, Rule);
+                CheckAndReportVariables(c, Rule, Language.Syntax.FieldDeclarationIdentifiers(c.Node));
             },
             Language.SyntaxKind.FieldDeclaration);
     }
 
-    private static void CheckAndReportVariables(ICollection<SyntaxToken> variables, SyntaxNodeAnalysisContext context, DiagnosticDescriptor rule)
+    private static void CheckAndReportVariables(SonarSyntaxNodeAnalysisContext context, DiagnosticDescriptor rule, ICollection<SyntaxToken> variables)
     {
         if (variables.Count <= 1)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/NameOfShouldBeUsedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/NameOfShouldBeUsedBase.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract IEnumerable<string> GetParameterNames(TMethodSyntax method); // Handle parameters with the same name (in the IDE it can happen)
         protected abstract bool IsStringLiteral(SyntaxToken t);
-        protected abstract bool LeastLanguageVersionMatches(SyntaxNodeAnalysisContext context);
+        protected abstract bool LeastLanguageVersionMatches(SonarSyntaxNodeAnalysisContext context);
         protected abstract bool IsArgumentExceptionCallingNameOf(SyntaxNode node, IEnumerable<string> arguments);
         protected abstract TMethodSyntax MethodSyntax(SyntaxNode node);
 
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void ReportIssues(SyntaxNodeAnalysisContext context)
+        private void ReportIssues(SonarSyntaxNodeAnalysisContext context)
         {
             if (!LeastLanguageVersionMatches(context))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/OptionalParameterNotPassedToBaseCallBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/OptionalParameterNotPassedToBaseCallBase.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.Rules
         protected const string DiagnosticId = "S3466";
         protected const string MessageFormat = "Pass the missing user-supplied parameter value{0} to this 'base' call.";
 
-        protected void ReportOptionalParameterNotPassedToBase(SyntaxNodeAnalysisContext c, TInvocationExpressionSyntax invocation)
+        protected void ReportOptionalParameterNotPassedToBase(SonarSyntaxNodeAnalysisContext c, TInvocationExpressionSyntax invocation)
         {
             if (!(c.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol calledMethod))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParameterNameMatchesOriginalBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParameterNameMatchesOriginalBase.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules
                 },
                 SyntaxKinds);
 
-        private void VerifyParameters(SyntaxNodeAnalysisContext context, TMethodDeclarationSyntax methodSyntax, IList<IParameterSymbol> expectedParameters, string expectedLocation)
+        private void VerifyParameters(SonarSyntaxNodeAnalysisContext context, TMethodDeclarationSyntax methodSyntax, IList<IParameterSymbol> expectedParameters, string expectedLocation)
         {
             foreach (var item in ParameterIdentifiers(methodSyntax)
                                     .Zip(expectedParameters, (actual, expected) => new { actual, expected })
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void VerifyGenericParameters(SyntaxNodeAnalysisContext context,
+        private void VerifyGenericParameters(SonarSyntaxNodeAnalysisContext context,
                                              TMethodDeclarationSyntax methodSyntax,
                                              IList<IParameterSymbol> actualParameters,
                                              IList<IParameterSymbol> expectedParameters,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules
         protected abstract SyntaxToken? GetArgumentIdentifier(TArgumentSyntax argument);
         protected abstract SyntaxToken? GetNameColonArgumentIdentifier(TArgumentSyntax argument);
 
-        internal void ReportIncorrectlyOrderedParameters(SyntaxNodeAnalysisContext analysisContext,
+        internal void ReportIncorrectlyOrderedParameters(SonarSyntaxNodeAnalysisContext analysisContext,
             MethodParameterLookupBase<TArgumentSyntax> methodParameterLookup, SeparatedSyntaxList<TArgumentSyntax> argumentList,
             Func<Location> getLocationToReport)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PartCreationPolicyShouldBeUsedWithExportAttributeBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PartCreationPolicyShouldBeUsedWithExportAttributeBase.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract TDeclarationSyntax GetTypeDeclaration(TAttributeSyntax attribute);
 
-        protected void AnalyzeNode(SyntaxNodeAnalysisContext c)
+        protected void AnalyzeNode(SonarSyntaxNodeAnalysisContext c)
         {
             var attribute = (TAttributeSyntax)c.Node;
             if (!IsPartCreationPolicyAttribute(attribute))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/RedundantNullCheckBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/RedundantNullCheckBase.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules
         protected abstract bool AreEquivalent(SyntaxNode node1, SyntaxNode node2);
 
         // LogicalAnd (C#) / AndAlso (VB)
-        protected void CheckAndExpression(SyntaxNodeAnalysisContext context)
+        protected void CheckAndExpression(SonarSyntaxNodeAnalysisContext context)
         {
             var binaryExpression = (TBinaryExpression)context.Node;
             var binaryExpressionLeft = GetLeftNode(binaryExpression);
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules
         }
 
         // LogicalOr (C#) / OrElse (VB)
-        protected void CheckOrExpression(SyntaxNodeAnalysisContext context)
+        protected void CheckOrExpression(SonarSyntaxNodeAnalysisContext context)
         {
             var binaryExpression = (TBinaryExpression)context.Node;
             var binaryExpressionLeft = GetLeftNode(binaryExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ReversedOperatorsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ReversedOperatorsBase.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules
         private static bool TiedTogether(FileLinePositionSpan left, FileLinePositionSpan right) =>
             left.EndLinePosition == right.StartLinePosition;
 
-        protected Action<SyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
+        protected Action<SonarSyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
             c =>
             {
                 var unaryExpression = (TUnaryExpressionSyntax)c.Node;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SecurityPInvokeMethodShouldNotBeCalledBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SecurityPInvokeMethodShouldNotBeCalledBase.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules
             dllName.Equals(InteropName, StringComparison.OrdinalIgnoreCase)
             || dllName.Equals(InteropDllName, StringComparison.OrdinalIgnoreCase);
 
-        private void CheckForIssue(SyntaxNodeAnalysisContext analysisContext)
+        private void CheckForIssue(SonarSyntaxNodeAnalysisContext analysisContext)
         {
             if (analysisContext.Node is TInvocationExpressionSyntax invocation
                 && Language.Syntax.NodeExpression(invocation) is { } directMethodCall

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ShiftDynamicNotIntegerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ShiftDynamicNotIntegerBase.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules
                 Language.SyntaxKind.RightShiftAssignmentStatement);
         }
 
-        protected void CheckExpressionWithTwoParts(SyntaxNodeAnalysisContext context, Func<SyntaxNode, SyntaxNode> getLeft, Func<SyntaxNode, SyntaxNode> getRight)
+        protected void CheckExpressionWithTwoParts(SonarSyntaxNodeAnalysisContext context, Func<SyntaxNode, SyntaxNode> getLeft, Func<SyntaxNode, SyntaxNode> getRight)
         {
             var expression = context.Node;
             var left = getLeft(expression);
@@ -57,9 +57,7 @@ namespace SonarAnalyzer.Rules
                 && ShouldRaise(context.SemanticModel, left, right))
             {
                 var typeInMessage = GetTypeNameForMessage(right, typeOfRight, context.SemanticModel);
-
-                context.ReportIssue(
-                    Diagnostic.Create(Rule, right.GetLocation(), typeInMessage));
+                context.ReportIssue(Diagnostic.Create(Rule, right.GetLocation(), typeInMessage));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SillyBitwiseOperationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SillyBitwiseOperationBase.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules
         protected SillyBitwiseOperationBase() =>
             Rule = Language.CreateDescriptor(DiagnosticId, MessageFormat, fadeOutCode: true);
 
-        protected void CheckBinary(SyntaxNodeAnalysisContext context, SyntaxNode left, SyntaxToken @operator, SyntaxNode right, int constValueToLookFor)
+        protected void CheckBinary(SonarSyntaxNodeAnalysisContext context, SyntaxNode left, SyntaxToken @operator, SyntaxNode right, int constValueToLookFor)
         {
             Location location;
             bool isReportingOnLeftKey;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/StringConcatenationInLoopBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/StringConcatenationInLoopBase.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules
                 SimpleAssignmentKinds.ToArray());
         }
 
-        private void CheckSimpleAssignment(SyntaxNodeAnalysisContext context)
+        private void CheckSimpleAssignment(SonarSyntaxNodeAnalysisContext context)
         {
             var assignment = (TAssignmentExpression)context.Node;
             if (!IsString(GetLeft(assignment), context.SemanticModel))
@@ -97,7 +97,7 @@ namespace SonarAnalyzer.Rules
             return nestedLeft;
         }
 
-        private void CheckCompoundAssignment(SyntaxNodeAnalysisContext context)
+        private void CheckCompoundAssignment(SonarSyntaxNodeAnalysisContext context)
         {
             var addAssignment = (TAssignmentExpression)context.Node;
             if (!IsString(GetLeft(addAssignment), context.SemanticModel))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/StringLiteralShouldNotBeDuplicatedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/StringLiteralShouldNotBeDuplicatedBase.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules
         protected abstract TSyntaxKind[] SyntaxKinds { get; }
 
         protected abstract bool IsMatchingMethodParameterName(TLiteralExpressionSyntax literalExpression);
-        protected abstract bool IsInnerInstance(SyntaxNodeAnalysisContext context);
+        protected abstract bool IsInnerInstance(SonarSyntaxNodeAnalysisContext context);
         protected abstract IEnumerable<TLiteralExpressionSyntax> FindLiteralExpressions(SyntaxNode node);
         protected abstract SyntaxToken LiteralToken(TLiteralExpressionSyntax literal);
 
@@ -54,13 +54,13 @@ namespace SonarAnalyzer.Rules
             // Hence the decision to do like other languages, at class-level
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, ReportOnViolation, SyntaxKinds);
 
-        protected virtual bool IsNamedTypeOrTopLevelMain(SyntaxNodeAnalysisContext context) =>
+        protected virtual bool IsNamedTypeOrTopLevelMain(SonarSyntaxNodeAnalysisContext context) =>
             IsNamedType(context);
 
-        protected static bool IsNamedType(SyntaxNodeAnalysisContext context) =>
+        protected static bool IsNamedType(SonarSyntaxNodeAnalysisContext context) =>
             context.ContainingSymbol.Kind == SymbolKind.NamedType;
 
-        private void ReportOnViolation(SyntaxNodeAnalysisContext context)
+        private void ReportOnViolation(SonarSyntaxNodeAnalysisContext context)
         {
             if (!IsNamedTypeOrTopLevelMain(context) || IsInnerInstance(context))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ThrowReservedExceptionsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ThrowReservedExceptionsBase.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules
                 KnownType.System_OutOfMemoryException
             );
 
-        protected void ReportReservedExceptionCreation(SyntaxNodeAnalysisContext context,
+        protected void ReportReservedExceptionCreation(SonarSyntaxNodeAnalysisContext context,
             SyntaxNode throwStatementExpression)
         {
             if (throwStatementExpression == null ||
@@ -48,8 +48,7 @@ namespace SonarAnalyzer.Rules
             var expressionType = context.SemanticModel.GetTypeInfo(throwStatementExpression).Type;
             if (expressionType.IsAny(ReservedExceptionTypeNames))
             {
-                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], throwStatementExpression.GetLocation(),
-                    expressionType.ToDisplayString()));
+                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], throwStatementExpression.GetLocation(), expressionType.ToDisplayString()));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ToStringShouldNotReturnNullBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ToStringShouldNotReturnNullBase.cs
@@ -41,7 +41,7 @@ public abstract class ToStringShouldNotReturnNullBase<TSyntaxKind> : SonarDiagno
             c => ToStringReturnsNull(c, c.Node),
             Language.SyntaxKind.ReturnStatement);
 
-    protected void ToStringReturnsNull(SyntaxNodeAnalysisContext context, SyntaxNode node)
+    protected void ToStringReturnsNull(SonarSyntaxNodeAnalysisContext context, SyntaxNode node)
     {
         if (node is not null && ReturnsNull(Language.Syntax.NodeExpression(node)) && WithinToString(node))
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UnconditionalJumpStatementBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UnconditionalJumpStatementBase.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract ISet<TSyntaxKind> LoopStatements { get; }
 
-        protected abstract LoopWalkerBase<TStatementSyntax, TSyntaxKind> GetWalker(SyntaxNodeAnalysisContext context);
+        protected abstract LoopWalkerBase<TStatementSyntax, TSyntaxKind> GetWalker(SonarSyntaxNodeAnalysisContext context);
 
         protected override string MessageFormat => "Refactor the containing loop to do more than one iteration.";
 
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules
         protected List<TStatementSyntax> UnconditionalContinues { get; } = new List<TStatementSyntax>();
         protected List<TStatementSyntax> UnconditionalTerminates { get; } = new List<TStatementSyntax>();
 
-        protected LoopWalkerBase(SyntaxNodeAnalysisContext context, ISet<TLanguageKindEnum> loopStatements)
+        protected LoopWalkerBase(SonarSyntaxNodeAnalysisContext context, ISet<TLanguageKindEnum> loopStatements)
         {
             rootExpression = context.Node;
             semanticModel = context.SemanticModel;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicRuleCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicRuleCheck.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         protected SemanticModel SemanticModel => context.SemanticModel;
 
         private readonly HashSet<Location> reportedDiagnostics = new();
-        private SyntaxNodeAnalysisContext context;
+        private SonarSyntaxNodeAnalysisContext context;
 
         protected abstract DiagnosticDescriptor Rule { get; }
 
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         /// </remarks>
         public abstract bool ShouldExecute();
 
-        public void Init(SonarAnalysisContext sonarContext, SyntaxNodeAnalysisContext nodeContext)
+        public void Init(SonarAnalysisContext sonarContext, SonarSyntaxNodeAnalysisContext nodeContext)
         {
             SonarContext = sonarContext;
             context = nodeContext;

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/BaseTypeContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/BaseTypeContext.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Helpers
         /// </summary>
         public IEnumerable<SyntaxNode> AllBaseTypeNodes { get; }
 
-        public BaseTypeContext(SyntaxNodeAnalysisContext context, IEnumerable<SyntaxNode> allBaseTypeNodes) : base(context) =>
+        public BaseTypeContext(SonarSyntaxNodeAnalysisContext context, IEnumerable<SyntaxNode> allBaseTypeNodes) : base(context) =>
             AllBaseTypeNodes = allBaseTypeNodes ?? Enumerable.Empty<SyntaxNode>();
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/BaseTypeTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/BaseTypeTracker.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Helpers.Trackers
             };
         }
 
-        protected override BaseTypeContext CreateContext(SyntaxNodeAnalysisContext context) =>
+        protected override BaseTypeContext CreateContext(SonarSyntaxNodeAnalysisContext context) =>
             GetBaseTypeNodes(context.Node) is { } baseTypeList
             && baseTypeList.Any()
             ? new BaseTypeContext(context, baseTypeList)

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/ElementAccessContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/ElementAccessContext.cs
@@ -24,7 +24,7 @@ namespace SonarAnalyzer.Helpers
     {
         public Lazy<IPropertySymbol> InvokedPropertySymbol { get; }
 
-        public ElementAccessContext(SyntaxNodeAnalysisContext context) : base(context) =>
+        public ElementAccessContext(SonarSyntaxNodeAnalysisContext context) : base(context) =>
             InvokedPropertySymbol = new Lazy<IPropertySymbol>(() => context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IPropertySymbol);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/ElementAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/ElementAccessTracker.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Helpers.Trackers
             context => context.InvokedPropertySymbol.Value != null
                        && context.InvokedPropertySymbol.Value.ContainingType.DerivesOrImplementsAny(types.ToImmutableArray());
 
-        protected override ElementAccessContext CreateContext(SyntaxNodeAnalysisContext context) =>
+        protected override ElementAccessContext CreateContext(SonarSyntaxNodeAnalysisContext context) =>
             new ElementAccessContext(context);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/FieldAccessContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/FieldAccessContext.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.Helpers
         public string FieldName { get; }
         public Lazy<IFieldSymbol> InvokedFieldSymbol { get; }
 
-        public FieldAccessContext(SyntaxNodeAnalysisContext context, string fieldName) : base(context)
+        public FieldAccessContext(SonarSyntaxNodeAnalysisContext context, string fieldName) : base(context)
         {
             FieldName = fieldName;
             InvokedFieldSymbol = new Lazy<IFieldSymbol>(() => SemanticModel.GetSymbolInfo(Node).Symbol as IFieldSymbol);

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/FieldAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/FieldAccessTracker.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Helpers.Trackers
         public Condition MatchField(params MemberDescriptor[] fields) =>
             context => MemberDescriptor.MatchesAny(context.FieldName, context.InvokedFieldSymbol, false, Language.NameComparison, fields);
 
-        protected override FieldAccessContext CreateContext(SyntaxNodeAnalysisContext context)
+        protected override FieldAccessContext CreateContext(SonarSyntaxNodeAnalysisContext context)
         {
             // We register for both MemberAccess and IdentifierName and we want to avoid raising two times for the same identifier.
             if (IsIdentifierWithinMemberAccess(context.Node))

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/InvocationContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/InvocationContext.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.Helpers
         public string MethodName { get; }
         public Lazy<IMethodSymbol> MethodSymbol { get; }
 
-        public InvocationContext(SyntaxNodeAnalysisContext context, string methodName) : this(context.Node, methodName, context.SemanticModel) { }
+        public InvocationContext(SonarSyntaxNodeAnalysisContext context, string methodName) : this(context.Node, methodName, context.SemanticModel) { }
 
         public InvocationContext(SyntaxNode node, string methodName, SemanticModel semanticModel) : base(node, semanticModel)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/InvocationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/InvocationTracker.cs
@@ -82,7 +82,7 @@ namespace SonarAnalyzer.Helpers.Trackers
                        && containingType.TypeArguments[1].Is(KnownType.Microsoft_Extensions_Primitives_StringValues);
             };
 
-        protected override InvocationContext CreateContext(SyntaxNodeAnalysisContext context) =>
+        protected override InvocationContext CreateContext(SonarSyntaxNodeAnalysisContext context) =>
             Language.Syntax.NodeExpression(context.Node) is { } expression
             && ExpectedExpressionIdentifier(expression) is { } identifier
                 ? new InvocationContext(context, identifier.ValueText) : null;

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/ObjectCreationContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/ObjectCreationContext.cs
@@ -24,7 +24,7 @@ namespace SonarAnalyzer.Helpers
     {
         public Lazy<IMethodSymbol> InvokedConstructorSymbol { get; }
 
-        public ObjectCreationContext(SyntaxNodeAnalysisContext context) : base(context) =>
+        public ObjectCreationContext(SonarSyntaxNodeAnalysisContext context) : base(context) =>
             InvokedConstructorSymbol = new Lazy<IMethodSymbol>(() => context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IMethodSymbol);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/ObjectCreationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/ObjectCreationTracker.cs
@@ -71,7 +71,7 @@ namespace SonarAnalyzer.Helpers.Trackers
                        && context.InvokedConstructorSymbol.Value.IsConstructor()
                        && context.InvokedConstructorSymbol.Value.ContainingType.Implements(baseType);
 
-        protected override ObjectCreationContext CreateContext(SyntaxNodeAnalysisContext context) =>
+        protected override ObjectCreationContext CreateContext(SonarSyntaxNodeAnalysisContext context) =>
             new ObjectCreationContext(context);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessContext.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.Helpers
         public string PropertyName { get; }
         public Lazy<IPropertySymbol> PropertySymbol { get; }
 
-        public PropertyAccessContext(SyntaxNodeAnalysisContext context, string propertyName) : base(context)
+        public PropertyAccessContext(SonarSyntaxNodeAnalysisContext context, string propertyName) : base(context)
         {
             PropertyName = propertyName;
             PropertySymbol = new Lazy<IPropertySymbol>(() => context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IPropertySymbol);

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessTracker.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Helpers.Trackers
         public Condition Or(Condition condition1, Condition condition2, Condition condition3) =>
             value => condition1(value) || condition2(value) || condition3(value);
 
-        protected override PropertyAccessContext CreateContext(SyntaxNodeAnalysisContext context)
+        protected override PropertyAccessContext CreateContext(SonarSyntaxNodeAnalysisContext context)
         {
             // We register for both MemberAccess and IdentifierName and we want to
             // avoid raising two times for the same identifier.

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/SyntaxBaseContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/SyntaxBaseContext.cs
@@ -26,7 +26,7 @@ namespace SonarAnalyzer.Helpers
         public SyntaxNode Node { get; }
         public Location PrimaryLocation { get; set; }
 
-        public SyntaxBaseContext(SyntaxNodeAnalysisContext context) : this(context.Node, context.SemanticModel) { }
+        public SyntaxBaseContext(SonarSyntaxNodeAnalysisContext context) : this(context.Node, context.SemanticModel) { }
 
         public SyntaxBaseContext(SyntaxNode node, SemanticModel semanticModel)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/SyntaxTrackerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/SyntaxTrackerBase.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.Helpers
         where TContext : SyntaxBaseContext
     {
         protected abstract TSyntaxKind[] TrackedSyntaxKinds { get; }
-        protected abstract TContext CreateContext(SyntaxNodeAnalysisContext context);
+        protected abstract TContext CreateContext(SonarSyntaxNodeAnalysisContext context);
 
         public void Track(TrackerInput input, params Condition[] conditions) =>
             Track(input, Array.Empty<object>(), conditions);
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Helpers
                   }
               });
 
-            void TrackAndReportIfNecessary(SyntaxNodeAnalysisContext c)
+            void TrackAndReportIfNecessary(SonarSyntaxNodeAnalysisContext c)
             {
                 if (CreateContext(c) is { } trackingContext
                     && conditions.All(c => c(trackingContext))

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeAnalysisContextExtensions.cs
@@ -20,8 +20,8 @@
 
 namespace SonarAnalyzer.Extensions;
 
-public static class SyntaxNodeAnalysisContextExtensions
+public static class SyntaxNodeAnalysisContextExtensions // FIXME: Doesnt' need to be an extension anymore
 {
-    public static bool IsInExpressionTree(this SyntaxNodeAnalysisContext context) =>
+    public static bool IsInExpressionTree(this SonarSyntaxNodeAnalysisContext context) =>
         context.Node.IsInExpressionTree(context.SemanticModel);
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
@@ -23,17 +23,17 @@ namespace SonarAnalyzer.Helpers
     public static class VisualBasicDiagnosticAnalyzerContextHelper  // FIXME: Move and rename
     {
         public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context,
-                                                                               Action<SyntaxNodeAnalysisContext> action,
+                                                                               Action<SonarSyntaxNodeAnalysisContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
         public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this ParameterLoadingAnalysisContext context,
-                                                                               Action<SyntaxNodeAnalysisContext> action,
+                                                                               Action<SonarSyntaxNodeAnalysisContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
         public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this SonarCompilationStartAnalysisContext context,
-                                                                               Action<SyntaxNodeAnalysisContext> action,
+                                                                               Action<SonarSyntaxNodeAnalysisContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BinaryOperationWithIdenticalExpressions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BinaryOperationWithIdenticalExpressions.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 SyntaxKindsToCheckAssignment);
         }
 
-        private static void ReportIfExpressionsMatch(SyntaxNodeAnalysisContext context, ExpressionSyntax left, ExpressionSyntax right,
+        private static void ReportIfExpressionsMatch(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax left, ExpressionSyntax right,
             SyntaxToken operatorToken)
         {
             if (VisualBasicEquivalenceChecker.AreEquivalent(left.RemoveParentheses(), right.RemoveParentheses()))

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanLiteralUnnecessary.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanLiteralUnnecessary.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             context.RegisterSyntaxNodeActionInNonGenerated(CheckConditional, SyntaxKind.TernaryConditionalExpression);
         }
 
-        private void CheckLogicalNot(SyntaxNodeAnalysisContext context)
+        private void CheckLogicalNot(SonarSyntaxNodeAnalysisContext context)
         {
             var logicalNot = (UnaryExpressionSyntax)context.Node;
             var logicalNotOperand = logicalNot.Operand.RemoveParentheses();
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             }
         }
 
-        private void CheckConditional(SyntaxNodeAnalysisContext context)
+        private void CheckConditional(SonarSyntaxNodeAnalysisContext context)
         {
             var conditional = (TernaryConditionalExpressionSyntax)context.Node;
             var whenTrue = conditional.WhenTrue;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameCondition.cs
@@ -37,12 +37,12 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
                     for (var i = 1; i < conditions.Length; i++)
                     {
-                        CheckConditionAt(i, conditions, c);
+                        CheckConditionAt(c, conditions, i);
                     }
                 },
                 SyntaxKind.MultiLineIfBlock);
 
-        private void CheckConditionAt(int currentIndex, ExpressionSyntax[] conditions, SyntaxNodeAnalysisContext context)
+        private void CheckConditionAt(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax[] conditions, int currentIndex)
         {
             for (var i = 0; i < currentIndex; i++)
             {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameImplementation.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     if (ifStatement.ElseClause != null &&
                         VisualBasicEquivalenceChecker.AreEquivalent(ifStatement.ElseClause.Statements, ifStatement.Statements))
                     {
-                        ReportIssue(ifStatement.ElseClause.Statements, ifStatement.Statements, c, "branch");
+                        ReportIssue(c, ifStatement.ElseClause.Statements, ifStatement.Statements, "branch");
                     }
                 },
                 SyntaxKind.SingleLineIfStatement);
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
                     for (var i = 1; i < statements.Count; i++)
                     {
-                        CheckStatementsAt(i, statements, c, "branch");
+                        CheckStatementsAt(c, statements, i, "branch");
                     }
                 },
                 SyntaxKind.MultiLineIfBlock);
@@ -74,14 +74,13 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var statements = select.CaseBlocks.Select(b => b.Statements).ToList();
                     for (var i = 1; i < statements.Count; i++)
                     {
-                        CheckStatementsAt(i, statements, c, "case");
+                        CheckStatementsAt(c, statements, i, "case");
                     }
                 },
                 SyntaxKind.SelectBlock);
         }
 
-        private static void CheckStatementsAt(int currentIndex, List<SyntaxList<StatementSyntax>> statements,
-            SyntaxNodeAnalysisContext context, string constructType)
+        private static void CheckStatementsAt(SonarSyntaxNodeAnalysisContext context, List<SyntaxList<StatementSyntax>> statements, int currentIndex, string constructType)
         {
             var currentBlockStatements = statements[currentIndex];
             if (currentBlockStatements.Count(IsApprovedStatement) < 2)
@@ -93,14 +92,13 @@ namespace SonarAnalyzer.Rules.VisualBasic
             {
                 if (VisualBasicEquivalenceChecker.AreEquivalent(currentBlockStatements, statements[j]))
                 {
-                    ReportIssue(currentBlockStatements, statements[j], context, constructType);
+                    ReportIssue(context, currentBlockStatements, statements[j], constructType);
                     return;
                 }
             }
         }
 
-        private static void ReportIssue(SyntaxList<StatementSyntax> statementsToReport, SyntaxList<StatementSyntax> locationProvider,
-            SyntaxNodeAnalysisContext context, string constructType)
+        private static void ReportIssue(SonarSyntaxNodeAnalysisContext context, SyntaxList<StatementSyntax> statementsToReport, SyntaxList<StatementSyntax> locationProvider, string constructType)
         {
             var firstStatement = statementsToReport.FirstOrDefault();
             if (firstStatement == null)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConstructorArgumentValueShouldExist.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConstructorArgumentValueShouldExist.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 .Select(x => x.Identifier.Identifier.ValueText);
         }
 
-        protected override void ReportIssue(SyntaxNodeAnalysisContext c, AttributeData constructorArgumentAttribute)
+        protected override void ReportIssue(SonarSyntaxNodeAnalysisContext c, AttributeData constructorArgumentAttribute)
         {
             var attributeSyntax =
                 (AttributeSyntax)constructorArgumentAttribute.ApplicationSyntaxReference.GetSyntax();

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyMethod.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyMethod.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             SyntaxKind.SubBlock
         };
 
-        protected override void CheckMethod(SyntaxNodeAnalysisContext context, bool isTestProject)
+        protected override void CheckMethod(SonarSyntaxNodeAnalysisContext context, bool isTestProject)
         {
             var methodBlock = (MethodBlockSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FieldShadowsParentField.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FieldShadowsParentField.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     {
                         foreach (var diagnostics in fieldDeclaration.Declarators.SelectMany(x => x.Names).SelectMany(x => CheckFields(c.SemanticModel, x)))
                         {
-                            c.ReportIssue(diagnostics, context);
+                            c.ReportIssue(diagnostics);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IfChainWithoutElse.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IfChainWithoutElse.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             ifSyntax.ElseIfBlocks.Any()
             && (ifSyntax.ElseBlock == null || IsEmptyBlock(ifSyntax));
 
-        protected override Location IssueLocation(SyntaxNodeAnalysisContext context, MultiLineIfBlockSyntax ifSyntax) =>
+        protected override Location IssueLocation(SonarSyntaxNodeAnalysisContext context, MultiLineIfBlockSyntax ifSyntax) =>
             ifSyntax.ElseIfBlocks.Last().ElseIfStatement.ElseIfKeyword.GetLocation();
 
         private static bool IsEmptyBlock(MultiLineIfBlockSyntax multiLineIfBlock) =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LooseFilePermissions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LooseFilePermissions.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         internal LooseFilePermissions(IAnalyzerConfiguration configuration) : base(configuration) { }
 
-        protected override void VisitAssignments(SyntaxNodeAnalysisContext context)
+        protected override void VisitAssignments(SonarSyntaxNodeAnalysisContext context)
         {
             var node = context.Node;
             if (IsFileAccessPermissions(node, context.SemanticModel) && !node.IsPartOfBinaryNegationOrCondition())
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             }
         }
 
-        protected override void VisitInvocations(SyntaxNodeAnalysisContext context)
+        protected override void VisitInvocations(SonarSyntaxNodeAnalysisContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if ((IsSetAccessRule(invocation, context.SemanticModel) || IsAddAccessRule(invocation, context.SemanticModel))

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodOverloadsShouldBeGrouped.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodOverloadsShouldBeGrouped.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             SyntaxKind.StructureBlock
         };
 
-        protected override MemberInfo CreateMemberInfo(SyntaxNodeAnalysisContext c, StatementSyntax member)
+        protected override MemberInfo CreateMemberInfo(SonarSyntaxNodeAnalysisContext c, StatementSyntax member)
         {
             if (member is ConstructorBlockSyntax constructor)
             {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NameOfShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NameOfShouldBeUsed.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 : paramGroups.Select(x => x.First().Identifier.Identifier.ValueText);
         }
 
-        protected override bool LeastLanguageVersionMatches(SyntaxNodeAnalysisContext context) =>
+        protected override bool LeastLanguageVersionMatches(SonarSyntaxNodeAnalysisContext context) =>
             context.Compilation.IsAtLeastLanguageVersion(LanguageVersion.VisualBasic14);
 
         protected override bool IsArgumentExceptionCallingNameOf(SyntaxNode node, IEnumerable<string> arguments) =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
@@ -42,16 +42,15 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 SyntaxKind.VariableDeclarator);
 
             context.RegisterSyntaxNodeActionInNonGenerated(
-                c => ProcessLoop((ForStatementSyntax)c.Node, f => f.ControlVariable, s => s.IsFor(), c),
+                c => ProcessLoop(c, (ForStatementSyntax)c.Node, f => f.ControlVariable, s => s.IsFor()),
                 SyntaxKind.ForStatement);
 
             context.RegisterSyntaxNodeActionInNonGenerated(
-                c => ProcessLoop((ForEachStatementSyntax)c.Node, f => f.ControlVariable, s => s.IsForEach(), c),
+                c => ProcessLoop(c, (ForEachStatementSyntax)c.Node, f => f.ControlVariable, s => s.IsForEach()),
                 SyntaxKind.ForEachStatement);
         }
 
-        private void ProcessLoop<T>(T loop, Func<T, VisualBasicSyntaxNode> GetControlVariable, Func<ILocalSymbol, bool> isDeclaredInLoop,
-            SyntaxNodeAnalysisContext context)
+        private void ProcessLoop<T>(SonarSyntaxNodeAnalysisContext context, T loop, Func<T, VisualBasicSyntaxNode> GetControlVariable, Func<ILocalSymbol, bool> isDeclaredInLoop)
         {
             var controlVar = GetControlVariable(loop);
             if (!(controlVar is IdentifierNameSyntax))
@@ -69,7 +68,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             context.ReportIssue(Diagnostic.Create(rule, controlVar.GetLocation(), Pattern));
         }
 
-        private void ProcessVariableDeclarator(SyntaxNodeAnalysisContext context)
+        private void ProcessVariableDeclarator(SonarSyntaxNodeAnalysisContext context)
         {
             var declarator = (VariableDeclaratorSyntax)context.Node;
             if (declarator.Parent is FieldDeclarationSyntax)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NoExceptionsInFinally.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NoExceptionsInFinally.cs
@@ -37,10 +37,10 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         private class ThrowInFinallyWalker : SafeVisualBasicSyntaxWalker
         {
-            private readonly SyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeAnalysisContext context;
             private readonly DiagnosticDescriptor rule;
 
-            public ThrowInFinallyWalker(SyntaxNodeAnalysisContext context, DiagnosticDescriptor rule)
+            public ThrowInFinallyWalker(SonarSyntaxNodeAnalysisContext context, DiagnosticDescriptor rule)
             {
                 this.context = context;
                 this.rule = rule;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 }, SyntaxKind.ObjectCreationExpression);
         }
 
-        private void AnalyzeArguments(SyntaxNodeAnalysisContext analysisContext, ArgumentListSyntax argumentList,
+        private void AnalyzeArguments(SonarSyntaxNodeAnalysisContext analysisContext, ArgumentListSyntax argumentList,
             Func<Location> getLocation)
         {
             if (argumentList == null)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SillyBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SillyBitwiseOperation.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 SyntaxKind.ExclusiveOrExpression);
         }
 
-        private void CheckBinary(SyntaxNodeAnalysisContext context, int constValueToLookFor)
+        private void CheckBinary(SonarSyntaxNodeAnalysisContext context, int constValueToLookFor)
         {
             var binary = (BinaryExpressionSyntax)context.Node;
             CheckBinary(context, binary.Left, binary.OperatorToken, binary.Right, constValueToLookFor);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringLiteralShouldNotBeDuplicated.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringLiteralShouldNotBeDuplicated.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 .Any(p => p.Identifier.Identifier.ValueText.Equals(literalExpression.Token.ValueText, StringComparison.OrdinalIgnoreCase))
                 ?? false;
 
-        protected override bool IsInnerInstance(SyntaxNodeAnalysisContext context) =>
+        protected override bool IsInnerInstance(SonarSyntaxNodeAnalysisContext context) =>
             context.Node.Ancestors().Any(x => x is ClassBlockSyntax || x is StructureBlockSyntax);
 
         protected override IEnumerable<LiteralExpressionSyntax> FindLiteralExpressions(SyntaxNode node) =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         protected override ControlFlowGraph CreateCfg(SemanticModel model, SyntaxNode node, CancellationToken cancel) =>
             node.CreateCfg(model, cancel);
 
-        protected override void AnalyzeSonar(SyntaxNodeAnalysisContext context, bool isTestProject, bool isScannerRun, SyntaxNode body, ISymbol symbol)
+        protected override void AnalyzeSonar(SonarSyntaxNodeAnalysisContext context, SyntaxNode body, ISymbol symbol)
         {
             // There are no old Sonar rules in VB.NET
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnconditionalJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnconditionalJumpStatement.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             SyntaxKind.SimpleDoLoopBlock
         };
 
-        protected override LoopWalkerBase<StatementSyntax, SyntaxKind> GetWalker(SyntaxNodeAnalysisContext context)
+        protected override LoopWalkerBase<StatementSyntax, SyntaxKind> GetWalker(SonarSyntaxNodeAnalysisContext context)
             => new LoopWalker(context, LoopStatements);
 
         private class LoopWalker : LoopWalkerBase<StatementSyntax, SyntaxKind>
@@ -71,7 +71,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
             protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
-            public LoopWalker(SyntaxNodeAnalysisContext context, ISet<SyntaxKind> loopStatements) : base(context, loopStatements) { }
+            public LoopWalker(SonarSyntaxNodeAnalysisContext context, ISet<SyntaxKind> loopStatements) : base(context, loopStatements) { }
 
             public override void Visit()
             {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseReturnStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseReturnStatement.cs
@@ -41,10 +41,10 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         private class IdentifierWalker : SafeVisualBasicSyntaxWalker
         {
-            private readonly SyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeAnalysisContext context;
             private readonly string name;
 
-            public IdentifierWalker(SyntaxNodeAnalysisContext context, string name)
+            public IdentifierWalker(SonarSyntaxNodeAnalysisContext context, string name)
             {
                 this.context = context;
                 this.name = name;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
                     var currentMemberExpression = simpleMemberAccess.Expression.RemoveParentheses();
                     while (simpleMemberAccess != null &&
-                        !CheckExpression(currentMemberExpression, c))
+                        !CheckExpression(c, currentMemberExpression))
                     {
                         simpleMemberAccess = currentMemberExpression as MemberAccessExpressionSyntax;
                         currentMemberExpression = simpleMemberAccess?.Expression.RemoveParentheses();
@@ -74,9 +74,9 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 SyntaxKind.SimpleMemberAccessExpression);
         }
 
-        private bool CheckExpression(ExpressionSyntax expression, SyntaxNodeAnalysisContext context)
+        private bool CheckExpression(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax expression)
         {
-            if (!IsCandidateForExtraction(expression, context))
+            if (!IsCandidateForExtraction(context, expression))
             {
                 return false;
             }
@@ -115,7 +115,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             return false;
         }
 
-        private static bool IsCandidateForExtraction(ExpressionSyntax currentMemberExpression, SyntaxNodeAnalysisContext context)
+        private static bool IsCandidateForExtraction(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax currentMemberExpression)
         {
             return currentMemberExpression != null &&
                 !currentMemberExpression.IsKind(SyntaxKind.IdentifierName) &&

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/DiagnosticAnalyzerContextHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/DiagnosticAnalyzerContextHelperTest.cs
@@ -405,13 +405,13 @@ $@"namespace PartiallyGenerated
         public readonly SyntaxTree Tree;
         private bool delegateWasInvoked;
 
-            public DummyAnalysisContext(TestContext testContext, params string[] unchangedFiles)
-            {
-                var sonarProjectConfig = TestHelper.CreateSonarProjectConfigWithUnchangedFiles(testContext, unchangedFiles);
-                var additionalFile = new AnalyzerAdditionalFile(sonarProjectConfig);
-                Options = new(ImmutableArray.Create<AdditionalText>(additionalFile));
-                (Tree, Model) = TestHelper.CompileCS("public class Sample { }");
-            }
+        public DummyAnalysisContext(TestContext testContext, params string[] unchangedFiles)
+        {
+            var sonarProjectConfig = TestHelper.CreateSonarProjectConfigWithUnchangedFiles(testContext, unchangedFiles);
+            var additionalFile = new AnalyzerAdditionalFile(sonarProjectConfig);
+            Options = new(ImmutableArray.Create<AdditionalText>(additionalFile));
+            (Tree, Model) = TestHelper.CompileCS("public class Sample { }");
+        }
 
         public void DelegateAction<T>(T arg) =>
             delegateWasInvoked = true;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SnippetCompiler.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SnippetCompiler.cs
@@ -21,6 +21,7 @@
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.VisualBasic;
+using Moq;
 using SonarAnalyzer.Common;
 using CSharpSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
 using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
@@ -140,8 +141,12 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public INamedTypeSymbol GetTypeByMetadataName(string metadataName) =>
             SemanticModel.Compilation.GetTypeByMetadataName(metadataName);
 
-        public SyntaxNodeAnalysisContext CreateAnalysisContext(SyntaxNode node) =>
-            new SyntaxNodeAnalysisContext(node, SemanticModel, null, null, null, CancellationToken.None);
+        public SonarSyntaxNodeAnalysisContext CreateAnalysisContext(SyntaxNode node)
+        {
+            var analysisContext = new SonarAnalysisContext(Mock.Of<AnalysisContext>(), Enumerable.Empty<DiagnosticDescriptor>());
+            var nodeContext =  new SyntaxNodeAnalysisContext(node, SemanticModel, null, null, null, default);
+            return new(analysisContext, nodeContext);
+        }
 
         private static bool HasCompilationErrors(Compilation compilation) =>
             compilation.GetDiagnostics().Any(IsCompilationError);
@@ -159,3 +164,4 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         }
     }
 }
+

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SnippetCompiler.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SnippetCompiler.cs
@@ -164,4 +164,3 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         }
     }
 }
-

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/DummyAnalyzer.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/DummyAnalyzer.cs
@@ -35,9 +35,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
         protected override VB.SyntaxKind NumericLiteralExpression => VB.SyntaxKind.NumericLiteralExpression;
     }
 
-    internal abstract class DummyAnalyzer<TSyntaxKind> : DiagnosticAnalyzer where TSyntaxKind : struct
+    internal abstract class DummyAnalyzer<TSyntaxKind> : SonarDiagnosticAnalyzer where TSyntaxKind : struct
     {
-        private static readonly DiagnosticDescriptor Rule = TestHelper.CreateDescriptor("SDummy");
+        private static readonly DiagnosticDescriptor Rule = TestHelper.CreateDescriptor("SDummy", DiagnosticDescriptorFactory.MainSourceScopeTag);
 
         protected abstract TSyntaxKind NumericLiteralExpression { get; }
 
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        public sealed override void Initialize(AnalysisContext context) =>
+        protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSyntaxNodeAction(c => c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation())), NumericLiteralExpression);
     }
 }


### PR DESCRIPTION
Part of #6540

Change `SyntaxNodeAnalysisContext` -> `SonarSyntaxNodeAnalysisContext` everywhere
Remove old `ReportIssue` extensions

All changes in rules are mechanical, except `SymbolicExecutionRunner` that was simplified.

Some of the rules were changed from `ReportDiagnostics` to `ReportIssue`