### PR TITLE
Refactor SonarAnalysisContext - Rename classes

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/CSharpSonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/CSharpSonarAnalysisContextExtensions.cs
@@ -18,9 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Helpers
+namespace SonarAnalyzer.Extensions
 {
-    internal static class CSharpDiagnosticAnalyzerContextHelper     // FIXME: Move and rename
+    internal static class CSharpSonarAnalysisContextExtensions
     {
         public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context,
                                                                                Action<SonarSyntaxNodeAnalysisContext> action,

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarSyntaxNodeAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarSyntaxNodeAnalysisContextExtensions.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Extensions;
 
-public static class SyntaxNodeAnalysisContextExtensions // FIXME: Doesn't need to be extension anymore
+public static class SonarSyntaxNodeAnalysisContextExtensions
 {
     public static bool IsTopLevelMain(this SonarSyntaxNodeAnalysisContext context) =>
         context.Node is CompilationUnitSyntax compilationUnitSyntax

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpDiagnosticAnalyzerContextHelper.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.Helpers
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this ParameterLoadingAnalysisContext context,
+        public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this SonarParametrizedAnalysisContext context,
                                                                                Action<SonarSyntaxNodeAnalysisContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Helpers
         public static void RegisterSyntaxTreeActionInNonGenerated(this SonarAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
             context.RegisterSyntaxTreeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterSyntaxTreeActionInNonGenerated(this ParameterLoadingAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
+        public static void RegisterSyntaxTreeActionInNonGenerated(this SonarParametrizedAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
             context.RegisterSyntaxTreeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, action);
 
         public static void RegisterCodeBlockStartActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveClassCoupling.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveClassCoupling.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class AvoidExcessiveClassCoupling : ParameterLoadingDiagnosticAnalyzer
+    public sealed class AvoidExcessiveClassCoupling : ParametrizedDiagnosticAnalyzer
     {
         private const string DiagnosticId = "S1200";
         private const string MessageFormat = "Split this {0} into smaller and more specialized ones to reduce its dependencies on other types from {1} to the maximum authorized {2} or less.";
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.Rules.CSharp
         [RuleParameter("max", PropertyType.Integer, "Maximum number of types a single type is allowed to depend upon", ThresholdDefaultValue)]
         public int Threshold { get; set; } = ThresholdDefaultValue;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context) =>
+        protected override void Initialize(SonarParametrizedAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
                 {
                     var typeDeclaration = (TypeDeclarationSyntax)c.Node;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveInheritance.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveInheritance.cs
@@ -23,7 +23,7 @@ using System.Text.RegularExpressions;
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class AvoidExcessiveInheritance : ParameterLoadingDiagnosticAnalyzer
+    public class AvoidExcessiveInheritance : ParametrizedDiagnosticAnalyzer
     {
         private const string DiagnosticId = "S110";
         private const string MessageFormat = "This {0} has {1} parents which is greater than {2} authorized.";
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context) =>
+        protected override void Initialize(SonarParametrizedAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
                 {
                     if (c.IsRedundantPositionalRecordContext())

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CognitiveComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CognitiveComplexity.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
         protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
                 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionComplexity.cs
@@ -24,7 +24,7 @@ using SonarAnalyzer.Metrics.CSharp;
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class FunctionComplexity : ParameterLoadingDiagnosticAnalyzer
+    public class FunctionComplexity : ParametrizedDiagnosticAnalyzer
     {
         private const string DiagnosticId = "S1541";
         private const string MessageFormat = "The Cyclomatic Complexity of this {2} is {1} which is greater than {0} authorized.";
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
                 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionNestingDepth.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionNestingDepth.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
         protected override ILanguageFacade Language => CSharpFacade.Instance;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context) =>
+        protected override void Initialize(SonarParametrizedAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
             {
                 var walker = new NestingDepthWalker(Maximum, token => c.ReportIssue(Diagnostic.Create(rule, token.GetLocation(), Maximum)));

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotHardcodeCredentials.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotHardcodeCredentials.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         internal /*for testing*/ DoNotHardcodeCredentials(IAnalyzerConfiguration configuration) : base(configuration) { }
 
-        protected override void InitializeActions(ParameterLoadingAnalysisContext context) =>
+        protected override void InitializeActions(SonarParametrizedAnalysisContext context) =>
             context.RegisterPostponedAction(
                 c =>
                 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveTooManyLines.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveTooManyLines.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override string MethodKeyword => "methods";
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
                 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyGenericParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyGenericParameters.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.CSharp
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class TooManyGenericParameters : ParameterLoadingDiagnosticAnalyzer
+    public class TooManyGenericParameters : ParametrizedDiagnosticAnalyzer
     {
         private const string DiagnosticId = "S2436";
         private const string MessageFormat = "Reduce the number of generic parameters in the '{0}' {1} to no more than the {2} authorized.";
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         [RuleParameter("maxMethod", PropertyType.Integer, "Maximum authorized number of generic parameters for methods.", DefaultMaxNumberOfGenericParametersInMethod)]
         public int MaxNumberOfGenericParametersInMethod { get; set; } = DefaultMaxNumberOfGenericParametersInMethod;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -73,31 +73,31 @@ public sealed class SonarAnalysisContext : SonarAnalysisContextBase
 
     // FIXME: Better names for these pairs
     public void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
     public void RegisterCodeBlockStartActionInNonGenerated<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action)
         where TSyntaxKind : struct =>
         analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action, generatedCodeRecognizer));    // FIXME: Rename generatedCodeRecognizer everywhere
 
     public void RegisterCompilationAction(Action<SonarCompilationAnalysisContext> action) =>
-        analysisContext.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
+        context.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
 
     public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
-        analysisContext.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
+        context.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
 
     public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
-        analysisContext.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
+        context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
 
     // FIXME: Better names for these pairs
     public void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-        analysisContext.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
+        context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
 
     public void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds)
         where TSyntaxKind : struct =>
         analysisContext.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action, generatedCodeRecognizer), syntaxKinds);
 
     public void RegisterSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
-        analysisContext.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
+        context.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
 
     public void RegisterSyntaxTreeActionInNonGenerated(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxTreeAnalysisContext> action) =>
         analysisContext.RegisterCompilationStartAction(WrapSyntaxTreeAction(action, generatedCodeRecognizer));

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -73,31 +73,31 @@ public sealed class SonarAnalysisContext : SonarAnalysisContextBase
 
     // FIXME: Better names for these pairs
     public void RegisterCodeBlockStartAction<TSyntaxKind>(Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action) where TSyntaxKind : struct =>
-        context.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
+        analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action));
 
     public void RegisterCodeBlockStartActionInNonGenerated<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action)
         where TSyntaxKind : struct =>
         analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action, generatedCodeRecognizer));    // FIXME: Rename generatedCodeRecognizer everywhere
 
     public void RegisterCompilationAction(Action<SonarCompilationAnalysisContext> action) =>
-        context.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
+        analysisContext.RegisterCompilationAction(c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action));
 
     public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
-        context.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
+        analysisContext.RegisterCompilationStartAction(c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action));
 
     public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
