### PR TITLE
Packages: Upgrade FluentAssertions

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/BasicBlockTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/BasicBlockTest.cs
@@ -149,7 +149,7 @@ public class Sample
             body.Kind.Should().Be(BasicBlockKind.Block);
             body.Operations.Should().HaveCount(1).And.Subject.Single().Should().BeAssignableTo<IExpressionStatementOperation>();
             body.BranchValue.Should().BeAssignableTo<ILiteralOperation>();
-            body.OperationsAndBranchValue.Should().OnlyContainInOrder(body.Operations[0], body.BranchValue);
+            body.OperationsAndBranchValue.Should().Equal(body.Operations[0], body.BranchValue);
             exit.Kind.Should().Be(BasicBlockKind.Exit);
             exit.Operations.Should().BeEmpty();
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/CaptureIdTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/CaptureIdTest.cs
@@ -62,7 +62,7 @@ public class Sample
             // Assert
             nestedRegionA.CaptureIds.Should().HaveCount(1).And.Contain(captureA).And.NotContain(captureB);
             nestedRegionB.CaptureIds.Should().HaveCount(1).And.Contain(captureB).And.NotContain(captureA);
-            nestedRegionA.CaptureIds.Single().GetHashCode().Should().Be(captureA.GetHashCode()).And.Should().NotBe(captureB.GetHashCode());
+            nestedRegionA.CaptureIds.Single().GetHashCode().Should().Be(captureA.GetHashCode()).And.NotBe(captureB.GetHashCode());
             nestedRegionA.CaptureIds.Single().Equals((object)captureA).Should().BeTrue();
             nestedRegionA.CaptureIds.Single().Equals((object)captureB).Should().BeFalse();
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
@@ -22,7 +22,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SonarAnalyzer.CFG;
 using SonarAnalyzer.CFG.Sonar;
-using SonarAnalyzer.UnitTest.Helpers;
 using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.UnitTest.CFG.Sonar
@@ -95,10 +94,10 @@ namespace NS
 
             conditionalBlock.TrueSuccessorBlock.Should().Be(trueCondition);
             conditionalBlock.FalseSuccessorBlock.Should().Be(falseCondition);
-            trueCondition.SuccessorBlocks.Should().OnlyContain(constructorBody);
-            falseCondition.SuccessorBlocks.Should().OnlyContain(constructorBody);
-            constructorBody.SuccessorBlocks.Should().OnlyContain(exit);
-            exit.PredecessorBlocks.Should().OnlyContain(constructorBody);
+            trueCondition.SuccessorBlocks.Should().Equal(constructorBody);
+            falseCondition.SuccessorBlocks.Should().Equal(constructorBody);
+            constructorBody.SuccessorBlocks.Should().Equal(exit);
+            exit.PredecessorBlocks.Should().Equal(constructorBody);
 
             VerifyAllInstructions(conditionalBlock, "true");
             VerifyAllInstructions(trueCondition, "5");
@@ -130,8 +129,8 @@ namespace NS
             var constructorBody = blocks[0];
             var exit = cfg.ExitBlock;
 
-            constructorBody.SuccessorBlocks.Should().OnlyContain(exit);
-            exit.PredecessorBlocks.Should().OnlyContain(constructorBody);
+            constructorBody.SuccessorBlocks.Should().Equal(exit);
+            exit.PredecessorBlocks.Should().Equal(constructorBody);
 
             VerifyAllInstructions(constructorBody, "5", ": this(5)");
             VerifyAllInstructions(exit);
@@ -162,8 +161,8 @@ namespace NS
             var constructorBody = blocks[0];
             var exit = cfg.ExitBlock;
 
-            constructorBody.SuccessorBlocks.Should().OnlyContain(exit);
-            exit.PredecessorBlocks.Should().OnlyContain(constructorBody);
+            constructorBody.SuccessorBlocks.Should().Equal(exit);
+            exit.PredecessorBlocks.Should().Equal(constructorBody);
 
             VerifyAllInstructions(constructorBody, "5", ": base(5)");
             VerifyAllInstructions(exit);
@@ -285,11 +284,11 @@ public class Sample
             var trueBlock = cfg.Blocks.ToList()[1];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(trueBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(trueBlock, exitBlock);
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
-            trueBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(branchBlock, trueBlock);
+            trueBlock.SuccessorBlocks.Should().Equal(exitBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(branchBlock, trueBlock);
 
             VerifyAllInstructions(branchBlock, "true");
             VerifyAllInstructions(trueBlock, "10", "x = 10");
@@ -365,12 +364,12 @@ public class Sample
             var falseBlock = cfg.Blocks.ToList()[2];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(trueBlock, falseBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(trueBlock, falseBlock);
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
-            trueBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            falseBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(trueBlock, falseBlock);
+            trueBlock.SuccessorBlocks.Should().Equal(exitBlock);
+            falseBlock.SuccessorBlocks.Should().Equal(exitBlock);
+            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { trueBlock, falseBlock });
         }
 
         [TestMethod]
@@ -384,15 +383,15 @@ public class Sample
             var trueBlockY = cfg.Blocks.ToList()[3];
             var exitBlock = cfg.ExitBlock;
 
-            firstCondition.SuccessorBlocks.Should().OnlyContainInOrder(trueBlockX, secondCondition);
+            firstCondition.SuccessorBlocks.Should().Equal(trueBlockX, secondCondition);
             firstCondition.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
-            trueBlockX.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            trueBlockX.SuccessorBlocks.Should().Equal(exitBlock);
 
-            secondCondition.SuccessorBlocks.Should().OnlyContainInOrder(trueBlockY, exitBlock);
+            secondCondition.SuccessorBlocks.Should().Equal(trueBlockY, exitBlock);
             secondCondition.BranchingNode.Kind().Should().Be(SyntaxKind.FalseLiteralExpression);
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(trueBlockX, trueBlockY, secondCondition);
+            exitBlock.PredecessorBlocks.Should().Equal(trueBlockX, trueBlockY, secondCondition);
         }
 
         [TestMethod]
@@ -407,18 +406,18 @@ public class Sample
             var falseBlockZ = cfg.Blocks.ToList()[4];
             var exitBlock = cfg.ExitBlock;
 
-            firstCondition.SuccessorBlocks.Should().OnlyContainInOrder(trueBlockX, secondCondition);
+            firstCondition.SuccessorBlocks.Should().Equal(trueBlockX, secondCondition);
             firstCondition.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
-            trueBlockX.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            trueBlockX.SuccessorBlocks.Should().Equal(exitBlock);
 
-            secondCondition.SuccessorBlocks.Should().OnlyContainInOrder(trueBlockY, falseBlockZ);
+            secondCondition.SuccessorBlocks.Should().Equal(trueBlockY, falseBlockZ);
             secondCondition.BranchingNode.Kind().Should().Be(SyntaxKind.FalseLiteralExpression);
 
-            trueBlockY.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            falseBlockZ.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            trueBlockY.SuccessorBlocks.Should().Equal(exitBlock);
+            falseBlockZ.SuccessorBlocks.Should().Equal(exitBlock);
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(trueBlockX, trueBlockY, falseBlockZ);
+            exitBlock.PredecessorBlocks.Should().Equal(trueBlockX, trueBlockY, falseBlockZ);
         }
 
         [TestMethod]
@@ -436,16 +435,16 @@ public class Sample
             var falseBlockY = cfg.Blocks.ToList()[3];
             var exitBlock = cfg.ExitBlock;
 
-            firstCondition.SuccessorBlocks.Should().OnlyContainInOrder(secondCondition, exitBlock);
+            firstCondition.SuccessorBlocks.Should().Equal(secondCondition, exitBlock);
             firstCondition.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
-            secondCondition.SuccessorBlocks.Should().OnlyContainInOrder(trueBlockX, falseBlockY);
+            secondCondition.SuccessorBlocks.Should().Equal(trueBlockX, falseBlockY);
             secondCondition.BranchingNode.Kind().Should().Be(SyntaxKind.FalseLiteralExpression);
 
-            trueBlockX.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            falseBlockY.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            trueBlockX.SuccessorBlocks.Should().Equal(exitBlock);
+            falseBlockY.SuccessorBlocks.Should().Equal(exitBlock);
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(trueBlockX, falseBlockY, firstCondition);
+            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { trueBlockX, falseBlockY, firstCondition });
         }
 
         [TestMethod]
@@ -465,10 +464,10 @@ public class Sample
 
             branchBlockA.TrueSuccessorBlock.Should().Be(branchBlockB);
             branchBlockA.FalseSuccessorBlock.Should().Be(branchBlockALeft);
-            branchBlockALeft.SuccessorBlocks.Should().OnlyContainInOrder(trueBlock, exit);
+            branchBlockALeft.SuccessorBlocks.Should().Equal(trueBlock, exit);
             branchBlockB.TrueSuccessorBlock.Should().Be(trueBlock);
             branchBlockB.FalseSuccessorBlock.Should().Be(exit);
-            trueBlock.SuccessorBlocks.Should().OnlyContain(exit);
+            trueBlock.SuccessorBlocks.Should().Equal(exit);
         }
 
         [TestMethod]
@@ -488,13 +487,13 @@ public class Sample
 
             branchBlockX.TrueSuccessorBlock.Should().Be(branchBlockY);
             branchBlockX.FalseSuccessorBlock.Should().Be(branchBlockXLeft);
-            branchBlockXLeft.SuccessorBlocks.Should().OnlyContainInOrder(condTrue, condFalse);
+            branchBlockXLeft.SuccessorBlocks.Should().Equal(condTrue, condFalse);
             branchBlockY.TrueSuccessorBlock.Should().Be(condTrue);
             branchBlockY.FalseSuccessorBlock.Should().Be(condFalse);
 
-            condFalse.SuccessorBlocks.Should().OnlyContain(after);
-            condTrue.SuccessorBlocks.Should().OnlyContain(after);
-            after.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            condFalse.SuccessorBlocks.Should().Equal(after);
+            condTrue.SuccessorBlocks.Should().Equal(after);
+            after.SuccessorBlocks.Should().Equal(exitBlock);
 
             VerifyAllInstructions(branchBlockX, "x");
             VerifyAllInstructions(branchBlockXLeft);
@@ -516,21 +515,21 @@ public class Sample
             var falseBlock = cfg.Blocks.ElementAt(3);
             var exitBlock = cfg.ExitBlock;
 
-            xBranchBlock.SuccessorBlocks.Should().OnlyContainInOrder(oBranchBlock, falseBlock);
+            xBranchBlock.SuccessorBlocks.Should().Equal(oBranchBlock, falseBlock);
             xBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKindEx.IsPatternExpression);
             VerifyAllInstructions(xBranchBlock, "cw0", "cw0()", "x", "10", "x is 10");
 
-            oBranchBlock.SuccessorBlocks.Should().OnlyContainInOrder(trueBlock, falseBlock);
+            oBranchBlock.SuccessorBlocks.Should().Equal(trueBlock, falseBlock);
             oBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKindEx.IsPatternExpression);
             VerifyAllInstructions(oBranchBlock, "o", "null", "o is null");
 
-            trueBlock.SuccessorBlocks.Should().OnlyContain(falseBlock);
+            trueBlock.SuccessorBlocks.Should().Equal(falseBlock);
             VerifyAllInstructions(trueBlock, "cw1", "cw1()");
 
-            falseBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            falseBlock.SuccessorBlocks.Should().Equal(exitBlock);
             VerifyAllInstructions(falseBlock, "cw2", "cw2()");
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(falseBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(falseBlock);
         }
 
         [TestMethod]
@@ -545,21 +544,21 @@ public class Sample
             var falseBlock = cfg.Blocks.ElementAt(3);
             var exitBlock = cfg.ExitBlock;
 
-            xBranchBlock.SuccessorBlocks.Should().OnlyContainInOrder(oBranchBlock, falseBlock);
+            xBranchBlock.SuccessorBlocks.Should().Equal(oBranchBlock, falseBlock);
             xBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKindEx.IsPatternExpression);
             VerifyAllInstructions(xBranchBlock, "cw0", "cw0()", "x", "x is int i");
 
-            oBranchBlock.SuccessorBlocks.Should().OnlyContainInOrder(trueBlock, falseBlock);
+            oBranchBlock.SuccessorBlocks.Should().Equal(trueBlock, falseBlock);
             oBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKindEx.IsPatternExpression);
             VerifyAllInstructions(oBranchBlock, "o", "o is string s");
 
-            trueBlock.SuccessorBlocks.Should().OnlyContain(falseBlock);
+            trueBlock.SuccessorBlocks.Should().Equal(falseBlock);
             VerifyAllInstructions(trueBlock, "cw1", "cw1()");
 
-            falseBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            falseBlock.SuccessorBlocks.Should().Equal(exitBlock);
             VerifyAllInstructions(falseBlock, "cw2", "cw2()");
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(falseBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(falseBlock);
         }
 
         [TestMethod]
@@ -578,13 +577,13 @@ public class Sample
             xBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.LogicalNotExpression);
             VerifyAllInstructions(xBranchBlock, "cw0", "cw0()", "x", "null", "x is null", "!(x is null)");
 
-            trueBlock.SuccessorBlocks.Should().OnlyContain(falseBlock);
+            trueBlock.SuccessorBlocks.Should().Equal(falseBlock);
             VerifyAllInstructions(trueBlock, "cw1", "cw1()");
 
-            falseBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            falseBlock.SuccessorBlocks.Should().Equal(exitBlock);
             VerifyAllInstructions(falseBlock, "cw2", "cw2()");
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(falseBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(falseBlock);
         }
 
         #endregion
@@ -601,12 +600,12 @@ public class Sample
                 .First(b => b.Instructions.Any(n => n.ToString() == "x = 10"));
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(branchBlock);
-            branchBlock.PredecessorBlocks.Should().OnlyContain(loopBodyBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(branchBlock);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(branchBlock);
+            branchBlock.PredecessorBlocks.Should().Equal(loopBodyBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(branchBlock);
 
             VerifyAllInstructions(branchBlock, "true");
             VerifyAllInstructions(loopBodyBlock, "10", "x = 10");
@@ -631,9 +630,9 @@ public class Sample
             branchBlockB.TrueSuccessorBlock.Should().Be(loopBodyBlock);
             branchBlockB.FalseSuccessorBlock.Should().Be(exitBlock);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(branchBlockA);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(branchBlockA);
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(branchBlockB);
+            exitBlock.PredecessorBlocks.Should().Equal(branchBlockB);
 
             VerifyAllInstructions(branchBlockA, "a");
             VerifyAllInstructions(branchBlockB, "b");
@@ -660,9 +659,9 @@ public class Sample
             branchBlockB.TrueSuccessorBlock.Should().Be(loopBodyBlock);
             branchBlockB.FalseSuccessorBlock.Should().Be(exitBlock);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(branchBlockA);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(branchBlockA);
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(branchBlockB, branchBlockA);
+            exitBlock.PredecessorBlocks.Should().Equal(branchBlockB, branchBlockA);
 
             VerifyAllInstructions(branchBlockA, "a");
             VerifyAllInstructions(branchBlockB, "b");
@@ -683,16 +682,16 @@ public class Sample
             secondBranchBlock.Instructions.Should().Contain(n => n.IsKind(SyntaxKind.FalseLiteralExpression));
             var exitBlock = cfg.ExitBlock;
 
-            firstBranchBlock.SuccessorBlocks.Should().OnlyContainInOrder(secondBranchBlock, exitBlock);
+            firstBranchBlock.SuccessorBlocks.Should().Equal(secondBranchBlock, exitBlock);
             firstBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
-            secondBranchBlock.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, firstBranchBlock);
+            secondBranchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, firstBranchBlock);
             secondBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.FalseLiteralExpression);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(secondBranchBlock);
-            firstBranchBlock.PredecessorBlocks.Should().OnlyContain(secondBranchBlock);
-            secondBranchBlock.PredecessorBlocks.Should().OnlyContain(firstBranchBlock, loopBodyBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(firstBranchBlock);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(secondBranchBlock);
+            firstBranchBlock.PredecessorBlocks.Should().Equal(secondBranchBlock);
+            secondBranchBlock.PredecessorBlocks.Should().Equal(firstBranchBlock, loopBodyBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(firstBranchBlock);
         }
 
         #endregion
@@ -712,13 +711,13 @@ public class Sample
             var branchBlockB = (BinaryBranchBlock)blocks[2];
             var exitBlock = cfg.ExitBlock;
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(branchBlockA);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(branchBlockA);
             branchBlockA.TrueSuccessorBlock.Should().Be(loopBodyBlock);
             branchBlockA.FalseSuccessorBlock.Should().Be(branchBlockB);
             branchBlockB.TrueSuccessorBlock.Should().Be(loopBodyBlock);
             branchBlockB.FalseSuccessorBlock.Should().Be(exitBlock);
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(branchBlockB);
+            exitBlock.PredecessorBlocks.Should().Equal(branchBlockB);
 
             VerifyAllInstructions(loopBodyBlock, "10", "x = 10");
         }
@@ -732,13 +731,13 @@ public class Sample
             var loopBodyBlock = cfg.EntryBlock;
             var exitBlock = cfg.ExitBlock;
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(branchBlock);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(branchBlock);
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
-            branchBlock.PredecessorBlocks.Should().OnlyContain(loopBodyBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(new[] { branchBlock });
+            branchBlock.PredecessorBlocks.Should().Equal(loopBodyBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(new[] { branchBlock });
 
             VerifyAllInstructions(loopBodyBlock, "10", "x = 10");
             VerifyAllInstructions(branchBlock, "true");
@@ -757,17 +756,17 @@ public class Sample
             trueBranchBlock.Instructions.Should().Contain(n => n.IsKind(SyntaxKind.TrueLiteralExpression));
             var exitBlock = cfg.ExitBlock;
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(falseBranchBlock);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(falseBranchBlock);
 
-            falseBranchBlock.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, trueBranchBlock);
+            falseBranchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, trueBranchBlock);
             falseBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.FalseLiteralExpression);
 
-            trueBranchBlock.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, exitBlock);
+            trueBranchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
             trueBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
-            falseBranchBlock.PredecessorBlocks.Should().OnlyContain(loopBodyBlock);
-            trueBranchBlock.PredecessorBlocks.Should().OnlyContain(falseBranchBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(trueBranchBlock);
+            falseBranchBlock.PredecessorBlocks.Should().Equal(loopBodyBlock);
+            trueBranchBlock.PredecessorBlocks.Should().Equal(falseBranchBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(trueBranchBlock);
         }
 
         [TestMethod]
@@ -796,18 +795,18 @@ public class Sample
             var exitBlock = blocks[4];
 
             defBlock.Should().Be(cfg.EntryBlock);
-            defBlock.SuccessorBlocks.Should().OnlyContainInOrder(ifBlock);
+            defBlock.SuccessorBlocks.Should().Equal(ifBlock);
             VerifyAllInstructions(defBlock, "p");
 
-            ifBlock.SuccessorBlocks.Should().OnlyContainInOrder(continueJump, doCondition);
+            ifBlock.SuccessorBlocks.Should().Equal(continueJump, doCondition);
             ifBlock.BranchingNode.Kind().Should().Be(SyntaxKind.InvocationExpression);
             VerifyAllInstructions(ifBlock, "unknown", "unknown()", "p = unknown()", "unknown", "unknown()");
 
-            continueJump.SuccessorBlocks.Should().OnlyContainInOrder(doCondition);
+            continueJump.SuccessorBlocks.Should().Equal(doCondition);
             continueJump.JumpNode.Kind().Should().Be(SyntaxKind.ContinueStatement);
             VerifyAllInstructions(continueJump, "0", "p = 0");
 
-            doCondition.SuccessorBlocks.Should().OnlyContainInOrder(ifBlock, exitBlock);
+            doCondition.SuccessorBlocks.Should().Equal(ifBlock, exitBlock);
             doCondition.BranchingNode.Kind().Should().Be(SyntaxKind.LogicalNotExpression);
             VerifyAllInstructions(doCondition, "p", "!p");
 
@@ -833,11 +832,11 @@ public class Sample
 
             collectionBlock.SuccessorBlocks.Should().Contain(foreachBlock);
 
-            foreachBlock.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, exitBlock);
+            foreachBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
             foreachBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForEachStatement);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(foreachBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(foreachBlock);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(foreachBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(foreachBlock);
 
             VerifyAllInstructions(collectionBlock, "collection");
             VerifyNoInstruction(foreachBlock);
@@ -867,16 +866,16 @@ public class Sample
 
             collection1Block.SuccessorBlocks.Should().Contain(foreach1Block);
 
-            foreach1Block.SuccessorBlocks.Should().OnlyContainInOrder(collection2Block, exitBlock);
+            foreach1Block.SuccessorBlocks.Should().Equal(collection2Block, exitBlock);
             foreach1Block.BranchingNode.Kind().Should().Be(SyntaxKind.ForEachStatement);
 
             collection2Block.SuccessorBlocks.Should().Contain(foreach2Block);
 
-            foreach2Block.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, foreach1Block);
+            foreach2Block.SuccessorBlocks.Should().Equal(loopBodyBlock, foreach1Block);
             foreach2Block.BranchingNode.Kind().Should().Be(SyntaxKind.ForEachStatement);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(foreach2Block);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(foreach1Block);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(foreach2Block);
+            exitBlock.PredecessorBlocks.Should().Equal(foreach1Block);
         }
 
         [TestMethod]
@@ -902,12 +901,12 @@ public class Sample
 
             forEachCollectionBlock.SuccessorBlocks.Should().Contain(foreachBlock);
 
-            foreachBlock.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, exitBlock);
+            foreachBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
             foreachBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForEachVariableStatement);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(foreachBlock);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(foreachBlock);
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(foreachBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(foreachBlock);
         }
 
         [TestMethod]
@@ -925,14 +924,14 @@ public class Sample
             collectionBlock.SuccessorBlocks.Should().Contain(foreachBlock);
             VerifyAllInstructions(collectionBlock, "GetAsync", "GetAsync()");
 
-            foreachBlock.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, exitBlock);
+            foreachBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
             foreachBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForEachStatement);
             VerifyNoInstruction(foreachBlock);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(foreachBlock);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(foreachBlock);
             VerifyAllInstructions(loopBodyBlock, "10", "x = 10");
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(foreachBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(foreachBlock);
         }
 
         #endregion
@@ -1015,21 +1014,21 @@ public class Sample
                 .First(b => b.Instructions.Any(n => n.ToString() == "x = 10"));
             var exitBlock = cfg.ExitBlock;
 
-            initBlockI.SuccessorBlocks.Should().OnlyContain(branchBlockTrue);
+            initBlockI.SuccessorBlocks.Should().Equal(branchBlockTrue);
 
-            branchBlockTrue.SuccessorBlocks.Should().OnlyContainInOrder(initBlockJ, exitBlock);
+            branchBlockTrue.SuccessorBlocks.Should().Equal(initBlockJ, exitBlock);
             branchBlockTrue.BranchingNode.Kind().Should().Be(SyntaxKind.ForStatement);
 
-            initBlockJ.SuccessorBlocks.Should().OnlyContain(branchBlockFalse);
+            initBlockJ.SuccessorBlocks.Should().Equal(branchBlockFalse);
 
-            branchBlockFalse.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, incrementorBlockI);
+            branchBlockFalse.SuccessorBlocks.Should().Equal(loopBodyBlock, incrementorBlockI);
             branchBlockFalse.BranchingNode.Kind().Should().Be(SyntaxKind.ForStatement);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(incrementorBlockJ);
-            incrementorBlockJ.SuccessorBlocks.Should().OnlyContain(branchBlockFalse);
-            incrementorBlockI.SuccessorBlocks.Should().OnlyContain(branchBlockTrue);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(incrementorBlockJ);
+            incrementorBlockJ.SuccessorBlocks.Should().Equal(branchBlockFalse);
+            incrementorBlockI.SuccessorBlocks.Should().Equal(branchBlockTrue);
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(branchBlockTrue);
+            exitBlock.PredecessorBlocks.Should().Equal(branchBlockTrue);
         }
 
         #endregion
