### PR TITLE
New Rules: S5842, S5856, S6326

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
@@ -55,6 +55,7 @@ internal sealed class CSharpFacade : ILanguageFacade<SyntaxKind>
         invocation switch
         {
             null => null,
+            AttributeSyntax x => new CSharpAttributeParameterLookup(x, methodSymbol),
             ObjectCreationExpressionSyntax x => new CSharpMethodParameterLookup(x.ArgumentList, methodSymbol),
             InvocationExpressionSyntax x => new CSharpMethodParameterLookup(x, methodSymbol),
             _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(invocation) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpAttributeParameterLookup.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Helpers/CSharpAttributeParameterLookup.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Helpers;
+
+internal class CSharpAttributeParameterLookup : MethodParameterLookupBase<AttributeArgumentSyntax>
+{
+    public CSharpAttributeParameterLookup(AttributeSyntax attribute, IMethodSymbol methodSymbol)
+        : base(attribute.ArgumentList?.Arguments, methodSymbol) { }
+
+    protected override SyntaxNode Expression(AttributeArgumentSyntax argument) =>
+        argument.Expression;
+
+    protected override SyntaxToken? GetNameColonArgumentIdentifier(AttributeArgumentSyntax argument) =>
+        argument.NameColon?.Name.Identifier;
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RegularExpressions/RegexMustHaveValidSyntax.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RegularExpressions/RegexMustHaveValidSyntax.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Rules.CSharp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RegexMustHaveValidSyntax : RegexMustHaveValidSyntaxBase<SyntaxKind>
+{
+    protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RegularExpressions/RegexShouldNotContainAdjecentWhitespace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RegularExpressions/RegexShouldNotContainAdjecentWhitespace.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Rules.CSharp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RegexShouldNotContainAdjecentWhitespace : RegexShouldNotContainAdjecentWhitespaceBase<SyntaxKind>
+{
+    protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
@@ -1,0 +1,28 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Rules.CSharp;
+
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RegexShouldNotRepresentEmptyString : RegexShouldNotRepresentEmptyStringBase<SyntaxKind>
+{
+    protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
+}

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -232,6 +232,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_ComponentModel_Composition_ExportAttribute = new("System.ComponentModel.Composition.ExportAttribute");
         internal static readonly KnownType System_ComponentModel_Composition_InheritedExportAttribute = new("System.ComponentModel.Composition.InheritedExportAttribute");
         internal static readonly KnownType System_ComponentModel_Composition_PartCreationPolicyAttribute = new("System.ComponentModel.Composition.PartCreationPolicyAttribute");
+        internal static readonly KnownType System_ComponentModel_DataAnnotations_RegularExpressionAttribute = new("System.ComponentModel.DataAnnotations.RegularExpressionAttribute");
         internal static readonly KnownType System_Configuration_ConfigXmlDocument = new("System.Configuration.ConfigXmlDocument");
         internal static readonly KnownType System_Console = new("System.Console");
         internal static readonly KnownType System_Data_Common_CommandTrees_DbExpression = new("System.Data.Common.CommandTrees.DbExpression");
@@ -451,6 +452,7 @@ namespace SonarAnalyzer.Helpers
         internal static readonly KnownType System_SystemException = new("System.SystemException");
         internal static readonly KnownType System_Text_RegularExpressions_Regex = new("System.Text.RegularExpressions.Regex");
         internal static readonly KnownType System_Text_RegularExpressions_RegexOptions = new("System.Text.RegularExpressions.RegexOptions");
+        internal static readonly KnownType System_Text_RegularExpressions_GeneratedRegexAttribute = new("System.Text.RegularExpressions.GeneratedRegexAttribute");
         internal static readonly KnownType System_Text_StringBuilder = new("System.Text.StringBuilder");
         internal static readonly KnownType System_Threading_Monitor = new("System.Threading.Monitor");
         internal static readonly KnownType System_Threading_Mutex = new("System.Threading.Mutex");

--- a/analyzers/src/SonarAnalyzer.Common/RegularExpressions/NodeValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/RegularExpressions/NodeValue.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.RegularExpressions;
+
+internal sealed class SyntaxNodeValue<TValue>
+{
+    public SyntaxNodeValue(SyntaxNode node, TValue value)
+    {
+        Node = node;
+        Value = value;
+    }
+
+    public SyntaxNode Node { get; }
+    public TValue Value { get; }
+}

--- a/analyzers/src/SonarAnalyzer.Common/RegularExpressions/RegexNode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/RegularExpressions/RegexNode.cs
@@ -1,0 +1,96 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#nullable enable
+
+using System.Text.RegularExpressions;
+
+namespace SonarAnalyzer.RegularExpressions;
+
+internal sealed class RegexNode
+{
+    public RegexNode(
+        SyntaxNodeValue<string?> pattern,
+        SyntaxNodeValue<RegexOptions?> options)
+    {
+        Pattern = pattern;
+        Options = options;
+    }
+
+    public SyntaxNodeValue<string?> Pattern { get; }
+    public SyntaxNodeValue<RegexOptions?> Options { get; }
+
+    public static RegexNode? FromCtor<TSyntaxKind>(SyntaxNode node, SemanticModel model, ILanguageFacade<TSyntaxKind> language) where TSyntaxKind : struct =>
+        language.Syntax.IsAnyKind(node, language.SyntaxKind.ObjectCreationExpressions)
+        && model.GetSymbolInfo(node).Symbol is IMethodSymbol method
+        && method.ContainingType.Is(KnownType.System_Text_RegularExpressions_Regex)
+        && method.IsConstructor()
+        ? FromSymbol(method, node, model, language)
+        : null;
+
+    public static RegexNode? FromMethod<TSyntaxKind>(SyntaxNode node, SemanticModel model, ILanguageFacade<TSyntaxKind> language) where TSyntaxKind : struct =>
+        language.Syntax.IsKind(node, language.SyntaxKind.InvocationExpression)
+        && language.Syntax.NodeIdentifier(node).GetValueOrDefault().Text is { } name
+        && MatchMethods.Any(x => x.Equals(name, language.NameComparison))
+        && model.GetSymbolInfo(node).Symbol is IMethodSymbol method
+        && method.ContainingType.Is(KnownType.System_Text_RegularExpressions_Regex)
+        ? FromSymbol(method, node, model, language)
+        : null;
+
+    public static RegexNode? FromAttribute<TSyntaxKind>(SyntaxNode node, SemanticModel model, ILanguageFacade<TSyntaxKind> language) where TSyntaxKind : struct
+    {
+        if (model.GetSymbolInfo(node).Symbol is IMethodSymbol method
+            && method.IsInType(KnownType.System_ComponentModel_DataAnnotations_RegularExpressionAttribute))
+        {
+            var parameters = language.MethodParameterLookup(node, method);
+            var pattern = TryGetNonParamsSyntax(method, parameters, "pattern");
+            return new RegexNode(
+             new(pattern, language.FindConstantValue(model, pattern) as string),
+             new(null, null));
+        }
+        return null;
+    }
+
+    private static RegexNode FromSymbol<TSyntaxKind>(IMethodSymbol method, SyntaxNode node, SemanticModel model, ILanguageFacade<TSyntaxKind> language) where TSyntaxKind : struct
+    {
+        var parameters = language.MethodParameterLookup(node, method);
+        var pattern = TryGetNonParamsSyntax(method, parameters, "pattern");
+        var options = TryGetNonParamsSyntax(method, parameters, "options");
+
+        return new RegexNode(
+            new(pattern, language.FindConstantValue(model, pattern) as string),
+            new(options, language.FindConstantValue(model, options) is RegexOptions value ? value : null));
+    }
+
+    private static SyntaxNode? TryGetNonParamsSyntax(IMethodSymbol method, IMethodParameterLookup parameters, string paramName) =>
+        method.Parameters.SingleOrDefault(x => x.Name == paramName) is { } param
+        && parameters.TryGetNonParamsSyntax(param, out var node)
+        ? node
+        : null;
+
+    private static readonly IReadOnlyList<string> MatchMethods = new[]
+    {
+        nameof(Regex.IsMatch),
+        nameof(Regex.Match),
+        nameof(Regex.Matches),
+        nameof(Regex.Replace),
+        nameof(Regex.Split),
+    };
+}

--- a/analyzers/src/SonarAnalyzer.Common/RegularExpressions/RegexNode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/RegularExpressions/RegexNode.cs
@@ -38,16 +38,14 @@ internal sealed class RegexNode
     public SyntaxNodeValue<RegexOptions?> Options { get; }
 
     public static RegexNode? FromCtor<TSyntaxKind>(SyntaxNode node, SemanticModel model, ILanguageFacade<TSyntaxKind> language) where TSyntaxKind : struct =>
-        language.Syntax.IsAnyKind(node, language.SyntaxKind.ObjectCreationExpressions)
-        && model.GetSymbolInfo(node).Symbol is IMethodSymbol method
+        model.GetSymbolInfo(node).Symbol is IMethodSymbol method
         && method.ContainingType.Is(KnownType.System_Text_RegularExpressions_Regex)
         && method.IsConstructor()
         ? FromSymbol(method, node, model, language)
         : null;
 
     public static RegexNode? FromMethod<TSyntaxKind>(SyntaxNode node, SemanticModel model, ILanguageFacade<TSyntaxKind> language) where TSyntaxKind : struct =>
-        language.Syntax.IsKind(node, language.SyntaxKind.InvocationExpression)
-        && language.Syntax.NodeIdentifier(node).GetValueOrDefault().Text is { } name
+        language.Syntax.NodeIdentifier(node).GetValueOrDefault().Text is { } name
         && MatchMethods.Any(x => x.Equals(name, language.NameComparison))
         && model.GetSymbolInfo(node).Symbol is IMethodSymbol method
         && method.ContainingType.Is(KnownType.System_Text_RegularExpressions_Regex)

--- a/analyzers/src/SonarAnalyzer.Common/RegularExpressions/RegexTree.cs
+++ b/analyzers/src/SonarAnalyzer.Common/RegularExpressions/RegexTree.cs
@@ -1,0 +1,78 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+#nullable enable
+
+using System.Text.RegularExpressions;
+
+namespace SonarAnalyzer.RegularExpressions;
+
+public sealed class RegexTree
+{
+    // NonBacktracking was added in .NET 7
+    // See: https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regexoptions?view=net-7.0
+    public static readonly RegexOptions NonBacktracking = (RegexOptions)1024;
+
+    private static readonly RegexOptions TestMask = RegexOptions.None
+        | RegexOptions.IgnoreCase
+        | RegexOptions.Multiline
+        | RegexOptions.ExplicitCapture
+        | RegexOptions.Singleline
+        | RegexOptions.IgnorePatternWhitespace
+        | RegexOptions.RightToLeft
+        | RegexOptions.ECMAScript
+        | RegexOptions.CultureInvariant
+        | NonBacktracking;
+
+    private RegexTree(Regex? regex, string pattern, RegexOptions? options, Exception? parseError)
+    {
+        Regex = regex;
+        Pattern = pattern;
+        Options = options;
+        ParseError = parseError;
+    }
+
+    public Regex? Regex { get; }
+    public string Pattern { get; }
+    public RegexOptions? Options { get; }
+    public Exception? ParseError { get; }
+
+    public bool MatchesEmptyString() =>
+        Regex is { } && Regex.IsMatch(string.Empty);
+
+    public bool AllowsBacktracking() =>
+        Options.HasValue && !Options.Value.HasFlag(NonBacktracking);
+
+    public bool ContainsAdjecentWhitespace() =>
+        Regex is { }
+        && !Options.GetValueOrDefault().HasFlag(RegexOptions.IgnorePatternWhitespace)
+        && Pattern.Contains("  ");
+
+    public static RegexTree Parse(string pattern, RegexOptions? options)
+    {
+        try
+        {
+            return new RegexTree(new(pattern, options.GetValueOrDefault() & TestMask), pattern, options, null);
+        }
+        catch (Exception x)
+        {
+            return new RegexTree(null, pattern, options, x);
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/Rules/RegularExpressions/RegexMustHaveValidSyntaxBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/RegularExpressions/RegexMustHaveValidSyntaxBase.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.RegularExpressions;
+
+namespace SonarAnalyzer.Rules;
+
+public abstract class RegexMustHaveValidSyntaxBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
+    where TSyntaxKind : struct
+{
+    private const string DiagnosticId = "S101"; //"S5856";
+
+    protected sealed override string MessageFormat => "The pattern contains a syntax error: {0}";
+
+    protected RegexMustHaveValidSyntaxBase() : base(DiagnosticId) { }
+
+    protected override void Initialize(SonarAnalysisContext context)
+    {
+        context.RegisterSyntaxNodeActionInNonGenerated(
+            Language.GeneratedCodeRecognizer,
+            c => Analyze(c, RegexNode.FromCtor(c.Node, c.SemanticModel, Language)),
+            Language.SyntaxKind.ObjectCreationExpressions);
+
+        context.RegisterSyntaxNodeActionInNonGenerated(
+            Language.GeneratedCodeRecognizer,
+            c => Analyze(c, RegexNode.FromMethod(c.Node, c.SemanticModel, Language)),
+            Language.SyntaxKind.InvocationExpression);
+
+        context.RegisterSyntaxNodeActionInNonGenerated(
+            Language.GeneratedCodeRecognizer,
+            c => Analyze(c, RegexNode.FromAttribute(c.Node, c.SemanticModel, Language)),
+            Language.SyntaxKind.Attribute);
+    }
+
+    private void Analyze(SyntaxNodeAnalysisContext c, RegexNode regex)
+    {
+        if (regex is { }
+            && regex.Pattern.Value is { } pattern
+            && RegexTree.Parse(pattern, regex.Options.Value).ParseError is { } error)
+        {
+            c.ReportIssue(Diagnostic.Create(Rule, regex.Pattern.Node.GetLocation(), error.Message));
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/Rules/RegularExpressions/RegexShouldNotContainAdjecentWhitespaceBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/RegularExpressions/RegexShouldNotContainAdjecentWhitespaceBase.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.RegularExpressions;
+
+namespace SonarAnalyzer.Rules;
+
+public abstract class RegexShouldNotContainAdjecentWhitespaceBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
+    where TSyntaxKind : struct
+{
+    private const string DiagnosticId = "S101"; //"S6326";
+
+    protected sealed override string MessageFormat => "The pattern contains adjacent whitespace.";
+
+    protected RegexShouldNotContainAdjecentWhitespaceBase() : base(DiagnosticId) { }
+
+    protected override void Initialize(SonarAnalysisContext context)
+    {
+        context.RegisterSyntaxNodeActionInNonGenerated(
+            Language.GeneratedCodeRecognizer,
+            c => Analyze(c, RegexNode.FromCtor(c.Node, c.SemanticModel, Language)),
+            Language.SyntaxKind.ObjectCreationExpressions);
+
+        context.RegisterSyntaxNodeActionInNonGenerated(
+            Language.GeneratedCodeRecognizer,
+            c => Analyze(c, RegexNode.FromMethod(c.Node, c.SemanticModel, Language)),
+            Language.SyntaxKind.InvocationExpression);
+
+        context.RegisterSyntaxNodeActionInNonGenerated(
+            Language.GeneratedCodeRecognizer,
+            c => Analyze(c, RegexNode.FromAttribute(c.Node, c.SemanticModel, Language)),
+            Language.SyntaxKind.Attribute);
+    }
+
+    private void Analyze(SyntaxNodeAnalysisContext c, RegexNode regex)
+    {
+        if (regex is { }
+            && regex.Pattern.Value is { } pattern
+            && RegexTree.Parse(pattern, regex.Options.Value).ContainsAdjecentWhitespace())
+        {
+            c.ReportIssue(Diagnostic.Create(Rule, regex.Pattern.Node.GetLocation()));
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/Rules/RegularExpressions/RegexShouldNotRepresentEmptyStringBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/RegularExpressions/RegexShouldNotRepresentEmptyStringBase.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.RegularExpressions;
+
+namespace SonarAnalyzer.Rules;
+
+public abstract class RegexShouldNotRepresentEmptyStringBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
+    where TSyntaxKind : struct
+{
+    private const string DiagnosticId = "S101"; //"S5842";
+
+    protected sealed override string MessageFormat => "The regular expression should not match an empty string.";
+
+    protected RegexShouldNotRepresentEmptyStringBase() : base(DiagnosticId) { }
+
+    protected override void Initialize(SonarAnalysisContext context)
+    {
+        context.RegisterSyntaxNodeActionInNonGenerated(
+            Language.GeneratedCodeRecognizer,
+            c => Analyze(c, RegexNode.FromCtor(c.Node, c.SemanticModel, Language)),
+            Language.SyntaxKind.ObjectCreationExpressions);
+
+        context.RegisterSyntaxNodeActionInNonGenerated(
+            Language.GeneratedCodeRecognizer,
+            c => Analyze(c, RegexNode.FromMethod(c.Node, c.SemanticModel, Language)),
+            Language.SyntaxKind.InvocationExpression);
+
+        context.RegisterSyntaxNodeActionInNonGenerated(
+            Language.GeneratedCodeRecognizer,
+            c => Analyze(c, RegexNode.FromAttribute(c.Node, c.SemanticModel, Language)),
+            Language.SyntaxKind.Attribute);
+    }
+
+    private void Analyze(SyntaxNodeAnalysisContext c, RegexNode regex)
+    {
+        if (regex is { }
+            && regex.Pattern.Value is { } pattern
+            && RegexTree.Parse(pattern, regex.Options.Value).MatchesEmptyString())
+        {
+            c.ReportIssue(Diagnostic.Create(Rule, regex.Pattern.Node.GetLocation()));
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicFacade.cs
@@ -54,6 +54,7 @@ internal sealed class VisualBasicFacade : ILanguageFacade<SyntaxKind>
         invocation switch
         {
             null => null,
+            AttributeSyntax x => new VisualBasicMethodParameterLookup(x.ArgumentList, methodSymbol),
             ObjectCreationExpressionSyntax x => new VisualBasicMethodParameterLookup(x.ArgumentList, methodSymbol),
             InvocationExpressionSyntax x => new VisualBasicMethodParameterLookup(x, methodSymbol),
             _ => throw new ArgumentException($"{invocation.GetType()} does not contain an ArgumentList.", nameof(invocation)),

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicMethodParameterLookup.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicMethodParameterLookup.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * SonarAnalyzer for .NET
- * Copyright (C) 2015-2022 SonarSource SA
+ * Copyright (C) 2015-2023 SonarSource SA
  * mailto: contact AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
@@ -18,23 +18,22 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Helpers
+namespace SonarAnalyzer.Helpers;
+
+internal class VisualBasicMethodParameterLookup : MethodParameterLookupBase<ArgumentSyntax>
 {
-    internal class VisualBasicMethodParameterLookup : MethodParameterLookupBase<ArgumentSyntax>
-    {
-        public VisualBasicMethodParameterLookup(ArgumentListSyntax argumentList, IMethodSymbol methodSymbol)
-            : base(argumentList?.Arguments, methodSymbol) { }
+    public VisualBasicMethodParameterLookup(ArgumentListSyntax argumentList, IMethodSymbol methodSymbol)
+        : base(argumentList?.Arguments, methodSymbol) { }
 
-        public VisualBasicMethodParameterLookup(InvocationExpressionSyntax invocation, IMethodSymbol methodSymbol)
-            : this(invocation.ArgumentList, methodSymbol) { }
+    public VisualBasicMethodParameterLookup(InvocationExpressionSyntax invocation, IMethodSymbol methodSymbol)
+        : this(invocation.ArgumentList, methodSymbol) { }
 
-        public VisualBasicMethodParameterLookup(ArgumentListSyntax argumentList, SemanticModel semanticModel)
-            : base(argumentList?.Arguments, argumentList == null ? null : semanticModel.GetSymbolInfo(argumentList.Parent).Symbol as IMethodSymbol) { }
+    public VisualBasicMethodParameterLookup(ArgumentListSyntax argumentList, SemanticModel semanticModel)
+        : base(argumentList?.Arguments, argumentList == null ? null : semanticModel.GetSymbolInfo(argumentList.Parent).Symbol as IMethodSymbol) { }
 
-        protected override SyntaxToken? GetNameColonArgumentIdentifier(ArgumentSyntax argument) =>
-            (argument as SimpleArgumentSyntax)?.NameColonEquals?.Name.Identifier;
+    protected override SyntaxToken? GetNameColonArgumentIdentifier(ArgumentSyntax argument) =>
+        (argument as SimpleArgumentSyntax)?.NameColonEquals?.Name.Identifier;
 
-        protected override SyntaxNode Expression(ArgumentSyntax argument) =>
-            argument.GetExpression();
-    }
+    protected override SyntaxNode Expression(ArgumentSyntax argument) =>
+        argument.GetExpression();
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RegularExpressions/RegexMustHaveValidSyntax.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RegularExpressions/RegexMustHaveValidSyntax.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Rules.VisualBasic;
+
+[DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+public sealed class RegexMustHaveValidSyntax : RegexMustHaveValidSyntaxBase<SyntaxKind>
+{
+    protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
+}

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RegularExpressions/RegexShouldNotContainAdjecentWhitespace.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RegularExpressions/RegexShouldNotContainAdjecentWhitespace.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Rules.VisualBasic;
+
+[DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+public sealed class RegexShouldNotContainAdjecentWhitespace : RegexShouldNotContainAdjecentWhitespaceBase<SyntaxKind>
+{
+    protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
+}

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
@@ -1,0 +1,28 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Rules.VisualBasic;
+
+
+[DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+public sealed class RegexShouldNotRepresentEmptyString : RegexShouldNotRepresentEmptyStringBase<SyntaxKind>
+{
+    protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/RegularExpressions/RegexTreeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/RegularExpressions/RegexTreeTest.cs
@@ -1,0 +1,66 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+using System.Text.RegularExpressions;
+using SonarAnalyzer.RegularExpressions;
+
+namespace SonarAnalyzer.UnitTest.RegularExpressions;
+
+[TestClass]
+public class RegexTreeTest
+{
+    [DataTestMethod]
+    [DataRow("[A", RegexOptions.None)]
+#if NET7_0_OR_GREATER
+    [DataRow(@"^([0-9]{2})(?<!00)$", RegexOptions.NonBacktracking)]
+#endif
+    public void Invalid_input_is_detected(string pattern, RegexOptions options) =>
+        RegexTree.Parse(pattern, options).ParseError.Should().NotBeNull();
+
+    [DataTestMethod]
+    [DataRow(".*")]
+    [DataRow("A?")]
+    [DataRow("A{0,}")]
+    [DataRow("(?:)*")]
+    public void Matches_empty_string(string pattern) =>
+        RegexTree.Parse(pattern, RegexOptions.None).MatchesEmptyString().Should().BeTrue();
+
+    [DataTestMethod]
+    [DataRow(".+")]
+    [DataRow("A?B")]
+    [DataRow("A{1,}")]
+    [DataRow("A(?:)+")]
+    public void Does_not_match_empty_string(string pattern) =>
+       RegexTree.Parse(pattern, RegexOptions.None).MatchesEmptyString().Should().BeFalse();
+
+    [DataTestMethod]
+    [DataRow("A  B")]
+    [DataRow("A   B")]
+    [DataRow(" A B C  ")]
+    public void Contains_adjecent_whitespace(string pattern) =>
+       RegexTree.Parse(pattern, RegexOptions.None).ContainsAdjecentWhitespace().Should().BeTrue();
+
+    [DataTestMethod]
+    [DataRow("A B")]
+    [DataRow("A  B", RegexOptions.IgnorePatternWhitespace)]
+    [DataRow("A   B", RegexOptions.IgnorePatternWhitespace)]
+    [DataRow(" A B C")]
+    public void Does_not_contain_adjecent_whitespace(string pattern, RegexOptions options = default) =>
+        RegexTree.Parse(pattern, options).ContainsAdjecentWhitespace().Should().BeFalse();
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RegularExpressions/RegexMustHaveValidSyntaxTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RegularExpressions/RegexMustHaveValidSyntaxTest.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using CS = SonarAnalyzer.Rules.CSharp;
+using VB = SonarAnalyzer.Rules.VisualBasic;
+
+namespace SonarAnalyzer.UnitTest.Rules;
+
+[TestClass]
+public class RegexMustHaveValidSyntaxTest
+{
+    private readonly VerifierBuilder builderCS = new VerifierBuilder()
+        .AddAnalyzer(() => new CS.RegexMustHaveValidSyntax())
+        .WithBasePath("RegularExpressions")
+        .AddReferences(MetadataReferenceFacade.RegularExpressions)
+        .AddReferences(NuGetMetadataReference.SystemComponentModelAnnotations());
+
+    private readonly VerifierBuilder builderVB = new VerifierBuilder()
+        .AddAnalyzer(() => new VB.RegexMustHaveValidSyntax())
+        .WithBasePath("RegularExpressions")
+        .AddReferences(MetadataReferenceFacade.RegularExpressions)
+        .AddReferences(NuGetMetadataReference.SystemComponentModelAnnotations());
+
+    [TestMethod]
+    public void RegexMustHaveValidSyntax_CS() =>
+        builderCS.AddPaths("RegexMustHaveValidSyntax.cs").Verify();
+
+#if NET
+    [TestMethod]
+    public void RegexMustHaveValidSyntax_CSharp9() =>
+        builderCS.AddPaths("RegexMustHaveValidSyntax.CSharp9.cs")
+        .WithOptions(ParseOptionsHelper.FromCSharp9)
+        .Verify();
+#endif
+
+    [TestMethod]
+    public void RegexMustHaveValidSyntax_VB() =>
+        builderVB.AddPaths("RegexMustHaveValidSyntax.vb").Verify();
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RegularExpressions/RegexShouldNotContainAdjecentWhitespaceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RegularExpressions/RegexShouldNotContainAdjecentWhitespaceTest.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using CS = SonarAnalyzer.Rules.CSharp;
+using VB = SonarAnalyzer.Rules.VisualBasic;
+
+namespace SonarAnalyzer.UnitTest.Rules;
+
+[TestClass]
+public class RegexShouldNotContainAdjecentWhitespaceTest
+{
+    private readonly VerifierBuilder builderCS = new VerifierBuilder()
+        .AddAnalyzer(() => new CS.RegexShouldNotContainAdjecentWhitespace())
+        .WithBasePath("RegularExpressions")
+        .AddReferences(MetadataReferenceFacade.RegularExpressions)
+        .AddReferences(NuGetMetadataReference.SystemComponentModelAnnotations());
+
+    private readonly VerifierBuilder builderVB = new VerifierBuilder()
+        .AddAnalyzer(() => new VB.RegexShouldNotContainAdjecentWhitespace())
+        .WithBasePath("RegularExpressions")
+        .AddReferences(MetadataReferenceFacade.RegularExpressions)
+        .AddReferences(NuGetMetadataReference.SystemComponentModelAnnotations());
+
+    [TestMethod]
+    public void RegexShouldNotContainAdjecentWhitespace_CS() =>
+        builderCS.AddPaths("RegexShouldNotContainAdjecentWhitespace.cs").Verify();
+
+    [TestMethod]
+    public void RegexShouldNotContainAdjecentWhitespace_CSharp9() =>
+        builderCS.AddPaths("RegexShouldNotContainAdjecentWhitespace.CSharp9.cs")
+        .WithOptions(ParseOptionsHelper.FromCSharp9)
+        .Verify();
+
+    [TestMethod]
+    public void RegexShouldNotContainAdjecentWhitespace_VB() =>
+        builderVB.AddPaths("RegexShouldNotContainAdjecentWhitespace.vb").Verify();
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RegularExpressions/RegexShouldNotRepresentEmptyStringTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RegularExpressions/RegexShouldNotRepresentEmptyStringTest.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using CS = SonarAnalyzer.Rules.CSharp;
+using VB = SonarAnalyzer.Rules.VisualBasic;
+
+namespace SonarAnalyzer.UnitTest.Rules;
+
+[TestClass]
+public class RegexShouldNotRepresentEmptyStringTest
+{
+    private readonly VerifierBuilder builderCS = new VerifierBuilder()
+        .AddAnalyzer(() => new CS.RegexShouldNotRepresentEmptyString())
+        .WithBasePath("RegularExpressions")
+        .AddReferences(MetadataReferenceFacade.RegularExpressions)
+        .AddReferences(NuGetMetadataReference.SystemComponentModelAnnotations());
+
+    private readonly VerifierBuilder builderVB = new VerifierBuilder()
+        .AddAnalyzer(() => new VB.RegexShouldNotRepresentEmptyString())
+        .WithBasePath("RegularExpressions")
+        .AddReferences(MetadataReferenceFacade.RegularExpressions)
+        .AddReferences(NuGetMetadataReference.SystemComponentModelAnnotations());
+
+    [TestMethod]
+    public void RegexShouldNotRepresentEmptyString_CS() =>
+        builderCS.AddPaths("RegexShouldNotRepresentEmptyString.cs").Verify();
+
+    [TestMethod]
+    public void RegexShouldNotRepresentEmptyString_CSharp9() =>
+        builderCS.AddPaths("RegexShouldNotRepresentEmptyString.CSharp9.cs")
+        .WithOptions(ParseOptionsHelper.FromCSharp9)
+        .Verify();
+
+    [TestMethod]
+    public void RegexShouldNotRepresentEmptyString_VB() =>
+        builderVB.AddPaths("RegexShouldNotRepresentEmptyString.vb").Verify();
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexMustHaveValidSyntax.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexMustHaveValidSyntax.CSharp9.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.RegularExpressions;
+
+class Compliant
+{
+    void ImplicitObject()
+    {
+        Regex defaultOrder = new("some pattern"); // Compliant
+    }
+}
+
+class Noncompliant
+{
+    void ImplicitObject()
+    {
+        Regex patternOnly = new("[A"); // Noncompliant {{The pattern contains a syntax error: Invalid pattern '[A' at offset 2. Unterminated [] set.}}
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexMustHaveValidSyntax.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexMustHaveValidSyntax.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+
+class Compliant
+{
+    void Ctor()
+    {
+        var defaultOrder = new Regex("some pattern", RegexOptions.None); // Compliant
+
+        var namedArgs = new Regex(
+            options: RegexOptions.None,
+            pattern: "some pattern");
+    }
+
+    void Static()
+    {
+        var isMatch = Regex.IsMatch("some input", "some pattern", RegexOptions.None); // Compliant
+    }
+
+    [RegularExpression("[0-9]+")] // Compliant
+    public string Attribute { get; set; }
+}
+
+class Noncompliant
+{
+    void Ctor()
+    {
+        var patternOnly = new Regex("[A"); // Noncompliant
+        //                          ^^^^
+    }
+
+    void Static()
+    {
+        var isMatch = Regex.IsMatch("some input", "[A"); // Noncompliant
+        //                                        ^^^^
+        var match = Regex.Match("some input", "[A"); // Noncompliant
+        var matches = Regex.Matches("some input", "[A"); // Noncompliant
+        var replace = Regex.Replace("some input", "[A", "some replacement"); // Noncompliant
+        var split = Regex.Split("some input", "[A"); // Noncompliant
+    }
+
+    [RegularExpression("[A")] // Noncompliant
+    public string Attribute { get; set; }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexMustHaveValidSyntax.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexMustHaveValidSyntax.vb
@@ -1,0 +1,34 @@
+﻿Imports System.ComponentModel.DataAnnotations
+Imports System.Text.RegularExpressions
+
+Class Compliant
+    Private Sub Ctor()
+        Dim defaultOrder = New Regex("some pattern", RegexOptions.None)
+        Dim namedArgs = New Regex(options:=RegexOptions.None, pattern:="some pattern")
+    End Sub
+
+    Private Sub [Static]()
+        Dim isMatch = Regex.IsMatch("some input", "some pattern", RegexOptions.None)
+    End Sub
+
+    <RegularExpression("[0-9]+")>
+    Public Property Attribute As String
+End Class
+
+Class Noncompliant
+    Private Sub Ctor()
+        Dim patternOnly = New Regex("[A") ' Noncompliant
+        '                           ^^^^
+    End Sub
+
+    Private Sub [Static]()
+        Dim isMatch = Regex.IsMatch("some input", "[A") ' Noncompliant
+        Dim match = Regex.Match("some input", "[A") ' Noncompliant
+        Dim matches = Regex.Matches("some input", "[A") ' Noncompliant
+        Dim replace = Regex.Replace("some input", "[A", "some replacement") ' Noncompliant
+        Dim split = Regex.Split("some input", "[A") ' Noncompliant
+    End Sub
+
+    <RegularExpression("[A")> ' Noncompliant
+    Public Property Attribute As String
+End Class

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotContainAdjecentWhitespace.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotContainAdjecentWhitespace.CSharp9.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.RegularExpressions;
+
+class Compliant
+{
+    void ImplicitObject()
+    {
+        Regex defaultOrder = new("some pattern"); // Compliant
+    }
+}
+
+class Noncompliant
+{
+    void ImplicitObject()
+    {
+        Regex patternOnly = new("A  B"); // Noncompliant {{The pattern contains adjacent whitespace.}}
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotContainAdjecentWhitespace.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotContainAdjecentWhitespace.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+
+class Compliant
+{
+    void Ctor()
+    {
+        var defaultOrder = new Regex("some pattern", RegexOptions.None); // Compliant
+
+        var namedArgs = new Regex(
+            options: RegexOptions.None,
+            pattern: "some pattern");
+    }
+
+    void Static()
+    {
+        var isMatch = Regex.IsMatch("some input", "some pattern", RegexOptions.None); // Compliant
+    }
+
+    [RegularExpression("[0-9]+")] // Compliant
+    public string Attribute { get; set; }
+}
+
+class Noncompliant
+{
+    void Ctor()
+    {
+        var patternOnly = new Regex("A  B"); // Noncompliant {{The pattern contains adjacent whitespace.}}
+        //                          ^^^^^^
+    }
+
+    void Static()
+    {
+        var isMatch = Regex.IsMatch("some input", "A  B"); // Noncompliant
+        //                                        ^^^^^^
+        var match = Regex.Match("some input", "A  B"); // Noncompliant
+        var matches = Regex.Matches("some input", "A  B"); // Noncompliant
+        var replace = Regex.Replace("some input", "A  B", "some replacement"); // Noncompliant
+        var split = Regex.Split("some input", "A  B"); // Noncompliant
+    }
+
+    [RegularExpression("A  B")] // Noncompliant
+    public string Attribute { get; set; }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotContainAdjecentWhitespace.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotContainAdjecentWhitespace.vb
@@ -1,0 +1,34 @@
+﻿Imports System.ComponentModel.DataAnnotations
+Imports System.Text.RegularExpressions
+
+Class Compliant
+    Private Sub Ctor()
+        Dim defaultOrder = New Regex("some pattern", RegexOptions.None)
+        Dim namedArgs = New Regex(options:=RegexOptions.None, pattern:="some pattern")
+    End Sub
+
+    Private Sub [Static]()
+        Dim isMatch = Regex.IsMatch("some input", "some pattern", RegexOptions.None)
+    End Sub
+
+    <RegularExpression("[0-9]+")>
+    Public Property Attribute As String
+End Class
+
+Class Noncompliant
+    Private Sub Ctor()
+        Dim patternOnly = New Regex("A  B") ' Noncompliant {{The pattern contains adjacent whitespace.}}
+        '                           ^^^^^^
+    End Sub
+
+    Private Sub [Static]()
+        Dim isMatch = Regex.IsMatch("some input", "A  B") ' Noncompliant
+        Dim match = Regex.Match("some input", "A  B") ' Noncompliant
+        Dim matches = Regex.Matches("some input", "A  B") ' Noncompliant
+        Dim replace = Regex.Replace("some input", "A  B", "some replacement") ' Noncompliant
+        Dim split = Regex.Split("some input", "A  B") ' Noncompliant
+    End Sub
+
+    <RegularExpression("A  B")> ' Noncompliant
+    Public Property Attribute As String
+End Class

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.CSharp9.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.RegularExpressions;
+
+class Compliant
+{
+    void ImplicitObject()
+    {
+        Regex defaultOrder = new("some pattern"); // Compliant
+    }
+}
+
+class Noncompliant
+{
+    void ImplicitObject()
+    {
+        Regex patternOnly = new("A*"); // Noncompliant {{The regular expression should not match an empty string.}}
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+
+class Compliant
+{
+    void Ctor()
+    {
+        var defaultOrder = new Regex("some pattern", RegexOptions.None); // Compliant
+
+        var namedArgs = new Regex(
+            options: RegexOptions.None,
+            pattern: "some pattern");
+    }
+
+    void Static()
+    {
+        var isMatch = Regex.IsMatch("some input", "some pattern", RegexOptions.None); // Compliant
+    }
+
+    [RegularExpression("[0-9]+")] // Compliant
+    public string Attribute { get; set; }
+}
+
+class Noncompliant
+{
+    void Ctor()
+    {
+        var patternOnly = new Regex("A*"); // Noncompliant {{The regular expression should not match an empty string.}}
+        //                          ^^^^
+    }
+
+    void Static()
+    {
+        var isMatch = Regex.IsMatch("some input", "A*"); // Noncompliant
+        //                                        ^^^^
+        var match = Regex.Match("some input", "A*"); // Noncompliant
+        var matches = Regex.Matches("some input", "A*"); // Noncompliant
+        var replace = Regex.Replace("some input", "A*", "some replacement"); // Noncompliant
+        var split = Regex.Split("some input", "A*"); // Noncompliant
+    }
+
+    [RegularExpression("A*")] // Noncompliant
+    public string Attribute { get; set; }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.vb
@@ -1,0 +1,34 @@
+﻿Imports System.ComponentModel.DataAnnotations
+Imports System.Text.RegularExpressions
+
+Class Compliant
+    Private Sub Ctor()
+        Dim defaultOrder = New Regex("some pattern", RegexOptions.None)
+        Dim namedArgs = New Regex(options:=RegexOptions.None, pattern:="some pattern")
+    End Sub
+
+    Private Sub [Static]()
+        Dim isMatch = Regex.IsMatch("some input", "some pattern", RegexOptions.None)
+    End Sub
+
+    <RegularExpression("[0-9]+")>
+    Public Property Attribute As String
+End Class
+
+Class Noncompliant
+    Private Sub Ctor()
+        Dim patternOnly = New Regex("A*") ' Noncompliant {{The regular expression should not match an empty string.}}
+        '                           ^^^^
+    End Sub
+
+    Private Sub [Static]()
+        Dim isMatch = Regex.IsMatch("some input", "A*") ' Noncompliant
+        Dim match = Regex.Match("some input", "A*") ' Noncompliant
+        Dim matches = Regex.Matches("some input", "A*") ' Noncompliant
+        Dim replace = Regex.Replace("some input", "A*", "some replacement") ' Noncompliant
+        Dim split = Regex.Split("some input", "A*") ' Noncompliant
+    End Sub
+
+    <RegularExpression("A*")> ' Noncompliant
+    Public Property Attribute As String
+End Class


### PR DESCRIPTION
I implemented 3 regular expression related rules:
- [x] [S5842](https://rules.sonarsource.com/java/RSPEC-5842)
- [x] [S5856](https://rules.sonarsource.com/java/RSPEC-5856)
- [x] [S6326](https://rules.sonarsource.com/java/RSPEC-6326)

I combined them, as I was searching for a way how the different regex rules could reuse code to reduce the required plumbing. I investigated the (re)use of MS internal `RegexTree`. Unfortunately, that did not help much. The real showstopper in the end is that the `RegexNode`'s in MS's regex tree, do not make a distinction between `AAA` and `A{3}`, or `A+` and `A{1,}`. This makes that most analysis can not performed.

The regex helper types I introduced:
## RegexTree
Allows to analyze a regex (in relation to its `RegexOptions`).

## RegexNode
Contains the Regex pattern and Regex options related `SyntaxNode`'s. Has factory methods to construct from
- ObjectCreationExpressions (`new Regex()`)
- InvocationExpression (`Regex.*`)
- Attribute (`[System.ComponentModel.DataAnnotations.RegularExpression]`)

The generated regex attribute should also be taken into account. That is on my TODO.

The 3 rules I choose, do not require a (full) parsing of the regular expression itself. That would blown up this PR too much.

[RSPEC-5842]: https://sonarsource.atlassian.net/browse/RSPEC-5842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSPEC-5856]: https://sonarsource.atlassian.net/browse/RSPEC-5856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