-        context.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
+        analysisContext.RegisterSymbolAction(c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action), symbolKinds);
 
     // FIXME: Better names for these pairs
     public void RegisterSyntaxNodeAction<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-        context.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
+        analysisContext.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action), syntaxKinds);
 
     public void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds)
         where TSyntaxKind : struct =>
         analysisContext.RegisterSyntaxNodeAction(c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action, generatedCodeRecognizer), syntaxKinds);
 
     public void RegisterSyntaxTreeAction(Action<SonarSyntaxTreeAnalysisContext> action) =>
-        context.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
+        analysisContext.RegisterCompilationStartAction(WrapSyntaxTreeAction(action));
 
     public void RegisterSyntaxTreeActionInNonGenerated(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxTreeAnalysisContext> action) =>
         analysisContext.RegisterCompilationStartAction(WrapSyntaxTreeAction(action, generatedCodeRecognizer));

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarParametrizedAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarParametrizedAnalysisContext.cs
@@ -22,13 +22,13 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace SonarAnalyzer.Helpers;
 
-public sealed class ParameterLoadingAnalysisContext : SonarAnalysisContextBase
+public sealed class SonarParametrizedAnalysisContext : SonarAnalysisContextBase
 {
     private readonly List<Action<SonarCompilationStartAnalysisContext>> postponedActions = new();
 
     public SonarAnalysisContext Context { get; }
 
-    internal ParameterLoadingAnalysisContext(SonarAnalysisContext context) =>
+    internal SonarParametrizedAnalysisContext(SonarAnalysisContext context) =>
         Context = context;
 
     public void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds)