@@ -1101,10 +1100,10 @@ public class Sample
             var exit = (ExitBlock)blocks.Last();
 
             block1.Instructions.Should().BeEmpty();
-            block1.SuccessorBlocks.Should().OnlyContain(exit);
+            block1.SuccessorBlocks.Should().Equal(exit);
 
             VerifyAllInstructions(block2, "cw0", "cw0()");
-            block2.SuccessorBlocks.Should().OnlyContain(exit);
+            block2.SuccessorBlocks.Should().Equal(exit);
         }
 
         [TestMethod]
@@ -1128,8 +1127,8 @@ public class Sample
             var bodyBlock = cfg.Blocks.Skip(1).First();
             var exitBlock = cfg.ExitBlock;
 
-            lockBlock.SuccessorBlocks.Should().OnlyContain(bodyBlock);
-            bodyBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            lockBlock.SuccessorBlocks.Should().Equal(bodyBlock);
+            bodyBlock.SuccessorBlocks.Should().Equal(exitBlock);
 
             lockBlock.LockNode.Kind().Should().Be(SyntaxKind.LockStatement);
 
@@ -1146,9 +1145,9 @@ public class Sample
             var bodyBlock = cfg.Blocks.Skip(2).First();
             var exitBlock = cfg.ExitBlock;
 
-            lockBlock.SuccessorBlocks.Should().OnlyContain(innerLockBlock);
-            innerLockBlock.SuccessorBlocks.Should().OnlyContain(bodyBlock);
-            bodyBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            lockBlock.SuccessorBlocks.Should().Equal(innerLockBlock);
+            innerLockBlock.SuccessorBlocks.Should().Equal(bodyBlock);
+            bodyBlock.SuccessorBlocks.Should().Equal(exitBlock);
 
             lockBlock.LockNode.Kind().Should().Be(SyntaxKind.LockStatement);
             lockBlock.Instructions.Should().Contain(n => n.IsKind(SyntaxKind.ThisExpression));
@@ -1271,9 +1270,9 @@ public class Sample
             var afterOp = blocks[2];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(trueABlock, afterOp);
-            trueABlock.SuccessorBlocks.Should().OnlyContain(afterOp);
-            afterOp.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(trueABlock, afterOp);
+            trueABlock.SuccessorBlocks.Should().Equal(afterOp);
+            afterOp.SuccessorBlocks.Should().Equal(exitBlock);
 
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.LogicalAndExpression);
 
@@ -1294,9 +1293,9 @@ public class Sample
             var afterOp = blocks[2];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(afterOp, falseABlock);
-            falseABlock.SuccessorBlocks.Should().OnlyContain(afterOp);
-            afterOp.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(afterOp, falseABlock);
+            falseABlock.SuccessorBlocks.Should().Equal(afterOp);
+            afterOp.SuccessorBlocks.Should().Equal(exitBlock);
 
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.LogicalOrExpression);
 
@@ -1319,11 +1318,11 @@ public class Sample
             var afterOp = blocks[4];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(trueABlock, afterAC);
-            trueABlock.SuccessorBlocks.Should().OnlyContain(afterAC);
-            afterAC.SuccessorBlocks.Should().OnlyContainInOrder(trueACBlock, afterOp);
-            trueACBlock.SuccessorBlocks.Should().OnlyContain(afterOp);
-            afterOp.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(trueABlock, afterAC);
+            trueABlock.SuccessorBlocks.Should().Equal(afterAC);
+            afterAC.SuccessorBlocks.Should().Equal(trueACBlock, afterOp);
+            trueACBlock.SuccessorBlocks.Should().Equal(afterOp);
+            afterOp.SuccessorBlocks.Should().Equal(exitBlock);
         }
 
         [TestMethod]
@@ -1345,12 +1344,12 @@ public class Sample
                 .First(b => b.Instructions.Any(n => n.ToString() == "y++"));
             var exitBlock = cfg.ExitBlock;
 
-            initBlock.SuccessorBlocks.Should().OnlyContain(aBlock);
-            aBlock.SuccessorBlocks.Should().OnlyContainInOrder(cBlock, acBlock);
-            cBlock.SuccessorBlocks.Should().OnlyContain(acBlock);
-            acBlock.SuccessorBlocks.Should().OnlyContainInOrder(bodyBlock, exitBlock);
-            bodyBlock.SuccessorBlocks.Should().OnlyContain(incrementBlock);
-            incrementBlock.SuccessorBlocks.Should().OnlyContain(aBlock);
+            initBlock.SuccessorBlocks.Should().Equal(aBlock);
+            aBlock.SuccessorBlocks.Should().Equal(cBlock, acBlock);
+            cBlock.SuccessorBlocks.Should().Equal(acBlock);
+            acBlock.SuccessorBlocks.Should().Equal(bodyBlock, exitBlock);
+            bodyBlock.SuccessorBlocks.Should().Equal(incrementBlock);
+            incrementBlock.SuccessorBlocks.Should().Equal(aBlock);
 
             acBlock.Instructions.Should().BeEmpty();
         }
@@ -1370,9 +1369,9 @@ public class Sample
             var assignmentBlock = blocks[2];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(bNullBlock, assignmentBlock);
-            bNullBlock.SuccessorBlocks.Should().OnlyContain(assignmentBlock);
-            assignmentBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(bNullBlock, assignmentBlock);
+            bNullBlock.SuccessorBlocks.Should().Equal(assignmentBlock);
+            assignmentBlock.SuccessorBlocks.Should().Equal(exitBlock);
 
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.CoalesceExpression);
 
@@ -1397,9 +1396,9 @@ public class Sample
             branchBlock.FalseSuccessorBlock.Should().Be(afterOp);
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.CoalesceExpression);
 
-            bNullBlock.SuccessorBlocks.Should().OnlyContain(afterOp);
+            bNullBlock.SuccessorBlocks.Should().Equal(afterOp);
 
-            afterOp.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            afterOp.SuccessorBlocks.Should().Equal(exitBlock);
 
             VerifyAllInstructions(branchBlock, "a");
             VerifyAllInstructions(bNullBlock, "c");
@@ -1429,10 +1428,10 @@ public class Sample
             cBlock.Instructions.Should().ContainSingle("c");
             cBlock.BranchingNode.Kind().Should().Be(SyntaxKind.CoalesceExpression);
 
-            dBlock.SuccessorBlocks.Should().OnlyContain(bcdBlock);
+            dBlock.SuccessorBlocks.Should().Equal(bcdBlock);
             dBlock.Instructions.Should().ContainSingle("d");
 
-            bcdBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            bcdBlock.SuccessorBlocks.Should().Equal(exitBlock);
             bcdBlock.Instructions.Should().ContainSingle("a = b ?? c ?? d");
         }
 
@@ -1483,8 +1482,8 @@ public class Sample
 
             branchBlock.TrueSuccessorBlock.Should().Be(throwBlock);
             branchBlock.FalseSuccessorBlock.Should().Be(assignmentBlock);
-            throwBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            assignmentBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            throwBlock.SuccessorBlocks.Should().Equal(exitBlock);
+            assignmentBlock.SuccessorBlocks.Should().Equal(exitBlock);
 
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.CoalesceExpression);
 
@@ -1548,10 +1547,10 @@ public class Sample
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKindEx.CoalesceAssignmentExpression);
             VerifyAllInstructions(branchBlock, "a");
 
-            blockWithB.SuccessorBlocks.Should().OnlyContain(assignmentBlock);
+            blockWithB.SuccessorBlocks.Should().Equal(assignmentBlock);
             VerifyAllInstructions(blockWithB, "b");
 
-            assignmentBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            assignmentBlock.SuccessorBlocks.Should().Equal(exitBlock);
             VerifyAllInstructions(assignmentBlock, "a ??= b");
         }
 
@@ -1615,10 +1614,10 @@ public class Sample
             coalesceBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.CoalesceExpression);
             coalesceBranchBlock.Instructions.Should().ContainSingle("b");
 
-            blockWithC.SuccessorBlocks.Should().OnlyContain(assignmentBlock);
+            blockWithC.SuccessorBlocks.Should().Equal(assignmentBlock);
             blockWithC.Instructions.Should().ContainSingle("c");
 
-            assignmentBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            assignmentBlock.SuccessorBlocks.Should().Equal(exitBlock);
             assignmentBlock.Instructions.Should().ContainSingle("a ??= b ?? c");
         }
 
@@ -1674,10 +1673,10 @@ public class Sample
             var after = blocks[3];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(condTrue, condFalse);
-            condFalse.SuccessorBlocks.Should().OnlyContain(after);
-            condTrue.SuccessorBlocks.Should().OnlyContain(after);
-            after.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(condTrue, condFalse);
+            condFalse.SuccessorBlocks.Should().Equal(after);
+            condTrue.SuccessorBlocks.Should().Equal(after);
+            after.SuccessorBlocks.Should().Equal(exitBlock);
 
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.IdentifierName);
 
@@ -1706,9 +1705,9 @@ public class Sample
             branchBlockB.TrueSuccessorBlock.Should().Be(condTrue);
             branchBlockB.FalseSuccessorBlock.Should().Be(condFalse);
 
-            condFalse.SuccessorBlocks.Should().OnlyContain(after);
-            condTrue.SuccessorBlocks.Should().OnlyContain(after);
-            after.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            condFalse.SuccessorBlocks.Should().Equal(after);
+            condTrue.SuccessorBlocks.Should().Equal(after);
+            after.SuccessorBlocks.Should().Equal(exitBlock);
 
             VerifyAllInstructions(branchBlockA, "x");
             VerifyAllInstructions(branchBlockB, "y");
@@ -1736,9 +1735,9 @@ public class Sample
             branchBlockB.TrueSuccessorBlock.Should().Be(condTrue);
             branchBlockB.FalseSuccessorBlock.Should().Be(condFalse);
 
-            condFalse.SuccessorBlocks.Should().OnlyContain(after);
-            condTrue.SuccessorBlocks.Should().OnlyContain(after);
-            after.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            condFalse.SuccessorBlocks.Should().Equal(after);
+            condTrue.SuccessorBlocks.Should().Equal(after);
+            after.SuccessorBlocks.Should().Equal(exitBlock);
 
             VerifyAllInstructions(branchBlockA, "x");
             VerifyAllInstructions(branchBlockB, "y");
@@ -1760,7 +1759,7 @@ public class Sample
             var cond3Block = blocks[4];
             VerifyAllInstructions(cond3Block, "cond3");
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(cond2Block, cond3Block);
+            branchBlock.SuccessorBlocks.Should().Equal(cond2Block, cond3Block);
             cond2Block.SuccessorBlocks.Should().HaveCount(2);
             cond3Block.SuccessorBlocks.Should().HaveCount(2);
 
@@ -1800,12 +1799,12 @@ public class Sample
             var assignmentBlock = blocks[3] as SimpleBlock;
             var exitBlock = cfg.ExitBlock;
 
-            binaryBranch.SuccessorBlocks.Should().OnlyContainInOrder(trueBlock, falseJumpBlock);
-            trueBlock.SuccessorBlocks.Should().OnlyContain(assignmentBlock);
+            binaryBranch.SuccessorBlocks.Should().Equal(trueBlock, falseJumpBlock);
+            trueBlock.SuccessorBlocks.Should().Equal(assignmentBlock);
             falseJumpBlock.SuccessorBlock.Should().Be(exitBlock);
             falseJumpBlock.WouldBeSuccessor.Should().Be(assignmentBlock);
-            assignmentBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(falseJumpBlock, assignmentBlock);
+            assignmentBlock.SuccessorBlocks.Should().Equal(exitBlock);
+            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { falseJumpBlock, assignmentBlock });
         }
 
         [TestMethod]
@@ -1820,10 +1819,10 @@ public class Sample
             var methodCallBlock = blocks[1] as SimpleBlock;
             var exitBlock = cfg.ExitBlock;
 
-            jumpBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            jumpBlock.SuccessorBlocks.Should().Equal(exitBlock);
             jumpBlock.WouldBeSuccessor.Should().Be(methodCallBlock);
-            methodCallBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(methodCallBlock, jumpBlock);
+            methodCallBlock.SuccessorBlocks.Should().Equal(exitBlock);
+            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { methodCallBlock, jumpBlock });
         }
 
         #endregion
@@ -1842,8 +1841,8 @@ public class Sample
 
             VerifyAllInstructions(rangeBlock, "1..4", "r = 1..4");
 
-            rangeBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(rangeBlock);
+            rangeBlock.SuccessorBlocks.Should().Equal(exitBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(rangeBlock);
         }
 
         [TestMethod]
@@ -1858,8 +1857,8 @@ public class Sample
 
             VerifyAllInstructions(rangeBlock, "^1", "index = ^1");
 
-            rangeBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(rangeBlock);
+            rangeBlock.SuccessorBlocks.Should().Equal(exitBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(rangeBlock);
         }
 
         #endregion
@@ -1880,8 +1879,8 @@ public class Sample
 
             oIsNullBranch.TrueSuccessorBlock.Should().Be(assignment);
             oIsNullBranch.FalseSuccessorBlock.Should().Be(oNotNull);
-            oNotNull.SuccessorBlocks.Should().OnlyContain(assignment);
-            assignment.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            oNotNull.SuccessorBlocks.Should().Equal(assignment);
+            assignment.SuccessorBlocks.Should().Equal(exitBlock);
 
             oIsNullBranch.BranchingNode.Kind().Should().Be(SyntaxKind.ConditionalAccessExpression);
 
@@ -1912,8 +1911,8 @@ public class Sample
             oIsNullBranch.FalseSuccessorBlock.Should().Be(methodCallIsNull);
             methodCallIsNull.TrueSuccessorBlock.Should().Be(assignment);
             methodCallIsNull.FalseSuccessorBlock.Should().Be(arrayAccess);
-            arrayAccess.SuccessorBlocks.Should().OnlyContain(assignment);
-            assignment.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            arrayAccess.SuccessorBlocks.Should().Equal(assignment);
+            assignment.SuccessorBlocks.Should().Equal(exitBlock);
         }
 
         [TestMethod]
@@ -1938,11 +1937,11 @@ public class Sample
 
             aObjIsNull.TrueSuccessorBlock.Should().Be(coalesceIsNullBranch);
             aObjIsNull.FalseSuccessorBlock.Should().Be(boolFieldAccess);
-            boolFieldAccess.SuccessorBlocks.Should().OnlyContainInOrder(coalesceIsNullBranch);
+            boolFieldAccess.SuccessorBlocks.Should().Equal(coalesceIsNullBranch);
             coalesceIsNullBranch.TrueSuccessorBlock.Should().Be(falseBlock);
             coalesceIsNullBranch.FalseSuccessorBlock.Should().Be(assignment);
-            falseBlock.SuccessorBlocks.Should().OnlyContainInOrder(assignment);
-            assignment.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            falseBlock.SuccessorBlocks.Should().Equal(assignment);
+            assignment.SuccessorBlocks.Should().Equal(exitBlock);
         }
 
         [TestMethod]
@@ -1967,11 +1966,11 @@ public class Sample
 
             aIsNullBranch.TrueSuccessorBlock.Should().Be(nullCheckBranch);
             aIsNullBranch.FalseSuccessorBlock.Should().Be(boolFieldAccess);
-            boolFieldAccess.SuccessorBlocks.Should().OnlyContainInOrder(nullCheckBranch);
+            boolFieldAccess.SuccessorBlocks.Should().Equal(nullCheckBranch);
             nullCheckBranch.TrueSuccessorBlock.Should().Be(trueBlock);
             nullCheckBranch.FalseSuccessorBlock.Should().Be(falseBlock);
-            trueBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            falseBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            trueBlock.SuccessorBlocks.Should().Equal(exitBlock);
+            falseBlock.SuccessorBlocks.Should().Equal(exitBlock);
         }
 
         [TestMethod]
@@ -1994,10 +1993,10 @@ public class Sample
 
             aIsNullBranch.TrueSuccessorBlock.Should().Be(isNullCheck);
             aIsNullBranch.FalseSuccessorBlock.Should().Be(boolFieldAccess);
-            boolFieldAccess.SuccessorBlocks.Should().OnlyContainInOrder(isNullCheck);
+            boolFieldAccess.SuccessorBlocks.Should().Equal(isNullCheck);
             isNullCheck.TrueSuccessorBlock.Should().Be(returnBlock);
             isNullCheck.FalseSuccessorBlock.Should().Be(exitBlock);
-            returnBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            returnBlock.SuccessorBlocks.Should().Equal(exitBlock);
         }
 
         #endregion
@@ -2037,15 +2036,15 @@ public class Sample
 
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
-            cw0.SuccessorBlocks.Should().OnlyContain(b);
-            b.SuccessorBlocks.Should().OnlyContainInOrder(c, bc);
-            c.SuccessorBlocks.Should().OnlyContain(bc);
-            bc.SuccessorBlocks.Should().OnlyContainInOrder(e, cw3);
-            e.SuccessorBlocks.Should().OnlyContainInOrder(cw1, cw2);
-            cw1.SuccessorBlocks.Should().OnlyContain(cw3);
-            cw3.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            cw2.SuccessorBlocks.Should().OnlyContain(d);
-            d.SuccessorBlocks.Should().OnlyContain(b);
+            cw0.SuccessorBlocks.Should().Equal(b);
+            b.SuccessorBlocks.Should().Equal(c, bc);
+            c.SuccessorBlocks.Should().Equal(bc);
+            bc.SuccessorBlocks.Should().Equal(e, cw3);
+            e.SuccessorBlocks.Should().Equal(cw1, cw2);
+            cw1.SuccessorBlocks.Should().Equal(cw3);
+            cw3.SuccessorBlocks.Should().Equal(exitBlock);
+            cw2.SuccessorBlocks.Should().Equal(d);
+            d.SuccessorBlocks.Should().Equal(b);
 
             bc.Instructions.Should().BeEmpty();
         }
@@ -2067,7 +2066,7 @@ public class Sample
             var afterWhile = blocks[6];
             var exit = blocks[7];
 
-            beforeWhile.SuccessorBlocks.Should().OnlyContain(branchBlockB);
+            beforeWhile.SuccessorBlocks.Should().Equal(branchBlockB);
             branchBlockB.TrueSuccessorBlock.Should().Be(branchBlockC);
             branchBlockB.FalseSuccessorBlock.Should().Be(afterWhile);
             branchBlockC.TrueSuccessorBlock.Should().Be(branchBlockE);
@@ -2075,8 +2074,8 @@ public class Sample
             branchBlockE.TrueSuccessorBlock.Should().Be(trueBlock);
             branchBlockE.FalseSuccessorBlock.Should().Be(afterIf);
             trueBlock.SuccessorBlock.Should().Be(afterWhile);
-            afterIf.SuccessorBlocks.Should().OnlyContain(branchBlockB);
-            afterWhile.SuccessorBlocks.Should().OnlyContain(exit);
+            afterIf.SuccessorBlocks.Should().Equal(branchBlockB);
+            afterWhile.SuccessorBlocks.Should().Equal(exit);
         }
 
         [TestMethod]
@@ -2105,12 +2104,12 @@ public class Sample
 
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
-            cw0.SuccessorBlocks.Should().OnlyContain(xs);
-            xs.SuccessorBlocks.Should().OnlyContainInOrder(e, cw3);
-            e.SuccessorBlocks.Should().OnlyContainInOrder(cw1, cw2);
-            cw1.SuccessorBlocks.Should().OnlyContain(cw3);
-            cw3.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            cw2.SuccessorBlocks.Should().OnlyContain(xs);
+            cw0.SuccessorBlocks.Should().Equal(xs);
+            xs.SuccessorBlocks.Should().Equal(e, cw3);
+            e.SuccessorBlocks.Should().Equal(cw1, cw2);
+            cw1.SuccessorBlocks.Should().Equal(cw3);
+            cw3.SuccessorBlocks.Should().Equal(exitBlock);
+            cw2.SuccessorBlocks.Should().Equal(xs);
         }
 
         [TestMethod]
@@ -2131,16 +2130,16 @@ public class Sample
             var afterWhile = blocks[6];
             var exit = blocks[7];
 
-            beforeDo.SuccessorBlocks.Should().OnlyContain(branchBlockE);
+            beforeDo.SuccessorBlocks.Should().Equal(branchBlockE);
             branchBlockE.TrueSuccessorBlock.Should().Be(trueBlock);
             branchBlockE.FalseSuccessorBlock.Should().Be(afterIf);
             trueBlock.SuccessorBlock.Should().Be(afterWhile);
-            afterIf.SuccessorBlocks.Should().OnlyContain(branchBlockB);
+            afterIf.SuccessorBlocks.Should().Equal(branchBlockB);
             branchBlockB.TrueSuccessorBlock.Should().Be(branchBlockC);
             branchBlockB.FalseSuccessorBlock.Should().Be(afterWhile);
             branchBlockC.TrueSuccessorBlock.Should().Be(branchBlockE);
             branchBlockC.FalseSuccessorBlock.Should().Be(afterWhile);
-            afterWhile.SuccessorBlocks.Should().OnlyContain(exit);
+            afterWhile.SuccessorBlocks.Should().Equal(exit);
         }
 
         [TestMethod]
@@ -2165,14 +2164,14 @@ public class Sample
 
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
-            cw0.SuccessorBlocks.Should().OnlyContainInOrder(case1Branch);
+            cw0.SuccessorBlocks.Should().Equal(case1Branch);
             case1Branch.TrueSuccessorBlock.Should().Be(cw1);
             case1Branch.FalseSuccessorBlock.Should().Be(case2Branch);
             case2Branch.TrueSuccessorBlock.Should().Be(cw1);
             case2Branch.FalseSuccessorBlock.Should().Be(cw3);
 
-            cw1.SuccessorBlocks.Should().OnlyContain(cw3);
-            cw3.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            cw1.SuccessorBlocks.Should().Equal(cw3);
+            cw3.SuccessorBlocks.Should().Equal(exitBlock);
         }
 
         #endregion
@@ -2212,15 +2211,15 @@ public class Sample
 
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
-            cw0.SuccessorBlocks.Should().OnlyContain(b);
-            b.SuccessorBlocks.Should().OnlyContainInOrder(c, bc);
-            c.SuccessorBlocks.Should().OnlyContain(bc);
-            bc.SuccessorBlocks.Should().OnlyContainInOrder(e, cw3);
-            e.SuccessorBlocks.Should().OnlyContainInOrder(cw1, cw2);
-            cw1.SuccessorBlocks.Should().OnlyContain(d);
-            cw3.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            cw2.SuccessorBlocks.Should().OnlyContain(d);
-            d.SuccessorBlocks.Should().OnlyContain(b);
+            cw0.SuccessorBlocks.Should().Equal(b);
+            b.SuccessorBlocks.Should().Equal(c, bc);
+            c.SuccessorBlocks.Should().Equal(bc);
+            bc.SuccessorBlocks.Should().Equal(e, cw3);
+            e.SuccessorBlocks.Should().Equal(cw1, cw2);
+            cw1.SuccessorBlocks.Should().Equal(d);
+            cw3.SuccessorBlocks.Should().Equal(exitBlock);
+            cw2.SuccessorBlocks.Should().Equal(d);
+            d.SuccessorBlocks.Should().Equal(b);
 
             bc.Instructions.Should().BeEmpty();
         }
@@ -2242,7 +2241,7 @@ public class Sample
             var afterWhile = blocks[6];
             var exit = blocks[7];
 
-            beforeWhile.SuccessorBlocks.Should().OnlyContain(branchBlockB);
+            beforeWhile.SuccessorBlocks.Should().Equal(branchBlockB);
             branchBlockB.TrueSuccessorBlock.Should().Be(branchBlockC);
             branchBlockB.FalseSuccessorBlock.Should().Be(afterWhile);
             branchBlockC.TrueSuccessorBlock.Should().Be(branchBlockE);
@@ -2250,8 +2249,8 @@ public class Sample
             branchBlockE.TrueSuccessorBlock.Should().Be(trueBlock);
             branchBlockE.FalseSuccessorBlock.Should().Be(afterIf);
             trueBlock.SuccessorBlock.Should().Be(branchBlockB);
