### PR TITLE
Packages: Remove dependencies to "Workspace" from the analyzers

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
+++ b/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
@@ -9,7 +9,7 @@
     <CompilerGeneratedFilesOutputPath>$(MSBuildProjectDirectory)\Lightup\.generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.3.2" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27">
       <!-- This package is a dependency of Microsoft.CodeAnalysis.CSharp.Workspaces. It is safe to use since it's compatible with .Net Portable runtime -->
       <NoWarn>NU1701</NoWarn>

--- a/analyzers/src/SonarAnalyzer.CFG/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.CFG/packages.lock.json
@@ -2,14 +2,13 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.6": {
-      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+      "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
         "requested": "[1.3.2, )",
         "resolved": "1.3.2",
-        "contentHash": "MwGmrrPx3okEJuCogSn4TM3yTtJUDdmTt8RXpnjVo0dPund0YSAq4bHQQ9bxgArbrrapcopJmkb7UOLAvanXkg==",
+        "contentHash": "GrYMp6ScZDOMR0fNn/Ce6SegNVFw1G/QRT/8FiKv7lAP+V6lEZx9e42n0FvFUgjjcKgcEJOI4muU6i+3LSvOBA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[1.3.2]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2]"
+          "Microsoft.CodeAnalysis.Common": "[1.3.2]"
         }
       },
       "Microsoft.Composition": {
@@ -92,23 +91,6 @@
           "System.Xml.XDocument": "4.0.11",
           "System.Xml.XPath.XDocument": "4.0.1",
           "System.Xml.XmlDocument": "4.0.1"
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp": {
-        "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "GrYMp6ScZDOMR0fNn/Ce6SegNVFw1G/QRT/8FiKv7lAP+V6lEZx9e42n0FvFUgjjcKgcEJOI4muU6i+3LSvOBA==",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[1.3.2]"
-        }
-      },
-      "Microsoft.CodeAnalysis.Workspaces.Common": {
-        "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "kvdo+rkImlx5MuBgkayl4OV3Mg8/qirUdYgCIfQ9EqN15QasJFlQXmDAtCGqpkK9sYLLO/VK+y+4mvKjfh/FOA==",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[1.3.2]",
-          "Microsoft.Composition": "1.0.27"
         }
       },
       "StyleCop.Analyzers.Unstable": {
@@ -329,14 +311,13 @@
       }
     },
     ".NETStandard,Version=v2.0": {
-      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+      "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
         "requested": "[1.3.2, )",
         "resolved": "1.3.2",
-        "contentHash": "MwGmrrPx3okEJuCogSn4TM3yTtJUDdmTt8RXpnjVo0dPund0YSAq4bHQQ9bxgArbrrapcopJmkb7UOLAvanXkg==",
+        "contentHash": "GrYMp6ScZDOMR0fNn/Ce6SegNVFw1G/QRT/8FiKv7lAP+V6lEZx9e42n0FvFUgjjcKgcEJOI4muU6i+3LSvOBA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[1.3.2]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2]"
+          "Microsoft.CodeAnalysis.Common": "[1.3.2]"
         }
       },
       "Microsoft.Composition": {
@@ -428,23 +409,6 @@
           "System.Xml.XDocument": "4.0.11",
           "System.Xml.XPath.XDocument": "4.0.1",
           "System.Xml.XmlDocument": "4.0.1"
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp": {
-        "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "GrYMp6ScZDOMR0fNn/Ce6SegNVFw1G/QRT/8FiKv7lAP+V6lEZx9e42n0FvFUgjjcKgcEJOI4muU6i+3LSvOBA==",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[1.3.2]"
-        }
-      },
-      "Microsoft.CodeAnalysis.Workspaces.Common": {
-        "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "kvdo+rkImlx5MuBgkayl4OV3Mg8/qirUdYgCIfQ9EqN15QasJFlQXmDAtCGqpkK9sYLLO/VK+y+4mvKjfh/FOA==",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[1.3.2]",
-          "Microsoft.Composition": "1.0.27"
         }
       },
       "Microsoft.NETCore.Platforms": {

--- a/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -12,7 +12,7 @@
   <!-- Warning: when adding a package reference, we must make sure this package is available on oldest supported .NET version (currently net46) or packaged with the analyzer.
        For instance, System.ValueTuple is not available in 4.6.1 and must be added to the final packaging if we add it here -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.3.2" />
     <PackageReference Include="SonarSource.CBDE" Version="1.0.0.32967">
       <!-- Development dependency, these assets will be consumed but won't flow to the parent project -->
       <PrivateAssets>all</PrivateAssets>

--- a/analyzers/src/SonarAnalyzer.CSharp/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.CSharp/packages.lock.json
@@ -2,14 +2,13 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.6": {
-      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+      "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
         "requested": "[1.3.2, )",
         "resolved": "1.3.2",
-        "contentHash": "MwGmrrPx3okEJuCogSn4TM3yTtJUDdmTt8RXpnjVo0dPund0YSAq4bHQQ9bxgArbrrapcopJmkb7UOLAvanXkg==",
+        "contentHash": "GrYMp6ScZDOMR0fNn/Ce6SegNVFw1G/QRT/8FiKv7lAP+V6lEZx9e42n0FvFUgjjcKgcEJOI4muU6i+3LSvOBA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[1.3.2]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2]"
+          "Microsoft.CodeAnalysis.Common": "[1.3.2]"
         }
       },
       "SonarSource.CBDE": {
@@ -102,14 +101,6 @@
           "System.Xml.XDocument": "4.0.11",
           "System.Xml.XPath.XDocument": "4.0.1",
           "System.Xml.XmlDocument": "4.0.1"
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp": {
-        "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "GrYMp6ScZDOMR0fNn/Ce6SegNVFw1G/QRT/8FiKv7lAP+V6lEZx9e42n0FvFUgjjcKgcEJOI4muU6i+3LSvOBA==",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[1.3.2]"
         }
       },
       "Microsoft.CodeAnalysis.Workspaces.Common": {
@@ -356,21 +347,20 @@
       "sonaranalyzer.cfg": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "Microsoft.CodeAnalysis.CSharp": "[1.3.2, )",
           "Microsoft.Composition": "[1.0.27, )",
           "System.Collections.Immutable": "[1.1.37, )"
         }
       }
     },
     ".NETStandard,Version=v2.0": {
-      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+      "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
         "requested": "[1.3.2, )",
         "resolved": "1.3.2",
-        "contentHash": "MwGmrrPx3okEJuCogSn4TM3yTtJUDdmTt8RXpnjVo0dPund0YSAq4bHQQ9bxgArbrrapcopJmkb7UOLAvanXkg==",
+        "contentHash": "GrYMp6ScZDOMR0fNn/Ce6SegNVFw1G/QRT/8FiKv7lAP+V6lEZx9e42n0FvFUgjjcKgcEJOI4muU6i+3LSvOBA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[1.3.2]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2]"
+          "Microsoft.CodeAnalysis.Common": "[1.3.2]"
         }
       },
       "NETStandard.Library": {
@@ -475,14 +465,6 @@
           "System.Xml.XDocument": "4.0.11",
           "System.Xml.XPath.XDocument": "4.0.1",
           "System.Xml.XmlDocument": "4.0.1"
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp": {
-        "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "GrYMp6ScZDOMR0fNn/Ce6SegNVFw1G/QRT/8FiKv7lAP+V6lEZx9e42n0FvFUgjjcKgcEJOI4muU6i+3LSvOBA==",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[1.3.2]"
         }
       },
       "Microsoft.CodeAnalysis.Workspaces.Common": {
@@ -1287,7 +1269,7 @@
       "sonaranalyzer.cfg": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "Microsoft.CodeAnalysis.CSharp": "[1.3.2, )",
           "Microsoft.Composition": "[1.0.27, )",
           "System.Collections.Immutable": "[1.1.37, )"
         }

