### PR TITLE
Fix S1067 FN: binary expressions should be treated as transparent

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/SyntaxKindEx.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/SyntaxKindEx.cs
@@ -28,6 +28,7 @@ namespace StyleCop.Analyzers.Lightup
         public const SyntaxKind IsPatternExpression = (SyntaxKind)8657;
         public const SyntaxKind RangeExpression = (SyntaxKind)8658;
         public const SyntaxKind ImplicitObjectCreationExpression = (SyntaxKind)8659;
+        public const SyntaxKind UnsignedRightShiftExpression = (SyntaxKind)8692;
         public const SyntaxKind CoalesceAssignmentExpression = (SyntaxKind)8725;
         public const SyntaxKind UnsignedRightShiftAssignmentExpression = (SyntaxKind)8726;
         public const SyntaxKind IndexExpression = (SyntaxKind)8741;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExpressionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExpressionComplexity.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.GreaterThanOrEqualExpression,
                 SyntaxKind.LeftShiftExpression,
                 SyntaxKind.RightShiftExpression,
-                SyntaxKindEx.UnsignedRightShiftAssignmentExpression,
+                SyntaxKindEx.UnsignedRightShiftExpression,
                 SyntaxKind.AddExpression,
                 SyntaxKind.SubtractExpression,
                 SyntaxKind.MultiplyExpression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExpressionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExpressionComplexity.cs
@@ -73,7 +73,6 @@ namespace SonarAnalyzer.Rules.CSharp
                     { RawKind: (int)SyntaxKindEx.AndPattern or (int)SyntaxKindEx.OrPattern } pattern when (BinaryPatternSyntaxWrapper)pattern is var patternWrapper =>
                         new[] { patternWrapper.Left.SyntaxNode, patternWrapper.Right.SyntaxNode },
                     AssignmentExpressionSyntax assigment => new[] { assigment.Left, assigment.Right },
-
                     ParenthesizedExpressionSyntax { Expression: { } expression } => new[] { expression },
                     PrefixUnaryExpressionSyntax { Operand: { } operand } => new[] { operand },
                     { RawKind: (int)SyntaxKindEx.ParenthesizedPattern } parenthesized when (ParenthesizedPatternSyntaxWrapper)parenthesized is var parenthesizedWrapped =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExpressionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExpressionComplexity.cs
@@ -27,6 +27,27 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override SyntaxKind[] TransparentKinds { get; } =
             {
+                // Binary
+                SyntaxKind.CoalesceExpression,
+                SyntaxKind.BitwiseOrExpression,
+                SyntaxKind.ExclusiveOrExpression,
+                SyntaxKind.BitwiseAndExpression,
+                SyntaxKind.EqualsExpression,
+                SyntaxKind.NotEqualsExpression,
+                SyntaxKind.LessThanExpression,
+                SyntaxKind.LessThanOrEqualExpression,
+                SyntaxKind.GreaterThanExpression,
+                SyntaxKind.GreaterThanOrEqualExpression,
+                SyntaxKind.LeftShiftExpression,
+                SyntaxKind.RightShiftExpression,
+                SyntaxKindEx.UnsignedRightShiftAssignmentExpression,
+                SyntaxKind.AddExpression,
+                SyntaxKind.SubtractExpression,
+                SyntaxKind.MultiplyExpression,
+                SyntaxKind.DivideExpression,
+                SyntaxKind.ModuloExpression,
+
+                // Unary
                 SyntaxKind.ParenthesizedExpression,
                 SyntaxKind.LogicalNotExpression,
                 SyntaxKindEx.ParenthesizedPattern,
@@ -47,7 +68,7 @@ namespace SonarAnalyzer.Rules.CSharp
             node switch
             {
                 ConditionalExpressionSyntax conditional => new[] { conditional.Condition, conditional.WhenTrue, conditional.WhenFalse },
-                BinaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalAndExpression or (int)SyntaxKind.LogicalOrExpression } binary => new[] { binary.Left, binary.Right },
+                BinaryExpressionSyntax binary when binary.Kind() is var kind && (TransparentKinds.Contains(kind) || ComplexityIncreasingKinds.Contains(kind)) => new[] { binary.Left, binary.Right },
                 { RawKind: (int)SyntaxKindEx.AndPattern or (int)SyntaxKindEx.OrPattern } pattern when (BinaryPatternSyntaxWrapper)pattern is var patternWrapper =>
                     new[] { patternWrapper.Left.SyntaxNode, patternWrapper.Right.SyntaxNode },
                 AssignmentExpressionSyntax { RawKind: (int)SyntaxKindEx.CoalesceAssignmentExpression } assigment => new[] { assigment.Left, assigment.Right },

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
@@ -60,7 +60,13 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow("i", "^")]
         [DataRow("i", "&")]
         [DataRow("i", ">>")]
+
+#if NET
+
         [DataRow("i", ">>>")]
+
+#endif
+
         [DataRow("i", "<<")]
         [DataRow("i", "+")]
         [DataRow("i", "-")]