-            afterIf.SuccessorBlocks.Should().OnlyContain(branchBlockB);
-            afterWhile.SuccessorBlocks.Should().OnlyContain(exit);
+            afterIf.SuccessorBlocks.Should().Equal(branchBlockB);
+            afterWhile.SuccessorBlocks.Should().Equal(exit);
         }
 
         [TestMethod]
@@ -2280,12 +2279,12 @@ public class Sample
 
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
-            cw0.SuccessorBlocks.Should().OnlyContain(foreachBlock);
-            foreachBlock.SuccessorBlocks.Should().OnlyContainInOrder(e, cw3);
-            e.SuccessorBlocks.Should().OnlyContainInOrder(cw1, cw2);
-            cw1.SuccessorBlocks.Should().OnlyContain(foreachBlock);
-            cw3.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            cw2.SuccessorBlocks.Should().OnlyContain(foreachBlock);
+            cw0.SuccessorBlocks.Should().Equal(foreachBlock);
+            foreachBlock.SuccessorBlocks.Should().Equal(e, cw3);
+            e.SuccessorBlocks.Should().Equal(cw1, cw2);
+            cw1.SuccessorBlocks.Should().Equal(foreachBlock);
+            cw3.SuccessorBlocks.Should().Equal(exitBlock);
+            cw2.SuccessorBlocks.Should().Equal(foreachBlock);
 
             foreachBlock.Instructions.Should().BeEmpty();
         }
@@ -2327,8 +2326,8 @@ public class Sample
             foreachDecision.TrueSuccessorBlock.Should().Be(beforeTry);
             foreachDecision.FalseSuccessorBlock.Should().Be(afterForeach);
             beforeTry.SuccessorBlock.Should().Be(insideTry);
-            insideTry.SuccessorBlocks.Should().OnlyContainInOrder(insideFinally);
-            insideFinally.SuccessorBlocks.Should().OnlyContainInOrder(afterFinally, exit);
+            insideTry.SuccessorBlocks.Should().Equal(insideFinally);
+            insideFinally.SuccessorBlocks.Should().Equal(afterFinally, exit);
             afterFinally.SuccessorBlock.Should().Be(foreachDecision);
             afterForeach.SuccessorBlock.Should().Be(exit);
         }
@@ -2351,16 +2350,16 @@ public class Sample
             var afterWhile = blocks[6];
             var exit = blocks[7];
 
-            beforeDo.SuccessorBlocks.Should().OnlyContain(branchBlockE);
+            beforeDo.SuccessorBlocks.Should().Equal(branchBlockE);
             branchBlockE.TrueSuccessorBlock.Should().Be(trueBlock);
             branchBlockE.FalseSuccessorBlock.Should().Be(afterIf);
             trueBlock.SuccessorBlock.Should().Be(branchBlockB);
-            afterIf.SuccessorBlocks.Should().OnlyContain(branchBlockB);
+            afterIf.SuccessorBlocks.Should().Equal(branchBlockB);
             branchBlockB.TrueSuccessorBlock.Should().Be(branchBlockC);
             branchBlockB.FalseSuccessorBlock.Should().Be(afterWhile);
             branchBlockC.TrueSuccessorBlock.Should().Be(branchBlockE);
             branchBlockC.FalseSuccessorBlock.Should().Be(afterWhile);
-            afterWhile.SuccessorBlocks.Should().OnlyContain(exit);
+            afterWhile.SuccessorBlocks.Should().Equal(exit);
         }
 
         #endregion
@@ -2394,15 +2393,15 @@ public class Sample
 
             tryStartBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(tryStartBlock, "before", "before()");
-            tryStartBlock.SuccessorBlocks.Should().OnlyContain(insideTryBlock);
+            tryStartBlock.SuccessorBlocks.Should().Equal(insideTryBlock);
 
             insideTryBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(insideTryBlock, "inside", "inside()");
-            insideTryBlock.SuccessorBlocks.Should().OnlyContain(finallyBlock);
+            insideTryBlock.SuccessorBlocks.Should().Equal(finallyBlock);
 
             finallyBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(finallyBlock, "fin", "fin()");
-            finallyBlock.SuccessorBlocks.Should().OnlyContain(afterFinallyBlock, exit);
+            finallyBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock, exit);
 
             afterFinallyBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
@@ -2442,19 +2441,19 @@ public class Sample
 
             beforeTryBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(beforeTryBlock, "before", "before()");
-            beforeTryBlock.SuccessorBlocks.Should().OnlyContain(insideTryBlock);
+            beforeTryBlock.SuccessorBlocks.Should().Equal(insideTryBlock);
 
             insideTryBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(insideTryBlock, "inside", "inside()");
-            insideTryBlock.SuccessorBlocks.Should().OnlyContain(catchBlock1 /*caught ex*/, catchBlock2 /*caught ex*/, afterFinallyBlock /*no ex*/, exit /*uncaught ex*/);
+            insideTryBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { catchBlock1 /*caught ex*/, catchBlock2 /*caught ex*/, afterFinallyBlock /*no ex*/, exit /*uncaught ex*/});
 
             catchBlock1.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(catchBlock1, "cat1", "cat1()");
-            catchBlock1.SuccessorBlocks.Should().OnlyContain(afterFinallyBlock);
+            catchBlock1.SuccessorBlocks.Should().Equal(afterFinallyBlock);
 
             catchBlock2.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(catchBlock2, "cat2", "cat2()");
-            catchBlock2.SuccessorBlocks.Should().OnlyContain(afterFinallyBlock);
+            catchBlock2.SuccessorBlocks.Should().Equal(afterFinallyBlock);
 
             afterFinallyBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
@@ -2494,19 +2493,19 @@ public class Sample
 
             tryStartBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(tryStartBlock, "before", "before()");
-            tryStartBlock.SuccessorBlocks.Should().OnlyContain(tryEndBlock);
+            tryStartBlock.SuccessorBlocks.Should().Equal(tryEndBlock);
 
             tryEndBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(tryEndBlock, "inside", "inside()");
-            tryEndBlock.SuccessorBlocks.Should().OnlyContain(catchBlock1 /*caught ex*/, catchBlock2 /*caught ex*/, afterFinallyBlock /*no ex*/);
+            tryEndBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { catchBlock1 /*caught ex*/, catchBlock2 /*caught ex*/, afterFinallyBlock /*no ex*/});
 
             catchBlock1.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(catchBlock1, "cat1", "cat1()");
-            catchBlock1.SuccessorBlocks.Should().OnlyContain(afterFinallyBlock);
+            catchBlock1.SuccessorBlocks.Should().Equal(afterFinallyBlock);
 
             catchBlock2.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(catchBlock2, "cat2", "cat2()");
-            catchBlock2.SuccessorBlocks.Should().OnlyContain(afterFinallyBlock);
+            catchBlock2.SuccessorBlocks.Should().Equal(afterFinallyBlock);
 
             afterFinallyBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
@@ -2551,23 +2550,23 @@ public class Sample
 
             tryStartBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(tryStartBlock, "before", "before()");
-            tryStartBlock.SuccessorBlocks.Should().OnlyContain(insideTryBlock);
+            tryStartBlock.SuccessorBlocks.Should().Equal(insideTryBlock);
 
             insideTryBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(insideTryBlock, "inside", "inside()");
-            insideTryBlock.SuccessorBlocks.Should().OnlyContain(catchBlock1 /*caught ex*/, catchBlock2 /*caught ex*/, finallyBlock);
+            insideTryBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { catchBlock1 /*caught ex*/, catchBlock2 /*caught ex*/, finallyBlock });
 
             catchBlock1.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(catchBlock1, "cat1", "cat1()");
-            catchBlock1.SuccessorBlocks.Should().OnlyContain(finallyBlock);
+            catchBlock1.SuccessorBlocks.Should().Equal(finallyBlock);
 
             catchBlock2.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(catchBlock2, "cat2", "cat2()");
-            catchBlock2.SuccessorBlocks.Should().OnlyContain(finallyBlock);
+            catchBlock2.SuccessorBlocks.Should().Equal(finallyBlock);
 
             finallyBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(finallyBlock, "fin", "fin()");
-            finallyBlock.SuccessorBlocks.Should().OnlyContain(afterFinallyBlock, exit);
+            finallyBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock, exit);
 
             afterFinallyBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
@@ -2612,23 +2611,23 @@ public class Sample
 
             tryStartBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(tryStartBlock, "before", "before()");
-            tryStartBlock.SuccessorBlocks.Should().OnlyContain(tryEndBlock);
+            tryStartBlock.SuccessorBlocks.Should().Equal(tryEndBlock);
 
             tryEndBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(tryEndBlock, "inside", "inside()");
-            tryEndBlock.SuccessorBlocks.Should().OnlyContain(catchBlock1 /*caught ex*/, catchBlock2 /*caught ex*/, finallyBlock /*no ex*/);
+            tryEndBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { catchBlock1 /*caught ex*/, catchBlock2 /*caught ex*/, finallyBlock /*no ex*/});
 
             catchBlock1.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(catchBlock1, "cat1", "cat1()");
-            catchBlock1.SuccessorBlocks.Should().OnlyContain(finallyBlock);
+            catchBlock1.SuccessorBlocks.Should().Equal(finallyBlock);
 
             catchBlock2.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(catchBlock2, "cat2", "cat2()");
-            catchBlock2.SuccessorBlocks.Should().OnlyContain(finallyBlock);
+            catchBlock2.SuccessorBlocks.Should().Equal(finallyBlock);
 
             finallyBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(finallyBlock, "fin", "fin()");
-            finallyBlock.SuccessorBlocks.Should().OnlyContain(afterFinallyBlock, exit);
+            finallyBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock, exit);
 
             afterFinallyBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
@@ -2674,25 +2673,25 @@ public class Sample
             var exit = blocks[7];
 
             VerifyAllInstructions(tryStartBlock, "before", "before()");
-            tryStartBlock.SuccessorBlocks.Should().OnlyContain(binaryBlock);
+            tryStartBlock.SuccessorBlocks.Should().Equal(binaryBlock);
 
             VerifyAllInstructions(binaryBlock, "true");
-            binaryBlock.SuccessorBlocks.Should().OnlyContain(tryEndBlock /*false*/, returnBlock /*true*/);
+            binaryBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { tryEndBlock /*false*/, returnBlock /*true*/});
 
             VerifyAllInstructions(returnBlock);
-            returnBlock.SuccessorBlocks.Should().OnlyContain(finallyBlock);
+            returnBlock.SuccessorBlocks.Should().Equal(finallyBlock);
 
             VerifyAllInstructions(tryEndBlock, "inside", "inside()");
-            tryEndBlock.SuccessorBlocks.Should().OnlyContain(catchBlock /*exception thrown*/, finallyBlock /*no exception*/);
+            tryEndBlock.SuccessorBlocks.Should().Equal(catchBlock /*exception thrown*/, finallyBlock /*no exception*/);
 
             VerifyAllInstructions(catchBlock, "cat", "cat()");
-            catchBlock.SuccessorBlocks.Should().OnlyContain(finallyBlock);
+            catchBlock.SuccessorBlocks.Should().Equal(finallyBlock);
 
             VerifyAllInstructions(finallyBlock, "fin", "fin()");
-            finallyBlock.SuccessorBlocks.Should().OnlyContain(afterFinallyBlock, exit);
+            finallyBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock, exit);
 
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
-            afterFinallyBlock.SuccessorBlocks.Should().OnlyContain(exit);
+            afterFinallyBlock.SuccessorBlocks.Should().Equal(exit);
 
             blocks.Last().Should().BeOfType<ExitBlock>();
         }
@@ -2735,25 +2734,25 @@ public class Sample
             var exit = blocks[7];
 
             VerifyAllInstructions(tryStartBlock, "before", "before()");
-            tryStartBlock.SuccessorBlocks.Should().OnlyContain(binaryBlock);
+            tryStartBlock.SuccessorBlocks.Should().Equal(binaryBlock);
 
             VerifyAllInstructions(binaryBlock, "true");
-            binaryBlock.SuccessorBlocks.Should().OnlyContain(tryEndBlock /*false*/, returnBlock /*true*/);
+            binaryBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { tryEndBlock /*false*/, returnBlock /*true*/});
 
             VerifyAllInstructions(returnBlock);
-            returnBlock.SuccessorBlocks.Should().OnlyContain(finallyBlock);
+            returnBlock.SuccessorBlocks.Should().Equal(finallyBlock);
 
             VerifyAllInstructions(tryEndBlock, "inside", "inside()");
-            tryEndBlock.SuccessorBlocks.Should().OnlyContain(catchBlock /*caught exception thrown*/, finallyBlock);
+            tryEndBlock.SuccessorBlocks.Should().Equal(catchBlock /*caught exception thrown*/, finallyBlock);
 
             VerifyAllInstructions(catchBlock, "cat", "cat()");
-            catchBlock.SuccessorBlocks.Should().OnlyContain(finallyBlock);
+            catchBlock.SuccessorBlocks.Should().Equal(finallyBlock);
 
             VerifyAllInstructions(finallyBlock, "fin", "fin()");
-            finallyBlock.SuccessorBlocks.Should().OnlyContain(afterFinallyBlock, exit);
+            finallyBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock, exit);
 
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
-            afterFinallyBlock.SuccessorBlocks.Should().OnlyContain(exit);
+            afterFinallyBlock.SuccessorBlocks.Should().Equal(exit);
 
             blocks.Last().Should().BeOfType<ExitBlock>();
         }
@@ -2791,22 +2790,22 @@ public class Sample
             var exit = blocks[6];
 
             VerifyAllInstructions(tryStartBlock, "before", "before()");
-            tryStartBlock.SuccessorBlocks.Should().OnlyContain(binaryBlock);
+            tryStartBlock.SuccessorBlocks.Should().Equal(binaryBlock);
 
             VerifyAllInstructions(binaryBlock, "true");
-            binaryBlock.SuccessorBlocks.Should().OnlyContain(tryEndBlock /*false*/, returnBlock /*true*/);
+            binaryBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { tryEndBlock /*false*/, returnBlock /*true*/});
 
             VerifyAllInstructions(returnBlock);
-            returnBlock.SuccessorBlocks.Should().OnlyContain(exit);
+            returnBlock.SuccessorBlocks.Should().Equal(exit);
 
             VerifyAllInstructions(tryEndBlock, "inside", "inside()");
-            tryEndBlock.SuccessorBlocks.Should().OnlyContain(catchBlock /*caught exception thrown*/, afterFinallyBlock /*no exception*/, exit /*uncaught exception*/);
+            tryEndBlock.SuccessorBlocks.Should().Equal(catchBlock /*caught exception thrown*/, afterFinallyBlock /*no exception*/, exit /*uncaught exception*/);
 
             VerifyAllInstructions(catchBlock, "cat", "cat()");
-            catchBlock.SuccessorBlocks.Should().OnlyContain(afterFinallyBlock);
+            catchBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock);
 
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
-            afterFinallyBlock.SuccessorBlocks.Should().OnlyContain(exit);
+            afterFinallyBlock.SuccessorBlocks.Should().Equal(exit);
 
             blocks.Last().Should().BeOfType<ExitBlock>();
         }
@@ -2844,22 +2843,22 @@ public class Sample
             var exit = blocks[6];
 
             VerifyAllInstructions(tryStartBlock, "before", "before()");
-            tryStartBlock.SuccessorBlocks.Should().OnlyContain(binaryBlock);
+            tryStartBlock.SuccessorBlocks.Should().Equal(binaryBlock);
 
             VerifyAllInstructions(binaryBlock, "true");
-            binaryBlock.SuccessorBlocks.Should().OnlyContain(tryEndBlock /*false*/, returnBlock /*true*/);
+            binaryBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { tryEndBlock /*false*/, returnBlock /*true*/});
 
             VerifyAllInstructions(returnBlock);
-            returnBlock.SuccessorBlocks.Should().OnlyContain(exit);
+            returnBlock.SuccessorBlocks.Should().Equal(exit);
 
             VerifyAllInstructions(tryEndBlock, "inside", "inside()");
-            tryEndBlock.SuccessorBlocks.Should().OnlyContain(catchBlock /*caught exception thrown*/, afterFinallyBlock /*no exception*/);
+            tryEndBlock.SuccessorBlocks.Should().Equal(catchBlock /*caught exception thrown*/, afterFinallyBlock /*no exception*/);
 
             VerifyAllInstructions(catchBlock, "cat", "cat()");
-            catchBlock.SuccessorBlocks.Should().OnlyContain(afterFinallyBlock);
+            catchBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock);
 
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
-            afterFinallyBlock.SuccessorBlocks.Should().OnlyContain(exit);
+            afterFinallyBlock.SuccessorBlocks.Should().Equal(exit);
 
             blocks.Last().Should().BeOfType<ExitBlock>();
         }
@@ -2892,23 +2891,23 @@ public class Sample
 
             tryStartBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(tryStartBlock, "cw0", "cw0()");
-            tryStartBlock.SuccessorBlocks.Should().OnlyContain(tryBodyBlock);
+            tryStartBlock.SuccessorBlocks.Should().Equal(tryBodyBlock);
 
             tryBodyBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(tryBodyBlock, "cw1", "cw1()");
-            tryBodyBlock.SuccessorBlocks.Should().OnlyContain(whenBlock, afterTryBlock, exit);
+            tryBodyBlock.SuccessorBlocks.Should().Equal(whenBlock, afterTryBlock, exit);
 
             whenBlock.Should().BeOfType<BinaryBranchBlock>();
             VerifyAllInstructions(whenBlock, "e", "e is InvalidOperationException");
-            whenBlock.SuccessorBlocks.Should().OnlyContain(catchBlock, afterTryBlock);
+            whenBlock.SuccessorBlocks.Should().Equal(catchBlock, afterTryBlock);
 
             catchBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(catchBlock, "cw2", "cw2()");
-            catchBlock.SuccessorBlocks.Should().OnlyContain(afterTryBlock);
+            catchBlock.SuccessorBlocks.Should().Equal(afterTryBlock);
 
             afterTryBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(afterTryBlock, "cw5", "cw5()");
-            afterTryBlock.SuccessorBlocks.Should().OnlyContain(exit);
+            afterTryBlock.SuccessorBlocks.Should().Equal(exit);
 
             exit.Should().BeOfType<ExitBlock>();
         }
@@ -2942,23 +2941,23 @@ public class Sample
 
             tryStartBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(tryStartBlock, "false", "shouldCatch = false");
-            tryStartBlock.SuccessorBlocks.Should().OnlyContain(tryBodyBlock);
+            tryStartBlock.SuccessorBlocks.Should().Equal(tryBodyBlock);
 
             tryBodyBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(tryBodyBlock, "true", "shouldCatch = true", "\"bar\"", "new InvalidOperationException(\"bar\")");
-            tryBodyBlock.SuccessorBlocks.Should().OnlyContain(whenBlock, afterTryBlock, exit);
+            tryBodyBlock.SuccessorBlocks.Should().Equal(whenBlock, afterTryBlock, exit);
 
             whenBlock.Should().BeOfType<BinaryBranchBlock>();
             VerifyAllInstructions(whenBlock, "shouldCatch");
-            whenBlock.SuccessorBlocks.Should().OnlyContain(catchBlock, afterTryBlock);
+            whenBlock.SuccessorBlocks.Should().Equal(catchBlock, afterTryBlock);
 
             catchBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(catchBlock, "cw2", "cw2()");
-            catchBlock.SuccessorBlocks.Should().OnlyContain(afterTryBlock);
+            catchBlock.SuccessorBlocks.Should().Equal(afterTryBlock);
 
             afterTryBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(afterTryBlock, "cw5", "cw5()");
-            afterTryBlock.SuccessorBlocks.Should().OnlyContain(exit);
+            afterTryBlock.SuccessorBlocks.Should().Equal(exit);
 
             exit.Should().BeOfType<ExitBlock>();
         }
@@ -2998,27 +2997,27 @@ public class Sample
             var exit = (ExitBlock)blocks.Last();
 
             VerifyAllInstructions(beforeDoBlock, "0", "attempts = 0");
-            beforeDoBlock.SuccessorBlocks.Should().OnlyContain(doBlock);
+            beforeDoBlock.SuccessorBlocks.Should().Equal(doBlock);
 
             VerifyAllInstructions(doBlock, "cw0", "cw0()");
-            doBlock.SuccessorBlocks.Should().OnlyContainInOrder(tryBody);
+            doBlock.SuccessorBlocks.Should().Equal(tryBody);
 
             VerifyAllInstructions(tryBody, "attempts", "attempts++", "cw1", "cw1()");
             // this is wrong, the tryBody should not have a connection with whileStmt, it can lead to FNs
-            tryBody.SuccessorBlocks.Should().OnlyContainInOrder(catchBlock, whileStmt, afterDoWhile);
+            tryBody.SuccessorBlocks.Should().Equal(catchBlock, whileStmt, afterDoWhile);
 
             tryStatementBranch.ReversedInstructions.Should().BeEmpty();
-            tryStatementBranch.SuccessorBlocks.Should().OnlyContainInOrder(catchBlock, whileStmt);
+            tryStatementBranch.SuccessorBlocks.Should().Equal(catchBlock, whileStmt);
 
             VerifyAllInstructions(catchBlock, "cw2", "cw2()");
-            catchBlock.SuccessorBlocks.Should().OnlyContain(whileStmt);
+            catchBlock.SuccessorBlocks.Should().Equal(whileStmt);
 
             VerifyAllInstructions(whileStmt, "true");
             whileStmt.TrueSuccessorBlock.Should().Be(doBlock);
             whileStmt.FalseSuccessorBlock.Should().Be(afterDoWhile);
 
             VerifyAllInstructions(afterDoWhile, "cw5", "cw5()");
-            afterDoWhile.SuccessorBlocks.Should().OnlyContain(exit);
+            afterDoWhile.SuccessorBlocks.Should().Equal(exit);
 
             exit.Should().BeOfType<ExitBlock>();
         }
@@ -3066,12 +3065,12 @@ public class Sample
             var exit = (ExitBlock)blocks.Last();
 
             VerifyAllInstructions(doBeforeTry, "cw0", "cw0()");
-            doBeforeTry.SuccessorBlocks.Should().OnlyContainInOrder(tryStatement);
+            doBeforeTry.SuccessorBlocks.Should().Equal(tryStatement);
 
             VerifyAllInstructions(tryStatement, "cw1", "cw1()");
-            tryStatement.SuccessorBlocks.Should().OnlyContainInOrder(catchBody, finallyBlock, afterDoWhile);
+            tryStatement.SuccessorBlocks.Should().Equal(catchBody, finallyBlock, afterDoWhile);
 
-            tryBody.SuccessorBlocks.Should().OnlyContainInOrder(catchBody, finallyBlock);
+            tryBody.SuccessorBlocks.Should().Equal(catchBody, finallyBlock);
 
             VerifyAllInstructions(catchBody, "cw2", "cw2()");
             catchBody.SuccessorBlock.Should().Be(whileStmt);
@@ -3080,7 +3079,7 @@ public class Sample
             // - EXIT
             // - WHILE (because of `continue`)
             // - afterDoWhile (because of `break`)
-            finallyBlock.SuccessorBlocks.Should().OnlyContainInOrder(afterTry, exit);
+            finallyBlock.SuccessorBlocks.Should().Equal(afterTry, exit);
             afterTry.SuccessorBlock.Should().Be(whileStmt);
 
             VerifyAllInstructions(whileStmt, "true");
@@ -3088,7 +3087,7 @@ public class Sample
             whileStmt.FalseSuccessorBlock.Should().Be(afterDoWhile);
 
             VerifyAllInstructions(afterDoWhile, "cw5", "cw5()");
-            afterDoWhile.SuccessorBlocks.Should().OnlyContain(exit);
+            afterDoWhile.SuccessorBlocks.Should().Equal(exit);
 
             exit.Should().BeOfType<ExitBlock>();
         }