--- a/analyzers/src/SonarAnalyzer.Common/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.Common/packages.lock.json
@@ -114,15 +114,6 @@
           "Microsoft.CodeAnalysis.Common": "[1.3.2]"
         }
       },
-      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
-        "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "MwGmrrPx3okEJuCogSn4TM3yTtJUDdmTt8RXpnjVo0dPund0YSAq4bHQQ9bxgArbrrapcopJmkb7UOLAvanXkg==",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[1.3.2]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2]"
-        }
-      },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
         "resolved": "1.2.0.435",
@@ -342,7 +333,7 @@
       "sonaranalyzer.cfg": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "Microsoft.CodeAnalysis.CSharp": "[1.3.2, )",
           "Microsoft.Composition": "[1.0.27, )",
           "System.Collections.Immutable": "[1.1.37, )"
         }
@@ -471,15 +462,6 @@
         "contentHash": "GrYMp6ScZDOMR0fNn/Ce6SegNVFw1G/QRT/8FiKv7lAP+V6lEZx9e42n0FvFUgjjcKgcEJOI4muU6i+3LSvOBA==",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[1.3.2]"
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
-        "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "MwGmrrPx3okEJuCogSn4TM3yTtJUDdmTt8RXpnjVo0dPund0YSAq4bHQQ9bxgArbrrapcopJmkb7UOLAvanXkg==",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[1.3.2]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2]"
         }
       },
       "Microsoft.NETCore.Platforms": {
@@ -1259,7 +1241,7 @@
       "sonaranalyzer.cfg": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "Microsoft.CodeAnalysis.CSharp": "[1.3.2, )",
           "Microsoft.Composition": "[1.0.27, )",
           "System.Collections.Immutable": "[1.1.37, )"
         }