@@ -78,8 +84,12 @@ namespace SonarAnalyzer.UnitTest.Rules
                 }
             }
             """)
+
+#if NET
+
             .WithOptions(ParseOptionsHelper.FromCSharp11)
-            .Verify();
+
+#endif
 
             .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
@@ -61,6 +61,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow("i", "^")]
         [DataRow("i", "&")]
         [DataRow("i", ">>")]
+        [DataRow("i", ">>>")]
         [DataRow("i", "<<")]
         [DataRow("i", "+")]
         [DataRow("i", "-")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
@@ -81,17 +81,6 @@ namespace SonarAnalyzer.UnitTest.Rules
             .WithOptions(ParseOptionsHelper.FromCSharp11)
             .Verify();
 
-        [TestMethod]
-        public void ExpressionComplexity_RootBinaryOperators() =>
-            builderCS.AddSnippet("""
-            class C
-            {
-                public void M(object o)
-                {
-                    var x = true && true && true && (((true ? o : o) as bool?) ?? true); // Compliant. The ? : expression is inside the binary as expression. The as expression starts a new root.
-                }
-            }
-            """)
             .Verify();
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
@@ -42,18 +42,17 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow(">")]
         [DataRow(">=")]
         public void ExpressionComplexity_TransparentComparissionOperators(string @operator) =>
-            builderCS
-                .AddSnippet($$$"""
-                class C
+            builderCS.AddSnippet($$$"""
+            class C
+            {
+                public void M()
                 {
-                    public void M()
-                    {
-                        var x = true && true && (1 {{{@operator}}} (true ? 1 : 1));         // Compliant (Make sure, the @operator is not increasing complexity)
-                        var y = true && true && true && (1 {{{@operator}}} (true ? 1 : 1)); // Noncompliant {{Reduce the number of conditional operators (4) used in the expression (maximum allowed 3).}}
-                    }
+                    var x = true && true && (1 {{{@operator}}} (true ? 1 : 1));         // Compliant (Make sure, the @operator is not increasing complexity)
+                    var y = true && true && true && (1 {{{@operator}}} (true ? 1 : 1)); // Noncompliant {{Reduce the number of conditional operators (4) used in the expression (maximum allowed 3).}}
                 }
-                """)
-                .Verify();
+            }
+            """)
+            .Verify();
 
         [DataTestMethod]
         [DataRow("o", "??")]
@@ -69,19 +68,18 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow("i", "/")]
         [DataRow("i", "%")]
         public void ExpressionComplexity_TransparentBinaryOperators(string parameter, string @operator) =>
-            builderCS
-                .AddSnippet($$"""
-                class C
+            builderCS.AddSnippet($$"""
+            class C
+            {
+                public void M(int i, object o, bool b)
                 {
-                    public void M(int i, object o, bool b)
-                    {
-                        var x = true && true && (({{parameter}} {{@operator}} (true ? {{parameter}} : {{parameter}})) == {{parameter}});         // Compliant
-                        var y = true && true && true && (({{parameter}} {{@operator}} (true ? {{parameter}} : {{parameter}})) == {{parameter}}); // Noncompliant
-                    }
+                    var x = true && true && (({{parameter}} {{@operator}} (true ? {{parameter}} : {{parameter}})) == {{parameter}});         // Compliant
+                    var y = true && true && true && (({{parameter}} {{@operator}} (true ? {{parameter}} : {{parameter}})) == {{parameter}}); // Noncompliant
                 }
-                """)
-                .WithOptions(ParseOptionsHelper.FromCSharp11)
-                .Verify();
+            }
+            """)
+            .WithOptions(ParseOptionsHelper.FromCSharp11)
+            .Verify();
 
 #if NET
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
@@ -71,7 +71,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             builderCS.AddSnippet($$"""
             class C
             {
-                public void M(int i, object o, bool b)
+                public void M(int i, object o)
                 {
                     var x = true && true && (({{parameter}} {{@operator}} (true ? {{parameter}} : {{parameter}})) == {{parameter}});         // Compliant
                     var y = true && true && true && (({{parameter}} {{@operator}} (true ? {{parameter}} : {{parameter}})) == {{parameter}}); // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
@@ -34,6 +34,54 @@ namespace SonarAnalyzer.UnitTest.Rules
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
 
+        [DataTestMethod]
+        [DataRow("==")]
+        [DataRow("!=")]
+        [DataRow("<")]
+        [DataRow("<=")]
+        [DataRow(">")]
+        [DataRow(">=")]
+        public void ExpressionComplexity_TransparentComparissionOperators(string @operator) =>
+            builderCS
+                .AddSnippet($$"""
+                class C
+                {
+                    public void M()
+                    {
+                        var x = true && true && (1 {{@operator}} (true ? 1 : 1));         // Compliant
+                        var y = true && true && true && (1 {{@operator}} (true ? 1 : 1)); // Noncompliant
+                    }
+                }
+                """)
+                .Verify();
+
+        [DataTestMethod]
+        [DataRow("o", "??")]
+        [DataRow("i", "|")]
+        [DataRow("i", "^")]
+        [DataRow("i", "&")]
+        [DataRow("i", ">>")]
+        [DataRow("i", "<<")]
+        [DataRow("i", "+")]
+        [DataRow("i", "-")]
+        [DataRow("i", "*")]
+        [DataRow("i", "/")]
+        [DataRow("i", "%")]
+        public void ExpressionComplexity_TransparentBinaryOperators(string parameter, string @operator) =>
+            builderCS
+                .AddSnippet($$"""
+                class C
+                {
+                    public void M(int i, object o, bool b)
+                    {
+                        var x = true && true && (({{parameter}} {{@operator}} (true ? {{parameter}} : {{parameter}})) == {{parameter}});         // Compliant
+                        var y = true && true && true && (({{parameter}} {{@operator}} (true ? {{parameter}} : {{parameter}})) == {{parameter}}); // Noncompliant
+                    }
+                }
+                """)
+                .WithOptions(ParseOptionsHelper.FromCSharp11)
+                .Verify();
+
 #if NET
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
@@ -92,7 +92,6 @@ namespace SonarAnalyzer.UnitTest.Rules
                 }
             }
             """)
-            .WithOptions(ParseOptionsHelper.FromCSharp11)
             .Verify();
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
@@ -81,6 +81,20 @@ namespace SonarAnalyzer.UnitTest.Rules
             .WithOptions(ParseOptionsHelper.FromCSharp11)
             .Verify();
 
+        [TestMethod]
+        public void ExpressionComplexity_RootBinaryOperators() =>
+            builderCS.AddSnippet("""
+            class C
+            {
+                public void M(object o)
+                {
+                    var x = true && true && true && (((true ? o : o) as bool?) ?? true); // Compliant. The ? : expression is inside the binary as expression. The as expression starts a new root.
+                }
+            }
+            """)
+            .WithOptions(ParseOptionsHelper.FromCSharp11)
+            .Verify();
+
 #if NET
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ExpressionComplexityTest.cs
@@ -43,13 +43,13 @@ namespace SonarAnalyzer.UnitTest.Rules
         [DataRow(">=")]
         public void ExpressionComplexity_TransparentComparissionOperators(string @operator) =>
             builderCS
-                .AddSnippet($$"""
+                .AddSnippet($$$"""
                 class C
                 {
                     public void M()
                     {
-                        var x = true && true && (1 {{@operator}} (true ? 1 : 1));         // Compliant
-                        var y = true && true && true && (1 {{@operator}} (true ? 1 : 1)); // Noncompliant
+                        var x = true && true && (1 {{{@operator}}} (true ? 1 : 1));         // Compliant (Make sure, the @operator is not increasing complexity)
+                        var y = true && true && true && (1 {{{@operator}}} (true ? 1 : 1)); // Noncompliant {{Reduce the number of conditional operators (4) used in the expression (maximum allowed 3).}}
                     }
                 }
                 """)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExpressionComplexity.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExpressionComplexity.cs