@@ -3153,9 +3152,9 @@ public class Sample
             elseIf.SuccessorBlock.Should().Be(afterDoWhile);
 
             // ToDo: this is weird and is basically skipped
-            tryStatement.SuccessorBlocks.Should().OnlyContainInOrder(finallyBody);
+            tryStatement.SuccessorBlocks.Should().Equal(finallyBody);
 
-            finallyBody.SuccessorBlocks.Should().OnlyContainInOrder(afterTry, exit);
+            finallyBody.SuccessorBlocks.Should().Equal(afterTry, exit);
             afterTry.SuccessorBlock.Should().Be(whileStmt);
 
             VerifyAllInstructions(whileStmt, "true");
@@ -3163,7 +3162,7 @@ public class Sample
             whileStmt.FalseSuccessorBlock.Should().Be(afterDoWhile);
 
             VerifyAllInstructions(afterDoWhile, "cw5", "cw5()");
-            afterDoWhile.SuccessorBlocks.Should().OnlyContain(exit);
+            afterDoWhile.SuccessorBlocks.Should().Equal(exit);
 
             exit.Should().BeOfType<ExitBlock>();
         }
@@ -3215,33 +3214,33 @@ public class Sample
             var exit = (ExitBlock)blocks.Last();
 
             VerifyAllInstructions(beforeDoBlock, "0", "attempts = 0");
-            beforeDoBlock.SuccessorBlocks.Should().OnlyContain(insideDoBeforeTry);
+            beforeDoBlock.SuccessorBlocks.Should().Equal(insideDoBeforeTry);
 
             VerifyAllInstructions(insideDoBeforeTry, "cw0", "cw0()");
-            insideDoBeforeTry.SuccessorBlocks.Should().OnlyContainInOrder(insideTry);
+            insideDoBeforeTry.SuccessorBlocks.Should().Equal(insideTry);
 
             VerifyAllInstructions(insideTry, "attempts", "attempts++", "cw1", "cw1()");
-            insideTry.SuccessorBlocks.Should().OnlyContainInOrder(catchBodyWithIf, whileStmt, afterDoWhile);
+            insideTry.SuccessorBlocks.Should().Equal(catchBodyWithIf, whileStmt, afterDoWhile);
 
             temporaryStrayBlock.ReversedInstructions.Should().BeEmpty();
-            temporaryStrayBlock.SuccessorBlocks.Should().OnlyContainInOrder(catchBodyWithIf, whileStmt);
+            temporaryStrayBlock.SuccessorBlocks.Should().Equal(catchBodyWithIf, whileStmt);
 
             VerifyAllInstructions(catchBodyWithIf, "cw2", "cw2()", "attempts", "retries", "attempts > retries");
             catchBodyWithIf.TrueSuccessorBlock.Should().Be(insideIfInsideCatch);
             catchBodyWithIf.FalseSuccessorBlock.Should().Be(afterIfInsideCatch);
 
             VerifyAllInstructions(insideIfInsideCatch, "cw3", "cw3()");
-            insideIfInsideCatch.SuccessorBlocks.Should().OnlyContain(exit);
+            insideIfInsideCatch.SuccessorBlocks.Should().Equal(exit);
 
             VerifyAllInstructions(afterIfInsideCatch, "cw4", "cw4()");
-            afterIfInsideCatch.SuccessorBlocks.Should().OnlyContain(whileStmt);
+            afterIfInsideCatch.SuccessorBlocks.Should().Equal(whileStmt);
 
             VerifyAllInstructions(whileStmt, "true");
             whileStmt.TrueSuccessorBlock.Should().Be(insideDoBeforeTry);
             whileStmt.FalseSuccessorBlock.Should().Be(afterDoWhile);
 
             VerifyAllInstructions(afterDoWhile, "cw5", "cw5()");
-            afterDoWhile.SuccessorBlocks.Should().OnlyContain(exit);
+            afterDoWhile.SuccessorBlocks.Should().Equal(exit);
 
             exit.Should().BeOfType<ExitBlock>();
         }
@@ -3281,10 +3280,10 @@ public class Sample
             var exit = (ExitBlock)blocks.Last();
 
             VerifyAllInstructions(beforeDoBlock, "0", "attempts = 0");
-            beforeDoBlock.SuccessorBlocks.Should().OnlyContain(insideDoBeforeTry);
+            beforeDoBlock.SuccessorBlocks.Should().Equal(insideDoBeforeTry);
 
             VerifyAllInstructions(insideDoBeforeTry, "cw0", "cw0()");
-            insideDoBeforeTry.SuccessorBlocks.Should().OnlyContainInOrder(insideTryIfStatement);
+            insideDoBeforeTry.SuccessorBlocks.Should().Equal(insideTryIfStatement);
 
             VerifyAllInstructions(insideTryIfStatement, "attempts");
             insideTryIfStatement.TrueSuccessorBlock.Should().Be(insideIf);
@@ -3292,9 +3291,9 @@ public class Sample
 
             insideIf.SuccessorBlock.Should().Be(finallyBifurcation);
 
-            finallyBifurcation.SuccessorBlocks.Should().OnlyContain(finallyBlock);
+            finallyBifurcation.SuccessorBlocks.Should().Equal(finallyBlock);
 
-            finallyBlock.SuccessorBlocks.Should().OnlyContainInOrder(whileStmt, exit);
+            finallyBlock.SuccessorBlocks.Should().Equal(whileStmt, exit);
 
             whileStmt.TrueSuccessorBlock.Should().Be(insideDoBeforeTry);
             whileStmt.FalseSuccessorBlock.Should().Be(afterDoWhile);
@@ -3356,35 +3355,35 @@ public class Sample
             exit.Should().BeOfType<ExitBlock>();
 
             beforeOuterTry.Should().BeOfType<SimpleBlock>();
-            beforeOuterTry.SuccessorBlocks.Should().OnlyContain(innerTryStartBlock);
+            beforeOuterTry.SuccessorBlocks.Should().Equal(innerTryStartBlock);
 
             innerTryStartBlock.Should().BeOfType<BranchBlock>();
-            innerTryStartBlock.SuccessorBlocks.Should().OnlyContain(innerReturnBlock /*no ex*/, outerCatchBlock, outerFinallyBlock);
+            innerTryStartBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { innerReturnBlock /*no ex*/, outerCatchBlock, outerFinallyBlock });
 
             innerReturnBlock.Should().BeOfType<BranchBlock>();
-            innerReturnBlock.SuccessorBlocks.Should().OnlyContain(innerTryEndBlock, innerCatchBlock);
+            innerReturnBlock.SuccessorBlocks.Should().Equal(innerTryEndBlock, innerCatchBlock);
 
             innerTryEndBlock.Should().BeOfType<JumpBlock>();
             VerifyAllInstructions(innerTryEndBlock, "foo", "foo()");
-            innerTryEndBlock.SuccessorBlocks.Should().OnlyContain(innerFinallyBlock);
+            innerTryEndBlock.SuccessorBlocks.Should().Equal(innerFinallyBlock);
 
             innerCatchBlock.Should().BeOfType<SimpleBlock>();
-            innerCatchBlock.SuccessorBlocks.Should().OnlyContain(innerFinallyBlock);
+            innerCatchBlock.SuccessorBlocks.Should().Equal(innerFinallyBlock);
 
             innerFinallyBlock.Should().BeOfType<BranchBlock>();
-            innerFinallyBlock.SuccessorBlocks.Should().OnlyContain(outerTryBlock, outerFinallyBlock);
+            innerFinallyBlock.SuccessorBlocks.Should().Equal(outerTryBlock, outerFinallyBlock);
 
             outerTryBlock.Should().BeOfType<BranchBlock>();
-            outerTryBlock.SuccessorBlocks.Should().OnlyContain(outerCatchBlock /*ex*/, outerFinallyBlock /*no ex*/);
+            outerTryBlock.SuccessorBlocks.Should().Equal(outerCatchBlock /*ex*/, outerFinallyBlock /*no ex*/);
 
             outerCatchBlock.Should().BeOfType<SimpleBlock>();
-            outerCatchBlock.SuccessorBlocks.Should().OnlyContain(outerFinallyBlock);
+            outerCatchBlock.SuccessorBlocks.Should().Equal(outerFinallyBlock);
 
             outerFinallyBlock.Should().BeOfType<BranchBlock>();
-            outerFinallyBlock.SuccessorBlocks.Should().OnlyContain(afterFinallyBlock, exit);
+            outerFinallyBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock, exit);
 
             afterFinallyBlock.Should().BeOfType<SimpleBlock>();
-            afterFinallyBlock.SuccessorBlocks.Should().OnlyContain(exit);
+            afterFinallyBlock.SuccessorBlocks.Should().Equal(exit);
         }
 
         [TestMethod]
@@ -3415,19 +3414,19 @@ public class Sample
             var exit = blocks[5];
 
             VerifyAllInstructions(beforeOuterTry, "5", "number = 5");
-            beforeOuterTry.SuccessorBlocks.Should().OnlyContain(tryStatementBlock);
+            beforeOuterTry.SuccessorBlocks.Should().Equal(tryStatementBlock);
 
             VerifyNoInstruction(tryStatementBlock);
-            tryStatementBlock.SuccessorBlocks.Should().OnlyContainInOrder(tryReturn, catchReturn);
+            tryStatementBlock.SuccessorBlocks.Should().Equal(tryReturn, catchReturn);
 
             VerifyAllInstructions(tryReturn, "bar", "bar()", "0");
-            tryReturn.SuccessorBlocks.Should().OnlyContain(exit);
+            tryReturn.SuccessorBlocks.Should().Equal(exit);
 
             VerifyAllInstructions(catchReturn, "number");
-            catchReturn.SuccessorBlocks.Should().OnlyContain(exit);
+            catchReturn.SuccessorBlocks.Should().Equal(exit);
 
             VerifyAllInstructions(afterTry, "foo", "foo()");
-            afterTry.SuccessorBlocks.Should().OnlyContain(exit);
+            afterTry.SuccessorBlocks.Should().Equal(exit);
 
             exit.Should().BeOfType<ExitBlock>();
         }
@@ -3461,22 +3460,22 @@ public class Sample
             var exit = (ExitBlock)blocks[6];
 
             VerifyAllInstructions(beforeOuterTry, "5", "number = 5");
-            beforeOuterTry.SuccessorBlocks.Should().OnlyContain(tryStatementBlock);
+            beforeOuterTry.SuccessorBlocks.Should().Equal(tryStatementBlock);
 
             VerifyNoInstruction(tryStatementBlock);
-            tryStatementBlock.SuccessorBlocks.Should().OnlyContainInOrder(tryReturn, ifInsideCatch);
+            tryStatementBlock.SuccessorBlocks.Should().Equal(tryReturn, ifInsideCatch);
 
             VerifyAllInstructions(tryReturn, "bar", "bar()", "0");
-            tryReturn.SuccessorBlocks.Should().OnlyContain(exit);
+            tryReturn.SuccessorBlocks.Should().Equal(exit);
 
             ifInsideCatch.TrueSuccessorBlock.Should().Be(returnInCatch);
             ifInsideCatch.FalseSuccessorBlock.Should().Be(afterTry);
 
             VerifyAllInstructions(returnInCatch, "number");
-            returnInCatch.SuccessorBlocks.Should().OnlyContain(exit);
+            returnInCatch.SuccessorBlocks.Should().Equal(exit);
 
             VerifyAllInstructions(afterTry, "foo", "foo()");
-            afterTry.SuccessorBlocks.Should().OnlyContain(exit);
+            afterTry.SuccessorBlocks.Should().Equal(exit);
 
             exit.Should().BeOfType<ExitBlock>();
         }
@@ -3513,7 +3512,7 @@ public class Sample
             var afterTry = (SimpleBlock)blocks[7];
             var exit = (ExitBlock)blocks[8];
 
-            beforeOuterTry.SuccessorBlocks.Should().OnlyContain(firstIf);
+            beforeOuterTry.SuccessorBlocks.Should().Equal(firstIf);
 
             firstIf.TrueSuccessorBlock.Should().Be(firstIfReturn);
             firstIfReturn.SuccessorBlock.Should().Be(exit);
@@ -3524,10 +3523,10 @@ public class Sample
             secondIf.FalseSuccessorBlock.Should().Be(tryStatementBranch);
 
             // ToDo: this tryStatementBranch is not always used as such, or is it?
-            tryStatementBranch.SuccessorBlocks.Should().OnlyContain(insideCatch, afterTry);
+            tryStatementBranch.SuccessorBlocks.Should().Equal(insideCatch, afterTry);
 
-            insideCatch.SuccessorBlocks.Should().OnlyContain(afterTry);
-            afterTry.SuccessorBlocks.Should().OnlyContain(exit);
+            insideCatch.SuccessorBlocks.Should().Equal(afterTry);
+            afterTry.SuccessorBlocks.Should().Equal(exit);
 
             exit.Should().BeOfType<ExitBlock>();
         }
@@ -3565,14 +3564,14 @@ public class Sample
 
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
-            cw0.SuccessorBlocks.Should().OnlyContainInOrder(branchCase1);
+            cw0.SuccessorBlocks.Should().Equal(branchCase1);
             branchCase1.TrueSuccessorBlock.Should().Be(case1Jump);
             branchCase1.FalseSuccessorBlock.Should().Be(branchCase2);
 
             branchCase2.TrueSuccessorBlock.Should().Be(case1Jump);
             branchCase2.FalseSuccessorBlock.Should().Be(branchCase3);
 
-            case1Jump.SuccessorBlocks.Should().OnlyContain(cw3);
+            case1Jump.SuccessorBlocks.Should().Equal(cw3);
 
             branchCase3.TrueSuccessorBlock.Should().Be(defaultCaseJump);
             branchCase3.FalseSuccessorBlock.Should().Be(branchDefault);
@@ -3580,11 +3579,11 @@ public class Sample
             branchDefault.TrueSuccessorBlock.Should().Be(defaultCaseJump);
             branchDefault.FalseSuccessorBlock.Should().Be(defaultCaseJump);
 
-            defaultCaseJump.SuccessorBlocks.Should().OnlyContain(cw3);
+            defaultCaseJump.SuccessorBlocks.Should().Equal(cw3);
 
-            cw1.SuccessorBlocks.Should().OnlyContain(cw3);
-            cw2.SuccessorBlocks.Should().OnlyContain(cw3);
-            cw3.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            cw1.SuccessorBlocks.Should().Equal(cw3);
+            cw2.SuccessorBlocks.Should().Equal(cw3);
+            cw3.SuccessorBlocks.Should().Equal(exitBlock);
 
             VerifyAllInstructions(cfg.EntryBlock, "cw0", "cw0()", "a");
             VerifyAllInstructions(cw1, "cw1", "cw1()");
@@ -3619,13 +3618,13 @@ public class Sample
 
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
-            cw0.SuccessorBlocks.Should().OnlyContainInOrder(branchCase1);
-            case1Jump.SuccessorBlocks.Should().OnlyContain(cw3);
-            case3Jump.SuccessorBlocks.Should().OnlyContain(cw3);
+            cw0.SuccessorBlocks.Should().Equal(branchCase1);
+            case1Jump.SuccessorBlocks.Should().Equal(cw3);
+            case3Jump.SuccessorBlocks.Should().Equal(cw3);
 
-            cw1.SuccessorBlocks.Should().OnlyContain(cw3);
-            cw2.SuccessorBlocks.Should().OnlyContain(cw3);
-            cw3.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            cw1.SuccessorBlocks.Should().Equal(cw3);
+            cw2.SuccessorBlocks.Should().Equal(cw3);
+            cw3.SuccessorBlocks.Should().Equal(exitBlock);
 
             branchCase2.Should().NotBeNull();
             branchCase3.Should().NotBeNull();
@@ -3661,9 +3660,9 @@ public class Sample
 
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
-            cw0.SuccessorBlocks.Should().OnlyContainInOrder(branchCase1);
-            case1Jump.SuccessorBlocks.Should().OnlyContain(defaultCaseJump);
-            defaultCaseJump.SuccessorBlocks.Should().OnlyContain(cw3);
+            cw0.SuccessorBlocks.Should().Equal(branchCase1);
+            case1Jump.SuccessorBlocks.Should().Equal(defaultCaseJump);
+            defaultCaseJump.SuccessorBlocks.Should().Equal(cw3);
 
             branchCase1.TrueSuccessorBlock.Should().Be(case1Jump);
             branchCase1.FalseSuccessorBlock.Should().Be(branchCase2);
@@ -3677,9 +3676,9 @@ public class Sample
             branchDefault.TrueSuccessorBlock.Should().Be(defaultCaseJump);
             branchDefault.FalseSuccessorBlock.Should().Be(defaultCaseJump);
 
-            cw1.SuccessorBlocks.Should().OnlyContain(defaultCaseJump);
-            cw2.SuccessorBlocks.Should().OnlyContain(cw3);
-            cw3.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            cw1.SuccessorBlocks.Should().Equal(defaultCaseJump);
+            cw2.SuccessorBlocks.Should().Equal(cw3);
+            cw3.SuccessorBlocks.Should().Equal(exitBlock);
         }
 
         [TestMethod]
@@ -3704,9 +3703,9 @@ public class Sample
 
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
-            cw0.SuccessorBlocks.Should().OnlyContainInOrder(branchEmpty);
-            caseEmptyJump.SuccessorBlocks.Should().OnlyContain(cw3);
-            caseAJump.SuccessorBlocks.Should().OnlyContain(caseEmptyJump);
+            cw0.SuccessorBlocks.Should().Equal(branchEmpty);
+            caseEmptyJump.SuccessorBlocks.Should().Equal(cw3);
+            caseAJump.SuccessorBlocks.Should().Equal(caseEmptyJump);
 
             branchEmpty.TrueSuccessorBlock.Should().Be(caseEmptyJump);
             branchEmpty.FalseSuccessorBlock.Should().Be(branchNull);
@@ -3747,9 +3746,9 @@ public class Sample
 
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
-            cw0.SuccessorBlocks.Should().OnlyContainInOrder(branchCase1);
-            case1Jump.SuccessorBlocks.Should().OnlyContain(defaultCaseJump);
-            defaultCaseJump.SuccessorBlocks.Should().OnlyContain(cw3);
+            cw0.SuccessorBlocks.Should().Equal(branchCase1);
+            case1Jump.SuccessorBlocks.Should().Equal(defaultCaseJump);
+            defaultCaseJump.SuccessorBlocks.Should().Equal(cw3);
 
             branchCase1.TrueSuccessorBlock.Should().Be(case1Jump);
             branchCase1.FalseSuccessorBlock.Should().Be(branchCase2);
@@ -3763,9 +3762,9 @@ public class Sample
             branchDefault.TrueSuccessorBlock.Should().Be(defaultCaseJump);
             branchDefault.FalseSuccessorBlock.Should().Be(defaultCaseJump);
 
-            cw1.SuccessorBlocks.Should().OnlyContain(defaultCaseJump);
-            cw2.SuccessorBlocks.Should().OnlyContain(cw3);
-            cw3.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            cw1.SuccessorBlocks.Should().Equal(defaultCaseJump);
+            cw2.SuccessorBlocks.Should().Equal(cw3);
+            cw3.SuccessorBlocks.Should().Equal(exitBlock);
         }
 
         [TestMethod]
@@ -3784,7 +3783,7 @@ public class Sample
             var lastBlock = (SimpleBlock)cfg.Blocks.ElementAt(6);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(7);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(caseIntBlock);
+            switchBlock.SuccessorBlocks.Should().Equal(caseIntBlock);
             VerifyAllInstructions(switchBlock, "cw0", "cw0()", "o");
 
             caseIntBlock.TrueSuccessorBlock.Should().Be(firstSectionBlock);
@@ -3825,7 +3824,7 @@ public class Sample
             var lastBlock = (SimpleBlock)cfg.Blocks.ElementAt(6);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(7);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(caseIntBlock);
+            switchBlock.SuccessorBlocks.Should().Equal(caseIntBlock);
             VerifyAllInstructions(switchBlock, "cw0", "cw0()", "o");
 
             caseIntBlock.TrueSuccessorBlock.Should().Be(caseIntWhenBlock);
@@ -3867,7 +3866,7 @@ public class Sample
             var afterSwitchBlock = (SimpleBlock)cfg.Blocks.ElementAt(6);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(7);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(caseZero);
+            switchBlock.SuccessorBlocks.Should().Equal(caseZero);
             VerifyAllInstructions(switchBlock, "cw", "cw()", "o");
 
             caseZero.TrueSuccessorBlock.Should().Be(caseZeroBlock);
@@ -3907,7 +3906,7 @@ public class Sample
             var afterSwitchBlock = (SimpleBlock)cfg.Blocks.ElementAt(5);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(6);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(caseOne);
+            switchBlock.SuccessorBlocks.Should().Equal(caseOne);
             VerifyAllInstructions(switchBlock, "cw", "cw()", "o");
 
             caseOne.SuccessorBlocks.Should().ContainInOrder(caseOneWhenBlock, defaultBlock);