--- a/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/ParametrizedDiagnosticAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.Common/DiagnosticAnalyzer/ParametrizedDiagnosticAnalyzer.cs
@@ -20,13 +20,13 @@
 
 namespace SonarAnalyzer.Helpers
 {
-    public abstract class ParameterLoadingDiagnosticAnalyzer : SonarDiagnosticAnalyzer  // FIXME: Rename To Sonar*
+    public abstract class ParametrizedDiagnosticAnalyzer : SonarDiagnosticAnalyzer
     {
-        protected abstract void Initialize(ParameterLoadingAnalysisContext context);
+        protected abstract void Initialize(SonarParametrizedAnalysisContext context);
 
         protected sealed override void Initialize(SonarAnalysisContext context)
         {
-            var parameterContext = new ParameterLoadingAnalysisContext(context);
+            var parameterContext = new SonarParametrizedAnalysisContext(context);
             Initialize(parameterContext);
 
             context.RegisterCompilationStartAction(

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxTreeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxTreeExtensions.cs
@@ -21,13 +21,13 @@
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 
-namespace SonarAnalyzer;
+namespace SonarAnalyzer.Extensions;
 
-internal static class DiagnosticAnalyzerContextHelper   // FIXME: Rename and move
+internal static class SyntaxTreeExtensions
 {
     private static readonly ConditionalWeakTable<Compilation, ConcurrentDictionary<SyntaxTree, bool>> GeneratedCodeCache = new();
 
-    public static bool IsGenerated(this SyntaxTree tree, GeneratedCodeRecognizer generatedCodeRecognizer, Compilation compilation)  // FIXME: Move
+    public static bool IsGenerated(this SyntaxTree tree, GeneratedCodeRecognizer generatedCodeRecognizer, Compilation compilation)
     {
         if (tree == null)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/ParameterLoader.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/ParameterLoader.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Helpers
          * - diffing the contents of the configuration file
          * - associating the file with a unique identifier for the build project
          */
-        internal static void SetParameterValues(ParameterLoadingDiagnosticAnalyzer parameteredAnalyzer,
+        internal static void SetParameterValues(ParametrizedDiagnosticAnalyzer parameteredAnalyzer,
             AnalyzerOptions options)
         {
             var sonarLintXml = options.SonarLintXml();

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CheckFileLicenseBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CheckFileLicenseBase.cs
@@ -23,7 +23,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class CheckFileLicenseBase : ParameterLoadingDiagnosticAnalyzer
+    public abstract class CheckFileLicenseBase : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S1451";
         internal const string HeaderFormatPropertyKey = nameof(HeaderFormat);
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules
         protected CheckFileLicenseBase() =>
             rule = Language.CreateDescriptor(DiagnosticId, MessageFormat, isEnabledByDefault: false);
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context) =>
+        protected override void Initialize(SonarParametrizedAnalysisContext context) =>
             context.RegisterSyntaxTreeActionInNonGenerated(Language.GeneratedCodeRecognizer, c =>
                 {
                     if (HeaderFormat == null)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CognitiveComplexityBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CognitiveComplexityBase.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class CognitiveComplexityBase<TSyntaxKind> : ParameterLoadingDiagnosticAnalyzer
+    public abstract class CognitiveComplexityBase<TSyntaxKind> : ParametrizedDiagnosticAnalyzer
         where TSyntaxKind : struct
     {
         protected const string DiagnosticId = "S3776";

--- a/analyzers/src/SonarAnalyzer.Common/Rules/EnumNameShouldFollowRegexBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/EnumNameShouldFollowRegexBase.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class EnumNameShouldFollowRegexBase<TSyntaxKind> : ParameterLoadingDiagnosticAnalyzer
+    public abstract class EnumNameShouldFollowRegexBase<TSyntaxKind> : ParametrizedDiagnosticAnalyzer
         where TSyntaxKind : struct
     {
         protected const string DiagnosticId = "S2342";
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules
         protected EnumNameShouldFollowRegexBase() =>
             rule = Language.CreateDescriptor(DiagnosticId, MessageFormat, isEnabledByDefault: false);
 
-        protected sealed override void Initialize(ParameterLoadingAnalysisContext context) =>
+        protected sealed override void Initialize(SonarParametrizedAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, c =>
                 {
                     var pattern = c.Node.HasFlagsAttribute(c.SemanticModel) ? FlagsEnumNamePattern : EnumNamePattern;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ExpressionComplexityBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ExpressionComplexityBase.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class ExpressionComplexityBase<TSyntaxKind> : ParameterLoadingDiagnosticAnalyzer
+    public abstract class ExpressionComplexityBase<TSyntaxKind> : ParametrizedDiagnosticAnalyzer
         where TSyntaxKind : struct, Enum
     {
         protected const string DiagnosticId = "S1067";
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules
         protected ExpressionComplexityBase() =>
             rule = Language.CreateDescriptor(DiagnosticId, MessageFormat, isEnabledByDefault: false);
 
-        protected sealed override void Initialize(ParameterLoadingAnalysisContext context) =>
+        protected sealed override void Initialize(SonarParametrizedAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(Language.GeneratedCodeRecognizer, c =>
                 {
                     if (IsRoot(c.Node))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FileLinesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FileLinesBase.cs
@@ -22,7 +22,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class FileLinesBase : ParameterLoadingDiagnosticAnalyzer
+    public abstract class FileLinesBase : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S104";
         internal const string MessageFormat = "This file has {1} lines, which is greater than {0} authorized. Split it into " +
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules
             DefaultValueMaximum)]
         public int Maximum { get; set; } = DefaultValueMaximum;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxTreeActionInNonGenerated(
                 GeneratedCodeRecognizer,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FunctionComplexityBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FunctionComplexityBase.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class FunctionComplexityBase : ParameterLoadingDiagnosticAnalyzer
+    public abstract class FunctionComplexityBase : ParametrizedDiagnosticAnalyzer
     {
         protected const string DiagnosticId = "S1541";
         protected const string MessageFormat = "The Cyclomatic Complexity of this {2} is {1} which is greater than {0} authorized.";
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract GeneratedCodeRecognizer GeneratedCodeRecognizer { get; }
 
-        protected abstract override void Initialize(ParameterLoadingAnalysisContext context);
+        protected abstract override void Initialize(SonarParametrizedAnalysisContext context);
 
         protected void CheckComplexity<TSyntax>(SonarSyntaxNodeAnalysisContext context, Func<TSyntax, SyntaxNode> nodeSelector, Func<TSyntax, Location> location,
             string declarationType)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FunctionNestingDepthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FunctionNestingDepthBase.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class FunctionNestingDepthBase : ParameterLoadingDiagnosticAnalyzer
+    public abstract class FunctionNestingDepthBase : ParametrizedDiagnosticAnalyzer
     {
         protected const string DiagnosticId = "S134";
         private const string MessageFormat = "Refactor this code to not nest more than {0} control flow statements.";

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -26,7 +26,7 @@ using SonarAnalyzer.Json.Parsing;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class DoNotHardcodeCredentialsBase<TSyntaxKind> : ParameterLoadingDiagnosticAnalyzer
+    public abstract class DoNotHardcodeCredentialsBase<TSyntaxKind> : ParametrizedDiagnosticAnalyzer
         where TSyntaxKind : struct
     {
         protected const char CredentialSeparator = ';';
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules
         private Regex passwordValuePattern;
 
         protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
-        protected abstract void InitializeActions(ParameterLoadingAnalysisContext context);
+        protected abstract void InitializeActions(SonarParametrizedAnalysisContext context);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
@@ -85,7 +85,7 @@ namespace SonarAnalyzer.Rules
                 $@"(?<{name}>[\w\d{Regex.Escape(UriPasswordSpecialCharacters)}{additionalCharacters}]+)";
         }
 
-        protected sealed override void Initialize(ParameterLoadingAnalysisContext context)
+        protected sealed override void Initialize(SonarParametrizedAnalysisContext context)
         {
             var input = new TrackerInput(context.Context, configuration, rule);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
@@ -24,7 +24,7 @@ using System.Xml.XPath;
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class RequestsWithExcessiveLengthBase<TSyntaxKind, TAttributeSyntax> : ParameterLoadingDiagnosticAnalyzer
+    public abstract class RequestsWithExcessiveLengthBase<TSyntaxKind, TAttributeSyntax> : ParametrizedDiagnosticAnalyzer
         where TSyntaxKind : struct
         where TAttributeSyntax : SyntaxNode
     {
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules
             rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
         }
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterPostponedAction(
                 c =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/LineLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/LineLengthBase.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class LineLengthBase : ParameterLoadingDiagnosticAnalyzer
+    public abstract class LineLengthBase : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S103";
         internal const string MessageFormat = "Split this {1} characters long line (which is greater than {0} authorized).";
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract GeneratedCodeRecognizer GeneratedCodeRecognizer { get; }
 
-        protected sealed override void Initialize(ParameterLoadingAnalysisContext context)
+        protected sealed override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxTreeActionInNonGenerated(
                 GeneratedCodeRecognizer,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MethodsShouldNotHaveTooManyLinesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MethodsShouldNotHaveTooManyLinesBase.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules
 {
     public abstract class MethodsShouldNotHaveTooManyLinesBase<TSyntaxKind, TBaseMethodSyntax>
-        : ParameterLoadingDiagnosticAnalyzer
+        : ParametrizedDiagnosticAnalyzer
         where TSyntaxKind : struct
         where TBaseMethodSyntax : SyntaxNode
     {
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules
         protected abstract SyntaxToken? GetMethodIdentifierToken(TBaseMethodSyntax baseMethodDeclaration);
         protected abstract string GetMethodKindAndName(SyntaxToken identifierToken);
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context) =>
+        protected override void Initialize(SonarParametrizedAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(
                 GeneratedCodeRecognizer,
                 c =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/StringLiteralShouldNotBeDuplicatedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/StringLiteralShouldNotBeDuplicatedBase.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class StringLiteralShouldNotBeDuplicatedBase<TSyntaxKind, TLiteralExpressionSyntax> : ParameterLoadingDiagnosticAnalyzer
+    public abstract class StringLiteralShouldNotBeDuplicatedBase<TSyntaxKind, TLiteralExpressionSyntax> : ParametrizedDiagnosticAnalyzer
         where TSyntaxKind : struct
         where TLiteralExpressionSyntax : SyntaxNode
     {
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules
         protected StringLiteralShouldNotBeDuplicatedBase() =>
             rule = Language.CreateDescriptor(DiagnosticId, MessageFormat, isEnabledByDefault: false);
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context) =>
+        protected override void Initialize(SonarParametrizedAnalysisContext context) =>
             // Ideally we would like to report at assembly/project level for the primary and all string instances for secondary
             // locations. The problem is that this scenario is not yet supported on SonarQube side.
             // Hence the decision to do like other languages, at class-level

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SwitchSectionShouldNotHaveTooManyStatementsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SwitchSectionShouldNotHaveTooManyStatementsBase.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class SwitchSectionShouldNotHaveTooManyStatementsBase : ParameterLoadingDiagnosticAnalyzer
+    public abstract class SwitchSectionShouldNotHaveTooManyStatementsBase : ParametrizedDiagnosticAnalyzer
     {
         protected const string DiagnosticId = "S1151";
         protected const string MessageFormat = "Reduce this {0} number of statements from {1} to at most {2}, for example by extracting code into a {3}.";

--- a/analyzers/src/SonarAnalyzer.Common/Rules/TooManyLabelsInSwitchBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/TooManyLabelsInSwitchBase.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class TooManyLabelsInSwitchBase<TSyntaxKind, TSwitchStatementSyntax> : ParameterLoadingDiagnosticAnalyzer
+    public abstract class TooManyLabelsInSwitchBase<TSyntaxKind, TSwitchStatementSyntax> : ParametrizedDiagnosticAnalyzer
         where TSyntaxKind : struct
         where TSwitchStatementSyntax : SyntaxNode
     {
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(Rule);
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 GeneratedCodeRecognizer,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/TooManyParametersBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/TooManyParametersBase.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Rules
 {
-    public abstract class TooManyParametersBase<TSyntaxKind, TParameterListSyntax> : ParameterLoadingDiagnosticAnalyzer
+    public abstract class TooManyParametersBase<TSyntaxKind, TParameterListSyntax> : ParametrizedDiagnosticAnalyzer
         where TSyntaxKind : struct
         where TParameterListSyntax : SyntaxNode
     {
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules
         protected TooManyParametersBase() =>
             rule = Language.CreateDescriptor(DiagnosticId, MessageFormat, isEnabledByDefault: false);
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context) =>
+        protected override void Initialize(SonarParametrizedAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(
                 Language.GeneratedCodeRecognizer,
                 c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarSyntaxNodeAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarSyntaxNodeAnalysisContextExtensions.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Extensions;
 
-public static class SyntaxNodeAnalysisContextExtensions // FIXME: Doesnt' need to be an extension anymore
+public static class SonarSyntaxNodeAnalysisContextExtensions
 {
     public static bool IsInExpressionTree(this SonarSyntaxNodeAnalysisContext context) =>
         context.Node.IsInExpressionTree(context.SemanticModel);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/VisualBasicSonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/VisualBasicSonarAnalysisContextExtensions.cs
@@ -18,9 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Helpers
+namespace SonarAnalyzer.Extensions
 {
-    public static class VisualBasicDiagnosticAnalyzerContextHelper  // FIXME: Move and rename
+    public static class VisualBasicSonarAnalysisContextExtensions
     {
         public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context,
                                                                                Action<SonarSyntaxNodeAnalysisContext> action,

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicDiagnosticAnalyzerContextHelper.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.Helpers
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this ParameterLoadingAnalysisContext context,
+        public static void RegisterSyntaxNodeActionInNonGenerated<TSyntaxKind>(this SonarParametrizedAnalysisContext context,
                                                                                Action<SonarSyntaxNodeAnalysisContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterSyntaxNodeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Helpers
         public static void RegisterSyntaxTreeActionInNonGenerated(this SonarAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
             context.RegisterSyntaxTreeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterSyntaxTreeActionInNonGenerated(this ParameterLoadingAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
+        public static void RegisterSyntaxTreeActionInNonGenerated(this SonarParametrizedAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
             context.RegisterSyntaxTreeActionInNonGenerated(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
         public static void RegisterCodeBlockStartActionInNonGenerated<TSyntaxKind>(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CognitiveComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CognitiveComplexity.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     {
         protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                  c => CheckComplexity<MethodBlockSyntax>(c, m => m, m => m.SubOrFunctionStatement.Identifier.GetLocation(),

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FunctionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FunctionComplexity.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c => CheckComplexity<MethodBlockBaseSyntax>(c, m => m.BlockStatement.GetLocation(), "procedure"),

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FunctionNestingDepth.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FunctionNestingDepth.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
     {
         protected override ILanguageFacade Language => VisualBasicFacade.Instance;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context) =>
+        protected override void Initialize(SonarParametrizedAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(c =>
             {
                 var walker = new NestingDepthWalker(Maximum, token => c.ReportIssue(Diagnostic.Create(rule, token.GetLocation(), Maximum)));

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DoNotHardcodeCredentials.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DoNotHardcodeCredentials.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         internal /*for testing*/ DoNotHardcodeCredentials(IAnalyzerConfiguration configuration) : base(configuration) { }
 
-        protected override void InitializeActions(ParameterLoadingAnalysisContext context) =>
+        protected override void InitializeActions(SonarParametrizedAnalysisContext context) =>
             context.RegisterPostponedAction(
                 c =>
                 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ClassName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ClassName.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class ClassName : ParameterLoadingDiagnosticAnalyzer
+    public sealed class ClassName : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S101";
         private const string MessageFormat = "Rename this class to match the regular expression: '{0}'.";
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             "Regular expression used to check the class names against.", NamingHelper.PascalCasingPattern)]
         public string Pattern { get; set; } = NamingHelper.PascalCasingPattern;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EnumerationValueName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EnumerationValueName.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class EnumerationValueName : ParameterLoadingDiagnosticAnalyzer
+    public sealed class EnumerationValueName : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S2343";
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             "Regular expression used to check the enumeration value names against.", NamingHelper.PascalCasingPattern)]
         public string Pattern { get; set; } = NamingHelper.PascalCasingPattern;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventHandlerName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventHandlerName.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class EventHandlerName : ParameterLoadingDiagnosticAnalyzer
+    public sealed class EventHandlerName : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S2347";
         private const string MessageFormat = "Rename event handler '{0}' to match the regular expression: '{1}'.";
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         [RuleParameter("format", PropertyType.String, "Regular expression used to check the even handler names against.", DefaultPattern)]
         public string Pattern { get; set; } = DefaultPattern;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context) =>
+        protected override void Initialize(SonarParametrizedAnalysisContext context) =>
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>
                 {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventName.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class EventName : ParameterLoadingDiagnosticAnalyzer
+    public sealed class EventName : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S2348";
         private const string MessageFormat = "Rename this event to match the regular expression: '{0}'.";
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             "Regular expression used to check the event names against.", NamingHelper.PascalCasingPattern)]
         public string Pattern { get; set; } = NamingHelper.PascalCasingPattern;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/FieldNameChecker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/FieldNameChecker.cs
@@ -20,13 +20,13 @@
 
 namespace SonarAnalyzer.Rules.VisualBasic
 {
-    public abstract class FieldNameChecker : ParameterLoadingDiagnosticAnalyzer
+    public abstract class FieldNameChecker : ParametrizedDiagnosticAnalyzer
     {
         public virtual string Pattern { get; set; }
 
         protected abstract bool IsCandidateSymbol(IFieldSymbol symbol);
 
-        protected sealed override void Initialize(ParameterLoadingAnalysisContext context)
+        protected sealed override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/FunctionName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/FunctionName.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class FunctionName : ParameterLoadingDiagnosticAnalyzer
+    public sealed class FunctionName : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S1542";
         private const string MessageFormat = "Rename {0} '{1}' to match the regular expression: '{2}'.";
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         [RuleParameter("format", PropertyType.String, "Regular expression used to check the function names against.", NamingHelper.PascalCasingPattern)]
         public string Pattern { get; set; } = NamingHelper.PascalCasingPattern;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/InterfaceName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/InterfaceName.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class InterfaceName : ParameterLoadingDiagnosticAnalyzer
+    public sealed class InterfaceName : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S114";
         private const string MessageFormat = "Rename this interface to match the regular expression: '{0}'.";
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             "Regular expression used to check the interface names against.", DefaultPattern)]
         public string Pattern { get; set; } = DefaultPattern;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class LocalVariableName : ParameterLoadingDiagnosticAnalyzer
+    public sealed class LocalVariableName : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S117";
         private const string MessageFormat = "Rename this local variable to match the regular expression: '{0}'.";
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             "Regular expression used to check the local variable names against.", NamingHelper.CamelCasingPattern)]
         public string Pattern { get; set; } = NamingHelper.CamelCasingPattern;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 ProcessVariableDeclarator,

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/NamespaceName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/NamespaceName.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class NamespaceName : ParameterLoadingDiagnosticAnalyzer
+    public sealed class NamespaceName : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S2304";
         private const string MessageFormat = "Rename this namespace to match the regular expression: '{0}'.";
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             "Regular expression used to check the namespace names against.", DefaultPattern)]
         public string Pattern { get; set; } = DefaultPattern;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ParameterName.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class ParameterName : ParameterLoadingDiagnosticAnalyzer
+    public sealed class ParameterName : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S1654";
         private const string MessageFormat = "Rename this parameter to match the regular expression: '{0}'.";
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             "Regular expression used to check the parameter names against.", NamingHelper.CamelCasingPattern)]
         public string Pattern { get; set; } = NamingHelper.CamelCasingPattern;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PropertyName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PropertyName.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class PropertyName : ParameterLoadingDiagnosticAnalyzer
+    public sealed class PropertyName : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S2366";
         private const string MessageFormat = "Rename this property to match the regular expression: '{0}'.";
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             "Regular expression used to check the property names against.", NamingHelper.PascalCasingPattern)]
         public string Pattern { get; set; } = NamingHelper.PascalCasingPattern;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/TypeParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/TypeParameterName.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class TypeParameterName : ParameterLoadingDiagnosticAnalyzer
+    public sealed class TypeParameterName : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S2373";
         private const string MessageFormat = "Rename '{0}' to match the regular expression: '{1}'.";
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             "Regular expression used to check the generic type parameter names against.", DefaultFormat)]
         public string Pattern { get; set; } = DefaultFormat;
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 isEnabledByDefault: false);
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class UseWithStatement : ParameterLoadingDiagnosticAnalyzer
+    public sealed class UseWithStatement : ParametrizedDiagnosticAnalyzer
     {
         internal const string DiagnosticId = "S2375";
         private const string MessageFormat = "Wrap this and the following {0} statement{2} that use '{1}' in a 'With' statement.";
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             typeof(ExpressionStatementSyntax)
         };
 
-        protected override void Initialize(ParameterLoadingAnalysisContext context)
+        protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionInNonGenerated(
                 c =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SyntaxTreeContextExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SyntaxTreeContextExtensionsTest.cs
@@ -21,6 +21,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Moq;
 using SonarAnalyzer.Common;
+using SonarAnalyzer.Extensions;
 using CS = SonarAnalyzer.Rules.CSharp;
 using VB = SonarAnalyzer.Rules.VisualBasic;
 
@@ -302,7 +303,7 @@ $@"namespace PartiallyGenerated
     [DataTestMethod]
     [DataRow(SnippetFileName, false)]
     [DataRow(AnotherFileName, true)]
-    public void RegisterSyntaxNodeActionInNonGenerated_UnchangedFiles_ParameterLoadingAnalysisContext(string unchangedFileName, bool expected)
+    public void RegisterSyntaxNodeActionInNonGenerated_UnchangedFiles_SonarParametrizedAnalysisContext(string unchangedFileName, bool expected)
     {
         var context = new DummyAnalysisContext(TestContext, unchangedFileName);
         var sut = new SonarParametrizedAnalysisContext(new(context, DummyMainDescriptor));
@@ -326,12 +327,12 @@ $@"namespace PartiallyGenerated
     [DataTestMethod]
     [DataRow(SnippetFileName, false)]
     [DataRow(AnotherFileName, true)]
-    public void RegisterSyntaxTreeActionInNonGenerated_UnchangedFiles_ParameterLoadingAnalysisContext(string unchangedFileName, bool expected)
+    public void RegisterSyntaxTreeActionInNonGenerated_UnchangedFiles_SonarParametrizedAnalysisContext(string unchangedFileName, bool expected)
     {
         var context = new DummyAnalysisContext(TestContext, unchangedFileName);
         var sut = new SonarParametrizedAnalysisContext(new(context, DummyMainDescriptor));
         sut.RegisterSyntaxTreeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, context.DelegateAction);
-        sut.ExecutePostponedActions(new(sut.Context, MockCompilationStartAnalysisContext(context)));  // Manual invocation, because ParameterLoadingAnalysisContext stores actions separately
+        sut.ExecutePostponedActions(new(sut.Context, MockCompilationStartAnalysisContext(context)));  // Manual invocation, because SonarParametrizedAnalysisContext stores actions separately
 
         context.AssertDelegateInvoked(expected);
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SyntaxTreeContextExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SyntaxTreeContextExtensionsTest.cs
@@ -27,8 +27,9 @@ using VB = SonarAnalyzer.Rules.VisualBasic;
 namespace SonarAnalyzer.UnitTest;
 
 [TestClass]
-public class DiagnosticAnalyzerContextHelperTest
+public class SyntaxTreeContextExtensionsTest
 {
+    // FIXME: Most of these UTs needs to go away
     private const string SnippetFileName = "snippet0.cs";
     private const string AnotherFileName = "Any other file name to make snippet0 considered as changed.cs";
 
@@ -304,7 +305,7 @@ $@"namespace PartiallyGenerated
     public void RegisterSyntaxNodeActionInNonGenerated_UnchangedFiles_ParameterLoadingAnalysisContext(string unchangedFileName, bool expected)
     {
         var context = new DummyAnalysisContext(TestContext, unchangedFileName);
-        var sut = new ParameterLoadingAnalysisContext(new(context, DummyMainDescriptor));
+        var sut = new SonarParametrizedAnalysisContext(new(context, DummyMainDescriptor));
         sut.RegisterSyntaxNodeActionInNonGenerated<SyntaxKind>(CSharpGeneratedCodeRecognizer.Instance, context.DelegateAction);
 
         context.AssertDelegateInvoked(expected);
@@ -328,7 +329,7 @@ $@"namespace PartiallyGenerated
     public void RegisterSyntaxTreeActionInNonGenerated_UnchangedFiles_ParameterLoadingAnalysisContext(string unchangedFileName, bool expected)
     {
         var context = new DummyAnalysisContext(TestContext, unchangedFileName);
-        var sut = new ParameterLoadingAnalysisContext(new(context, DummyMainDescriptor));
+        var sut = new SonarParametrizedAnalysisContext(new(context, DummyMainDescriptor));
         sut.RegisterSyntaxTreeActionInNonGenerated(CSharpGeneratedCodeRecognizer.Instance, context.DelegateAction);
         sut.ExecutePostponedActions(new(sut.Context, MockCompilationStartAnalysisContext(context)));  // Manual invocation, because ParameterLoadingAnalysisContext stores actions separately
 


### PR DESCRIPTION
Part of #6532

Rename classes, change their namespace
Align `ParameterLoadingAnalyzerContext` with other `Sonar*`-named contexts