@@ -26,9 +26,12 @@ namespace Tests.Diagnostics
             var m = true && true && true && call(true && true && true && true && true, true, true) && true;
             //                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                          [iss1] {{Reduce the number of conditional operators (4) used in the expression (maximum allowed 3).}}
             //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ @-1 [iss2] {{Reduce the number of conditional operators (4) used in the expression (maximum allowed 3).}}
+
             call(
                 a =>
                 a = ((a1 ? false : true) || a1 || true && false && true || false)); // Noncompliant
+
+            var n = (true && true && true) == (true && true && true); // Noncompliant
 
             for (var i = a1 ? (b1==0 ? (c1 ? (d1 ? 1 : 1) : 1) : 1) : 1; i < 1; i++) {} // Noncompliant
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExpressionComplexity.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExpressionComplexity.cs
@@ -32,6 +32,7 @@ namespace Tests.Diagnostics
                 a = ((a1 ? false : true) || a1 || true && false && true || false)); // Noncompliant
 
             var n = (true && true && true) == (true && true && true); // Noncompliant
+            n = true && true && true && (((true ? new object() : new object()) as bool?) ?? true); // Compliant. The ? : expression is inside the binary as expression. The as expression starts a new root.
 
             for (var i = a1 ? (b1==0 ? (c1 ? (d1 ? 1 : 1) : 1) : 1) : 1; i < 1; i++) {} // Noncompliant
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExpressionComplexity.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ExpressionComplexity.cs
@@ -23,6 +23,9 @@ namespace Tests.Diagnostics
 
             var h = v1 ??= v2 ??= v3 ??= v4 ??= v5; // Noncompliant
 
+            var m = true && true && true && call(true && true && true && true && true, true, true) && true;
+            //                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                          [iss1] {{Reduce the number of conditional operators (4) used in the expression (maximum allowed 3).}}
+            //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ @-1 [iss2] {{Reduce the number of conditional operators (4) used in the expression (maximum allowed 3).}}
             call(
                 a =>
                 a = ((a1 ? false : true) || a1 || true && false && true || false)); // Noncompliant


### PR DESCRIPTION
Follow up to #6500

Other binary expressions should be considered as part of the tree and be visited also.