@@ -4173,7 +4172,7 @@ var result = first switch {""a"" => second switch {""x"" => 1, _ => 2}, ""b"" =>
             var lastBlock = (SimpleBlock)cfg.Blocks.ElementAt(6);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(7);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(caseIntBlock);
+            switchBlock.SuccessorBlocks.Should().Equal(caseIntBlock);
             VerifyAllInstructions(switchBlock, "cw0", "cw0()", "o");
 
             caseIntBlock.TrueSuccessorBlock.Should().Be(firstSectionBlock);
@@ -4214,7 +4213,7 @@ var result = first switch {""a"" => second switch {""x"" => 1, _ => 2}, ""b"" =>
             var lastBlock = (SimpleBlock)cfg.Blocks.ElementAt(6);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(7);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(caseIntBlock);
+            switchBlock.SuccessorBlocks.Should().Equal(caseIntBlock);
             VerifyAllInstructions(switchBlock, "cw0", "cw0()", "o");
 
             caseIntBlock.TrueSuccessorBlock.Should().Be(firstSectionBlock);
@@ -4253,7 +4252,7 @@ var result = first switch {""a"" => second switch {""x"" => 1, _ => 2}, ""b"" =>
             var lastBlock = (SimpleBlock)cfg.Blocks.ElementAt(4);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(5);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(caseIntBlock);
+            switchBlock.SuccessorBlocks.Should().Equal(caseIntBlock);
             VerifyAllInstructions(switchBlock, "cw0", "cw0()", "o");
 
             caseIntBlock.TrueSuccessorBlock.Should().Be(firstSectionBlock);
@@ -4287,7 +4286,7 @@ var result = first switch {""a"" => second switch {""x"" => 1, _ => 2}, ""b"" =>
             var lastBlock = (SimpleBlock)cfg.Blocks.ElementAt(6);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(7);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(caseIntBlock);
+            switchBlock.SuccessorBlocks.Should().Equal(caseIntBlock);
             VerifyAllInstructions(switchBlock, "cw0", "cw0()", "o");
 
             caseIntBlock.TrueSuccessorBlock.Should().Be(intSectionBlock);
@@ -4333,7 +4332,7 @@ cw1(); // afterSwitchBlock
             var afterSwitchBlock = (SimpleBlock)cfg.Blocks.ElementAt(4);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(5);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(branchBlock);
+            switchBlock.SuccessorBlocks.Should().Equal(branchBlock);
             VerifyAllInstructions(switchBlock, "cw", "cw()", "o");
 
             branchBlock.TrueSuccessorBlock.Should().Be(caseZero);
@@ -4382,16 +4381,16 @@ cw1(); // afterSwitchBlock
             var afterSwitchBlock = (SimpleBlock)cfg.Blocks.ElementAt(7);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(8);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(case1Block);
+            switchBlock.SuccessorBlocks.Should().Equal(case1Block);
             case1Block.TrueSuccessorBlock.Should().Be(firstCaseIfBlock);
             case1Block.FalseSuccessorBlock.Should().Be(defaultBranchBlock);
             firstCaseIfBlock.TrueSuccessorBlock.Should().Be(trueBranchBlock);
             firstCaseIfBlock.FalseSuccessorBlock.Should().Be(falseBranchBlock);
-            trueBranchBlock.SuccessorBlocks.Should().OnlyContain(breakJump);
-            breakJump.SuccessorBlocks.Should().OnlyContain(afterSwitchBlock);
-            afterSwitchBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            falseBranchBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            defaultBranchBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            trueBranchBlock.SuccessorBlocks.Should().Equal(breakJump);
+            breakJump.SuccessorBlocks.Should().Equal(afterSwitchBlock);
+            afterSwitchBlock.SuccessorBlocks.Should().Equal(exitBlock);
+            falseBranchBlock.SuccessorBlocks.Should().Equal(exitBlock);
+            defaultBranchBlock.SuccessorBlocks.Should().Equal(exitBlock);
         }
 
         [TestMethod]
@@ -4418,7 +4417,7 @@ cw3();
             var afterSwitchBlock = (SimpleBlock)cfg.Blocks.ElementAt(7);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(8);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(patternCase);
+            switchBlock.SuccessorBlocks.Should().Equal(patternCase);
 
             patternCase.TrueSuccessorBlock.Should().Be(sublistAnyCondition);
             patternCase.FalseSuccessorBlock.Should().Be(defaultBlock);
@@ -4462,7 +4461,7 @@ switch (index)
             var defaultBlock = (JumpBlock)cfg.Blocks.ElementAt(4);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(5);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(caseZero);
+            switchBlock.SuccessorBlocks.Should().Equal(caseZero);
 
             caseZero.TrueSuccessorBlock.Should().Be(caseZeroWhenException);
             caseZero.FalseSuccessorBlock.Should().Be(defaultBlock);
@@ -4502,7 +4501,7 @@ switch (o)
             var breakBlock = (JumpBlock)cfg.Blocks.ElementAt(7);
             var exitBlock = (ExitBlock)cfg.Blocks.ElementAt(8);
 
-            switchBlock.SuccessorBlocks.Should().OnlyContain(caseZero);
+            switchBlock.SuccessorBlocks.Should().Equal(caseZero);
 
             caseZero.TrueSuccessorBlock.Should().Be(caseZeroWhenException);
             caseZero.FalseSuccessorBlock.Should().Be(caseOne);
@@ -4553,12 +4552,12 @@ switch (o)
             (a.JumpNode as LabeledStatementSyntax).Identifier.ValueText.Should().Be("a");
             (b.JumpNode as LabeledStatementSyntax).Identifier.ValueText.Should().Be("b");
 
-            entry.SuccessorBlocks.Should().OnlyContain(a);
-            a.SuccessorBlocks.Should().OnlyContain(b);
-            b.SuccessorBlocks.Should().OnlyContain(cond);
-            cond.SuccessorBlocks.Should().OnlyContainInOrder(cw1, cw2);
-            cw1.SuccessorBlocks.Should().OnlyContain(a);
-            cw2.SuccessorBlocks.Should().OnlyContain(cfg.ExitBlock);
+            entry.SuccessorBlocks.Should().Equal(a);
+            a.SuccessorBlocks.Should().Equal(b);
+            b.SuccessorBlocks.Should().Equal(cond);
+            cond.SuccessorBlocks.Should().Equal(cw1, cw2);
+            cw1.SuccessorBlocks.Should().Equal(a);
+            cw2.SuccessorBlocks.Should().Equal(cfg.ExitBlock);
         }
 
         [TestMethod]
@@ -4585,12 +4584,12 @@ switch (o)
             (a.JumpNode as LabeledStatementSyntax).Identifier.ValueText.Should().Be("a");
             (b.JumpNode as LabeledStatementSyntax).Identifier.ValueText.Should().Be("b");
 
-            entry.SuccessorBlocks.Should().OnlyContain(a);
-            a.SuccessorBlocks.Should().OnlyContain(b);
-            b.SuccessorBlocks.Should().OnlyContain(cond);
-            cond.SuccessorBlocks.Should().OnlyContainInOrder(cw1, cw2);
-            cw1.SuccessorBlocks.Should().OnlyContain(b);
-            cw2.SuccessorBlocks.Should().OnlyContain(cfg.ExitBlock);
+            entry.SuccessorBlocks.Should().Equal(a);
+            a.SuccessorBlocks.Should().Equal(b);
+            b.SuccessorBlocks.Should().Equal(cond);
+            cond.SuccessorBlocks.Should().Equal(cw1, cw2);
+            cw1.SuccessorBlocks.Should().Equal(b);
+            cw2.SuccessorBlocks.Should().Equal(cfg.ExitBlock);
         }
 
         #endregion
@@ -5122,15 +5121,15 @@ namespace NS
             var loopBodyBlock = blocks[2];
             var exitBlock = cfg.ExitBlock;
 
-            initBlock.SuccessorBlocks.Should().OnlyContain(branchBlock);
+            initBlock.SuccessorBlocks.Should().Equal(branchBlock);
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForStatement);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(incrementorBlock);
-            incrementorBlock.SuccessorBlocks.Should().OnlyContain(branchBlock);
-            branchBlock.PredecessorBlocks.Should().OnlyContain(initBlock, incrementorBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(branchBlock);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(incrementorBlock);
+            incrementorBlock.SuccessorBlocks.Should().Equal(branchBlock);
+            branchBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { initBlock, incrementorBlock });
+            exitBlock.PredecessorBlocks.Should().Equal(branchBlock);
         }
 
         private static void VerifyInstructions(Block block, int fromIndex, params string[] instructions)
@@ -5173,7 +5172,7 @@ namespace NS
         {
             VerifyCfg(cfg, 2);
 
-            cfg.EntryBlock.SuccessorBlocks.Should().OnlyContain(cfg.ExitBlock);
+            cfg.EntryBlock.SuccessorBlocks.Should().Equal(cfg.ExitBlock);
         }
 
         private static void VerifyEmptyCfg(IControlFlowGraph cfg) =>
@@ -5203,13 +5202,13 @@ namespace NS
 
             initializerBlock.SuccessorBlock.Should().Be(branchBlock);
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForStatement);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(incrementorBlock);
-            incrementorBlock.SuccessorBlocks.Should().OnlyContain(branchBlock);
-            branchBlock.PredecessorBlocks.Should().OnlyContain(incrementorBlock, initializerBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(branchBlock);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(incrementorBlock);
+            incrementorBlock.SuccessorBlocks.Should().Equal(branchBlock);
+            branchBlock.PredecessorBlocks.Should().Equal(incrementorBlock, initializerBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(branchBlock);
         }
 
         private static void VerifyForStatementNoIncrementor(IControlFlowGraph cfg)
@@ -5222,16 +5221,16 @@ namespace NS
                 .First(b => b.Instructions.Any(n => n.ToString() == "x = 10"));
             var exitBlock = cfg.ExitBlock;
 
-            initBlock.SuccessorBlocks.Should().OnlyContain(branchBlock);
+            initBlock.SuccessorBlocks.Should().Equal(branchBlock);
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForStatement);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(branchBlock);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(branchBlock);
 
-            branchBlock.PredecessorBlocks.Should().OnlyContain(initBlock, loopBodyBlock);
+            branchBlock.PredecessorBlocks.Should().Equal(initBlock, loopBodyBlock);
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(branchBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(branchBlock);
         }
 
         private static void VerifyForStatementEmpty(IControlFlowGraph cfg)
@@ -5246,12 +5245,12 @@ namespace NS
 
             initializerBlock.SuccessorBlock.Should().Be(branchBlock);
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(loopBodyBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForStatement);
 
-            loopBodyBlock.SuccessorBlocks.Should().OnlyContain(branchBlock);
-            branchBlock.PredecessorBlocks.Should().OnlyContain(loopBodyBlock, initializerBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(branchBlock);
+            loopBodyBlock.SuccessorBlocks.Should().Equal(branchBlock);
+            branchBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, initializerBlock });
+            exitBlock.PredecessorBlocks.Should().Equal(branchBlock);
         }
 
         private static void VerifySimpleJumpBlock(IControlFlowGraph cfg, SyntaxKind kind)
@@ -5261,8 +5260,8 @@ namespace NS
             var bodyBlock = cfg.Blocks.ToList()[1];
             var exitBlock = cfg.ExitBlock;
 
-            jumpBlock.SuccessorBlocks.Should().OnlyContain(bodyBlock);
-            bodyBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            jumpBlock.SuccessorBlocks.Should().Equal(bodyBlock);
+            bodyBlock.SuccessorBlocks.Should().Equal(exitBlock);
 
             jumpBlock.JumpNode.Kind().Should().Be(kind);
         }
@@ -5276,11 +5275,11 @@ namespace NS
             var falseBlock = blocks[2];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(trueBlock, falseBlock);
-            trueBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(trueBlock, falseBlock);
+            trueBlock.SuccessorBlocks.Should().Equal(exitBlock);
             trueBlock.JumpNode.Kind().Should().Be(kind);
-            falseBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
-            exitBlock.PredecessorBlocks.Should().OnlyContain(trueBlock, falseBlock);
+            falseBlock.SuccessorBlocks.Should().Equal(exitBlock);
+            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { trueBlock, falseBlock });
         }
 
         private static void VerifyJumpWithExpression(IControlFlowGraph cfg, SyntaxKind kind)
@@ -5292,13 +5291,13 @@ namespace NS
             var falseBlock = blocks[2];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().OnlyContainInOrder(trueBlock, falseBlock);
-            trueBlock.SuccessorBlocks.Should().OnlyContain(exitBlock);
+            branchBlock.SuccessorBlocks.Should().Equal(trueBlock, falseBlock);
+            trueBlock.SuccessorBlocks.Should().Equal(exitBlock);
             trueBlock.JumpNode.Kind().Should().Be(kind);
 
             trueBlock.Instructions.Should().Contain(n => n.IsKind(SyntaxKind.IdentifierName) && n.ToString() == "ii");
 
-            exitBlock.PredecessorBlocks.Should().OnlyContain(trueBlock, falseBlock);
+            exitBlock.PredecessorBlocks.Should().Equal(trueBlock, falseBlock);
         }
 
         #endregion

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
@@ -284,11 +284,11 @@ public class Sample
             var trueBlock = cfg.Blocks.ToList()[1];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().Equal(trueBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlock, exitBlock });
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
             trueBlock.SuccessorBlocks.Should().Equal(exitBlock);
-            exitBlock.PredecessorBlocks.Should().Equal(branchBlock, trueBlock);
+            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { branchBlock, trueBlock });
 
             VerifyAllInstructions(branchBlock, "true");
             VerifyAllInstructions(trueBlock, "10", "x = 10");
@@ -364,7 +364,7 @@ public class Sample
             var falseBlock = cfg.Blocks.ToList()[2];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().Equal(trueBlock, falseBlock);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlock, falseBlock });
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
             trueBlock.SuccessorBlocks.Should().Equal(exitBlock);
@@ -383,15 +383,15 @@ public class Sample
             var trueBlockY = cfg.Blocks.ToList()[3];
             var exitBlock = cfg.ExitBlock;
 
-            firstCondition.SuccessorBlocks.Should().Equal(trueBlockX, secondCondition);
+            firstCondition.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlockX, secondCondition });
             firstCondition.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
             trueBlockX.SuccessorBlocks.Should().Equal(exitBlock);
 
-            secondCondition.SuccessorBlocks.Should().Equal(trueBlockY, exitBlock);
+            secondCondition.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlockY, exitBlock });
             secondCondition.BranchingNode.Kind().Should().Be(SyntaxKind.FalseLiteralExpression);
 
-            exitBlock.PredecessorBlocks.Should().Equal(trueBlockX, trueBlockY, secondCondition);
+            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { trueBlockX, trueBlockY, secondCondition });
         }
 
         [TestMethod]
@@ -406,18 +406,18 @@ public class Sample
             var falseBlockZ = cfg.Blocks.ToList()[4];
             var exitBlock = cfg.ExitBlock;
 
-            firstCondition.SuccessorBlocks.Should().Equal(trueBlockX, secondCondition);
+            firstCondition.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlockX, secondCondition });
             firstCondition.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
             trueBlockX.SuccessorBlocks.Should().Equal(exitBlock);
 
-            secondCondition.SuccessorBlocks.Should().Equal(trueBlockY, falseBlockZ);
+            secondCondition.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlockY, falseBlockZ });
             secondCondition.BranchingNode.Kind().Should().Be(SyntaxKind.FalseLiteralExpression);
 
             trueBlockY.SuccessorBlocks.Should().Equal(exitBlock);
             falseBlockZ.SuccessorBlocks.Should().Equal(exitBlock);
 
-            exitBlock.PredecessorBlocks.Should().Equal(trueBlockX, trueBlockY, falseBlockZ);
+            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { trueBlockX, trueBlockY, falseBlockZ });
         }
 
         [TestMethod]
@@ -435,10 +435,10 @@ public class Sample
             var falseBlockY = cfg.Blocks.ToList()[3];
             var exitBlock = cfg.ExitBlock;
 
-            firstCondition.SuccessorBlocks.Should().Equal(secondCondition, exitBlock);
+            firstCondition.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { secondCondition, exitBlock });
             firstCondition.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
-            secondCondition.SuccessorBlocks.Should().Equal(trueBlockX, falseBlockY);
+            secondCondition.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlockX, falseBlockY });
             secondCondition.BranchingNode.Kind().Should().Be(SyntaxKind.FalseLiteralExpression);
 
             trueBlockX.SuccessorBlocks.Should().Equal(exitBlock);
@@ -464,7 +464,7 @@ public class Sample
 
             branchBlockA.TrueSuccessorBlock.Should().Be(branchBlockB);
             branchBlockA.FalseSuccessorBlock.Should().Be(branchBlockALeft);
-            branchBlockALeft.SuccessorBlocks.Should().Equal(trueBlock, exit);
+            branchBlockALeft.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlock, exit });
             branchBlockB.TrueSuccessorBlock.Should().Be(trueBlock);
             branchBlockB.FalseSuccessorBlock.Should().Be(exit);
             trueBlock.SuccessorBlocks.Should().Equal(exit);
@@ -487,7 +487,7 @@ public class Sample
 
             branchBlockX.TrueSuccessorBlock.Should().Be(branchBlockY);
             branchBlockX.FalseSuccessorBlock.Should().Be(branchBlockXLeft);
-            branchBlockXLeft.SuccessorBlocks.Should().Equal(condTrue, condFalse);
+            branchBlockXLeft.SuccessorBlocks.Should().BeEquivalentTo(new[] { condTrue, condFalse });
             branchBlockY.TrueSuccessorBlock.Should().Be(condTrue);
             branchBlockY.FalseSuccessorBlock.Should().Be(condFalse);
 
@@ -515,11 +515,11 @@ public class Sample
             var falseBlock = cfg.Blocks.ElementAt(3);
             var exitBlock = cfg.ExitBlock;
 
-            xBranchBlock.SuccessorBlocks.Should().Equal(oBranchBlock, falseBlock);
+            xBranchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { oBranchBlock, falseBlock });
             xBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKindEx.IsPatternExpression);
             VerifyAllInstructions(xBranchBlock, "cw0", "cw0()", "x", "10", "x is 10");
 
-            oBranchBlock.SuccessorBlocks.Should().Equal(trueBlock, falseBlock);
+            oBranchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlock, falseBlock });
             oBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKindEx.IsPatternExpression);
             VerifyAllInstructions(oBranchBlock, "o", "null", "o is null");
 
@@ -544,11 +544,11 @@ public class Sample
             var falseBlock = cfg.Blocks.ElementAt(3);
             var exitBlock = cfg.ExitBlock;
 
-            xBranchBlock.SuccessorBlocks.Should().Equal(oBranchBlock, falseBlock);
+            xBranchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { oBranchBlock, falseBlock });
             xBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKindEx.IsPatternExpression);
             VerifyAllInstructions(xBranchBlock, "cw0", "cw0()", "x", "x is int i");
 
-            oBranchBlock.SuccessorBlocks.Should().Equal(trueBlock, falseBlock);
+            oBranchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlock, falseBlock });
             oBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKindEx.IsPatternExpression);
             VerifyAllInstructions(oBranchBlock, "o", "o is string s");
 
@@ -600,7 +600,7 @@ public class Sample
                 .First(b => b.Instructions.Any(n => n.ToString() == "x = 10"));
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, exitBlock });
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(branchBlock);
@@ -661,7 +661,7 @@ public class Sample
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(branchBlockA);
 
-            exitBlock.PredecessorBlocks.Should().Equal(branchBlockB, branchBlockA);
+            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { branchBlockB, branchBlockA });
 
             VerifyAllInstructions(branchBlockA, "a");
             VerifyAllInstructions(branchBlockB, "b");
@@ -682,15 +682,15 @@ public class Sample
             secondBranchBlock.Instructions.Should().Contain(n => n.IsKind(SyntaxKind.FalseLiteralExpression));
             var exitBlock = cfg.ExitBlock;
 
-            firstBranchBlock.SuccessorBlocks.Should().Equal(secondBranchBlock, exitBlock);
+            firstBranchBlock.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { secondBranchBlock, exitBlock });
             firstBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
-            secondBranchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, firstBranchBlock);
+            secondBranchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, firstBranchBlock });
             secondBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.FalseLiteralExpression);
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(secondBranchBlock);
             firstBranchBlock.PredecessorBlocks.Should().Equal(secondBranchBlock);
-            secondBranchBlock.PredecessorBlocks.Should().Equal(firstBranchBlock, loopBodyBlock);
+            secondBranchBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { firstBranchBlock, loopBodyBlock });
             exitBlock.PredecessorBlocks.Should().Equal(firstBranchBlock);
         }
 
@@ -733,7 +733,7 @@ public class Sample
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(branchBlock);
 
-            branchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, exitBlock });
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
             branchBlock.PredecessorBlocks.Should().Equal(loopBodyBlock);
@@ -758,10 +758,10 @@ public class Sample
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(falseBranchBlock);
 
-            falseBranchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, trueBranchBlock);
+            falseBranchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, trueBranchBlock });
             falseBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.FalseLiteralExpression);
 
-            trueBranchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
+            trueBranchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, exitBlock });
             trueBranchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.TrueLiteralExpression);
 
             falseBranchBlock.PredecessorBlocks.Should().Equal(loopBodyBlock);
@@ -798,7 +798,7 @@ public class Sample
             defBlock.SuccessorBlocks.Should().Equal(ifBlock);
             VerifyAllInstructions(defBlock, "p");
 
-            ifBlock.SuccessorBlocks.Should().Equal(continueJump, doCondition);
+            ifBlock.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { continueJump, doCondition });
             ifBlock.BranchingNode.Kind().Should().Be(SyntaxKind.InvocationExpression);
             VerifyAllInstructions(ifBlock, "unknown", "unknown()", "p = unknown()", "unknown", "unknown()");
 
@@ -806,7 +806,7 @@ public class Sample
             continueJump.JumpNode.Kind().Should().Be(SyntaxKind.ContinueStatement);
             VerifyAllInstructions(continueJump, "0", "p = 0");
 
-            doCondition.SuccessorBlocks.Should().Equal(ifBlock, exitBlock);
+            doCondition.SuccessorBlocks.Should().BeEquivalentTo(new[] { ifBlock, exitBlock });
             doCondition.BranchingNode.Kind().Should().Be(SyntaxKind.LogicalNotExpression);
             VerifyAllInstructions(doCondition, "p", "!p");
 
@@ -832,7 +832,7 @@ public class Sample
 
             collectionBlock.SuccessorBlocks.Should().Contain(foreachBlock);
 
-            foreachBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
+            foreachBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, exitBlock });
             foreachBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForEachStatement);
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(foreachBlock);
@@ -866,12 +866,12 @@ public class Sample
 
             collection1Block.SuccessorBlocks.Should().Contain(foreach1Block);
 
-            foreach1Block.SuccessorBlocks.Should().Equal(collection2Block, exitBlock);
+            foreach1Block.SuccessorBlocks.Should().BeEquivalentTo(new[] { collection2Block, exitBlock });
             foreach1Block.BranchingNode.Kind().Should().Be(SyntaxKind.ForEachStatement);
 
             collection2Block.SuccessorBlocks.Should().Contain(foreach2Block);
 
-            foreach2Block.SuccessorBlocks.Should().Equal(loopBodyBlock, foreach1Block);
+            foreach2Block.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, foreach1Block });
             foreach2Block.BranchingNode.Kind().Should().Be(SyntaxKind.ForEachStatement);
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(foreach2Block);
@@ -901,7 +901,7 @@ public class Sample
 
             forEachCollectionBlock.SuccessorBlocks.Should().Contain(foreachBlock);
 
-            foreachBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
+            foreachBlock.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { loopBodyBlock, exitBlock });
             foreachBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForEachVariableStatement);
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(foreachBlock);
@@ -924,7 +924,7 @@ public class Sample
             collectionBlock.SuccessorBlocks.Should().Contain(foreachBlock);
             VerifyAllInstructions(collectionBlock, "GetAsync", "GetAsync()");
 
-            foreachBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
+            foreachBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, exitBlock });
             foreachBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForEachStatement);
             VerifyNoInstruction(foreachBlock);
 
@@ -1016,12 +1016,12 @@ public class Sample
 
             initBlockI.SuccessorBlocks.Should().Equal(branchBlockTrue);
 
-            branchBlockTrue.SuccessorBlocks.Should().Equal(initBlockJ, exitBlock);
+            branchBlockTrue.SuccessorBlocks.Should().BeEquivalentTo(new[] { initBlockJ, exitBlock });
             branchBlockTrue.BranchingNode.Kind().Should().Be(SyntaxKind.ForStatement);
 
             initBlockJ.SuccessorBlocks.Should().Equal(branchBlockFalse);
 
-            branchBlockFalse.SuccessorBlocks.Should().Equal(loopBodyBlock, incrementorBlockI);
+            branchBlockFalse.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, incrementorBlockI });
             branchBlockFalse.BranchingNode.Kind().Should().Be(SyntaxKind.ForStatement);
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(incrementorBlockJ);
@@ -1270,7 +1270,7 @@ public class Sample
             var afterOp = blocks[2];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().Equal(trueABlock, afterOp);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueABlock, afterOp });
             trueABlock.SuccessorBlocks.Should().Equal(afterOp);
             afterOp.SuccessorBlocks.Should().Equal(exitBlock);
 
@@ -1293,7 +1293,7 @@ public class Sample
             var afterOp = blocks[2];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().Equal(afterOp, falseABlock);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { afterOp, falseABlock });
             falseABlock.SuccessorBlocks.Should().Equal(afterOp);
             afterOp.SuccessorBlocks.Should().Equal(exitBlock);
 
@@ -1318,9 +1318,9 @@ public class Sample
             var afterOp = blocks[4];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().Equal(trueABlock, afterAC);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueABlock, afterAC });
             trueABlock.SuccessorBlocks.Should().Equal(afterAC);
-            afterAC.SuccessorBlocks.Should().Equal(trueACBlock, afterOp);
+            afterAC.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueACBlock, afterOp });
             trueACBlock.SuccessorBlocks.Should().Equal(afterOp);
             afterOp.SuccessorBlocks.Should().Equal(exitBlock);
         }
@@ -1345,9 +1345,9 @@ public class Sample
             var exitBlock = cfg.ExitBlock;
 
             initBlock.SuccessorBlocks.Should().Equal(aBlock);
-            aBlock.SuccessorBlocks.Should().Equal(cBlock, acBlock);
+            aBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { cBlock, acBlock });
             cBlock.SuccessorBlocks.Should().Equal(acBlock);
-            acBlock.SuccessorBlocks.Should().Equal(bodyBlock, exitBlock);
+            acBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { bodyBlock, exitBlock });
             bodyBlock.SuccessorBlocks.Should().Equal(incrementBlock);
             incrementBlock.SuccessorBlocks.Should().Equal(aBlock);
 
