### PR TITLE
Fix S3353: Add support for different function types

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
@@ -128,7 +128,12 @@ public sealed class UnchangedLocalVariablesShouldBeConst : SonarDiagnosticAnalyz
                 .Any(x => IsMutatingUse(semanticModel, x));
 
         static bool IsMethodLike(SyntaxNode arg) =>
-            arg is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax or LambdaExpressionSyntax or GlobalStatementSyntax;
+            arg is BaseMethodDeclarationSyntax
+                or AccessorDeclarationSyntax
+                or LambdaExpressionSyntax
+                or AnonymousFunctionExpressionSyntax
+                or GlobalStatementSyntax
+            || LocalFunctionStatementSyntaxWrapper.IsInstance(arg);
     }
 
     private static bool IsMutatingUse(SemanticModel semanticModel, IdentifierNameSyntax identifier) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnchangedLocalVariablesShouldBeConst.CSharp9.cs
@@ -42,6 +42,32 @@ public record Rec
         {
         }
     }
+
+    public void Test_Shadowing()
+    {
+        int shadowed = 0;
+        shadowed++;
+
+        void LocalFunction()
+        {
+            int shadowed = 0; // Noncompliant
+        }
+
+        Action a1 = () =>
+        {
+            int shadow = 0; // Noncompliant
+        };
+
+        Action<int> a2 = x =>
+        {
+            int shadow = 0; // Noncompliant
+        };
+
+        Action a3 = delegate ()
+        {
+            int shadow = 0; // Noncompliant
+        };
+    }
 }
 
 public record RecordWithImplicitOperator


### PR DESCRIPTION
The rule was missing some constructs that form a method boundary. I added support for these and added some tests. I was expecting this to cause problems with shadowed locals/fields but it turned out that there was an additional symbol checked which prevented this. The fix is therefore only a small performance optimization but the added tests are useful anyhow.