### PR TITLE
Disable Incremental analysis ITs

### DIFF
--- a/its/src/test/java/com/sonar/it/csharp/IncrementalAnalysisTest.java
+++ b/its/src/test/java/com/sonar/it/csharp/IncrementalAnalysisTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -74,7 +75,8 @@ public class IncrementalAnalysisTest {
     assertThat(allIssues.get(0).getRule()).isEqualTo("csharpsquid:S1134");
   }
 
-  // ToDo: Re-enable this UT after SQ/S4NET fix: @Test
+  @Test
+  @Ignore // ToDo: Re-enable this IT after SQ/S4NET fix
   public void incrementalPrAnalysis_cacheAvailableNoChanges_nothingReported() throws IOException {
     Tests.analyzeProject(temp, PROJECT, null, "sonar.branch.name", "base-branch");
     Path projectDir = Tests.projectDir(temp, PROJECT);
@@ -90,7 +92,8 @@ public class IncrementalAnalysisTest {
     assertThat(allIssues).isEmpty();
   }
 
-  // ToDo: Re-enable this UT after SQ/S4NET fix: @Test
+  @Test
+  @Ignore // ToDo: Re-enable this IT after SQ/S4NET fix
   public void incrementalPrAnalysis_cacheAvailableChangesDone_issuesReportedForChangedFiles() throws IOException {
     Tests.analyzeProject(temp, PROJECT, null, "sonar.branch.name", "base-branch");
     Path projectDir = Tests.projectDir(temp, PROJECT);
@@ -119,7 +122,8 @@ public class IncrementalAnalysisTest {
     assertThat(allIssues.get(1).getComponent()).isEqualTo("IncrementalPRAnalysis:IncrementalPRAnalysis/WithChanges.cs");
   }
 
-  // ToDo: Re-enable this UT after SQ/S4NET fix: @Test
+  @Test
+  @Ignore // ToDo: Re-enable this IT after SQ/S4NET fix
   public void incrementalPrAnalysis_cacheAvailableProjectBaseDirChanged_everythingIsReanalyzed() throws IOException {
     Tests.analyzeProject(temp, PROJECT, null, "sonar.branch.name", "base-branch");
     Path projectDir = Tests.projectDir(temp, PROJECT);
@@ -143,7 +147,8 @@ public class IncrementalAnalysisTest {
     assertThat(allIssues.get(2).getComponent()).isEqualTo("IncrementalPRAnalysis:WithChanges.cs");
   }
 
-  // ToDo: Re-enable this UT after SQ/S4NET fix: @Test
+  @Test
+  @Ignore // ToDo: Re-enable this IT after SQ/S4NET fix
   public void incrementalPrAnalysis_cacheAvailableDuplicationIntroduced_duplicationReportedForChangedFile() throws IOException {
     String projectName = "IncrementalPRAnalysisDuplication";
     Tests.analyzeProject(temp, projectName, null, "sonar.branch.name", "base-branch");

--- a/its/src/test/java/com/sonar/it/csharp/IncrementalAnalysisTest.java
+++ b/its/src/test/java/com/sonar/it/csharp/IncrementalAnalysisTest.java
@@ -23,21 +23,20 @@ package com.sonar.it.csharp;
 import com.sonar.it.shared.TestUtils;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.ScannerForMSBuild;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sonarqube.ws.Duplications;
 import org.sonarqube.ws.Issues;
-
-import java.io.BufferedWriter;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.List;
 
 import static com.sonar.it.csharp.Tests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,7 +74,7 @@ public class IncrementalAnalysisTest {
     assertThat(allIssues.get(0).getRule()).isEqualTo("csharpsquid:S1134");
   }
 
-  @Test
+  // ToDo: Re-enable this UT after SQ/S4NET fix: @Test
   public void incrementalPrAnalysis_cacheAvailableNoChanges_nothingReported() throws IOException {
     Tests.analyzeProject(temp, PROJECT, null, "sonar.branch.name", "base-branch");
     Path projectDir = Tests.projectDir(temp, PROJECT);
@@ -91,7 +90,7 @@ public class IncrementalAnalysisTest {
     assertThat(allIssues).isEmpty();
   }
 
-  @Test
+  // ToDo: Re-enable this UT after SQ/S4NET fix: @Test
   public void incrementalPrAnalysis_cacheAvailableChangesDone_issuesReportedForChangedFiles() throws IOException {
     Tests.analyzeProject(temp, PROJECT, null, "sonar.branch.name", "base-branch");
     Path projectDir = Tests.projectDir(temp, PROJECT);
@@ -120,7 +119,7 @@ public class IncrementalAnalysisTest {
     assertThat(allIssues.get(1).getComponent()).isEqualTo("IncrementalPRAnalysis:IncrementalPRAnalysis/WithChanges.cs");
   }
 
-  @Test
+  // ToDo: Re-enable this UT after SQ/S4NET fix: @Test
   public void incrementalPrAnalysis_cacheAvailableProjectBaseDirChanged_everythingIsReanalyzed() throws IOException {
     Tests.analyzeProject(temp, PROJECT, null, "sonar.branch.name", "base-branch");
     Path projectDir = Tests.projectDir(temp, PROJECT);
@@ -144,7 +143,7 @@ public class IncrementalAnalysisTest {
     assertThat(allIssues.get(2).getComponent()).isEqualTo("IncrementalPRAnalysis:WithChanges.cs");
   }
 
-  @Test
+  // ToDo: Re-enable this UT after SQ/S4NET fix: @Test
   public void incrementalPrAnalysis_cacheAvailableDuplicationIntroduced_duplicationReportedForChangedFile() throws IOException {
     String projectName = "IncrementalPRAnalysisDuplication";
     Tests.analyzeProject(temp, projectName, null, "sonar.branch.name", "base-branch");
@@ -159,7 +158,8 @@ public class IncrementalAnalysisTest {
 
     assertTrue(endStepResults.isSuccess());
     assertCacheIsUsed(beginStepResults, projectName);
-    List<Duplications.Duplication> duplications = TestUtils.getDuplication(ORCHESTRATOR, "IncrementalPRAnalysisDuplication:IncrementalPRAnalysisDuplication/CopyClass.cs", "42").getDuplicationsList();
+    List<Duplications.Duplication> duplications = TestUtils.getDuplication(ORCHESTRATOR, "IncrementalPRAnalysisDuplication:IncrementalPRAnalysisDuplication/CopyClass.cs", "42")
+      .getDuplicationsList();
     assertThat(duplications).isNotEmpty();
   }
 
@@ -214,10 +214,9 @@ public class IncrementalAnalysisTest {
 
   private BeginAndEndStepResults executeAnalysisForPRBranch(String project, Path projectDir, String subProjectName) {
     ScannerForMSBuild beginStep;
-    if (subProjectName.isEmpty()){
+    if (subProjectName.isEmpty()) {
       beginStep = TestUtils.createBeginStep(project, projectDir);
-    }
-    else {
+    } else {
       beginStep = TestUtils.createBeginStep(project, projectDir, subProjectName);
     }
 
@@ -226,7 +225,7 @@ public class IncrementalAnalysisTest {
       .setProperty("sonar.pullrequest.key", "42")
       .setProperty("sonar.pullrequest.branch", "pull-request")
       .setProperty("sonar.verbose", "true"));
-    TestUtils.runMSBuild(ORCHESTRATOR, projectDir,"/t:Restore,Rebuild");
+    TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Restore,Rebuild");
     BuildResult endStepResults = ORCHESTRATOR.executeBuild(TestUtils.createEndStep(projectDir));
 
     return new BeginAndEndStepResults(beginStepResults, endStepResults);


### PR DESCRIPTION
Cache API used by incremental analysis has changed on SQ side and ITs are failing.

This will temporary disable them to unblock other work.

`@Disable` annotation is available from JUnit 5, we use version 4 so I've just commented the annotations with `ToDo`