@@ -1369,7 +1369,7 @@ public class Sample
             var assignmentBlock = blocks[2];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().Equal(bNullBlock, assignmentBlock);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { bNullBlock, assignmentBlock });
             bNullBlock.SuccessorBlocks.Should().Equal(assignmentBlock);
             assignmentBlock.SuccessorBlocks.Should().Equal(exitBlock);
 
@@ -1673,7 +1673,7 @@ public class Sample
             var after = blocks[3];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().Equal(condTrue, condFalse);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { condTrue, condFalse });
             condFalse.SuccessorBlocks.Should().Equal(after);
             condTrue.SuccessorBlocks.Should().Equal(after);
             after.SuccessorBlocks.Should().Equal(exitBlock);
@@ -1759,7 +1759,7 @@ public class Sample
             var cond3Block = blocks[4];
             VerifyAllInstructions(cond3Block, "cond3");
 
-            branchBlock.SuccessorBlocks.Should().Equal(cond2Block, cond3Block);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { cond2Block, cond3Block });
             cond2Block.SuccessorBlocks.Should().HaveCount(2);
             cond3Block.SuccessorBlocks.Should().HaveCount(2);
 
@@ -1799,7 +1799,7 @@ public class Sample
             var assignmentBlock = blocks[3] as SimpleBlock;
             var exitBlock = cfg.ExitBlock;
 
-            binaryBranch.SuccessorBlocks.Should().Equal(trueBlock, falseJumpBlock);
+            binaryBranch.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlock, falseJumpBlock });
             trueBlock.SuccessorBlocks.Should().Equal(assignmentBlock);
             falseJumpBlock.SuccessorBlock.Should().Be(exitBlock);
             falseJumpBlock.WouldBeSuccessor.Should().Be(assignmentBlock);
@@ -2037,10 +2037,10 @@ public class Sample
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
             cw0.SuccessorBlocks.Should().Equal(b);
-            b.SuccessorBlocks.Should().Equal(c, bc);
+            b.SuccessorBlocks.Should().BeEquivalentTo(new[] { c, bc });
             c.SuccessorBlocks.Should().Equal(bc);
-            bc.SuccessorBlocks.Should().Equal(e, cw3);
-            e.SuccessorBlocks.Should().Equal(cw1, cw2);
+            bc.SuccessorBlocks.Should().BeEquivalentTo(new[] { e, cw3 });
+            e.SuccessorBlocks.Should().BeEquivalentTo(new[] { cw1, cw2 });
             cw1.SuccessorBlocks.Should().Equal(cw3);
             cw3.SuccessorBlocks.Should().Equal(exitBlock);
             cw2.SuccessorBlocks.Should().Equal(d);
@@ -2105,8 +2105,8 @@ public class Sample
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
             cw0.SuccessorBlocks.Should().Equal(xs);
-            xs.SuccessorBlocks.Should().Equal(e, cw3);
-            e.SuccessorBlocks.Should().Equal(cw1, cw2);
+            xs.SuccessorBlocks.Should().BeEquivalentTo(new[] { e, cw3 });
+            e.SuccessorBlocks.Should().BeEquivalentTo(new[] { cw1, cw2 });
             cw1.SuccessorBlocks.Should().Equal(cw3);
             cw3.SuccessorBlocks.Should().Equal(exitBlock);
             cw2.SuccessorBlocks.Should().Equal(xs);
@@ -2212,10 +2212,10 @@ public class Sample
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
             cw0.SuccessorBlocks.Should().Equal(b);
-            b.SuccessorBlocks.Should().Equal(c, bc);
+            b.SuccessorBlocks.Should().BeEquivalentTo(new[] { c, bc });
             c.SuccessorBlocks.Should().Equal(bc);
-            bc.SuccessorBlocks.Should().Equal(e, cw3);
-            e.SuccessorBlocks.Should().Equal(cw1, cw2);
+            bc.SuccessorBlocks.Should().BeEquivalentTo(new[] { e, cw3 });
+            e.SuccessorBlocks.Should().BeEquivalentTo(new[] { cw1, cw2 });
             cw1.SuccessorBlocks.Should().Equal(d);
             cw3.SuccessorBlocks.Should().Equal(exitBlock);
             cw2.SuccessorBlocks.Should().Equal(d);
@@ -2280,8 +2280,8 @@ public class Sample
             cw0.Should().BeSameAs(cfg.EntryBlock);
 
             cw0.SuccessorBlocks.Should().Equal(foreachBlock);
-            foreachBlock.SuccessorBlocks.Should().Equal(e, cw3);
-            e.SuccessorBlocks.Should().Equal(cw1, cw2);
+            foreachBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { e, cw3 });
+            e.SuccessorBlocks.Should().BeEquivalentTo(new[] { cw1, cw2 });
             cw1.SuccessorBlocks.Should().Equal(foreachBlock);
             cw3.SuccessorBlocks.Should().Equal(exitBlock);
             cw2.SuccessorBlocks.Should().Equal(foreachBlock);
@@ -2327,7 +2327,7 @@ public class Sample
             foreachDecision.FalseSuccessorBlock.Should().Be(afterForeach);
             beforeTry.SuccessorBlock.Should().Be(insideTry);
             insideTry.SuccessorBlocks.Should().Equal(insideFinally);
-            insideFinally.SuccessorBlocks.Should().Equal(afterFinally, exit);
+            insideFinally.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { afterFinally, exit });
             afterFinally.SuccessorBlock.Should().Be(foreachDecision);
             afterForeach.SuccessorBlock.Should().Be(exit);
         }
@@ -2401,7 +2401,7 @@ public class Sample
 
             finallyBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(finallyBlock, "fin", "fin()");
-            finallyBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock, exit);
+            finallyBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { afterFinallyBlock, exit });
 
             afterFinallyBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
@@ -2566,7 +2566,7 @@ public class Sample
 
             finallyBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(finallyBlock, "fin", "fin()");
-            finallyBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock, exit);
+            finallyBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { afterFinallyBlock, exit });
 
             afterFinallyBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
@@ -2627,7 +2627,7 @@ public class Sample
 
             finallyBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(finallyBlock, "fin", "fin()");
-            finallyBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock, exit);
+            finallyBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { afterFinallyBlock, exit });
 
             afterFinallyBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
@@ -2682,13 +2682,13 @@ public class Sample
             returnBlock.SuccessorBlocks.Should().Equal(finallyBlock);
 
             VerifyAllInstructions(tryEndBlock, "inside", "inside()");
-            tryEndBlock.SuccessorBlocks.Should().Equal(catchBlock /*exception thrown*/, finallyBlock /*no exception*/);
+            tryEndBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { catchBlock /*exception thrown*/, finallyBlock /*no exception*/});
 
             VerifyAllInstructions(catchBlock, "cat", "cat()");
             catchBlock.SuccessorBlocks.Should().Equal(finallyBlock);
 
             VerifyAllInstructions(finallyBlock, "fin", "fin()");
-            finallyBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock, exit);
+            finallyBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { afterFinallyBlock, exit });
 
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
             afterFinallyBlock.SuccessorBlocks.Should().Equal(exit);
@@ -2743,13 +2743,13 @@ public class Sample
             returnBlock.SuccessorBlocks.Should().Equal(finallyBlock);
 
             VerifyAllInstructions(tryEndBlock, "inside", "inside()");
-            tryEndBlock.SuccessorBlocks.Should().Equal(catchBlock /*caught exception thrown*/, finallyBlock);
+            tryEndBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { catchBlock /*caught exception thrown*/, finallyBlock });
 
             VerifyAllInstructions(catchBlock, "cat", "cat()");
             catchBlock.SuccessorBlocks.Should().Equal(finallyBlock);
 
             VerifyAllInstructions(finallyBlock, "fin", "fin()");
-            finallyBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock, exit);
+            finallyBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { afterFinallyBlock, exit });
 
             VerifyAllInstructions(afterFinallyBlock, "after", "after()");
             afterFinallyBlock.SuccessorBlocks.Should().Equal(exit);
@@ -2799,7 +2799,7 @@ public class Sample
             returnBlock.SuccessorBlocks.Should().Equal(exit);
 
             VerifyAllInstructions(tryEndBlock, "inside", "inside()");
-            tryEndBlock.SuccessorBlocks.Should().Equal(catchBlock /*caught exception thrown*/, afterFinallyBlock /*no exception*/, exit /*uncaught exception*/);
+            tryEndBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { catchBlock /*caught exception thrown*/, afterFinallyBlock /*no exception*/, exit /*uncaught exception*/});
 
             VerifyAllInstructions(catchBlock, "cat", "cat()");
             catchBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock);
@@ -2852,7 +2852,7 @@ public class Sample
             returnBlock.SuccessorBlocks.Should().Equal(exit);
 
             VerifyAllInstructions(tryEndBlock, "inside", "inside()");
-            tryEndBlock.SuccessorBlocks.Should().Equal(catchBlock /*caught exception thrown*/, afterFinallyBlock /*no exception*/);
+            tryEndBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { catchBlock /*caught exception thrown*/, afterFinallyBlock /*no exception*/});
 
             VerifyAllInstructions(catchBlock, "cat", "cat()");
             catchBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock);
@@ -2895,11 +2895,11 @@ public class Sample
 
             tryBodyBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(tryBodyBlock, "cw1", "cw1()");
-            tryBodyBlock.SuccessorBlocks.Should().Equal(whenBlock, afterTryBlock, exit);
+            tryBodyBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { whenBlock, afterTryBlock, exit });
 
             whenBlock.Should().BeOfType<BinaryBranchBlock>();
             VerifyAllInstructions(whenBlock, "e", "e is InvalidOperationException");
-            whenBlock.SuccessorBlocks.Should().Equal(catchBlock, afterTryBlock);
+            whenBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { catchBlock, afterTryBlock });
 
             catchBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(catchBlock, "cw2", "cw2()");
@@ -2945,11 +2945,11 @@ public class Sample
 
             tryBodyBlock.Should().BeOfType<BranchBlock>();
             VerifyAllInstructions(tryBodyBlock, "true", "shouldCatch = true", "\"bar\"", "new InvalidOperationException(\"bar\")");
-            tryBodyBlock.SuccessorBlocks.Should().Equal(whenBlock, afterTryBlock, exit);
+            tryBodyBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { whenBlock, afterTryBlock, exit });
 
             whenBlock.Should().BeOfType<BinaryBranchBlock>();
             VerifyAllInstructions(whenBlock, "shouldCatch");
-            whenBlock.SuccessorBlocks.Should().Equal(catchBlock, afterTryBlock);
+            whenBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { catchBlock, afterTryBlock });
 
             catchBlock.Should().BeOfType<SimpleBlock>();
             VerifyAllInstructions(catchBlock, "cw2", "cw2()");
@@ -3004,10 +3004,10 @@ public class Sample
 
             VerifyAllInstructions(tryBody, "attempts", "attempts++", "cw1", "cw1()");
             // this is wrong, the tryBody should not have a connection with whileStmt, it can lead to FNs
-            tryBody.SuccessorBlocks.Should().Equal(catchBlock, whileStmt, afterDoWhile);
+            tryBody.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { catchBlock, whileStmt, afterDoWhile });
 
             tryStatementBranch.ReversedInstructions.Should().BeEmpty();
-            tryStatementBranch.SuccessorBlocks.Should().Equal(catchBlock, whileStmt);
+            tryStatementBranch.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { catchBlock, whileStmt });
 
             VerifyAllInstructions(catchBlock, "cw2", "cw2()");
             catchBlock.SuccessorBlocks.Should().Equal(whileStmt);
@@ -3068,9 +3068,9 @@ public class Sample
             doBeforeTry.SuccessorBlocks.Should().Equal(tryStatement);
 
             VerifyAllInstructions(tryStatement, "cw1", "cw1()");
-            tryStatement.SuccessorBlocks.Should().Equal(catchBody, finallyBlock, afterDoWhile);
+            tryStatement.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { catchBody, finallyBlock, afterDoWhile });
 
-            tryBody.SuccessorBlocks.Should().Equal(catchBody, finallyBlock);
+            tryBody.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { catchBody, finallyBlock });
 
             VerifyAllInstructions(catchBody, "cw2", "cw2()");
             catchBody.SuccessorBlock.Should().Be(whileStmt);
@@ -3079,7 +3079,7 @@ public class Sample
             // - EXIT
             // - WHILE (because of `continue`)
             // - afterDoWhile (because of `break`)
-            finallyBlock.SuccessorBlocks.Should().Equal(afterTry, exit);
+            finallyBlock.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { afterTry, exit });
             afterTry.SuccessorBlock.Should().Be(whileStmt);
 
             VerifyAllInstructions(whileStmt, "true");
@@ -3154,7 +3154,7 @@ public class Sample
             // ToDo: this is weird and is basically skipped
             tryStatement.SuccessorBlocks.Should().Equal(finallyBody);
 
-            finallyBody.SuccessorBlocks.Should().Equal(afterTry, exit);
+            finallyBody.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { afterTry, exit });
             afterTry.SuccessorBlock.Should().Be(whileStmt);
 
             VerifyAllInstructions(whileStmt, "true");
@@ -3220,10 +3220,10 @@ public class Sample
             insideDoBeforeTry.SuccessorBlocks.Should().Equal(insideTry);
 
             VerifyAllInstructions(insideTry, "attempts", "attempts++", "cw1", "cw1()");
-            insideTry.SuccessorBlocks.Should().Equal(catchBodyWithIf, whileStmt, afterDoWhile);
+            insideTry.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { catchBodyWithIf, whileStmt, afterDoWhile });
 
             temporaryStrayBlock.ReversedInstructions.Should().BeEmpty();
-            temporaryStrayBlock.SuccessorBlocks.Should().Equal(catchBodyWithIf, whileStmt);
+            temporaryStrayBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { catchBodyWithIf, whileStmt });
 
             VerifyAllInstructions(catchBodyWithIf, "cw2", "cw2()", "attempts", "retries", "attempts > retries");
             catchBodyWithIf.TrueSuccessorBlock.Should().Be(insideIfInsideCatch);
@@ -3293,7 +3293,7 @@ public class Sample
 
             finallyBifurcation.SuccessorBlocks.Should().Equal(finallyBlock);
 
-            finallyBlock.SuccessorBlocks.Should().Equal(whileStmt, exit);
+            finallyBlock.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { whileStmt, exit });
 
             whileStmt.TrueSuccessorBlock.Should().Be(insideDoBeforeTry);
             whileStmt.FalseSuccessorBlock.Should().Be(afterDoWhile);
@@ -3361,7 +3361,7 @@ public class Sample
             innerTryStartBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { innerReturnBlock /*no ex*/, outerCatchBlock, outerFinallyBlock });
 
             innerReturnBlock.Should().BeOfType<BranchBlock>();
-            innerReturnBlock.SuccessorBlocks.Should().Equal(innerTryEndBlock, innerCatchBlock);
+            innerReturnBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { innerTryEndBlock, innerCatchBlock });
 
             innerTryEndBlock.Should().BeOfType<JumpBlock>();
             VerifyAllInstructions(innerTryEndBlock, "foo", "foo()");
@@ -3371,16 +3371,16 @@ public class Sample
             innerCatchBlock.SuccessorBlocks.Should().Equal(innerFinallyBlock);
 
             innerFinallyBlock.Should().BeOfType<BranchBlock>();
-            innerFinallyBlock.SuccessorBlocks.Should().Equal(outerTryBlock, outerFinallyBlock);
+            innerFinallyBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { outerTryBlock, outerFinallyBlock });
 
             outerTryBlock.Should().BeOfType<BranchBlock>();
-            outerTryBlock.SuccessorBlocks.Should().Equal(outerCatchBlock /*ex*/, outerFinallyBlock /*no ex*/);
+            outerTryBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { outerCatchBlock /*ex*/, outerFinallyBlock /*no ex*/});
 
             outerCatchBlock.Should().BeOfType<SimpleBlock>();
             outerCatchBlock.SuccessorBlocks.Should().Equal(outerFinallyBlock);
 
             outerFinallyBlock.Should().BeOfType<BranchBlock>();
-            outerFinallyBlock.SuccessorBlocks.Should().Equal(afterFinallyBlock, exit);
+            outerFinallyBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { afterFinallyBlock, exit });
 
             afterFinallyBlock.Should().BeOfType<SimpleBlock>();
             afterFinallyBlock.SuccessorBlocks.Should().Equal(exit);
@@ -3417,7 +3417,7 @@ public class Sample
             beforeOuterTry.SuccessorBlocks.Should().Equal(tryStatementBlock);
 
             VerifyNoInstruction(tryStatementBlock);
-            tryStatementBlock.SuccessorBlocks.Should().Equal(tryReturn, catchReturn);
+            tryStatementBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { tryReturn, catchReturn });
 
             VerifyAllInstructions(tryReturn, "bar", "bar()", "0");
             tryReturn.SuccessorBlocks.Should().Equal(exit);
@@ -3463,7 +3463,7 @@ public class Sample
             beforeOuterTry.SuccessorBlocks.Should().Equal(tryStatementBlock);
 
             VerifyNoInstruction(tryStatementBlock);
-            tryStatementBlock.SuccessorBlocks.Should().Equal(tryReturn, ifInsideCatch);
+            tryStatementBlock.SuccessorBlocks.Should().BeEquivalentTo(new Block[] { tryReturn, ifInsideCatch });
 
             VerifyAllInstructions(tryReturn, "bar", "bar()", "0");
             tryReturn.SuccessorBlocks.Should().Equal(exit);
@@ -3523,7 +3523,7 @@ public class Sample
             secondIf.FalseSuccessorBlock.Should().Be(tryStatementBranch);
 
             // ToDo: this tryStatementBranch is not always used as such, or is it?
-            tryStatementBranch.SuccessorBlocks.Should().Equal(insideCatch, afterTry);
+            tryStatementBranch.SuccessorBlocks.Should().BeEquivalentTo(new[] { insideCatch, afterTry });
 
             insideCatch.SuccessorBlocks.Should().Equal(afterTry);
             afterTry.SuccessorBlocks.Should().Equal(exit);
@@ -4555,7 +4555,7 @@ switch (o)
             entry.SuccessorBlocks.Should().Equal(a);
             a.SuccessorBlocks.Should().Equal(b);
             b.SuccessorBlocks.Should().Equal(cond);
-            cond.SuccessorBlocks.Should().Equal(cw1, cw2);
+            cond.SuccessorBlocks.Should().BeEquivalentTo(new[] { cw1, cw2 });
             cw1.SuccessorBlocks.Should().Equal(a);
             cw2.SuccessorBlocks.Should().Equal(cfg.ExitBlock);
         }
@@ -4587,7 +4587,7 @@ switch (o)
             entry.SuccessorBlocks.Should().Equal(a);
             a.SuccessorBlocks.Should().Equal(b);
             b.SuccessorBlocks.Should().Equal(cond);
-            cond.SuccessorBlocks.Should().Equal(cw1, cw2);
+            cond.SuccessorBlocks.Should().BeEquivalentTo(new[] { cw1, cw2 });
             cw1.SuccessorBlocks.Should().Equal(b);
             cw2.SuccessorBlocks.Should().Equal(cfg.ExitBlock);
         }
@@ -5123,7 +5123,7 @@ namespace NS
 
             initBlock.SuccessorBlocks.Should().Equal(branchBlock);
 
-            branchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, exitBlock });
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForStatement);
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(incrementorBlock);
@@ -5202,12 +5202,12 @@ namespace NS
 
             initializerBlock.SuccessorBlock.Should().Be(branchBlock);
 
-            branchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, exitBlock });
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForStatement);
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(incrementorBlock);
             incrementorBlock.SuccessorBlocks.Should().Equal(branchBlock);
-            branchBlock.PredecessorBlocks.Should().Equal(incrementorBlock, initializerBlock);
+            branchBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { incrementorBlock, initializerBlock });
             exitBlock.PredecessorBlocks.Should().Equal(branchBlock);
         }
 
@@ -5223,12 +5223,12 @@ namespace NS
 
             initBlock.SuccessorBlocks.Should().Equal(branchBlock);
 
-            branchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, exitBlock });
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForStatement);
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(branchBlock);
 
-            branchBlock.PredecessorBlocks.Should().Equal(initBlock, loopBodyBlock);
+            branchBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { initBlock, loopBodyBlock });
 
             exitBlock.PredecessorBlocks.Should().Equal(branchBlock);
         }
@@ -5245,7 +5245,7 @@ namespace NS
 
             initializerBlock.SuccessorBlock.Should().Be(branchBlock);
 
-            branchBlock.SuccessorBlocks.Should().Equal(loopBodyBlock, exitBlock);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { loopBodyBlock, exitBlock });
             branchBlock.BranchingNode.Kind().Should().Be(SyntaxKind.ForStatement);
 
             loopBodyBlock.SuccessorBlocks.Should().Equal(branchBlock);
@@ -5275,7 +5275,7 @@ namespace NS
             var falseBlock = blocks[2];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().Equal(trueBlock, falseBlock);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlock, falseBlock });
             trueBlock.SuccessorBlocks.Should().Equal(exitBlock);
             trueBlock.JumpNode.Kind().Should().Be(kind);
             falseBlock.SuccessorBlocks.Should().Equal(exitBlock);
@@ -5291,13 +5291,13 @@ namespace NS
             var falseBlock = blocks[2];
             var exitBlock = cfg.ExitBlock;
 
-            branchBlock.SuccessorBlocks.Should().Equal(trueBlock, falseBlock);
+            branchBlock.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlock, falseBlock });
             trueBlock.SuccessorBlocks.Should().Equal(exitBlock);
             trueBlock.JumpNode.Kind().Should().Be(kind);
 
             trueBlock.Instructions.Should().Contain(n => n.IsKind(SyntaxKind.IdentifierName) && n.ToString() == "ii");
 
-            exitBlock.PredecessorBlocks.Should().Equal(trueBlock, falseBlock);
+            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { trueBlock, falseBlock });
         }
 
         #endregion

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/BidirectionalDictionaryTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/BidirectionalDictionaryTests.cs
@@ -54,8 +54,8 @@ namespace SonarAnalyzer.UnitTest.Common
             sut.Add(4, 14);
             sut.Add(5, 15);
 
