### PR TITLE
Refactor SonarAnalysisContext - Move HasMatchingScope

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -112,7 +112,7 @@ public sealed class SonarAnalysisContext : SonarAnalysisContextBase
         // First, we need to ensure the rule does apply to the current scope (main vs test source).
         // Second, we call an external delegate (set by legacy SonarLint for VS) to ensure the rule should be run (usually
         // the decision is made on based on whether the project contains the analyzer as NuGet).
-        if (supportedDiagnostics.Any(x => x.HasMatchingScope(context.Compilation, context.IsTestProject(), context.IsScannerRun()))
+        if (context.HasMatchingScope(supportedDiagnostics)
             && (generatedCodeRecognizer is null || context.ShouldAnalyze(generatedCodeRecognizer))
             && LegacyIsRegisteredActionEnabled(supportedDiagnostics, context.Tree))
         {

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.ComponentModel.Design;
 using System.IO;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Text;

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -109,34 +109,4 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
 
     public bool ShouldAnalyze(GeneratedCodeRecognizer generatedCodeRecognizer) =>
         ShouldAnalyze(generatedCodeRecognizer, Tree, Compilation, Options);
-
-    private protected void ReportIssue(ReportingContext reportingContext)   // FIXME: Change design to make this public on one place
-    {
-        if (!reportingContext.Diagnostic.Descriptor.HasMatchingScope(reportingContext.Compilation, IsTestProject(), ProjectConfiguration().IsScannerRun))
-        {
-            return;
-        }
-
-        if (reportingContext is { Compilation: { } compilation, Diagnostic.Location: { Kind: LocationKind.SourceFile, SourceTree: { } tree } }
-            && !compilation.ContainsSyntaxTree(tree))
-        {
-            Debug.Fail("Primary location should be part of the compilation. An AD0001 is raised if this is not the case.");
-            return;
-        }
-
-        // This is the current way SonarLint will handle how and what to report.
-        if (SonarAnalysisContext.ReportDiagnostic is not null)
-        {
-            Debug.Assert(SonarAnalysisContext.ShouldDiagnosticBeReported == null, "Not expecting SonarLint to set both the old and the new delegates.");
-            SonarAnalysisContext.ReportDiagnostic(reportingContext);
-            return;
-        }
-
-        // Standalone NuGet, Scanner run and SonarLint < 4.0 used with latest NuGet
-        if (!VbcHelper.IsTriggeringVbcError(reportingContext.Diagnostic)
-            && (SonarAnalysisContext.ShouldDiagnosticBeReported?.Invoke(reportingContext.SyntaxTree, reportingContext.Diagnostic) ?? true))
-        {
-            reportingContext.ReportDiagnostic(reportingContext.Diagnostic);
-        }
-    }
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarParametrizedAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarParametrizedAnalysisContext.cs
@@ -39,7 +39,7 @@ public sealed class SonarParametrizedAnalysisContext : SonarAnalysisContextBase
     {
         // This is tricky. SyntaxTree actions do not have compilation. So we register them in CompilationStart.
         // ParametrizedAnalyzer postpones CompilationStartActions to enforce that parameters are already set when the postponed action is executed.
-        var wrappedAction = Context.WrapSyntaxTreeAction(action, generatedCodeRecognizer);  // FIXME: Revisit
+        var wrappedAction = Context.WrapSyntaxTreeAction(action, generatedCodeRecognizer);
         RegisterPostponedAction(startContext => wrappedAction(startContext.Context));
     }
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
@@ -28,7 +28,7 @@ public abstract class SonarReportingContextBase<TContext> : SonarAnalysisContext
 
     public void ReportIssue(Diagnostic diagnostic)  // FIXME: Make this obsolete
     {
-        if (diagnostic.Descriptor.HasMatchingScope(Compilation, IsTestProject(), IsScannerRun()))
+        if (HasMatchingScope(diagnostic.Descriptor))
         {
             var reportingContext = CreateReportingContext(diagnostic);
             if (reportingContext is { Compilation: { } compilation, Diagnostic.Location: { Kind: LocationKind.SourceFile, SourceTree: { } tree } } && !compilation.ContainsSyntaxTree(tree))

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxNodeAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxNodeAnalysisContext.cs
@@ -32,9 +32,6 @@ public sealed class SonarSyntaxNodeAnalysisContext : SonarReportingContextBase<S
 
     internal SonarSyntaxNodeAnalysisContext(SonarAnalysisContext analysisContext, SyntaxNodeAnalysisContext context) : base(analysisContext, context) { }
 
-    private protected override ReportingContext CreateReportingContext(Diagnostic diagnostic) =>
-        new(this, diagnostic);
-
     /// <summary>
     /// Roslyn invokes the analyzer twice for positional records. The first invocation is for the class declaration and the second for the ctor represented by the positional parameter list.
     /// This behavior has been fixed since the Roslyn version 4.2.0 but we still need this for the proper support of Roslyn 4.0.0.
@@ -56,4 +53,7 @@ public sealed class SonarSyntaxNodeAnalysisContext : SonarReportingContextBase<S
         Context.ContainingSymbol is IMethodSymbol method && method.HasAttribute(KnownType.Microsoft_Azure_WebJobs_FunctionNameAttribute)
             ? method
             : null;
+
+    private protected override ReportingContext CreateReportingContext(Diagnostic diagnostic) =>
+        new(this, diagnostic);
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxTreeAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxTreeAnalysisContext.cs
@@ -23,12 +23,12 @@ namespace SonarAnalyzer;
 public sealed class SonarSyntaxTreeAnalysisContext : SonarReportingContextBase<SyntaxTreeAnalysisContext>
 {
     public override SyntaxTree Tree => Context.Tree;
-    public override Compilation Compilation { get; }    // SyntaxTreeAnalysisContext doesn't hold a Compilation reference
+    public override Compilation Compilation { get; }    // SyntaxTreeAnalysisContext doesn't hold a Compilation reference, we need to provide it from CompilationStart context via constructor
     public override AnalyzerOptions Options => Context.Options;
     public override CancellationToken Cancel => Context.CancellationToken;
 
     internal SonarSyntaxTreeAnalysisContext(SonarAnalysisContext analysisContext, SyntaxTreeAnalysisContext context, Compilation compilation) : base(analysisContext, context) =>
-        Compilation = compilation;
+        Compilation = compilation ?? throw new ArgumentNullException(nameof(compilation));
 
     private protected override ReportingContext CreateReportingContext(Diagnostic diagnostic) =>
         new(this, diagnostic);

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/DiagnosticDescriptorExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/DiagnosticDescriptorExtensions.cs
@@ -18,29 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using static SonarAnalyzer.Helpers.DiagnosticDescriptorFactory;
-
 namespace SonarAnalyzer.Extensions;
 
 public static class DiagnosticDescriptorExtensions
 {
-    public static bool HasMatchingScope(this DiagnosticDescriptor descriptor, Compilation compilation, bool isTestProject, bool isScannerRun)   // FIXME: Pass context instead?
-    {
-        if (compilation is null)
-        {
-            return true;    // We don't know the project type without the compilation so let's run the rule
-        }
-        // MMF-2297: Test Code as 1st Class Citizen is not ready on server side yet.
-        // ScannerRun: Only utility rules and rules with TEST-ONLY scope are executed for test projects for now.
-        // SonarLint & Standalone NuGet: Respect the scope as before.
-        return isTestProject
-            ? ContainsTag(TestSourceScopeTag) && !(isScannerRun && ContainsTag(MainSourceScopeTag) && !ContainsTag(UtilityTag))
-            : ContainsTag(MainSourceScopeTag);
-
-        bool ContainsTag(string tag) =>
-            descriptor.CustomTags.Contains(tag);
-    }
-
     public static Diagnostic CreateDiagnostic(this DiagnosticDescriptor descriptor,
                                               Compilation compilation,
                                               Location location,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
@@ -48,8 +48,7 @@ namespace SonarAnalyzer.Rules
 
         // We need to rewrite this https://github.com/SonarSource/sonar-dotnet/issues/4824
         protected static bool IsEnabled(SonarSyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor) =>
-            descriptor.HasMatchingScope(context.Compilation, context.IsTestProject(), context.IsScannerRun())
-            && descriptor.GetEffectiveSeverity(context.Compilation.Options) != ReportDiagnostic.Suppress;
+            context.HasMatchingScope(descriptor) && descriptor.GetEffectiveSeverity(context.Compilation.Options) != ReportDiagnostic.Suppress;
 
         protected void Analyze<TNode>(SonarAnalysisContext analysisContext, SonarSyntaxNodeAnalysisContext context, Func<TNode, SyntaxNode> getBody) where TNode : SyntaxNode
         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextBaseTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextBaseTest.cs
@@ -18,14 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarAnalyzer.Extensions;
-
-using static SonarAnalyzer.Helpers.DiagnosticDescriptorFactory;
-
-namespace SonarAnalyzer.UnitTest.Extensions;
+namespace SonarAnalyzer.UnitTest.AnalysisContext;
 
 [TestClass]
-public class DiagnosticDescriptorExtensionsTest
+public class SonarAnalysisContextBaseTest
 {
     private const string MainTag = "MainSourceScope";
     private const string TestTag = "TestSourceScope";

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.ShouldAnalyze.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.ShouldAnalyze.cs
@@ -74,12 +74,6 @@ public partial class SonarAnalysisContextTest
         ShouldAnalyze(options).Should().BeTrue();
     }
 
-    private static bool ShouldAnalyze(AnalyzerOptions options)
-    {
-        var (compilation, tree) = CreateDummyCompilation(AnalyzerLanguage.CSharp, OtherFileName);
-        return CreateSut().ShouldAnalyze(CSharpGeneratedCodeRecognizer.Instance, tree, compilation, options);
-    }
-
     [DataTestMethod]
     [DataRow(GeneratedFileName, false)]
     [DataRow(OtherFileName, true)]
@@ -383,6 +377,12 @@ public partial class SonarAnalysisContextTest
     {
         var compilation = SolutionBuilder.Create().AddProject(language).AddSnippet(string.Empty, OtherFileName + language.FileExtension).GetCompilation();
         return (compilation, compilation.SyntaxTrees.Single(x => x.FilePath.Contains(treeFileName)));
+    }
+
+    private static bool ShouldAnalyze(AnalyzerOptions options)
+    {
+        var (compilation, tree) = CreateDummyCompilation(AnalyzerLanguage.CSharp, OtherFileName);
+        return CreateSut().ShouldAnalyze(CSharpGeneratedCodeRecognizer.Instance, tree, compilation, options);
     }
 
     private static void VerifyEmpty(string fileName, string snippet, DiagnosticAnalyzer analyzer)


### PR DESCRIPTION
Part of #6532

Previous changes showed that `HasMatchingScope` always depends on data from `SonarAnalysisContextBase`. 
It is now also clear, that `Compilation` is never null after this redesign.