--- a/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/SonarAnalyzer.RuleDescriptorGenerator.csproj
+++ b/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/SonarAnalyzer.RuleDescriptorGenerator.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <!-- Roslyn packages are needed to properly load rule types at runtime -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.3.2" />
   </ItemGroup>
 </Project>

--- a/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.RuleDescriptorGenerator/packages.lock.json
@@ -2,16 +2,6 @@
   "version": 1,
   "dependencies": {
     "net6.0": {
-      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
-        "type": "Direct",
-        "requested": "[1.3.2, )",
-        "resolved": "1.3.2",
-        "contentHash": "MwGmrrPx3okEJuCogSn4TM3yTtJUDdmTt8RXpnjVo0dPund0YSAq4bHQQ9bxgArbrrapcopJmkb7UOLAvanXkg==",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[1.3.2]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2]"
-        }
-      },
       "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
         "type": "Direct",
         "requested": "[1.3.2, )",
@@ -928,7 +918,7 @@
       "sonaranalyzer.cfg": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "Microsoft.CodeAnalysis.CSharp": "[1.3.2, )",
           "Microsoft.Composition": "[1.0.27, )",
           "System.Collections.Immutable": "[1.1.37, )"
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/packages.lock.json
@@ -106,15 +106,6 @@
           "Microsoft.CodeAnalysis.Common": "[1.3.2]"
         }
       },
-      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
-        "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "MwGmrrPx3okEJuCogSn4TM3yTtJUDdmTt8RXpnjVo0dPund0YSAq4bHQQ9bxgArbrrapcopJmkb7UOLAvanXkg==",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[1.3.2]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2]"
-        }
-      },
       "Microsoft.CodeAnalysis.VisualBasic": {
         "type": "Transitive",
         "resolved": "1.3.2",
@@ -367,7 +358,7 @@
       "sonaranalyzer.cfg": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "Microsoft.CodeAnalysis.CSharp": "[1.3.2, )",
           "Microsoft.Composition": "[1.0.27, )",
           "System.Collections.Immutable": "[1.1.37, )"
         }
@@ -488,15 +479,6 @@
         "contentHash": "GrYMp6ScZDOMR0fNn/Ce6SegNVFw1G/QRT/8FiKv7lAP+V6lEZx9e42n0FvFUgjjcKgcEJOI4muU6i+3LSvOBA==",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[1.3.2]"
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
-        "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "MwGmrrPx3okEJuCogSn4TM3yTtJUDdmTt8RXpnjVo0dPund0YSAq4bHQQ9bxgArbrrapcopJmkb7UOLAvanXkg==",
-        "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "[1.3.2]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2]"
         }
       },
       "Microsoft.CodeAnalysis.VisualBasic": {
@@ -1309,7 +1291,7 @@
       "sonaranalyzer.cfg": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "Microsoft.CodeAnalysis.CSharp": "[1.3.2, )",
           "Microsoft.Composition": "[1.0.27, )",
           "System.Collections.Immutable": "[1.1.37, )"
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/packages.lock.json
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/packages.lock.json
@@ -355,7 +355,7 @@
       "sonaranalyzer.cfg": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "Microsoft.CodeAnalysis.CSharp": "[1.3.2, )",
           "Microsoft.Composition": "[1.0.27, )",
           "System.Collections.Immutable": "[1.1.37, )"
         }
@@ -363,7 +363,7 @@
       "sonaranalyzer.csharp": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "Microsoft.CodeAnalysis.CSharp": "[1.3.2, )",
           "SonarAnalyzer": "[1.0.0, )",
           "System.Collections.Immutable": "[1.1.37, )"
         }
@@ -944,7 +944,7 @@
       "sonaranalyzer.cfg": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "Microsoft.CodeAnalysis.CSharp": "[1.3.2, )",
           "Microsoft.Composition": "[1.0.27, )",
           "System.Collections.Immutable": "[1.1.37, )"
         }
@@ -952,7 +952,7 @@
       "sonaranalyzer.csharp": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "Microsoft.CodeAnalysis.CSharp": "[1.3.2, )",
           "SonarAnalyzer": "[1.0.0, )",
           "System.Collections.Immutable": "[1.1.37, )"
         }


### PR DESCRIPTION
The "Workspace" packages should not be used from within an analyzer. They are meant to be used to deal with csproj and sln. An analyzer doesn't have any access to any of the information provided in these packages and ITs are failing if functionality from these packages are used (see e.g https://github.com/SonarSource/sonar-dotnet/pull/6611/checks?check_run_id=10604878476)
We should remove any references (except for the unit test project)