-            sut.AKeys.Should().BeEquivalentTo(1, 2, 3, 4, 5);
-            sut.BKeys.Should().BeEquivalentTo(11, 12, 13, 14, 15);
+            sut.AKeys.Should().BeEquivalentTo(new[] {1, 2, 3, 4, 5});
+            sut.BKeys.Should().BeEquivalentTo(new[] {11, 12, 13, 14, 15});
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/DistrubtionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/DistrubtionTest.cs
@@ -29,41 +29,41 @@ namespace SonarAnalyzer.UnitTest.Common
         public void Distribution()
         {
             var distribution = new Distribution(new[] { 0, 10, 20 });
-            distribution.Ranges.Should().BeEquivalentTo(0, 10, 20);
-            distribution.Values.Should().BeEquivalentTo(0, 0, 0);
+            distribution.Ranges.Should().BeEquivalentTo(new[] {0, 10, 20});
+            distribution.Values.Should().BeEquivalentTo(new[] {0, 0, 0});
             distribution.ToString().Should().BeEquivalentTo("0=0;10=0;20=0");
 
             distribution.Add(0);
-            distribution.Values.Should().BeEquivalentTo(1, 0, 0);
+            distribution.Values.Should().BeEquivalentTo(new[] {1, 0, 0});
             distribution.ToString().Should().BeEquivalentTo("0=1;10=0;20=0");
 
             distribution.Add(9);
-            distribution.Values.Should().BeEquivalentTo(2, 0, 0);
+            distribution.Values.Should().BeEquivalentTo(new[] {2, 0, 0});
             distribution.ToString().Should().BeEquivalentTo("0=2;10=0;20=0");
 
             distribution.Add(12);
-            distribution.Values.Should().BeEquivalentTo(2, 1, 0);
+            distribution.Values.Should().BeEquivalentTo(new[] {2, 1, 0});
             distribution.ToString().Should().BeEquivalentTo("0=2;10=1;20=0");
 
             distribution.Add(3);
-            distribution.Values.Should().BeEquivalentTo(3, 1, 0);
+            distribution.Values.Should().BeEquivalentTo(new[] {3, 1, 0});
             distribution.ToString().Should().BeEquivalentTo("0=3;10=1;20=0");
 
             distribution.Add(10);
-            distribution.Values.Should().BeEquivalentTo(3, 2, 0);
+            distribution.Values.Should().BeEquivalentTo(new[] {3, 2, 0});
             distribution.ToString().Should().BeEquivalentTo("0=3;10=2;20=0");
 
             distribution.Add(99);
-            distribution.Values.Should().BeEquivalentTo(3, 2, 1);
+            distribution.Values.Should().BeEquivalentTo(new[] {3, 2, 1});
             distribution.ToString().Should().BeEquivalentTo("0=3;10=2;20=1");
 
             distribution = new Distribution(new[] { 7, 13 });
-            distribution.Ranges.Should().BeEquivalentTo(7, 13);
-            distribution.Values.Should().BeEquivalentTo(0, 0);
+            distribution.Ranges.Should().BeEquivalentTo(new[] {7, 13});
+            distribution.Values.Should().BeEquivalentTo(new[] {0, 0});
             distribution.ToString().Should().BeEquivalentTo("7=0;13=0");
 
             distribution.Add(5);
-            distribution.Values.Should().BeEquivalentTo(1, 0);
+            distribution.Values.Should().BeEquivalentTo(new[] {1, 0});
             distribution.ToString().Should().BeEquivalentTo("7=1;13=0");
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/MetricsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/MetricsTest.cs
@@ -48,16 +48,16 @@ namespace SonarAnalyzer.UnitTest.Common
         [TestMethod]
         public void LinesOfCode()
         {
-            LinesOfCode(AnalyzerLanguage.CSharp, string.Empty).Should().BeEquivalentTo();
-            LinesOfCode(AnalyzerLanguage.CSharp, "/* ... */\n").Should().BeEquivalentTo();
-            LinesOfCode(AnalyzerLanguage.CSharp, "namespace X { }").Should().BeEquivalentTo(1);
-            LinesOfCode(AnalyzerLanguage.CSharp, "namespace X \n { \n }").Should().BeEquivalentTo(1, 2, 3);
-            LinesOfCode(AnalyzerLanguage.CSharp, "public class Sample { public Sample() { System.Console.WriteLine(@\"line1 \n line2 \n line3 \n line 4\"); } }").Should().BeEquivalentTo(1, 2, 3, 4);
+            LinesOfCode(AnalyzerLanguage.CSharp, string.Empty).Should().BeEmpty();
+            LinesOfCode(AnalyzerLanguage.CSharp, "/* ... */\n").Should().BeEmpty();
+            LinesOfCode(AnalyzerLanguage.CSharp, "namespace X { }").Should().Equal(1);
+            LinesOfCode(AnalyzerLanguage.CSharp, "namespace X \n { \n }").Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            LinesOfCode(AnalyzerLanguage.CSharp, "public class Sample { public Sample() { System.Console.WriteLine(@\"line1 \n line2 \n line3 \n line 4\"); } }").Should().BeEquivalentTo(new[] { 1, 2, 3, 4 });
 
-            LinesOfCode(AnalyzerLanguage.VisualBasic, string.Empty).Should().BeEquivalentTo();
-            LinesOfCode(AnalyzerLanguage.VisualBasic, "'\n").Should().BeEquivalentTo();
-            LinesOfCode(AnalyzerLanguage.VisualBasic, "Module Module1 : End Module").Should().BeEquivalentTo(1);
-            LinesOfCode(AnalyzerLanguage.VisualBasic, "Module Module1 \n  \n End Module").Should().BeEquivalentTo(1, 3);
+            LinesOfCode(AnalyzerLanguage.VisualBasic, string.Empty).Should().BeEmpty();
+            LinesOfCode(AnalyzerLanguage.VisualBasic, "'\n").Should().BeEmpty();
+            LinesOfCode(AnalyzerLanguage.VisualBasic, "Module Module1 : End Module").Should().BeEquivalentTo(new[] { 1 });
+            LinesOfCode(AnalyzerLanguage.VisualBasic, "Module Module1 \n  \n End Module").Should().BeEquivalentTo(new[] { 1, 3 });
             LinesOfCode(AnalyzerLanguage.VisualBasic,
 @"Public Class SomeClass
  Public Sub New()
@@ -66,119 +66,119 @@ line2
 line3
 line 4"")
  End Sub
-End Class").Should().BeEquivalentTo(1, 2, 3, 4, 5, 6, 7, 8);
+End Class").Should().BeEquivalentTo(new[] { 1, 2, 3, 4, 5, 6, 7, 8 });
         }
 
         [TestMethod]
         public void CommentsWithoutHeaders()
         {
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, string.Empty).NonBlank.Should().BeEquivalentTo();
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, string.Empty).NoSonar.Should().BeEquivalentTo();
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, string.Empty).NonBlank.Should().BeEmpty();
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, string.Empty).NoSonar.Should().BeEmpty();
 
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "#if DEBUG\nfoo\n#endif").NonBlank.Should().BeEquivalentTo();
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; \n#if DEBUG\nfoo\n#endif").NonBlank.Should().BeEquivalentTo();
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "#if DEBUG\nfoo\n#endif").NonBlank.Should().BeEmpty();
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; \n#if DEBUG\nfoo\n#endif").NonBlank.Should().BeEmpty();
 
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "// foo").NonBlank.Should().BeEquivalentTo();
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "#if DEBUG\nfoo\n#endif\n// foo").NonBlank.Should().BeEquivalentTo();
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "// foo").NonBlank.Should().BeEmpty();
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "#if DEBUG\nfoo\n#endif\n// foo").NonBlank.Should().BeEmpty();
 
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; // l1").NonBlank.Should().BeEquivalentTo(1);
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; // l1\n// l2").NonBlank.Should().BeEquivalentTo(1, 2);
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* l1 */").NonBlank.Should().BeEquivalentTo(1);
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* l1 \n l2 */").NonBlank.Should().BeEquivalentTo(1, 2);
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* l1 \n l2 */").NonBlank.Should().BeEquivalentTo(1, 2);
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /// foo").NonBlank.Should().BeEquivalentTo(1);
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /** foo */").NonBlank.Should().BeEquivalentTo(1);
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; // l1").NonBlank.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; // l1\n// l2").NonBlank.Should().BeEquivalentTo(new[] { 1, 2 });
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* l1 */").NonBlank.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* l1 \n l2 */").NonBlank.Should().BeEquivalentTo(new[] { 1, 2 });
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* l1 \n l2 */").NonBlank.Should().BeEquivalentTo(new[] { 1, 2 });
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /// foo").NonBlank.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /** foo */").NonBlank.Should().BeEquivalentTo(new[] { 1 });
 
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /** foo \n \n bar */").NonBlank.Should().BeEquivalentTo(1, 3);
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /** foo \r \r bar */").NonBlank.Should().BeEquivalentTo(1, 3);
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /** foo \r\n \r\n bar */").NonBlank.Should().BeEquivalentTo(1, 3);
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /** foo \n \n bar */").NonBlank.Should().BeEquivalentTo(new[] { 1, 3 });
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /** foo \r \r bar */").NonBlank.Should().BeEquivalentTo(new[] { 1, 3 });
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /** foo \r\n \r\n bar */").NonBlank.Should().BeEquivalentTo(new[] { 1, 3 });
 
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; // NOSONAR").NoSonar.Should().BeEquivalentTo(1);
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; // ooNOSONARoo").NoSonar.Should().BeEquivalentTo(1);
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; // nosonar").NoSonar.Should().BeEquivalentTo();
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; // nOSonAr").NoSonar.Should().BeEquivalentTo();
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; // NOSONAR").NoSonar.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; // ooNOSONARoo").NoSonar.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; // nosonar").NoSonar.Should().BeEmpty();
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; // nOSonAr").NoSonar.Should().BeEmpty();
 
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* NOSONAR */ /* foo*/").NoSonar.Should().BeEquivalentTo(1);
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* NOSONAR */ /* foo */").NonBlank.Should().BeEquivalentTo();
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* NOSONAR */ /* foo*/").NoSonar.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* NOSONAR */ /* foo */").NonBlank.Should().BeEmpty();
 
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* foo*/ /* NOSONAR */").NoSonar.Should().BeEquivalentTo(1);
-            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* foo*/ /* NOSONAR */").NonBlank.Should().BeEquivalentTo();
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* foo*/ /* NOSONAR */").NoSonar.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithoutHeaders(AnalyzerLanguage.CSharp, "using System; /* foo*/ /* NOSONAR */").NonBlank.Should().BeEmpty();
 
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, string.Empty).NonBlank.Should().BeEquivalentTo();
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, string.Empty).NoSonar.Should().BeEquivalentTo();
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, string.Empty).NonBlank.Should().BeEmpty();
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, string.Empty).NoSonar.Should().BeEmpty();
 
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "#If DEBUG Then\nfoo\n#End If").NonBlank.Should().BeEquivalentTo();
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System \n#If DEBUG Then\nfoo\n#End If").NonBlank.Should().BeEquivalentTo();
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "#If DEBUG Then\nfoo\n#End If").NonBlank.Should().BeEmpty();
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System \n#If DEBUG Then\nfoo\n#End If").NonBlank.Should().BeEmpty();
 
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "' foo").NonBlank.Should().BeEquivalentTo();
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "#If DEBUG Then\nfoo\n#End If\n' foo").NonBlank.Should().BeEquivalentTo();
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "' foo").NonBlank.Should().BeEmpty();
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "#If DEBUG Then\nfoo\n#End If\n' foo").NonBlank.Should().BeEmpty();
 
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' l1").NonBlank.Should().BeEquivalentTo(1);
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' l1\n' l2").NonBlank.Should().BeEquivalentTo(1, 2);
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ''' foo").NonBlank.Should().BeEquivalentTo(1);
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' l1").NonBlank.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' l1\n' l2").NonBlank.Should().BeEquivalentTo(new[] { 1, 2 });
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ''' foo").NonBlank.Should().BeEquivalentTo(new[] { 1 });
 
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' NOSONAR").NoSonar.Should().BeEquivalentTo(1);
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' ooNOSONARoo").NoSonar.Should().BeEquivalentTo(1);
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' nosonar").NoSonar.Should().BeEquivalentTo();
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' nOSonAr").NoSonar.Should().BeEquivalentTo();
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' NOSONAR").NoSonar.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' ooNOSONARoo").NoSonar.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' nosonar").NoSonar.Should().BeEmpty();
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' nOSonAr").NoSonar.Should().BeEmpty();
 
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' fndskgjsdkl \n ' {00000000-0000-0000-0000-000000000000}\n").NonBlank.Should().BeEquivalentTo(1, 2);
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' fndskgjsdkl \n ' {00000000-0000-0000-0000-000000000000}\n").NonBlank.Should().BeEquivalentTo(new[] { 1, 2 });
         }
 
         [TestMethod]
         public void CommentsWithHeaders()
         {
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, string.Empty).NonBlank.Should().BeEquivalentTo();
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, string.Empty).NoSonar.Should().BeEquivalentTo();
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, string.Empty).NonBlank.Should().BeEmpty();
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, string.Empty).NoSonar.Should().BeEmpty();
 
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "#if DEBUG\nfoo\n#endif").NonBlank.Should().BeEquivalentTo();
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; \n#if DEBUG\nfoo\n#endif").NonBlank.Should().BeEquivalentTo();
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "#if DEBUG\nfoo\n#endif").NonBlank.Should().BeEmpty();
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; \n#if DEBUG\nfoo\n#endif").NonBlank.Should().BeEmpty();
 
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "// foo").NonBlank.Should().BeEquivalentTo(1);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "#if DEBUG\nfoo\n#endif\n// foo").NonBlank.Should().BeEquivalentTo(4);
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "// foo").NonBlank.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "#if DEBUG\nfoo\n#endif\n// foo").NonBlank.Should().BeEquivalentTo(new[] { 4 });
 
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; // l1").NonBlank.Should().BeEquivalentTo(1);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; // l1\n// l2").NonBlank.Should().BeEquivalentTo(1, 2);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* l1 */").NonBlank.Should().BeEquivalentTo(1);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* l1 \n l2 */").NonBlank.Should().BeEquivalentTo(1, 2);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* l1 \n l2 */").NonBlank.Should().BeEquivalentTo(1, 2);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /// foo").NonBlank.Should().BeEquivalentTo(1);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /** foo */").NonBlank.Should().BeEquivalentTo(1);
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; // l1").NonBlank.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; // l1\n// l2").NonBlank.Should().BeEquivalentTo(new[] { 1, 2 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* l1 */").NonBlank.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* l1 \n l2 */").NonBlank.Should().BeEquivalentTo(new[] { 1, 2 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* l1 \n l2 */").NonBlank.Should().BeEquivalentTo(new[] { 1, 2 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /// foo").NonBlank.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /** foo */").NonBlank.Should().BeEquivalentTo(new[] { 1 });
 
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /** foo \n \n bar */").NonBlank.Should().BeEquivalentTo(1, 3);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /** foo \r \r bar */").NonBlank.Should().BeEquivalentTo(1, 3);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /** foo \r\n \r\n bar */").NonBlank.Should().BeEquivalentTo(1, 3);
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /** foo \n \n bar */").NonBlank.Should().BeEquivalentTo(new[] { 1, 3 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /** foo \r \r bar */").NonBlank.Should().BeEquivalentTo(new[] { 1, 3 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /** foo \r\n \r\n bar */").NonBlank.Should().BeEquivalentTo(new[] { 1, 3 });
 
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; // NOSONAR").NoSonar.Should().BeEquivalentTo(1);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; // ooNOSONARoo").NoSonar.Should().BeEquivalentTo(1);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; // nosonar").NoSonar.Should().BeEquivalentTo();
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; // nOSonAr").NoSonar.Should().BeEquivalentTo();
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; // NOSONAR").NoSonar.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; // ooNOSONARoo").NoSonar.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; // nosonar").NoSonar.Should().BeEmpty();
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; // nOSonAr").NoSonar.Should().BeEmpty();
 
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* NOSONAR */ /* foo*/").NoSonar.Should().BeEquivalentTo(1);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* NOSONAR */ /* foo */").NonBlank.Should().BeEquivalentTo();
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* NOSONAR */ /* foo*/").NoSonar.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* NOSONAR */ /* foo */").NonBlank.Should().BeEmpty();
 
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* foo*/ /* NOSONAR */").NoSonar.Should().BeEquivalentTo(1);
-            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* foo*/ /* NOSONAR */").NonBlank.Should().BeEquivalentTo();
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* foo*/ /* NOSONAR */").NoSonar.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithHeaders(AnalyzerLanguage.CSharp, "using System; /* foo*/ /* NOSONAR */").NonBlank.Should().BeEmpty();
 
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, string.Empty).NonBlank.Should().BeEquivalentTo();
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, string.Empty).NoSonar.Should().BeEquivalentTo();
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, string.Empty).NonBlank.Should().BeEmpty();
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, string.Empty).NoSonar.Should().BeEmpty();
 
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "#If DEBUG Then\nfoo\n#End If").NonBlank.Should().BeEquivalentTo();
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System \n#If DEBUG Then\nfoo\n#End If").NonBlank.Should().BeEquivalentTo();
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "#If DEBUG Then\nfoo\n#End If").NonBlank.Should().BeEmpty();
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System \n#If DEBUG Then\nfoo\n#End If").NonBlank.Should().BeEmpty();
 
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "' foo").NonBlank.Should().BeEquivalentTo(1);
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "#If DEBUG Then\nfoo\n#End If\n' foo").NonBlank.Should().BeEquivalentTo(4);
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "' foo").NonBlank.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "#If DEBUG Then\nfoo\n#End If\n' foo").NonBlank.Should().BeEquivalentTo(new[] { 4 });
 
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' l1").NonBlank.Should().BeEquivalentTo(1);
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' l1\n' l2").NonBlank.Should().BeEquivalentTo(1, 2);
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ''' foo").NonBlank.Should().BeEquivalentTo(1);
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' l1").NonBlank.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' l1\n' l2").NonBlank.Should().BeEquivalentTo(new[] { 1, 2 });
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ''' foo").NonBlank.Should().BeEquivalentTo(new[] { 1 });
 
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' NOSONAR").NoSonar.Should().BeEquivalentTo(1);
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' ooNOSONARoo").NoSonar.Should().BeEquivalentTo(1);
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' nosonar").NoSonar.Should().BeEquivalentTo();
-            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' nOSonAr").NoSonar.Should().BeEquivalentTo();
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' NOSONAR").NoSonar.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' ooNOSONARoo").NoSonar.Should().BeEquivalentTo(new[] { 1 });
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' nosonar").NoSonar.Should().BeEmpty();
+            CommentsWithHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' nOSonAr").NoSonar.Should().BeEmpty();
 
-            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' fndskgjsdkl \n ' {00000000-0000-0000-0000-000000000000}\n").NonBlank.Should().BeEquivalentTo(1, 2);
+            CommentsWithoutHeaders(AnalyzerLanguage.VisualBasic, "Imports System ' fndskgjsdkl \n ' {00000000-0000-0000-0000-000000000000}\n").NonBlank.Should().BeEquivalentTo(new[] { 1, 2 });
         }
 
         [TestMethod]
@@ -549,7 +549,7 @@ End Class")
         public void ExecutableLinesMetricsIsPopulated_CSharp() =>
             ExecutableLines(AnalyzerLanguage.CSharp,
                 @"public class Sample { public void Foo(int x) { int i = 0; if (i == 0) {i++;i--;} else { while(true){i--;} } } }")
-                .Should().BeEquivalentTo(new[] { 1 });
+                .Should().Equal(1);
 
         [TestMethod]
         public void ExecutableLinesMetricsIsPopulated_VB() =>
@@ -560,7 +560,7 @@ End Class")
         End If
     End Sub
 End Module")
-                .Should().BeEquivalentTo(new[] { 3 });
+                .Should().Equal(3);
 
         private static int Lines(AnalyzerLanguage language, string text) =>
             MetricsFor(language, text).LineCount;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticDescriptorFactoryTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DiagnosticDescriptorFactoryTest.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
             result.IsEnabledByDefault.Should().BeTrue();
             result.Description.ToString().Should().Be("Sxxxx Description");
             result.HelpLinkUri.Should().Be("https://rules.sonarsource.com/csharp/RSPEC-xxxx");
-            result.CustomTags.Should().OnlyContain(LanguageNames.CSharp, DiagnosticDescriptorFactory.MainSourceScopeTag, DiagnosticDescriptorFactory.SonarWayTag);
+            result.CustomTags.Should().BeEquivalentTo(LanguageNames.CSharp, DiagnosticDescriptorFactory.MainSourceScopeTag, DiagnosticDescriptorFactory.SonarWayTag);
         }
 
         [TestMethod]
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
             result.IsEnabledByDefault.Should().BeTrue();
             result.Description.ToString().Should().Be("Sxxxx Description");
             result.HelpLinkUri.Should().Be("https://rules.sonarsource.com/vbnet/RSPEC-xxxx");
-            result.CustomTags.Should().OnlyContain(LanguageNames.VisualBasic, DiagnosticDescriptorFactory.MainSourceScopeTag, DiagnosticDescriptorFactory.SonarWayTag);
+            result.CustomTags.Should().BeEquivalentTo(LanguageNames.VisualBasic, DiagnosticDescriptorFactory.MainSourceScopeTag, DiagnosticDescriptorFactory.SonarWayTag);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/MethodParameterLookupTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/MethodParameterLookupTest.cs
@@ -214,7 +214,7 @@ End Module
                 {
                     if (parameter.IsParams && lookup.TryGetSyntax(parameter, out var expressions))
                     {
-                        expressions.Select(x => ConstantValue(x)).Should().BeEquivalentTo((IEnumerable)ExtractExpectedValue(expectedArguments, parameter.Name));
+                        expressions.Select(x => ConstantValue(x)).Should().BeEquivalentTo(((IEnumerable)ExtractExpectedValue(expectedArguments, parameter.Name)).Cast<object>());
                     }
                     else if (!parameter.IsParams && lookup.TryGetNonParamsSyntax(parameter, out var expression))
                     {
@@ -239,7 +239,8 @@ End Module
                         var expected = ExtractExpectedValue(expectedArguments, symbol.Name);
                         if (symbol.IsParams)
                         {
-                            ((IEnumerable)expected).Should().Contain(value); // Expected contains all values {1, 2, 3} for ParamArray/params, but foreach is probing one at a time
+                            expected.Should().BeOfType(value.GetType().MakeArrayType());
+                            ((IEnumerable)expected).Cast<object>().Should().Contain(value); // Expected contains all values {1, 2, 3} for ParamArray/params, but foreach is probing one at a time
                         }
                         else
                         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/MethodParameterLookupTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/MethodParameterLookupTest.cs
@@ -239,8 +239,8 @@ End Module
                         var expected = ExtractExpectedValue(expectedArguments, symbol.Name);
                         if (symbol.IsParams)
                         {
-                            expected.Should().BeOfType(value.GetType().MakeArrayType());
-                            ((IEnumerable)expected).Cast<object>().Should().Contain(value); // Expected contains all values {1, 2, 3} for ParamArray/params, but foreach is probing one at a time
+                            // Expected contains all values {1, 2, 3} for ParamArray/params, but foreach is probing one at a time
+                            expected.Should().BeAssignableTo<IEnumerable>().Which.Cast<object>().Should().Contain(value);
                         }
                         else
                         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/MethodParameterLookupTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/MethodParameterLookupTest.cs
@@ -214,7 +214,8 @@ End Module
                 {
                     if (parameter.IsParams && lookup.TryGetSyntax(parameter, out var expressions))
                     {
-                        expressions.Select(x => ConstantValue(x)).Should().BeEquivalentTo(((IEnumerable)ExtractExpectedValue(expectedArguments, parameter.Name)).Cast<object>());
+                        var expected = ExtractExpectedValue(expectedArguments, parameter.Name).Should().BeAssignableTo<IEnumerable>().Subject.Cast<object>();
+                        expressions.Select(x => ConstantValue(x)).Should().Equal(expected);
                     }
                     else if (!parameter.IsParams && lookup.TryGetNonParamsSyntax(parameter, out var expression))
                     {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/OperationExecutionOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/OperationExecutionOrderTest.cs
@@ -129,7 +129,7 @@ Method(4);";
                     list.Add(operation.Instance.Kind + ": " + operation.Instance.Syntax);
                 }
             }
-            list.Should().OnlyContainInOrder(expected);
+            list.Should().Equal(expected);
         }
 
         private static OperationExecutionOrder Compile(string methodBody, bool reverseOrder)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/SymbolHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/SymbolHelperTest.cs
@@ -174,7 +174,7 @@ namespace NS
             baseTypes = derived1Type.GetSelfAndBaseTypes().ToList();
             baseTypes.Should().HaveCount(3);
             baseTypes.Should().HaveElementAt(0, derived1Type);
-            baseTypes.Should().HaveElementAt(1, testCode.GetTypeSymbol("Base"));
+            baseTypes.Should().HaveElementAt(1, testCode.GetTypeSymbol("Base").Should().BeAssignableTo<INamedTypeSymbol>().Subject);
             baseTypes.Should().HaveElementAt(2, objectType);
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Json/JsonWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Json/JsonWalkerTest.cs
@@ -42,7 +42,7 @@ public class JsonWalkerTest
         var sut = new JsonWalkerCollector();
         sut.Visit(JsonNode.FromString(json));
         sut.VisitedKeys.Should().BeEquivalentTo("OuterKey", "OuterBool", "OuterNull", "NestedArray", "InnerKey");
-        sut.VisitedValues.Should().BeEquivalentTo("OuterValue", true, null, "Array1", "Array2-Nested1", null, "Array2-Nested2", "Array2-NestedObject", "Array3");
+        sut.VisitedValues.Should().BeEquivalentTo(new object[] { "OuterValue", true, null, "Array1", "Array2-Nested1", null, "Array2-Nested2", "Array2-NestedObject", "Array3" });
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
@@ -40,11 +40,10 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void Verify_Method_PreciseLocation_CS(ProjectType projectType) =>
             Verify("Method.cs", projectType, references =>
             {
-                references.Select(x => x.Declaration.StartLine).Should().BeEquivalentTo(1, 3, 5, 7);   // class 'Sample' on line 1, method 'Method' on line 3, method 'method' on line 5 and method 'Go' on line 7
+                references.Select(x => x.Declaration.StartLine).Should().BeEquivalentTo(new[] { 1, 3, 5, 7 });   // class 'Sample' on line 1, method 'Method' on line 3, method 'method' on line 5 and method 'Go' on line 7
                 var methodDeclaration = references.Single(x => x.Declaration.StartLine == 3);
                 methodDeclaration.Declaration.Should().BeEquivalentTo(new TextRange { StartLine = 3, EndLine = 3, StartOffset = 16, EndOffset = 22 });
-                methodDeclaration.Reference.Should().HaveCount(1);
-                methodDeclaration.Reference.Single().Should().BeEquivalentTo(new TextRange { StartLine = 9, EndLine = 9, StartOffset = 8, EndOffset = 14 });
+                methodDeclaration.Reference.Should().Equal(new TextRange { StartLine = 9, EndLine = 9, StartOffset = 8, EndOffset = 14 });
             });
 
         [DataTestMethod]
@@ -53,18 +52,17 @@ namespace SonarAnalyzer.UnitTest.Rules
         public void Verify_Method_PreciseLocation_VB(ProjectType projectType) =>
             Verify("Method.vb", projectType, references =>
             {
-                references.Select(x => x.Declaration.StartLine).Should().BeEquivalentTo(1, 3, 6, 10);
+                references.Select(x => x.Declaration.StartLine).Should().BeEquivalentTo(new[] { 1, 3, 6, 10 });
 
                 var procedureDeclaration = references.Single(x => x.Declaration.StartLine == 3);
                 procedureDeclaration.Declaration.Should().BeEquivalentTo(new TextRange { StartLine = 3, EndLine = 3, StartOffset = 15, EndOffset = 21 });
-                procedureDeclaration.Reference.Should().HaveCount(2);
-                procedureDeclaration.Reference[0].Should().BeEquivalentTo(new TextRange { StartLine = 11, EndLine = 11, StartOffset = 8, EndOffset = 14 });
-                procedureDeclaration.Reference[1].Should().BeEquivalentTo(new TextRange { StartLine = 13, EndLine = 13, StartOffset = 8, EndOffset = 14 });
+                procedureDeclaration.Reference.Should().Equal(
+                    new TextRange { StartLine = 11, EndLine = 11, StartOffset = 8, EndOffset = 14 },
+                    new TextRange { StartLine = 13, EndLine = 13, StartOffset = 8, EndOffset = 14 });
 
                 var functionDeclaration = references.Single(x => x.Declaration.StartLine == 6);
                 functionDeclaration.Declaration.Should().BeEquivalentTo(new TextRange { StartLine = 6, EndLine = 6, StartOffset = 13, EndOffset = 23 });
-                functionDeclaration.Reference.Should().HaveCount(1);
-                functionDeclaration.Reference.Single().Should().BeEquivalentTo(new TextRange { StartLine = 12, EndLine = 12, StartOffset = 8, EndOffset = 18 });
+                functionDeclaration.Reference.Should().Equal(new TextRange { StartLine = 12, EndLine = 12, StartOffset = 8, EndOffset = 18 });
             });
 
         [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="altcover" Version="8.6.14" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ExplodedNodeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ExplodedNodeTest.cs
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         {
             var block = TestHelper.CompileCfgBodyCS("var value = 42;").Blocks[1];
             // Visualize operations to understand the rest of this UT
-            block.OperationsAndBranchValue.ToExecutionOrder().Select(TestHelper.Serialize).Should().OnlyContainInOrder(
+            block.OperationsAndBranchValue.ToExecutionOrder().Select(TestHelper.Serialize).Should().Equal(
                  "LocalReference: value = 42 (Implicit)",
                  "Literal: 42",
                  "SimpleAssignment: value = 42 (Implicit)");
@@ -78,7 +78,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         {
             var block = TestHelper.CompileCfgBodyVB("Dim Value As Integer = 42").Blocks[1];
             // Visualize operations to understand the rest of this UT
-            block.OperationsAndBranchValue.ToExecutionOrder().Select(TestHelper.Serialize).Should().OnlyContainInOrder(
+            block.OperationsAndBranchValue.ToExecutionOrder().Select(TestHelper.Serialize).Should().Equal(
                 "LocalReference: Value (Implicit)",
                 "Literal: 42",
                 "SimpleAssignment: Value As Integer = 42 (Implicit)");

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -378,7 +378,7 @@ if (this.ObjectField == null)
 }}
 Tag(""After"", this.ObjectField);";
             var validator = SETestContext.CreateCS(code).Validator;
-            validator.TagValues("After").Should().BeEquivalentTo(
+            validator.TagValues("After").Should().Equal(
                 new SymbolicValue().WithConstraint(ObjectConstraint.NotNull),
                 new SymbolicValue());
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SonarExplodedGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SonarExplodedGraphTest.cs
@@ -918,7 +918,7 @@ namespace Namespace
                 """;
             var context = new ExplodedGraphContext(testInput);
             var walk = () => context.WalkWithInstructions(2);
-            walk.Should().Throw<Exception>().WithMessage("Expected NumberOfExitBlockReached to be 1, but found 0.");
+            walk.Should().Throw<Exception>().WithMessage("Expected NumberOfExitBlockReached to be 1, but found 0 (difference of -1).");
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SymbolicValues/NullableSymbolicValue_TrySetConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SymbolicValues/NullableSymbolicValue_TrySetConstraint.cs
@@ -114,7 +114,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(null, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -124,7 +124,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(BoolConstraint.True, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -154,7 +154,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(NullableConstraint.HasValue, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -174,7 +174,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(ObjectConstraint.NotNull, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -184,7 +184,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(null, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -204,7 +204,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(BoolConstraint.False, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -224,7 +224,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(NullableConstraint.HasValue, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -244,7 +244,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(ObjectConstraint.NotNull, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -254,7 +254,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(null, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -284,7 +284,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(NullableConstraint.NoValue, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -304,7 +304,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(ObjectConstraint.Null, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -324,7 +324,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(null, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -368,7 +368,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(NullableConstraint.HasValue, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -388,7 +388,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(ObjectConstraint.NotNull, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -398,7 +398,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(null, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -428,7 +428,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(NullableConstraint.NoValue, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -448,7 +448,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(ObjectConstraint.Null, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -468,7 +468,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(null, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -512,7 +512,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(NullableConstraint.HasValue, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -532,7 +532,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(ObjectConstraint.NotNull, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         [TestMethod]
@@ -542,7 +542,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetConstraint(null, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         private static void ShouldHaveConstraint(ProgramState ps, SymbolicValue sv, SymbolicConstraint constraint)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SymbolicValues/NullableSymbolicValue_TrySetOppositeConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SymbolicValues/NullableSymbolicValue_TrySetOppositeConstraint.cs
@@ -105,7 +105,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
 
             var newProgramStates = nullableSymbolicValue.TrySetOppositeConstraint(ObjectConstraint.NotNull, ps).ToList();
 
-            newProgramStates.Should().BeEquivalentTo(ps);
+            newProgramStates.Should().Equal(ps);
         }
 
         private static void ShouldHaveConstraint(ProgramState ps, SymbolicValue sv, SymbolicConstraint expectedConstraint)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SymbolicValues/SymbolicValue_TrySetConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SymbolicValues/SymbolicValue_TrySetConstraint.cs
@@ -619,7 +619,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar.SymbolicValues
             var inputProgramState = SetupProgramState(sv, new[] { BoolConstraint.True });
             var newProgramStates = sv.TrySetConstraint(ObjectConstraint.NotNull, inputProgramState);
 
-            newProgramStates.Should().ContainSingle().And.BeEquivalentTo(inputProgramState);
+            newProgramStates.Should().ContainSingle().And.Equal(inputProgramState);
         }
 
         private static IList<IList<SymbolicConstraint>> ProgramStateList(params IList<SymbolicConstraint>[] programStates) => programStates;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/FluentTestHelper.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/FluentTestHelper.cs
@@ -18,27 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using FluentAssertions.Collections;
 using FluentAssertions.Primitives;
 
 namespace SonarAnalyzer.UnitTest.Helpers
 {
     internal static class FluentTestHelper
     {
-        public static void OnlyContain<T, TAssertions>(this SelfReferencingCollectionAssertions<T, TAssertions> self, params T[] expected)
-             where TAssertions : SelfReferencingCollectionAssertions<T, TAssertions>
-        {
-            _ = expected ?? throw new ArgumentNullException(nameof(expected));
-            self.Subject.Should().Contain(expected).And.HaveSameCount(expected);
-        }
-
-        public static void OnlyContainInOrder<T, TAssertions>(this SelfReferencingCollectionAssertions<T, TAssertions> self, params T[] expected)
-             where TAssertions : SelfReferencingCollectionAssertions<T, TAssertions>
-        {
-            _ = expected ?? throw new ArgumentNullException(nameof(expected));
-            self.Subject.Should().ContainInOrder(expected).And.BeEquivalentTo(expected);    // BeEquivalentTo to have better collection message
-        }
-
         public static void BeIgnoringLineEndings(this StringAssertions stringAssertions, string expected) =>
             stringAssertions.Subject.ToUnixLineEndings().Should().Be(expected.ToUnixLineEndings());
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/ValidatorTestCheck.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/ValidatorTestCheck.cs
@@ -59,10 +59,10 @@ namespace SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution
         }
 
         public void ValidateOrder(params string[] expected) =>
-            postProcessed.Select(x => TestHelper.Serialize(x.Operation)).Should().OnlyContainInOrder(expected);
+            postProcessed.Select(x => TestHelper.Serialize(x.Operation)).Should().Equal(expected);
 
         public void ValidateTagOrder(params string[] expected) =>
-            tags.Select(x => x.Name).Should().OnlyContainInOrder(expected);
+            tags.Select(x => x.Name).Should().Equal(expected);
 
         public void Validate(string operation, Action<SymbolicContext> action) =>
             action(postProcessed.Single(x => TestHelper.Serialize(x.Operation) == operation));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/IssueLocationCollectorTest.GetExpectedIssueLocations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/IssueLocationCollectorTest.GetExpectedIssueLocations.cs
@@ -139,8 +139,8 @@ Noncompliant - this should not be detected as expected issue
 
             locations.Select(l => l.IsPrimary).Should().BeEquivalentTo(new[] { true, false, false, false });
             locations.Select(l => l.LineNumber).Should().Equal(3, 3, 3, 3);
-            locations.Select(l => l.Start).Should().Equal(new[] { 16, 27, 20, 21 });
-            locations.Select(l => l.Length).Should().Equal(new[] { 3, 1, 6, 4 });
+            locations.Select(l => l.Start).Should().Equal(16, 27, 20, 21);
+            locations.Select(l => l.Length).Should().Equal(3, 1, 6, 4);
         }
 
         [TestMethod]
@@ -160,8 +160,8 @@ Noncompliant - this should not be detected as expected issue
 
             locations.Select(l => l.IsPrimary).Should().BeEquivalentTo(new[] { true, false });
             locations.Select(l => l.LineNumber).Should().Equal(3, 3);
-            locations.Select(l => l.Start).Should().Equal(new[] { 16, 27 });
-            locations.Select(l => l.Length).Should().Equal(new[] { 3, 1 });
+            locations.Select(l => l.Start).Should().Equal(16, 27);
+            locations.Select(l => l.Length).Should().Equal(3, 1);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/IssueLocationCollectorTest.GetIssueLocations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/IssueLocationCollectorTest.GetIssueLocations.cs
@@ -266,8 +266,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
                 expectedLineNumbers: new[] { 1 },
                 expectedMessages: new[] { "MyMessage" },
                 expectedIssueIds: new[] { "myIssueId" });
-            result.Select(issue => issue.Start).Should().Equal(new[] { 4 });
-            result.Select(issue => issue.Length).Should().Equal(new[] { 16 });
+            result.Select(issue => issue.Start).Should().Equal(4);
+            result.Select(issue => issue.Length).Should().Equal(16);
         }
 
         [TestMethod]
@@ -286,8 +286,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
                 expectedLineNumbers: new[] { 1 },
                 expectedMessages: new[] { "MyMessage" },
                 expectedIssueIds: new[] { "myIssueId" });
-            result.Select(issue => issue.Start).Should().Equal(new[] { 4 });
-            result.Select(issue => issue.Length).Should().Equal(new[] { 16 });
+            result.Select(issue => issue.Start).Should().Equal(4);
+            result.Select(issue => issue.Length).Should().Equal(16);
         }
 
         [TestMethod]
@@ -306,8 +306,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
                 expectedLineNumbers: new[] { 1 },
                 expectedMessages: new[] { "MyMessage" },
                 expectedIssueIds: new[] { "myIssueId" });
-            result.Select(issue => issue.Start).Should().Equal(new[] { 4 });
-            result.Select(issue => issue.Length).Should().Equal(new[] { 16 });
+            result.Select(issue => issue.Start).Should().Equal(4);
+            result.Select(issue => issue.Length).Should().Equal(16);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/ParseOptionsHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/ParseOptionsHelperTest.cs
@@ -35,30 +35,36 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
             var csVersions = ParseOptionsHelper.FromCSharp6.Cast<CS.CSharpParseOptions>().Select(x => x.LanguageVersion);
             if (!TestContextHelper.IsAzureDevOpsContext || TestContextHelper.IsPullRequestBuild)
             {
-                csVersions.Should().BeEquivalentTo(CS.LanguageVersion.CSharp6);
-                vbVersions.Should().BeEquivalentTo(VB.LanguageVersion.VisualBasic12);
+                csVersions.Should().BeEquivalentTo(new[] { CS.LanguageVersion.CSharp6 });
+                vbVersions.Should().BeEquivalentTo(new[] { VB.LanguageVersion.VisualBasic12 });
             }
             else
             {
                 // This should fail when we add new language version
                 csVersions.Should().BeEquivalentTo(
-                    CS.LanguageVersion.CSharp6,
-                    CS.LanguageVersion.CSharp7,
-                    CS.LanguageVersion.CSharp7_1,
-                    CS.LanguageVersion.CSharp7_2,
-                    CS.LanguageVersion.CSharp7_3,
-                    CS.LanguageVersion.CSharp8,
-                    CS.LanguageVersion.CSharp9,
-                    CS.LanguageVersion.CSharp10,
-                    CS.LanguageVersion.CSharp11);
+                    new[]
+                    {
+                        CS.LanguageVersion.CSharp6,
+                        CS.LanguageVersion.CSharp7,
+                        CS.LanguageVersion.CSharp7_1,
+                        CS.LanguageVersion.CSharp7_2,
+                        CS.LanguageVersion.CSharp7_3,
+                        CS.LanguageVersion.CSharp8,
+                        CS.LanguageVersion.CSharp9,
+                        CS.LanguageVersion.CSharp10,
+                        CS.LanguageVersion.CSharp11
+                    });
 
                 vbVersions.Should().BeEquivalentTo(
-                    VB.LanguageVersion.VisualBasic12,
-                    VB.LanguageVersion.VisualBasic14,
-                    VB.LanguageVersion.VisualBasic15,
-                    VB.LanguageVersion.VisualBasic15_3,
-                    VB.LanguageVersion.VisualBasic15_5,
-                    VB.LanguageVersion.VisualBasic16);
+                    new[]
+                    {
+                        VB.LanguageVersion.VisualBasic12,
+                        VB.LanguageVersion.VisualBasic14,
+                        VB.LanguageVersion.VisualBasic15,
+                        VB.LanguageVersion.VisualBasic15_3,
+                        VB.LanguageVersion.VisualBasic15_5,
+                        VB.LanguageVersion.VisualBasic16
+                    });
             }
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierBuilderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierBuilderTest.cs
@@ -191,8 +191,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
             var one = Empty.WithOnlyDiagnostics(NullPointerDereference.S2259);
             var two = one.WithOnlyDiagnostics(PublicMethodArgumentsShouldBeCheckedForNull.S3900, ConditionEvaluatesToConstant.S2583);
             Empty.OnlyDiagnostics.Should().BeEmpty();
-            one.OnlyDiagnostics.Should().BeEquivalentTo(NullPointerDereference.S2259);
-            two.OnlyDiagnostics.Should().BeEquivalentTo(PublicMethodArgumentsShouldBeCheckedForNull.S3900, ConditionEvaluatesToConstant.S2583);
+            one.OnlyDiagnostics.Should().BeEquivalentTo(new[] { NullPointerDereference.S2259 });
+            two.OnlyDiagnostics.Should().BeEquivalentTo(new[] { PublicMethodArgumentsShouldBeCheckedForNull.S3900, ConditionEvaluatesToConstant.S2583 });
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierBuilderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/VerifierBuilderTest.cs
@@ -74,8 +74,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework.Tests
             var one = Empty.AddSnippet("First");
             var two = one.AddSnippet("Second", "WithFileName.cs");
             Empty.Snippets.Should().BeEmpty();
-            one.Snippets.Should().BeEquivalentTo(new Snippet("First", null));
-            two.Snippets.Should().BeEquivalentTo(new Snippet("First", null), new Snippet("Second", "WithFileName.cs"));
+            one.Snippets.Should().Equal(new Snippet("First", null));
+            two.Snippets.Should().Equal(new Snippet("First", null), new Snippet("Second", "WithFileName.cs"));
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestSuiteInitialization.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestSuiteInitialization.cs
@@ -30,6 +30,8 @@ namespace SonarAnalyzer.UnitTest
         [AssemblyInitialize]
         public static void AssemblyInit(TestContext context)
         {
+            ConfigureFluentValidation();
+
             Console.WriteLine(@"Running tests initialization...");
             Console.WriteLine(@$"Build reason: {Environment.GetEnvironmentVariable(TestContextHelper.BuildReason) ?? "Not set / Local build"}");
 
@@ -38,6 +40,11 @@ namespace SonarAnalyzer.UnitTest
 
             var vbVersions = ParseOptionsHelper.Default(LanguageNames.VisualBasic).Cast<VisualBasicParseOptions>().Select(x => x.LanguageVersion.ToDisplayString());
             Console.WriteLine(@"VB.Net versions used for analysis: " + string.Join(", ", vbVersions));
+        }
+
+        private static void ConfigureFluentValidation()
+        {
+            AssertionOptions.FormattingOptions.MaxLines = -1;
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestSuiteInitialization.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestSuiteInitialization.cs
@@ -45,6 +45,7 @@ namespace SonarAnalyzer.UnitTest
         private static void ConfigureFluentValidation()
         {
             AssertionOptions.FormattingOptions.MaxLines = -1;
+            AssertionOptions.FormattingOptions.MaxDepth = 5; // Keeping the default for MaxDepth of 5 as a good compromise. Change it here if needed.
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/packages.lock.json
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/packages.lock.json
@@ -10,9 +10,13 @@
       },
       "FluentAssertions": {
         "type": "Direct",
-        "requested": "[5.10.3, )",
-        "resolved": "5.10.3",
-        "contentHash": "gVPEVp1hLVqcv+7Q2wiDf7kqCNn7+bQcQ0jbJ2mcRT6CeRoZl1tNkqvzSIhvekyldDptk77j1b03MXTTRIqqpg=="
+        "requested": "[6.8.0, )",
+        "resolved": "6.8.0",
+        "contentHash": "NfSlAG97wMxS48Ov+wQEhJITdn4bKrgtKrG4sCPrFBVKozpC57lQ2vzsPdxUOsPbfEgEQTMtvCDECxIlDBfgNA==",
+        "dependencies": {
+          "System.Net.Http": "4.3.4",
+          "System.Threading.Tasks.Extensions": "4.5.0"
+        }
       },
       "FluentAssertions.Analyzers": {
         "type": "Direct",
@@ -287,6 +291,11 @@
           "System.Composition.Runtime": "6.0.0"
         }
       },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "3qjaHvxQPDpSOYICjUoTsmoq5u6QJAFRUITgeT/4gqkF1bajbSmb1kwSxEA8AHlofqgcKJcM8udgieRNhaJ5Cg=="
+      },
       "System.IO.Pipelines": {
         "type": "Transitive",
         "resolved": "6.0.3",
@@ -307,6 +316,14 @@
           "System.Runtime.CompilerServices.Unsafe": "4.5.3"
         }
       },
+      "System.Net.Http": {
+        "type": "Transitive",
+        "resolved": "4.3.4",
+        "contentHash": "aOa2d51SEbmM+H+Csw7yJOuNZoHkrP2XnAurye5HWYgGVVU54YZDvsLUYRv6h18X3sPnjNCANmN7ZhIPiqMcjA==",
+        "dependencies": {
+          "System.Security.Cryptography.X509Certificates": "4.3.0"
+        }
+      },
       "System.Numerics.Vectors": {
         "type": "Transitive",
         "resolved": "4.5.0",
@@ -320,10 +337,45 @@
           "System.Collections.Immutable": "5.0.0"
         }
       },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "JufQi0vPQ0xGnAczR13AUFglDyVYt4Kqnz1AZaiKZ5+GICq0/1MH/mO/eAJHt/mHW1zjKBJd7kV26SrxddAhiw=="
+      },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Security.Cryptography.Algorithms": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "W1kd2Y8mYSCgc3ULTAZ0hOP2dSdG5YauTb1089T0/kRcN2MpSAW1izOFROrJgxSlMn3ArsgHXagigyi+ibhevg==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1DEWjZZly9ae9C79vFwqaO5kaOlI5q+3/55ohmq/7dpDyDfc8lYe7YVxJUZ5MF/NtbkRjwFRo14yM4OEo9EmDw=="
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7bDIyVFNL/xKeFHjhobUAQqSpJq9YTOpbEs6mR233Et01STBMXNAc/V+BM6dwYGc95gVh/Zf+iVXWzj3mE8DWg=="
+      },
+      "System.Security.Cryptography.X509Certificates": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "t2Tmu6Y2NtJ2um0RtcuhP7ZdNNxXEgUm2JeoA/0NvlMjAhKCnM1NX07TDl3244mVp3QU6LPEhT3HTtH1uF7IYw==",
+        "dependencies": {
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0"
+        }
       },
       "System.Text.Encoding.CodePages": {
         "type": "Transitive",
@@ -387,9 +439,9 @@
       },
       "FluentAssertions": {
         "type": "Direct",
-        "requested": "[5.10.3, )",
-        "resolved": "5.10.3",
-        "contentHash": "gVPEVp1hLVqcv+7Q2wiDf7kqCNn7+bQcQ0jbJ2mcRT6CeRoZl1tNkqvzSIhvekyldDptk77j1b03MXTTRIqqpg==",
+        "requested": "[6.8.0, )",
+        "resolved": "6.8.0",
+        "contentHash": "NfSlAG97wMxS48Ov+wQEhJITdn4bKrgtKrG4sCPrFBVKozpC57lQ2vzsPdxUOsPbfEgEQTMtvCDECxIlDBfgNA==",
         "dependencies": {
           "System.Configuration.ConfigurationManager": "4.4.0"
         }


### PR DESCRIPTION
See also https://fluentassertions.com/upgradingtov6
The main changes made are with respect to collections.
* The custom `OnlyContainInOrder` and `OnlyContain` are replaced
  * `OnlyContainInOrder` -> `Equal`
  * `OnlyContain` -> `BeEquivalentTo`
* `BeEquivalentTo` -> needs an array to be passed in now.
* Support for non-generic collections was dropped in V6 which results in some `.Cast<object>()` intermediate steps.
* Equivalence checks changed in some edge cases.
