### PR TITLE
Refactor SonarAnalysisContext - Rename reporting contexts

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/CBDE/CbdeHandler.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/CBDE/CbdeHandler.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.CBDE
         // this is the place where the cbde executable is unpacked. It is in a temp folder
         private static string extractedCbdeBinaryPath;
 
-        private readonly Action<SonarCompilationAnalysisContext, string, string, Location> raiseIssue;
+        private readonly Action<SonarCompilationReportingContext, string, string, Location> raiseIssue;
         // This is used by unit tests that want to check the log (whose path is the parameter of this action) contains what is expected
         private readonly Action<string> onCbdeExecution;
         // the cbdeExecutablePath is normally the extractedCbdeBinaryPath, but can be different in tests
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.CBDE
         private string cbdePerfLogFile;
         private string moreDetailsMessage;
 
-        public CbdeHandler(Action<SonarCompilationAnalysisContext, string, string, Location> raiseIssue,
+        public CbdeHandler(Action<SonarCompilationReportingContext, string, string, Location> raiseIssue,
             bool unitTest,
             string testCbdeBinaryPath = null, // Used by unit tests
             Action<string> onCbdeExecution = null) // Used by unit tests
@@ -267,7 +267,7 @@ Stack trace: {e.StackTrace}";
             PerformanceLog(perfLog.ToString());
         }
 
-        private void RunCbdeAndRaiseIssues(SonarCompilationAnalysisContext c)
+        private void RunCbdeAndRaiseIssues(SonarCompilationReportingContext c)
         {
             Log("Running CBDE");
             using (var cbdeProcess = new Process())
@@ -341,7 +341,7 @@ Stack trace: {e.StackTrace}";
         private void Cleanup() =>
             logStringBuilder.Clear();
 
-        private void RaiseIssueFromXElement(SonarCompilationAnalysisContext context, XElement issue)
+        private void RaiseIssueFromXElement(SonarCompilationReportingContext context, XElement issue)
         {
             var key = issue.Attribute("key").Value;
             var message = issue.Attribute("message").Value;
@@ -372,7 +372,7 @@ Stack trace: {e.StackTrace}";
             throw new CbdeException($"CBDE external process reported an error{moreDetailsMessage}");
         }
 
-        private void RaiseIssuesFromResultFile(SonarCompilationAnalysisContext context)
+        private void RaiseIssuesFromResultFile(SonarCompilationReportingContext context)
         {
             LogIfFailure($"- parsing file {cbdeResultsPath}");
             try

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarAnalysisContextExtensions.cs
@@ -23,34 +23,34 @@ namespace SonarAnalyzer.Extensions
     internal static class SonarAnalysisContextExtensions
     {
         public static void RegisterNodeAction<TSyntaxKind>(this SonarAnalysisContext context,
-                                                                               Action<SonarSyntaxNodeAnalysisContext> action,
+                                                                               Action<SonarSyntaxNodeReportingContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterNodeAction(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
         public static void RegisterNodeAction<TSyntaxKind>(this SonarParametrizedAnalysisContext context,
-                                                                               Action<SonarSyntaxNodeAnalysisContext> action,
+                                                                               Action<SonarSyntaxNodeReportingContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterNodeAction(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
         public static void RegisterNodeAction<TSyntaxKind>(this SonarCompilationStartAnalysisContext context,
-                                                                               Action<SonarSyntaxNodeAnalysisContext> action,
+                                                                               Action<SonarSyntaxNodeReportingContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterNodeAction(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterTreeAction(this SonarAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
+        public static void RegisterTreeAction(this SonarAnalysisContext context, Action<SonarSyntaxTreeReportingContext> action) =>
             context.RegisterTreeAction(CSharpGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterTreeAction(this SonarParametrizedAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
+        public static void RegisterTreeAction(this SonarParametrizedAnalysisContext context, Action<SonarSyntaxTreeReportingContext> action) =>
             context.RegisterTreeAction(CSharpGeneratedCodeRecognizer.Instance, action);
 
         public static void RegisterCodeBlockStartAction<TSyntaxKind>(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action)
             where TSyntaxKind : struct =>
             context.RegisterCodeBlockStartAction(CSharpGeneratedCodeRecognizer.Instance, action);
 
-        public static void ReportIssue(this SonarCompilationAnalysisContext context, Diagnostic diagnostic) =>
+        public static void ReportIssue(this SonarCompilationReportingContext context, Diagnostic diagnostic) =>
             context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
 
-        public static void ReportIssue(this SonarSymbolAnalysisContext context, Diagnostic diagnostic) =>
+        public static void ReportIssue(this SonarSymbolReportingContext context, Diagnostic diagnostic) =>
             context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarSyntaxNodeAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarSyntaxNodeAnalysisContextExtensions.cs
@@ -22,11 +22,11 @@ namespace SonarAnalyzer.Extensions;
 
 public static class SonarSyntaxNodeAnalysisContextExtensions
 {
-    public static bool IsTopLevelMain(this SonarSyntaxNodeAnalysisContext context) =>
+    public static bool IsTopLevelMain(this SonarSyntaxNodeReportingContext context) =>
         context.Node is CompilationUnitSyntax compilationUnitSyntax
         && compilationUnitSyntax.IsTopLevelMain()
         && context.ContainingSymbol.IsGlobalNamespace(); // Needed to avoid the duplicate calls from Roslyn 4.0.0
 
-    public static bool IsInExpressionTree(this SonarSyntaxNodeAnalysisContext context) =>
+    public static bool IsInExpressionTree(this SonarSyntaxNodeReportingContext context) =>
         context.Node.IsInExpressionTree(context.SemanticModel);
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AllBranchesShouldNotHaveSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AllBranchesShouldNotHaveSameImplementation.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ElseClause);
         }
 
-        private static void Analyze(SonarSyntaxNodeAnalysisContext context, SwitchExpressionSyntaxWrapper switchExpression)
+        private static void Analyze(SonarSyntaxNodeReportingContext context, SwitchExpressionSyntaxWrapper switchExpression)
         {
             var arms = switchExpression.Arms;
             if (arms.Count < 2)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ArrayCovariance.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ArrayCovariance.cs
@@ -37,13 +37,13 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(RaiseOnArrayCovarianceInCastExpression, SyntaxKind.CastExpression);
         }
 
-        private static void RaiseOnArrayCovarianceInSimpleAssignmentExpression(SonarSyntaxNodeAnalysisContext context)
+        private static void RaiseOnArrayCovarianceInSimpleAssignmentExpression(SonarSyntaxNodeReportingContext context)
         {
             var assignment = (AssignmentExpressionSyntax)context.Node;
             VerifyExpression(assignment.Right, context.SemanticModel.GetTypeInfo(assignment.Left).Type, context);
         }
 
-        private static void RaiseOnArrayCovarianceInVariableDeclaration(SonarSyntaxNodeAnalysisContext context)
+        private static void RaiseOnArrayCovarianceInVariableDeclaration(SonarSyntaxNodeReportingContext context)
         {
             var variableDeclaration = (VariableDeclarationSyntax)context.Node;
             var baseType = context.SemanticModel.GetTypeInfo(variableDeclaration.Type).Type;
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void RaiseOnArrayCovarianceInInvocationExpression(SonarSyntaxNodeAnalysisContext context)
+        private static void RaiseOnArrayCovarianceInInvocationExpression(SonarSyntaxNodeReportingContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             var methodParameterLookup = new CSharpMethodParameterLookup(invocation, context.SemanticModel);
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void RaiseOnArrayCovarianceInCastExpression(SonarSyntaxNodeAnalysisContext context)
+        private static void RaiseOnArrayCovarianceInCastExpression(SonarSyntaxNodeReportingContext context)
         {
             var castExpression = (CastExpressionSyntax)context.Node;
             var baseType = context.SemanticModel.GetTypeInfo(castExpression.Type).Type;
@@ -78,7 +78,7 @@ namespace SonarAnalyzer.Rules.CSharp
             VerifyExpression(castExpression.Expression, baseType, context);
         }
 
-        private static void VerifyExpression(SyntaxNode node, ITypeSymbol baseType, SonarSyntaxNodeAnalysisContext context)
+        private static void VerifyExpression(SyntaxNode node, ITypeSymbol baseType, SonarSyntaxNodeReportingContext context)
         {
             foreach (var pair in GetPossibleTypes(node, context.SemanticModel).Where(pair => AreCovariantArrayTypes(pair.Symbol, baseType)))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BinaryOperationWithIdenticalExpressions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BinaryOperationWithIdenticalExpressions.cs
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.InvocationExpression);
         }
 
-        private static void ReportOnObjectEqualsMatches(SonarSyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation)
+        private static void ReportOnObjectEqualsMatches(SonarSyntaxNodeReportingContext context, InvocationExpressionSyntax invocation)
         {
             var methodSymbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
 
@@ -109,7 +109,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static SyntaxNode RemoveParentheses(SyntaxNode node) =>
             node is ExpressionSyntax expression ? expression.RemoveParentheses() : node;
 
-        private static void ReportIfOperatorExpressionsMatch(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax left, ExpressionSyntax right, SyntaxToken operatorToken)
+        private static void ReportIfOperatorExpressionsMatch(SonarSyntaxNodeReportingContext context, ExpressionSyntax left, ExpressionSyntax right, SyntaxToken operatorToken)
         {
             if (CSharpEquivalenceChecker.AreEquivalent(left.RemoveParentheses(), right.RemoveParentheses()))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BooleanLiteralUnnecessary.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BooleanLiteralUnnecessary.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(CheckForLoopCondition, SyntaxKind.ForStatement);
         }
 
-        private void CheckForLoopCondition(SonarSyntaxNodeAnalysisContext context)
+        private void CheckForLoopCondition(SonarSyntaxNodeReportingContext context)
         {
             var forLoop = (ForStatementSyntax)context.Node;
 
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void CheckLogicalNot(SonarSyntaxNodeAnalysisContext context)
+        private void CheckLogicalNot(SonarSyntaxNodeReportingContext context)
         {
             var logicalNot = (PrefixUnaryExpressionSyntax)context.Node;
             var logicalNotOperand = logicalNot.Operand.RemoveParentheses();
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 node.IsKind(SyntaxKind.TrueLiteralExpression) || node.IsKind(SyntaxKind.FalseLiteralExpression);
         }
 
-        private void CheckConditional(SonarSyntaxNodeAnalysisContext context)
+        private void CheckConditional(SonarSyntaxNodeReportingContext context)
         {
             var conditional = (ConditionalExpressionSyntax)context.Node;
             var whenTrue = conditional.WhenTrue;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CallToAsyncMethodShouldNotBeBlocking.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CallToAsyncMethodShouldNotBeBlocking.cs
@@ -75,7 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(ReportOnViolation, SyntaxKind.SimpleMemberAccessExpression);
 
-        private static void ReportOnViolation(SonarSyntaxNodeAnalysisContext context)
+        private static void ReportOnViolation(SonarSyntaxNodeReportingContext context)
         {
             var simpleMemberAccess = (MemberAccessExpressionSyntax)context.Node;
             var memberAccessNameName = simpleMemberAccess.GetName();
@@ -114,7 +114,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.ReportIssue(Diagnostic.Create(context.IsAzureFunction() ? RuleS6422 : RuleS4462, simpleMemberAccess.GetLocation(), MemberNameToMessageArguments[memberAccessNameName]));
         }
 
-        private static bool IsAwaited(SonarSyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax simpleMemberAccess)
+        private static bool IsAwaited(SonarSyntaxNodeReportingContext context, MemberAccessExpressionSyntax simpleMemberAccess)
         {
             return context.SemanticModel.GetSymbolInfo(simpleMemberAccess.Expression).Symbol is { } accessedSymbol
                    && simpleMemberAccess.FirstAncestorOrSelf<StatementSyntax>() is { } currentStatement

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CallerInformationParametersShouldBeLast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CallerInformationParametersShouldBeLast.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ConstructorDeclaration,
                 SyntaxKindEx.LocalFunctionStatement);
 
-        private static void ReportOnViolation(SonarSyntaxNodeAnalysisContext context)
+        private static void ReportOnViolation(SonarSyntaxNodeReportingContext context)
         {
             var methodDeclaration = context.Node;
             var parameterList = LocalFunctionStatementSyntaxWrapper.IsInstance(methodDeclaration)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CastConcreteTypeToInterface.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CastConcreteTypeToInterface.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.AsExpression);
         }
 
-        private static void CheckForIssue(SonarSyntaxNodeAnalysisContext context, SyntaxNode fromExpression, SyntaxNode toExpression)
+        private static void CheckForIssue(SonarSyntaxNodeReportingContext context, SyntaxNode fromExpression, SyntaxNode toExpression)
         {
             var castedFrom = context.SemanticModel.GetTypeInfo(fromExpression).Type;
             var castedTo = context.SemanticModel.GetTypeInfo(toExpression).Type;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CastShouldNotBeDuplicated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CastShouldNotBeDuplicated.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(CasePatternSwitchLabel, SyntaxKindEx.CasePatternSwitchLabel);
         }
 
-        private static void CasePatternSwitchLabel(SonarSyntaxNodeAnalysisContext analysisContext)
+        private static void CasePatternSwitchLabel(SonarSyntaxNodeReportingContext analysisContext)
         {
             var casePatternSwitch = (CasePatternSwitchLabelSyntaxWrapper)analysisContext.Node;
             if (casePatternSwitch.SyntaxNode.GetFirstNonParenthesizedParent().GetFirstNonParenthesizedParent() is not SwitchStatementSyntax parentSwitchStatement)
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                      parentSwitchStatement);
         }
 
-        private static void SwitchExpressionArm(SonarSyntaxNodeAnalysisContext analysisContext)
+        private static void SwitchExpressionArm(SonarSyntaxNodeReportingContext analysisContext)
         {
             var isSwitchExpression = (SwitchExpressionArmSyntaxWrapper)analysisContext.Node;
             var parent = isSwitchExpression.SyntaxNode.GetFirstNonParenthesizedParent();
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                      isSwitchExpression);
         }
 
-        private static void IsPatternExpression(SonarSyntaxNodeAnalysisContext analysisContext)
+        private static void IsPatternExpression(SonarSyntaxNodeReportingContext analysisContext)
         {
             var isPatternExpression = (IsPatternExpressionSyntaxWrapper)analysisContext.Node;
             if (isPatternExpression.SyntaxNode.GetFirstNonParenthesizedParent() is not IfStatementSyntax parentIfStatement)
@@ -83,7 +83,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                      parentIfStatement.Statement);
         }
 
-        private static void IsExpression(SonarSyntaxNodeAnalysisContext analysisContext)
+        private static void IsExpression(SonarSyntaxNodeReportingContext analysisContext)
         {
             var isExpression = (BinaryExpressionSyntax)analysisContext.Node;
 
@@ -98,7 +98,7 @@ namespace SonarAnalyzer.Rules.CSharp
             ReportPatternAtMainVariable(analysisContext, isExpression.Left, isExpression.GetLocation(), parentIfStatement.Statement, castType, ReplaceWithAsAndNullCheckMessage);
         }
 
-        private static List<Location> GetDuplicatedCastLocations(SonarSyntaxNodeAnalysisContext analysisContext, SyntaxNode parentStatement, TypeSyntax castType, SyntaxNode typedVariable)
+        private static List<Location> GetDuplicatedCastLocations(SonarSyntaxNodeReportingContext analysisContext, SyntaxNode parentStatement, TypeSyntax castType, SyntaxNode typedVariable)
         {
             var typeExpressionSymbol = analysisContext.SemanticModel.GetSymbolInfo(typedVariable).Symbol
                                        ?? analysisContext.SemanticModel.GetDeclaredSymbol(typedVariable);
@@ -115,7 +115,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 Equals(analysisContext.SemanticModel.GetSymbolInfo(castExpression.Expression).Symbol, typeExpressionSymbol);
         }
 
-        private static void ProcessPatternExpression(SonarSyntaxNodeAnalysisContext analysisContext,
+        private static void ProcessPatternExpression(SonarSyntaxNodeReportingContext analysisContext,
                                                      SyntaxNode isPattern,
                                                      SyntaxNode mainVariableExpression,
                                                      SyntaxNode parentStatement)
@@ -209,7 +209,7 @@ namespace SonarAnalyzer.Rules.CSharp
             return null;
         }
 
-        private static void ReportPatternAtMainVariable(SonarSyntaxNodeAnalysisContext context,
+        private static void ReportPatternAtMainVariable(SonarSyntaxNodeReportingContext context,
                                                         SyntaxNode variableExpression,
                                                         Location mainLocation,
                                                         SyntaxNode parentStatement,
@@ -224,7 +224,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportPatternAtCastLocation(SonarSyntaxNodeAnalysisContext context,
+        private static void ReportPatternAtCastLocation(SonarSyntaxNodeReportingContext context,
                                                         SyntaxNode variableExpression,
                                                         Location patternLocation,
                                                         SyntaxNode parentStatement,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CbdeHandlerRule.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CbdeHandlerRule.cs
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
         }
 
         // This functions is called for each issue found by cbde after it runs
-        private void OnCbdeIssue(SonarCompilationAnalysisContext context, string key, string message, Location loc)
+        private void OnCbdeIssue(SonarCompilationReportingContext context, string key, string message, Location loc)
         {
             if (!ruleIdToDiagDescriptor.ContainsKey(key))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CheckArgumentException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CheckArgumentException.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(CheckForIssue, SyntaxKind.ObjectCreationExpression, SyntaxKindEx.ImplicitObjectCreationExpression);
 
-        private static void CheckForIssue(SonarSyntaxNodeAnalysisContext analysisContext)
+        private static void CheckForIssue(SonarSyntaxNodeReportingContext analysisContext)
         {
             var objectCreation = ObjectCreationFactory.Create(analysisContext.Node);
             var methodSymbol = objectCreation.MethodSymbol(analysisContext.SemanticModel);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassAndMethodName.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassAndMethodName.cs
@@ -114,7 +114,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKindEx.LocalFunctionStatement);
         }
 
-        private static void CheckTypeName(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckTypeName(SonarSyntaxNodeReportingContext context)
         {
             var typeDeclaration = (BaseTypeDeclarationSyntax)context.Node;
             var identifier = typeDeclaration.Identifier;
@@ -158,7 +158,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckMemberName(SonarSyntaxNodeAnalysisContext context, SyntaxToken identifier)
+        private static void CheckMemberName(SonarSyntaxNodeReportingContext context, SyntaxToken identifier)
         {
             var symbol = context.SemanticModel.GetDeclaredSymbol(context.Node);
             if (symbol == null)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeAbstract.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeAbstract.cs
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static IEnumerable<IMethodSymbol> GetAllOverrideMethods(INamedTypeSymbol symbol) =>
             GetAllMethods(symbol).Where(m => m.IsOverride);
 
-        private static void Report(SonarSymbolAnalysisContext context, INamedTypeSymbol symbol, string message)
+        private static void Report(SonarSymbolReportingContext context, INamedTypeSymbol symbol, string message)
         {
             foreach (var declaringSyntaxReference in symbol.DeclaringSyntaxReferences)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithOnlyStaticMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithOnlyStaticMember.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 },
                 SymbolKind.NamedType);
 
-        private static void CheckClasses(SonarSymbolAnalysisContext context, INamedTypeSymbol utilityClass)
+        private static void CheckClasses(SonarSymbolReportingContext context, INamedTypeSymbol utilityClass)
         {
             if (!ClassIsRelevant(utilityClass))
             {
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckConstructors(SonarSymbolAnalysisContext context, INamedTypeSymbol utilityClass)
+        private static void CheckConstructors(SonarSymbolReportingContext context, INamedTypeSymbol utilityClass)
         {
             if (!ClassQualifiesForIssue(utilityClass) || !HasMembersAndAllAreStaticExceptConstructors(utilityClass))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsReuseClients.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsReuseClients.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.CSharp
             },
             SyntaxKind.ObjectCreationExpression, SyntaxKindEx.ImplicitObjectCreationExpression);
 
-        private static bool IsAssignedForReuse(SonarSyntaxNodeAnalysisContext context) =>
+        private static bool IsAssignedForReuse(SonarSyntaxNodeReportingContext context) =>
             !IsInVariableDeclaration(context.Node)
             && (IsInFieldOrPropertyInitializer(context.Node) || IsAssignedToStaticFieldOrProperty(context));
 
@@ -75,11 +75,11 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool IsInFieldOrPropertyInitializer(SyntaxNode node) =>
             node.Ancestors().Any(x => x.IsAnyKind(SyntaxKind.FieldDeclaration, SyntaxKind.PropertyDeclaration));
 
-        private static bool IsAssignedToStaticFieldOrProperty(SonarSyntaxNodeAnalysisContext context) =>
+        private static bool IsAssignedToStaticFieldOrProperty(SonarSyntaxNodeReportingContext context) =>
             context.Node.Parent.WalkUpParentheses() is AssignmentExpressionSyntax assignment
                 && context.SemanticModel.GetSymbolInfo(assignment.Left, context.Cancel).Symbol is { IsStatic: true, Kind: SymbolKind.Field or SymbolKind.Property };
 
-        private static bool IsResuableClient(SonarSyntaxNodeAnalysisContext context)
+        private static bool IsResuableClient(SonarSyntaxNodeReportingContext context)
         {
             var objectCreation = ObjectCreationFactory.Create(context.Node);
             return ReusableClients.Any(x => objectCreation.IsKnownType(x, context.SemanticModel));

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsStateless.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsStateless.cs
@@ -69,7 +69,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.Argument);
         }
 
-        private static void CheckTarget(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax target)
+        private static void CheckTarget(SonarSyntaxNodeReportingContext context, ExpressionSyntax target)
         {
             if (context.IsAzureFunction()
                 && context.SemanticModel.GetSymbolInfo((target as ElementAccessExpressionSyntax)?.Expression ?? target).Symbol is { } symbol

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CollectionQuerySimplification.cs
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(CheckCountCall, SyntaxKind.InvocationExpression);
         }
 
-        private static void CheckCountCall(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckCountCall(SonarSyntaxNodeReportingContext context)
         {
             const string CountName = "Count";
 
@@ -97,7 +97,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 semanticModel.GetTypeInfo(expression).Type.GetMembers(CountName).OfType<IPropertySymbol>().Any();
         }
 
-        private static void CheckToCollectionCalls(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckToCollectionCalls(SonarSyntaxNodeReportingContext context)
         {
             var outerInvocation = (InvocationExpressionSyntax)context.Node;
             if (!(context.SemanticModel.GetSymbolInfo(outerInvocation).Symbol is IMethodSymbol outerMethodSymbol) ||
@@ -169,7 +169,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 methodSymbol.ContainingType.ConstructedFrom.Is(KnownType.System_Collections_Generic_List_T));
         }
 
-        private static void CheckExtensionMethodsOnIEnumerable(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckExtensionMethodsOnIEnumerable(SonarSyntaxNodeReportingContext context)
         {
             var outerInvocation = (InvocationExpressionSyntax)context.Node;
             if (!(context.SemanticModel.GetSymbolInfo(outerInvocation).Symbol is IMethodSymbol outerMethodSymbol) ||
@@ -232,7 +232,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 : invocation.ArgumentList.Arguments.Skip(1).ToList();
         }
 
-        private static void CheckForCastSimplification(SonarSyntaxNodeAnalysisContext context,
+        private static void CheckForCastSimplification(SonarSyntaxNodeReportingContext context,
                                                        IMethodSymbol outerMethodSymbol,
                                                        InvocationExpressionSyntax outerInvocation,
                                                        IMethodSymbol innerMethodSymbol,
@@ -396,7 +396,7 @@ namespace SonarAnalyzer.Rules.CSharp
             return true;
         }
 
-        private static bool CheckForSimplifiable(SonarSyntaxNodeAnalysisContext context,
+        private static bool CheckForSimplifiable(SonarSyntaxNodeReportingContext context,
                                                  IMethodSymbol outerMethodSymbol,
                                                  InvocationExpressionSyntax outerInvocation,
                                                  IMethodSymbol innerMethodSymbol,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentedOutCode.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentedOutCode.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     }
                 });
 
-        private static void CheckTrivia(SonarSyntaxTreeAnalysisContext context, IEnumerable<SyntaxTrivia> trivia)
+        private static void CheckTrivia(SonarSyntaxTreeReportingContext context, IEnumerable<SyntaxTrivia> trivia)
         {
             var shouldReport = true;
             foreach (var trivium in trivia)
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckMultilineComment(SonarSyntaxTreeAnalysisContext context, SyntaxTrivia trivia)
+        private static void CheckMultilineComment(SonarSyntaxTreeReportingContext context, SyntaxTrivia trivia)
         {
             var triviaLines = TriviaContent().Split(MetricsBase.LineTerminators, StringSplitOptions.None);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalSimplification.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalSimplification.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(CheckNotPattern, SyntaxKindEx.NotPattern);
         }
 
-        private static void CheckNotPattern(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckNotPattern(SonarSyntaxNodeReportingContext context)
         {
             var wrapper = (UnaryPatternSyntaxWrapper)context.Node;
             if (wrapper.Pattern.IsNot()
@@ -78,7 +78,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckCoalesceExpression(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckCoalesceExpression(SonarSyntaxNodeReportingContext context)
         {
             if (context.Node.GetFirstNonParenthesizedParent() is AssignmentExpressionSyntax assignment
                 && !assignment.Parent.IsKind(SyntaxKind.ObjectInitializerExpression)
@@ -92,7 +92,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckIfStatement(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckIfStatement(SonarSyntaxNodeReportingContext context)
         {
             var ifStatement = (IfStatementSyntax)context.Node;
             if (ifStatement.Parent is ElseClauseSyntax)
@@ -122,7 +122,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckConditionalExpression(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckConditionalExpression(SonarSyntaxNodeReportingContext context)
         {
             var conditional = (ConditionalExpressionSyntax)context.Node;
             var condition = conditional.Condition.RemoveParentheses();
@@ -183,7 +183,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool IsNullAndValueType(ITypeSymbol typeNull, ITypeSymbol typeValue) =>
             typeNull == null && typeValue is {IsValueType: true};
 
-        private static bool CanBeSimplified(SonarSyntaxNodeAnalysisContext context,
+        private static bool CanBeSimplified(SonarSyntaxNodeReportingContext context,
                                             StatementSyntax statement1,
                                             StatementSyntax statement2,
                                             SyntaxNode comparedToNull,
@@ -343,7 +343,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static ImmutableDictionary<string, string> BuildCodeFixProperties(SonarSyntaxNodeAnalysisContext c, string simplifiedOperator = null)
+        private static ImmutableDictionary<string, string> BuildCodeFixProperties(SonarSyntaxNodeReportingContext c, string simplifiedOperator = null)
         {
             var ret = new Dictionary<string, string> { {IsCoalesceAssignmentSupportedKey, c.Compilation.IsCoalesceAssignmentSupported().ToString() }};
             if (simplifiedOperator != null)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameImplementation.cs
@@ -85,7 +85,7 @@ namespace SonarAnalyzer.Rules.CSharp
                       .Union(switchSection.Statements.OfType<BlockSyntax>().SelectMany(block => block.Statements))
                       .Union(switchSection.Statements.Where(s => !s.IsKind(SyntaxKind.Block)));
 
-        private static void CheckStatement(SonarSyntaxNodeAnalysisContext context, SyntaxNode statement, IEnumerable<StatementSyntax> precedingStatements)
+        private static void CheckStatement(SonarSyntaxNodeReportingContext context, SyntaxNode statement, IEnumerable<StatementSyntax> precedingStatements)
         {
             if (statement.ChildNodes().Count() < 2)
             {
@@ -99,7 +99,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportSyntaxNode(SonarSyntaxNodeAnalysisContext context, SyntaxNode node, SyntaxNode precedingNode, string errorMessageDiscriminator) =>
+        private static void ReportSyntaxNode(SonarSyntaxNodeReportingContext context, SyntaxNode node, SyntaxNode precedingNode, string errorMessageDiscriminator) =>
             context.ReportIssue(Rule.CreateDiagnostic(context.Compilation,
                 node.GetLocation(),
                 additionalLocations: new[] { precedingNode.GetLocation() },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.SwitchStatement);
         }
 
-        private static void CheckMatchingExpressionsInSucceedingStatements<T>(SonarSyntaxNodeAnalysisContext context, Func<T, ExpressionSyntax> expression) where T : StatementSyntax
+        private static void CheckMatchingExpressionsInSucceedingStatements<T>(SonarSyntaxNodeReportingContext context, Func<T, ExpressionSyntax> expression) where T : StatementSyntax
         {
             var currentStatement = (T)context.Node;
             if (currentStatement.GetPrecedingStatement() is T previousStatement)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorArgumentValueShouldExist.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorArgumentValueShouldExist.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 .Select(x => x.Identifier.ValueText);
         }
 
-        protected override void ReportIssue(SonarSyntaxNodeAnalysisContext c, AttributeData constructorArgumentAttribute)
+        protected override void ReportIssue(SonarSyntaxNodeReportingContext c, AttributeData constructorArgumentAttribute)
         {
             var attributeSyntax =
                 (AttributeSyntax)constructorArgumentAttribute.ApplicationSyntaxReference.GetSyntax();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorOverridableCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorOverridableCall.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.InvocationExpression);
         }
 
-        private static void CheckOverridableCallInConstructor(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckOverridableCallInConstructor(SonarSyntaxNodeReportingContext context)
         {
             var invocationExpression = (InvocationExpressionSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ControlCharacterInString.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ControlCharacterInString.cs
@@ -102,7 +102,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.InterpolatedStringText);
         }
 
-        private static void CheckControlCharacter(SonarSyntaxNodeAnalysisContext c, string text, int displayPosIncrement)
+        private static void CheckControlCharacter(SonarSyntaxNodeReportingContext c, string text, int displayPosIncrement)
         {
             if (IsInescapableString(c.Node) || IsInescepableInterpolatedString(c.Node.Parent) || IsInescapableUtf8String(c.Node))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CryptographicKeyShouldNotBeTooShort.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CryptographicKeyShouldNotBeTooShort.cs
@@ -121,7 +121,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.SimpleAssignmentExpression);
         }
 
-        private void CheckAlgorithmCreation(SonarSyntaxNodeAnalysisContext c, ITypeSymbol containingType, InvocationExpressionSyntax invocation)
+        private void CheckAlgorithmCreation(SonarSyntaxNodeReportingContext c, ITypeSymbol containingType, InvocationExpressionSyntax invocation)
         {
             var firstParam = invocation.ArgumentList.Get(0);
             if (firstParam == null || containingType == null)
@@ -139,7 +139,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void CheckBouncyCastleEllipticCurve(SonarSyntaxNodeAnalysisContext c, ITypeSymbol containingType, InvocationExpressionSyntax invocation)
+        private void CheckBouncyCastleEllipticCurve(SonarSyntaxNodeReportingContext c, ITypeSymbol containingType, InvocationExpressionSyntax invocation)
         {
             var firstParam = invocation.ArgumentList.Get(0);
             if (firstParam == null || containingType == null || !containingType.IsAny(BouncyCastleCurveClasses))
@@ -153,7 +153,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void CheckSystemSecurityEllipticCurve(SonarSyntaxNodeAnalysisContext c, ITypeSymbol containingType, SyntaxNode syntaxElement, ArgumentListSyntax argumentList)
+        private void CheckSystemSecurityEllipticCurve(SonarSyntaxNodeReportingContext c, ITypeSymbol containingType, SyntaxNode syntaxElement, ArgumentListSyntax argumentList)
         {
             var firstParam = argumentList.Get(0);
             if (firstParam == null || containingType == null || !containingType.DerivesFromAny(SystemSecurityCryptographyCurveClasses))
@@ -167,7 +167,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void CheckCurveNameKeyLength(SonarSyntaxNodeAnalysisContext c, SyntaxNode syntaxElement, string curveName)
+        private void CheckCurveNameKeyLength(SonarSyntaxNodeReportingContext c, SyntaxNode syntaxElement, string curveName)
         {
             var match = namedEllipticCurve.Match(curveName);
             if (match.Success && int.TryParse(match.Groups["KeyLength"].Value, out var keyLength) && keyLength < MinimalEllipticCurveKeyLength)
@@ -176,7 +176,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckSystemSecurityCryptographyAlgorithms(SonarSyntaxNodeAnalysisContext c, ITypeSymbol containingType, IObjectCreation objectCreation)
+        private static void CheckSystemSecurityCryptographyAlgorithms(SonarSyntaxNodeReportingContext c, ITypeSymbol containingType, IObjectCreation objectCreation)
         {
             // DSACryptoServiceProvider is always noncompliant as it has a max key size of 1024
             // RSACryptoServiceProvider() and RSACryptoServiceProvider(System.Security.Cryptography.CspParameters) constructors are noncompliants as they have a default key size of 1024
@@ -192,14 +192,14 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static bool HasDefaultSize(SonarSyntaxNodeAnalysisContext c, ArgumentListSyntax argumentList) =>
+        private static bool HasDefaultSize(SonarSyntaxNodeReportingContext c, ArgumentListSyntax argumentList) =>
             argumentList == null
             || argumentList.Arguments.Count == 0
             || (argumentList.Arguments.Count == 1
                 && c.SemanticModel.GetTypeInfo(argumentList.Arguments[0].Expression).Type is ITypeSymbol type
                 && type.Is(KnownType.System_Security_Cryptography_CspParameters));
 
-        private static void CheckGenericDsaRsaCryptographyAlgorithms(SonarSyntaxNodeAnalysisContext c, ITypeSymbol containingType, SyntaxNode syntaxElement, SyntaxNode keyLengthSyntax)
+        private static void CheckGenericDsaRsaCryptographyAlgorithms(SonarSyntaxNodeReportingContext c, ITypeSymbol containingType, SyntaxNode syntaxElement, SyntaxNode keyLengthSyntax)
         {
             if (containingType.DerivesFromAny(SystemSecurityCryptographyDsaRsa) && keyLengthSyntax != null && IsInvalidCommonKeyLength(c, keyLengthSyntax))
             {
@@ -207,7 +207,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckBouncyCastleParametersGenerators(SonarSyntaxNodeAnalysisContext c, ITypeSymbol containingType, InvocationExpressionSyntax invocation)
+        private static void CheckBouncyCastleParametersGenerators(SonarSyntaxNodeReportingContext c, ITypeSymbol containingType, InvocationExpressionSyntax invocation)
         {
             if (invocation.ArgumentList.Get(0) is { } firstParam
                 && containingType != null
@@ -219,7 +219,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckBouncyCastleKeyGenerationParameters(SonarSyntaxNodeAnalysisContext c, ITypeSymbol containingType, IObjectCreation objectCreation)
+        private static void CheckBouncyCastleKeyGenerationParameters(SonarSyntaxNodeReportingContext c, ITypeSymbol containingType, IObjectCreation objectCreation)
         {
             if (objectCreation.ArgumentList.Get(2) is { } keyLengthParam
                 && containingType.Is(KnownType.Org_BouncyCastle_Crypto_Parameters_RsaKeyGenerationParameters)
@@ -229,7 +229,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static bool IsInvalidCommonKeyLength(SonarSyntaxNodeAnalysisContext c, SyntaxNode keyLengthSyntax) =>
+        private static bool IsInvalidCommonKeyLength(SonarSyntaxNodeReportingContext c, SyntaxNode keyLengthSyntax) =>
             keyLengthSyntax.FindConstantValue(c.SemanticModel) is int keyLength && keyLength < MinimalCommonKeyLength;
 
         private static string GetMethodName(InvocationExpressionSyntax invocationExpression) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DatabasePasswordsShouldBeSecure.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DatabasePasswordsShouldBeSecure.cs
@@ -69,7 +69,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterCompilationAction(CheckAppSettings);
         }
 
-        private void CheckWebConfig(SonarCompilationAnalysisContext c)
+        private void CheckWebConfig(SonarCompilationReportingContext c)
         {
             foreach (var fullPath in c.WebConfigFiles())
             {
@@ -81,7 +81,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void CheckAppSettings(SonarCompilationAnalysisContext c)
+        private void CheckAppSettings(SonarCompilationReportingContext c)
         {
             foreach (var fullPath in c.AppSettingsFiles())
             {
@@ -89,7 +89,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void CheckAppSettingJson(SonarCompilationAnalysisContext c, string fullPath)
+        private void CheckAppSettingJson(SonarCompilationReportingContext c, string fullPath)
         {
             var appSettings = File.ReadAllText(fullPath);
             if (appSettings.Contains("\"ConnectionStrings\"") && JsonNode.FromString(appSettings) is { } json)
@@ -98,7 +98,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void ReportEmptyPassword(SonarCompilationAnalysisContext c, XDocument doc, string webConfigPath)
+        private void ReportEmptyPassword(SonarCompilationReportingContext c, XDocument doc, string webConfigPath)
         {
             foreach (var addAttribute in doc.XPathSelectElements("configuration/connectionStrings/add"))
             {
@@ -112,7 +112,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void ReportEmptyPassword(SonarCompilationAnalysisContext c, JsonNode doc, string appSettingsPath)
+        private void ReportEmptyPassword(SonarCompilationReportingContext c, JsonNode doc, string appSettingsPath)
         {
             if (doc.TryGetPropertyNode("ConnectionStrings", out var connectionStrings) && connectionStrings.Kind == Kind.Object)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.RoslynCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.RoslynCfg.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             private readonly RoslynLiveVariableAnalysis lva;
 
-            public RoslynChecker(SonarSyntaxNodeAnalysisContext context, RoslynLiveVariableAnalysis lva) : base(context, lva) =>
+            public RoslynChecker(SonarSyntaxNodeReportingContext context, RoslynLiveVariableAnalysis lva) : base(context, lva) =>
                 this.lva = lva;
 
             protected override State CreateState(BasicBlock block) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.SonarCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.SonarCfg.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             private readonly SyntaxNode node;
 
-            public SonarChecker(SonarSyntaxNodeAnalysisContext context, SonarCSharpLiveVariableAnalysis lva, SyntaxNode node) : base(context, lva) =>
+            public SonarChecker(SonarSyntaxNodeReportingContext context, SonarCSharpLiveVariableAnalysis lva, SyntaxNode node) : base(context, lva) =>
                 this.node = node;
 
             protected override State CreateState(Block block) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
@@ -72,10 +72,10 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKindEx.LocalFunctionStatement);
         }
 
-        private void CheckForDeadStores<T>(SonarSyntaxNodeAnalysisContext context, ISymbol symbol, Func<T, CSharpSyntaxNode> bodyOrExpressionBody) where T : SyntaxNode =>
+        private void CheckForDeadStores<T>(SonarSyntaxNodeReportingContext context, ISymbol symbol, Func<T, CSharpSyntaxNode> bodyOrExpressionBody) where T : SyntaxNode =>
             CheckForDeadStores(context, symbol, bodyOrExpressionBody((T)context.Node));
 
-        private void CheckForDeadStores(SonarSyntaxNodeAnalysisContext context, ISymbol symbol, CSharpSyntaxNode node)
+        private void CheckForDeadStores(SonarSyntaxNodeReportingContext context, ISymbol symbol, CSharpSyntaxNode node)
         {
             if (symbol != null && node != null)
             {
@@ -101,12 +101,12 @@ namespace SonarAnalyzer.Rules.CSharp
         private abstract class CheckerBase<TCfg, TBlock>
         {
             private readonly LiveVariableAnalysisBase<TCfg, TBlock> lva;
-            private readonly SonarSyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeReportingContext context;
             private readonly ISet<ISymbol> capturedVariables;
 
             protected abstract State CreateState(TBlock block);
 
-            protected CheckerBase(SonarSyntaxNodeAnalysisContext context, LiveVariableAnalysisBase<TCfg, TBlock> lva)
+            protected CheckerBase(SonarSyntaxNodeReportingContext context, LiveVariableAnalysisBase<TCfg, TBlock> lva)
             {
                 this.context = context;
                 this.lva = lva;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DebugAssertHasNoSideEffects.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DebugAssertHasNoSideEffects.cs
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
             return memberBinding?.Name?.Identifier.ValueText;
         }
 
-        private static bool IsDebugAssert(SonarSyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation) =>
+        private static bool IsDebugAssert(SonarSyntaxNodeReportingContext context, InvocationExpressionSyntax invocation) =>
             invocation.Expression is MemberAccessExpressionSyntax memberAccess
             && memberAccess.Name.Identifier.ValueText == nameof(System.Diagnostics.Debug.Assert)
             && context.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol symbol

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeclareEventHandlersCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeclareEventHandlersCorrectly.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                SyntaxKind.EventDeclaration);
         }
 
-        private static void AnalyzeEventType(SonarSyntaxNodeAnalysisContext analysisContext, TypeSyntax typeSyntax, ISymbol eventSymbol)
+        private static void AnalyzeEventType(SonarSyntaxNodeReportingContext analysisContext, TypeSyntax typeSyntax, ISymbol eventSymbol)
         {
             if (!eventSymbol.IsOverride
                 && eventSymbol.GetInterfaceMember() is null

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableMemberInNonDisposableClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableMemberInNonDisposableClass.cs
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.CSharp
             || typeSymbol.Implements(KnownType.System_IDisposable)
             || typeSymbol.Implements(KnownType.System_IAsyncDisposable);
 
-        private static string GetMessage(SonarSymbolAnalysisContext context, INamespaceOrTypeSymbol namedType)
+        private static string GetMessage(SonarSymbolReportingContext context, INamespaceOrTypeSymbol namedType)
         {
             var disposableFields = namedType.GetMembers()
                                             .OfType<IFieldSymbol>()

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableNotDisposed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableNotDisposed.cs
@@ -105,7 +105,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 },
                 SymbolKind.NamedType);
 
-        private static NodeAndModel<SyntaxNode> CreateNodeAndModel(SonarSymbolAnalysisContext c, SyntaxReference syntaxReference) =>
+        private static NodeAndModel<SyntaxNode> CreateNodeAndModel(SonarSymbolReportingContext c, SyntaxReference syntaxReference) =>
             new(c.Compilation.GetSemanticModel(syntaxReference.SyntaxTree), syntaxReference.GetSyntax());
 
         private static void TrackInitializedLocalsAndPrivateFields(INamedTypeSymbol namedType,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableReturnedFromUsing.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableReturnedFromUsing.cs
@@ -84,7 +84,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.LocalDeclarationStatement);
         }
 
-        private static void CheckReturns(SonarSyntaxNodeAnalysisContext c, SyntaxToken usingKeyword, SyntaxNode body, HashSet<ISymbol> declaredSymbols)
+        private static void CheckReturns(SonarSyntaxNodeReportingContext c, SyntaxToken usingKeyword, SyntaxNode body, HashSet<ISymbol> declaredSymbols)
         {
             if (declaredSymbols.Count == 0)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeNotImplementingDispose.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeNotImplementingDispose.cs
@@ -107,7 +107,7 @@ namespace SonarAnalyzer.Rules.CSharp
             disposeMethodsCalledFromDispose.Add(invokedMethod);
         }
 
-        private static void ReportDisposeMethods(SonarSymbolAnalysisContext context, IEnumerable<IMethodSymbol> disposeMethods)
+        private static void ReportDisposeMethods(SonarSymbolReportingContext context, IEnumerable<IMethodSymbol> disposeMethods)
         {
             foreach (var disposeMethod in disposeMethods)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCheckZeroSizeCollection.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCheckZeroSizeCollection.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(AnalyzePropertyPatternClause, SyntaxKindEx.PropertyPatternClause);
         }
 
-        private void AnalyzePropertyPatternClause(SonarSyntaxNodeAnalysisContext c)
+        private void AnalyzePropertyPatternClause(SonarSyntaxNodeReportingContext c)
         {
             var propertyPatternClause = (PropertyPatternClauseSyntaxWrapper)c.Node;
 
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void AnalyzePatterns(SonarSyntaxNodeAnalysisContext c, ExpressionSyntax expression, SyntaxNode pattern)
+        private void AnalyzePatterns(SonarSyntaxNodeReportingContext c, ExpressionSyntax expression, SyntaxNode pattern)
         {
             var objectToPatternMap = new Dictionary<ExpressionSyntax, SyntaxNode>();
             PatternExpressionObjectToPatternMapping.MapObjectToPattern(expression, pattern, objectToPatternMap);
@@ -66,13 +66,13 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void AnalyzeIsPatternExpression(SonarSyntaxNodeAnalysisContext c)
+        private void AnalyzeIsPatternExpression(SonarSyntaxNodeReportingContext c)
         {
             var isPatternExpression = (IsPatternExpressionSyntaxWrapper)c.Node;
             AnalyzePatterns(c, isPatternExpression.Expression, isPatternExpression.Pattern);
         }
 
-        private void AnalyzeSwitchExpression(SonarSyntaxNodeAnalysisContext c)
+        private void AnalyzeSwitchExpression(SonarSyntaxNodeReportingContext c)
         {
             var switchExpression = (SwitchExpressionSyntaxWrapper)c.Node;
 
@@ -82,7 +82,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void AnalyzeSwitchStatement(SonarSyntaxNodeAnalysisContext c)
+        private void AnalyzeSwitchStatement(SonarSyntaxNodeReportingContext c)
         {
             var switchStatement = (SwitchStatementSyntax)c.Node;
             foreach (var section in switchStatement.Sections)
@@ -94,7 +94,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void CheckPatternCondition(SonarSyntaxNodeAnalysisContext context, SyntaxNode expression, SyntaxNode pattern)
+        private void CheckPatternCondition(SonarSyntaxNodeReportingContext context, SyntaxNode expression, SyntaxNode pattern)
         {
             if (pattern.DescendantNodesAndSelf().FirstOrDefault(x => x.IsKind(SyntaxKindEx.RelationalPattern)) is { } relationalPatternNode
                 && ((RelationalPatternSyntaxWrapper)relationalPatternNode) is var relationalPattern

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotExposeListT.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotExposeListT.cs
@@ -100,7 +100,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.FieldDeclaration);
         }
 
-        private static void ReportIfListT(SonarSyntaxNodeAnalysisContext context, TypeSyntax typeSyntax, string memberType)
+        private static void ReportIfListT(SonarSyntaxNodeReportingContext context, TypeSyntax typeSyntax, string memberType)
         {
             if (typeSyntax != null && typeSyntax.IsKnownType(KnownType.System_Collections_Generic_List_T, context.SemanticModel))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotOverloadOperatorEqual.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotOverloadOperatorEqual.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(CheckForIssue, SyntaxKind.OperatorDeclaration);
 
-        private static void CheckForIssue(SonarSyntaxNodeAnalysisContext analysisContext)
+        private static void CheckForIssue(SonarSyntaxNodeReportingContext analysisContext)
         {
             var declaration = (OperatorDeclarationSyntax)analysisContext.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotTestThisWithIsOperator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotTestThisWithIsOperator.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(AnalyzeSwitchStatement, SyntaxKind.SwitchStatement);
         }
 
-        private static void AnalyzeIsExpression(SonarSyntaxNodeAnalysisContext context)
+        private static void AnalyzeIsExpression(SonarSyntaxNodeReportingContext context)
         {
             if (IsThisExpressionSyntax(((BinaryExpressionSyntax)context.Node).Left))
             {
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void AnalyzeIsPatternExpression(SonarSyntaxNodeAnalysisContext context)
+        private static void AnalyzeIsPatternExpression(SonarSyntaxNodeReportingContext context)
         {
             if (IsThisExpressionSyntax(((IsPatternExpressionSyntaxWrapper)context.Node).Expression) && ContainsTypeCheckInPattern(context.Node))
             {
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void AnalyzeSwitchStatement(SonarSyntaxNodeAnalysisContext context)
+        private static void AnalyzeSwitchStatement(SonarSyntaxNodeReportingContext context)
         {
             var switchStatement = (SwitchStatementSyntax)context.Node;
             if (IsThisExpressionSyntax(switchStatement.Expression))
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void AnalyzeSwitchExpression(SonarSyntaxNodeAnalysisContext context)
+        private static void AnalyzeSwitchExpression(SonarSyntaxNodeReportingContext context)
         {
             var switchExpression = (SwitchExpressionSyntaxWrapper)context.Node;
             if (IsThisExpressionSyntax(switchExpression.GoverningExpression))
@@ -122,10 +122,10 @@ namespace SonarAnalyzer.Rules.CSharp
                                                                   SyntaxKindEx.Subpattern))
                                                  .IsKind(SyntaxKindEx.Subpattern);
 
-        private static void ReportDiagnostic(SonarSyntaxNodeAnalysisContext context, SyntaxNode node) =>
+        private static void ReportDiagnostic(SonarSyntaxNodeReportingContext context, SyntaxNode node) =>
             context.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
 
-        private static void ReportDiagnostic(SonarSyntaxNodeAnalysisContext context, SyntaxNode node, IList<SecondaryLocation> secondaryLocations)
+        private static void ReportDiagnostic(SonarSyntaxNodeReportingContext context, SyntaxNode node, IList<SecondaryLocation> secondaryLocations)
         {
             if (secondaryLocations.Any())
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyMethod.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKindEx.LocalFunctionStatement
             };
 
-        protected override void CheckMethod(SonarSyntaxNodeAnalysisContext context)
+        protected override void CheckMethod(SonarSyntaxNodeReportingContext context)
         {
             if (LocalFunctionStatementSyntaxWrapper.IsInstance(context.Node))
             {
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static bool ShouldMethodBeExcluded(SonarSyntaxNodeAnalysisContext context, BaseMethodDeclarationSyntax methodNode) =>
+        private static bool ShouldMethodBeExcluded(SonarSyntaxNodeReportingContext context, BaseMethodDeclarationSyntax methodNode) =>
             methodNode.Modifiers.Any(SyntaxKind.VirtualKeyword)
             || context.SemanticModel.GetDeclaredSymbol(methodNode) is { IsOverride: true, OverriddenMethod.IsAbstract: true }
             || (methodNode.Modifiers.Any(SyntaxKind.OverrideKeyword) && context.IsTestProject());

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.LogicalOrExpression);
         }
 
-        private static void CheckLogicalExpression(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckLogicalExpression(SonarSyntaxNodeReportingContext context)
         {
             var binaryExpression = (BinaryExpressionSyntax)context.Node;
             var left = TryGetBinaryExpression(binaryExpression.Left);
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static string GetMessageEqualityPart(bool isEquality) =>
             isEquality ? "equality" : "inequality";
 
-        private static void CheckEquality(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckEquality(SonarSyntaxNodeReportingContext context)
         {
             var equals = (BinaryExpressionSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnModulus.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnModulus.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(VisitEquality, SyntaxKind.EqualsExpression, SyntaxKind.NotEqualsExpression);
 
-        private static void VisitEquality(SonarSyntaxNodeAnalysisContext c)
+        private static void VisitEquality(SonarSyntaxNodeReportingContext c)
         {
             var equalsExpression = (BinaryExpressionSyntax)c.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionShouldNotBeThrownFromUnexpectedMethods.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionShouldNotBeThrownFromUnexpectedMethods.cs
@@ -74,7 +74,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ConversionOperatorDeclaration);
         }
 
-        private static void CheckForIssue<TSyntax>(SonarSyntaxNodeAnalysisContext analysisContext, Func<TSyntax, bool> isTrackedSyntax, ImmutableArray<KnownType> allowedThrowTypes)
+        private static void CheckForIssue<TSyntax>(SonarSyntaxNodeReportingContext analysisContext, Func<TSyntax, bool> isTrackedSyntax, ImmutableArray<KnownType> allowedThrowTypes)
             where TSyntax : SyntaxNode
         {
             var syntax = (TSyntax)analysisContext.Node;
@@ -118,7 +118,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static bool IsModuleInitializer(IMethodSymbol methodSymbol) =>
             methodSymbol.AnyAttributeDerivesFrom(KnownType.System_Runtime_CompilerServices_ModuleInitializerAttribute);
 
-        private static void ReportOnInvalidThrow(SonarSyntaxNodeAnalysisContext analysisContext, SyntaxNode node, ImmutableArray<KnownType> allowedTypes)
+        private static void ReportOnInvalidThrow(SonarSyntaxNodeReportingContext analysisContext, SyntaxNode node, ImmutableArray<KnownType> allowedTypes)
         {
             if (node.ArrowExpressionBody() is { } expressionBody
                 && GetLocationToReport(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionComplexity.cs
@@ -86,12 +86,12 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKindEx.InitAccessorDeclaration);
         }
 
-        private void CheckComplexity<TSyntax>(SonarSyntaxNodeAnalysisContext context, Func<TSyntax, Location> getLocation, string declarationType, bool onlyGlobalStatements = false)
+        private void CheckComplexity<TSyntax>(SonarSyntaxNodeReportingContext context, Func<TSyntax, Location> getLocation, string declarationType, bool onlyGlobalStatements = false)
             where TSyntax : SyntaxNode =>
             CheckComplexity(context, getLocation, n => n, declarationType, onlyGlobalStatements);
 
         private void CheckComplexity<TSyntax>(
-            SonarSyntaxNodeAnalysisContext context,
+            SonarSyntaxNodeReportingContext context,
             Func<TSyntax, Location> getLocation,
             Func<TSyntax, SyntaxNode> getNodeToCheck,
             string declarationType,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericReadonlyFieldPropertyAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericReadonlyFieldPropertyAssignment.cs
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PostIncrementExpression);
         }
 
-        private static void ProcessPropertyChange(SonarSyntaxNodeAnalysisContext context, SemanticModel semanticModel, ExpressionSyntax expression)
+        private static void ProcessPropertyChange(SonarSyntaxNodeReportingContext context, SemanticModel semanticModel, ExpressionSyntax expression)
         {
             if (TupleExpressionSyntaxWrapper.IsInstance(expression))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterInOut.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterInOut.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #region Top level
 
-        private static void CheckInterfaceVariance(SonarSyntaxNodeAnalysisContext context, InterfaceDeclarationSyntax declaration)
+        private static void CheckInterfaceVariance(SonarSyntaxNodeReportingContext context, InterfaceDeclarationSyntax declaration)
         {
             var interfaceType = context.SemanticModel.GetDeclaredSymbol(declaration);
             if (interfaceType == null)
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             }
         }
-        private static void CheckDelegateVariance(SonarSyntaxNodeAnalysisContext context, DelegateDeclarationSyntax declaration)
+        private static void CheckDelegateVariance(SonarSyntaxNodeReportingContext context, DelegateDeclarationSyntax declaration)
         {
             var declaredSymbol = context.SemanticModel.GetDeclaredSymbol(declaration);
             if (declaredSymbol == null)
@@ -170,7 +170,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #endregion
 
-        private static void ReportIssue(SonarSyntaxNodeAnalysisContext context, ITypeParameterSymbol typeParameter, VarianceKind variance)
+        private static void ReportIssue(SonarSyntaxNodeReportingContext context, ITypeParameterSymbol typeParameter, VarianceKind variance)
         {
             if (!typeParameter.DeclaringSyntaxReferences.Any())
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterUnused.cs
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules.CSharp
                  SyntaxKind.StructDeclaration);
         }
 
-        private static void CheckGenericTypeParameters(SonarSyntaxNodeAnalysisContext c, ISymbol symbol)
+        private static void CheckGenericTypeParameters(SonarSyntaxNodeReportingContext c, ISymbol symbol)
         {
             var info = CreateParametersInfo(c);
             if (info?.Parameters is null || info.Parameters.Parameters.Count == 0)
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static ParametersInfo CreateParametersInfo(SonarSyntaxNodeAnalysisContext c) =>
+        private static ParametersInfo CreateParametersInfo(SonarSyntaxNodeReportingContext c) =>
             c.Node switch
             {
                 InterfaceDeclarationSyntax interfaceDeclaration => new ParametersInfo(interfaceDeclaration.TypeParameterList, "interface"),
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
             && semanticModel.GetDeclaredSymbol(methodDeclaration) is { } methodSymbol
             && methodSymbol.IsChangeable();
 
-        private static List<string> GetUsedTypeParameters(SonarSyntaxNodeAnalysisContext context, IEnumerable<SyntaxNode> declarations, string[] typeParameterNames) =>
+        private static List<string> GetUsedTypeParameters(SonarSyntaxNodeReportingContext context, IEnumerable<SyntaxNode> declarations, string[] typeParameterNames) =>
             declarations.SelectMany(x => x.DescendantNodes())
                 .OfType<IdentifierNameSyntax>()
                 .Where(x => x.Parent is not TypeParameterConstraintClauseSyntax && typeParameterNames.Contains(x.Identifier.ValueText))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeEqualsOverride.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeEqualsOverride.cs
@@ -86,7 +86,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal static bool MethodIsRelevant(ISymbol symbol, ISet<string> methodNames) =>
             methodNames.Contains(symbol.Name) && symbol.IsOverride;
 
-        private static bool TryGetLocationFromInvocationInsideMethod(SonarSyntaxNodeAnalysisContext context, ISymbol symbol, out Location location)
+        private static bool TryGetLocationFromInvocationInsideMethod(SonarSyntaxNodeReportingContext context, ISymbol symbol, out Location location)
         {
             location = null;
             var invocation = (InvocationExpressionSyntax)context.Node;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeMutable.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeMutable.cs
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static SecondaryLocation CreateSecondaryLocation(SimpleNameSyntax identifierSyntax) =>
             new SecondaryLocation(identifierSyntax.GetLocation(), string.Format(SecondaryMessageFormat, identifierSyntax.Identifier.Text));
 
-        private static IEnumerable<IdentifierNameSyntax> GetAllFirstMutableFieldsUsed(SonarSyntaxNodeAnalysisContext context,
+        private static IEnumerable<IdentifierNameSyntax> GetAllFirstMutableFieldsUsed(SonarSyntaxNodeReportingContext context,
                                                                                       ICollection<IFieldSymbol> fieldsOfClass,
                                                                                       IEnumerable<IdentifierNameSyntax> identifiers)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetTypeWithIsAssignableFrom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetTypeWithIsAssignableFrom.cs
@@ -92,7 +92,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKindEx.IsPatternExpression);
         }
 
-        private static void CheckAsOperatorComparedToNull(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax sideA, ExpressionSyntax sideB)
+        private static void CheckAsOperatorComparedToNull(SonarSyntaxNodeReportingContext context, ExpressionSyntax sideA, ExpressionSyntax sideB)
         {
             if (sideA.RemoveParentheses().IsKind(SyntaxKind.AsExpression) && sideB.RemoveParentheses().IsKind(SyntaxKind.NullLiteralExpression))
             {
@@ -100,7 +100,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckGetTypeAndTypeOfEquality(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax sideA, ExpressionSyntax sideB)
+        private static void CheckGetTypeAndTypeOfEquality(SonarSyntaxNodeReportingContext context, ExpressionSyntax sideA, ExpressionSyntax sideB)
         {
             if (sideA.ToStringContains("GetType")
                 && sideB is TypeOfExpressionSyntax sideBTypeOf
@@ -113,7 +113,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckForIsInstanceOfType(SonarSyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax memberAccess, IMethodSymbol methodSymbol)
+        private static void CheckForIsInstanceOfType(SonarSyntaxNodeReportingContext context, MemberAccessExpressionSyntax memberAccess, IMethodSymbol methodSymbol)
         {
             if (methodSymbol.Name == "IsInstanceOfType" && memberAccess.Expression is TypeOfExpressionSyntax)
             {
@@ -121,7 +121,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckForIsAssignableFrom(SonarSyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax memberAccess, IMethodSymbol methodSymbol, ExpressionSyntax argument)
+        private static void CheckForIsAssignableFrom(SonarSyntaxNodeReportingContext context, MemberAccessExpressionSyntax memberAccess, IMethodSymbol methodSymbol, ExpressionSyntax argument)
         {
             if (methodSymbol.Name == nameof(Type.IsAssignableFrom) && (argument as InvocationExpressionSyntax).IsGetTypeCall(context.SemanticModel))
             {
@@ -144,7 +144,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 _ => null
             };
 
-        private static void ReportDiagnostic(SonarSyntaxNodeAnalysisContext context, string messageArg, bool useIsOperator = false, bool shouldRemoveGetType = false)
+        private static void ReportDiagnostic(SonarSyntaxNodeReportingContext context, string messageArg, bool useIsOperator = false, bool shouldRemoveGetType = false)
         {
             var properties = ImmutableDictionary<string, string>.Empty
                 .Add(UseIsOperatorKey, useIsOperator.ToString())

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GuardConditionOnEqualsOverride.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GuardConditionOnEqualsOverride.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     cb.RegisterNodeAction(c => CheckInvocationInsideMethod(c, methodSymbol), SyntaxKind.InvocationExpression);
                 });
 
-        private static void CheckInvocationInsideMethod(SonarSyntaxNodeAnalysisContext context, ISymbol symbol)
+        private static void CheckInvocationInsideMethod(SonarSyntaxNodeReportingContext context, ISymbol symbol)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if (!(context.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol invokedMethod)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
@@ -125,7 +125,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 context.RegisterNodeAction(VisitAssignments, SyntaxKind.SimpleAssignmentExpression);
             });
 
-        private void VisitObjectCreation(SonarSyntaxNodeAnalysisContext context)
+        private void VisitObjectCreation(SonarSyntaxNodeReportingContext context)
         {
             var objectCreation = ObjectCreationFactory.Create(context.Node);
 
@@ -139,7 +139,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void VisitInvocationExpression(SonarSyntaxNodeAnalysisContext context)
+        private void VisitInvocationExpression(SonarSyntaxNodeReportingContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if (telnetRegexForIdentifier.IsMatch(invocation.Expression.ToString()))
@@ -148,7 +148,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void VisitAssignments(SonarSyntaxNodeAnalysisContext context)
+        private static void VisitAssignments(SonarSyntaxNodeReportingContext context)
         {
             var assignment = (AssignmentExpressionSyntax)context.Node;
             if (assignment.Left is MemberAccessExpressionSyntax memberAccess
@@ -160,7 +160,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void VisitStringExpressions(SonarSyntaxNodeAnalysisContext c)
+        private void VisitStringExpressions(SonarSyntaxNodeReportingContext c)
         {
             if (GetUnsafeProtocol(c.Node, c.SemanticModel) is { } unsafeProtocol)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         ImplicitObjectCreationExpression);
                 });
 
-        private static void CheckIgnoreAntiforgeryTokenAttribute(SonarSyntaxNodeAnalysisContext c)
+        private static void CheckIgnoreAntiforgeryTokenAttribute(SonarSyntaxNodeReportingContext c)
         {
             var shouldReport = c.Node switch
             {
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportDiagnostic(SonarSyntaxNodeAnalysisContext context) =>
+        private static void ReportDiagnostic(SonarSyntaxNodeReportingContext context) =>
             context.ReportIssue(Diagnostic.Create(Rule, context.Node.GetLocation()));
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/InsecureDeserialization.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/InsecureDeserialization.cs
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKindEx.RecordStructDeclaration,
             SyntaxKind.StructDeclaration);
 
-        private static void ReportOnInsecureDeserializations(SonarSyntaxNodeAnalysisContext context, TypeDeclarationSyntax declaration, ITypeSymbol typeSymbol)
+        private static void ReportOnInsecureDeserializations(SonarSyntaxNodeReportingContext context, TypeDeclarationSyntax declaration, ITypeSymbol typeSymbol)
         {
             var implementsISerializable = ImplementsISerializable(typeSymbol);
             var implementsIDeserializationCallback = ImplementsIDeserializationCallback(typeSymbol);
@@ -83,7 +83,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             }
 
-            static void ReportIssue(SonarSyntaxNodeAnalysisContext context, ConstructorInfo constructor) =>
+            static void ReportIssue(SonarSyntaxNodeReportingContext context, ConstructorInfo constructor) =>
                 context.ReportIssue(Diagnostic.Create(Rule, constructor.GetReportLocation()));
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/LooseFilePermissions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/LooseFilePermissions.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         internal LooseFilePermissions(IAnalyzerConfiguration configuration) : base(configuration) { }
 
-        protected override void VisitAssignments(SonarSyntaxNodeAnalysisContext context)
+        protected override void VisitAssignments(SonarSyntaxNodeReportingContext context)
         {
             var node = context.Node;
             if (IsFileAccessPermissions(node, context.SemanticModel) && !node.IsPartOfBinaryNegationOrCondition())
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        protected override void VisitInvocations(SonarSyntaxNodeAnalysisContext context)
+        protected override void VisitInvocations(SonarSyntaxNodeReportingContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if ((IsSetAccessRule(invocation, context.SemanticModel) || IsAddAccessRule(invocation, context.SemanticModel))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/PermissiveCors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/PermissiveCors.cs
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 tracker.MatchConstructor(KnownType.Microsoft_AspNetCore_Cors_Infrastructure_CorsPolicyBuilder),
                 c => ContainsStar(ObjectCreationFactory.Create(c.Node), c.SemanticModel));
 
-        private void VisitAttribute(SonarSyntaxNodeAnalysisContext context)
+        private void VisitAttribute(SonarSyntaxNodeReportingContext context)
         {
             var attribute = (AttributeSyntax)context.Node;
             if (attribute.IsKnownType(KnownType.System_Web_Http_Cors_EnableCorsAttribute, context.SemanticModel)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/IfChainWithoutElse.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/IfChainWithoutElse.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
            ifSyntax.Parent.IsKind(SyntaxKind.ElseClause)
            && (ifSyntax.Else == null || IsEmptyBlock(ifSyntax.Else));
 
-        protected override Location IssueLocation(SonarSyntaxNodeAnalysisContext context, IfStatementSyntax ifSyntax)
+        protected override Location IssueLocation(SonarSyntaxNodeReportingContext context, IfStatementSyntax ifSyntax)
         {
             var parentElse = (ElseClauseSyntax)ifSyntax.Parent;
             var diff = ifSyntax.IfKeyword.Span.End - parentElse.ElseKeyword.SpanStart;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementSerializationMethodsCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementSerializationMethodsCorrectly.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
             base.Initialize(context);
         }
 
-        private void ReportOnAttributes(SonarSyntaxNodeAnalysisContext context, IEnumerable<AttributeSyntax> attributes, string memberType)
+        private void ReportOnAttributes(SonarSyntaxNodeReportingContext context, IEnumerable<AttributeSyntax> attributes, string memberType)
         {
             foreach (var attribute in attributes)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/IndentSingleLineFollowingConditional.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/IndentSingleLineFollowingConditional.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(CheckElse, SyntaxKind.ElseClause);
         }
 
-        private static void CheckWhile(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckWhile(SonarSyntaxNodeReportingContext context)
         {
             var whileStatement = (WhileStatementSyntax)context.Node;
             if (!IsStatementIndentationOk(whileStatement, whileStatement.Statement))
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckDo(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckDo(SonarSyntaxNodeReportingContext context)
         {
             var doStatement = (DoStatementSyntax)context.Node;
             if (!IsStatementIndentationOk(doStatement, doStatement.Statement))
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckFor(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckFor(SonarSyntaxNodeReportingContext context)
         {
             var forStatement = (ForStatementSyntax)context.Node;
             if (!IsStatementIndentationOk(forStatement, forStatement.Statement))
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckForEach(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckForEach(SonarSyntaxNodeReportingContext context)
         {
             var forEachStatement = (ForEachStatementSyntax)context.Node;
             if (!IsStatementIndentationOk(forEachStatement, forEachStatement.Statement))
@@ -84,7 +84,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckIf(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckIf(SonarSyntaxNodeReportingContext context)
         {
             var ifStatement = (IfStatementSyntax)context.Node;
 
@@ -115,7 +115,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckElse(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckElse(SonarSyntaxNodeReportingContext context)
         {
             var elseClause = (ElseClauseSyntax)context.Node;
             if (!IsStatementIndentationOk(elseClause, elseClause.Statement))
@@ -129,7 +129,7 @@ namespace SonarAnalyzer.Rules.CSharp
             conditionallyExecutedNode is BlockSyntax ||
             VisualIndentComparer.IsSecondIndentLonger(controlNode, conditionallyExecutedNode);
 
-        private static void ReportIssue(SonarSyntaxNodeAnalysisContext context, Location primaryLocation,
+        private static void ReportIssue(SonarSyntaxNodeReportingContext context, Location primaryLocation,
             SyntaxNode secondaryLocationNode, string conditionLabelText) =>
                context.ReportIssue(Rule.CreateDiagnostic(context.Compilation, primaryLocation, new[] { GetFirstLineOfNode(secondaryLocationNode) }, conditionLabelText));
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.RoslynCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.RoslynCfg.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
         private sealed class RoslynChecker : IChecker
         {
-            public void CheckForNoExitProperty(SonarSyntaxNodeAnalysisContext c, PropertyDeclarationSyntax property, IPropertySymbol propertySymbol)
+            public void CheckForNoExitProperty(SonarSyntaxNodeReportingContext c, PropertyDeclarationSyntax property, IPropertySymbol propertySymbol)
             {
                 if (property.ExpressionBody?.Expression != null)
                 {
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             }
 
-            public void CheckForNoExitMethod(SonarSyntaxNodeAnalysisContext c, CSharpSyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol)
+            public void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, CSharpSyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol)
             {
                 if (body.CreateCfg(c.SemanticModel, c.Cancel) is { } cfg)
                 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.SonarCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.SonarCfg.cs
@@ -26,7 +26,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
         public class SonarChecker : IChecker
         {
-            public void CheckForNoExitProperty(SonarSyntaxNodeAnalysisContext c, PropertyDeclarationSyntax property, IPropertySymbol propertySymbol)
+            public void CheckForNoExitProperty(SonarSyntaxNodeReportingContext c, PropertyDeclarationSyntax property, IPropertySymbol propertySymbol)
             {
                 IControlFlowGraph cfg;
                 if (property.ExpressionBody?.Expression != null)
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             }
 
-            public void CheckForNoExitMethod(SonarSyntaxNodeAnalysisContext c, CSharpSyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol)
+            public void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, CSharpSyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol)
             {
                 if (CSharpControlFlowGraph.TryGet(body, c.SemanticModel, out var cfg))
                 {
@@ -71,7 +71,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             }
 
-            private static void CheckInfiniteJumpLoop(SonarSyntaxNodeAnalysisContext context, SyntaxNode body, IControlFlowGraph cfg, string declarationType)
+            private static void CheckInfiniteJumpLoop(SonarSyntaxNodeReportingContext context, SyntaxNode body, IControlFlowGraph cfg, string declarationType)
             {
                 if (body == null)
                 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
@@ -75,7 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PropertyDeclaration);
         }
 
-        private void CheckForNoExitMethod(SonarSyntaxNodeAnalysisContext c, CSharpSyntaxNode body, SyntaxToken identifier)
+        private void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, CSharpSyntaxNode body, SyntaxToken identifier)
         {
             if (body != null && c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol symbol)
             {
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private sealed class RecursionContext<TControlFlowGraph>
         {
-            private readonly SonarSyntaxNodeAnalysisContext analysisContext;
+            private readonly SonarSyntaxNodeReportingContext analysisContext;
             private readonly string messageArg;
             private readonly Location issueLocation;
 
@@ -104,7 +104,7 @@ namespace SonarAnalyzer.Rules.CSharp
             public ISymbol AnalyzedSymbol { get; }
             public SemanticModel SemanticModel => analysisContext.SemanticModel;
 
-            public RecursionContext(SonarSyntaxNodeAnalysisContext analysisContext,
+            public RecursionContext(SonarSyntaxNodeReportingContext analysisContext,
                                     TControlFlowGraph controlFlowGraph,
                                     ISymbol analyzedSymbol,
                                     Location issueLocation,
@@ -123,8 +123,8 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private interface IChecker
         {
-            void CheckForNoExitProperty(SonarSyntaxNodeAnalysisContext c, PropertyDeclarationSyntax property, IPropertySymbol propertySymbol);
-            void CheckForNoExitMethod(SonarSyntaxNodeAnalysisContext c, CSharpSyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol);
+            void CheckForNoExitProperty(SonarSyntaxNodeReportingContext c, PropertyDeclarationSyntax property, IPropertySymbol propertySymbol);
+            void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, CSharpSyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfaceMethodsShouldBeCallableByChildTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfaceMethodsShouldBeCallableByChildTypes.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.EventDeclaration);
         }
 
-        private static void ReportOnIssue<TMemberSyntax>(SonarSyntaxNodeAnalysisContext analysisContext,
+        private static void ReportOnIssue<TMemberSyntax>(SonarSyntaxNodeReportingContext analysisContext,
                                                          Func<TMemberSyntax, ExplicitInterfaceSpecifierSyntax> getExplicitInterfaceSpecifier,
                                                          Func<TMemberSyntax, SyntaxToken> getIdentifierName,
                                                          Func<TMemberSyntax, TMemberSyntax, bool> areMembersEquivalent)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterface.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InvalidCastToInterface.cs
@@ -80,7 +80,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 });
         }
 
-        private static void CheckTypesForInvalidCast(SonarSyntaxNodeAnalysisContext context, INamedTypeSymbol interfaceType, INamedTypeSymbol expressionType,
+        private static void CheckTypesForInvalidCast(SonarSyntaxNodeReportingContext context, INamedTypeSymbol interfaceType, INamedTypeSymbol expressionType,
             Dictionary<INamedTypeSymbol, HashSet<INamedTypeSymbol>> interfaceImplementerMappings, Location issueLocation)
         {
             if (interfaceType == null ||
@@ -115,7 +115,7 @@ namespace SonarAnalyzer.Rules.CSharp
             interfaceImplementerMappings.ContainsKey(type) &&
             interfaceImplementerMappings[type].Any(t => t.IsClassOrStruct());
 
-        private static void ReportIssue(SonarSyntaxNodeAnalysisContext context, ISymbol interfaceType, ITypeSymbol expressionType, Location issueLocation)
+        private static void ReportIssue(SonarSyntaxNodeReportingContext context, ISymbol interfaceType, ITypeSymbol expressionType, Location issueLocation)
         {
             var interfaceTypeName = interfaceType.ToMinimalDisplayString(context.SemanticModel, issueLocation.SourceSpan.Start);
             var expressionTypeName = expressionType.ToMinimalDisplayString(context.SemanticModel, issueLocation.SourceSpan.Start);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ObjectCreationExpression);
         }
 
-        private static void CheckCall(SonarSyntaxNodeAnalysisContext context, SyntaxNode node, ArgumentListSyntax argumentList)
+        private static void CheckCall(SonarSyntaxNodeReportingContext context, SyntaxNode node, ArgumentListSyntax argumentList)
         {
             if (argumentList == null
                 || argumentList.Arguments.Count == 0

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/IssueSuppression.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/IssueSuppression.cs
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 });
         }
 
-        private static void CheckTrivias(SonarSyntaxTreeAnalysisContext c, SyntaxTriviaList triviaList)
+        private static void CheckTrivias(SonarSyntaxTreeReportingContext c, SyntaxTriviaList triviaList)
         {
             var pragmaWarnings = triviaList
                 .Where(t => t.HasStructure)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LiteralsShouldNotBePassedAsLocalizedParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LiteralsShouldNotBePassedAsLocalizedParameters.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(AnalyzeAssignments, SyntaxKind.SimpleAssignmentExpression);
         }
 
-        private static void AnalyzeInvocations(SonarSyntaxNodeAnalysisContext context)
+        private static void AnalyzeInvocations(SonarSyntaxNodeReportingContext context)
         {
             var invocationSyntax = (InvocationExpressionSyntax)context.Node;
             if (!(context.SemanticModel.GetSymbolInfo(invocationSyntax).Symbol is IMethodSymbol methodSymbol)
@@ -80,7 +80,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void AnalyzeAssignments(SonarSyntaxNodeAnalysisContext context)
+        private static void AnalyzeAssignments(SonarSyntaxNodeReportingContext context)
         {
             var assignmentSyntax = (AssignmentExpressionSyntax)context.Node;
             if (CSharpDebugOnlyCodeHelper.IsCallerInConditionalDebug(assignmentSyntax, context.SemanticModel))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LoopsAndLinq.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LoopsAndLinq.cs
@@ -92,7 +92,7 @@ namespace SonarAnalyzer.Rules.CSharp
         ///  - the property is used more than once
         ///  - the property is the right side of a variable declaration.
         /// </remarks>
-        private static void CheckIfCanBeSimplifiedUsingSelect(SonarSyntaxNodeAnalysisContext c, ForEachStatementSyntax forEachStatementSyntax)
+        private static void CheckIfCanBeSimplifiedUsingSelect(SonarSyntaxNodeReportingContext c, ForEachStatementSyntax forEachStatementSyntax)
         {
             var declaredSymbol = new Lazy<ILocalSymbol>(() => c.SemanticModel.GetDeclaredSymbol(forEachStatementSyntax));
             var expressionTypeIsOrImplementsIEnumerable = new Lazy<bool>(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializedToDefault.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializedToDefault.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(CheckAutoProperty, SyntaxKind.PropertyDeclaration);
         }
 
-        private static void CheckAutoProperty(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckAutoProperty(SonarSyntaxNodeReportingContext context)
         {
             var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
 
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckEvent(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckEvent(SonarSyntaxNodeReportingContext context)
         {
             var field = (EventFieldDeclarationSyntax)context.Node;
 
@@ -78,7 +78,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckField(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckField(SonarSyntaxNodeReportingContext context)
         {
             var field = (FieldDeclarationSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializerRedundant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializerRedundant.cs
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.StructDeclaration,
                 SyntaxKind.InterfaceDeclaration);
 
-        private void CheckInstanceMembers(SonarSyntaxNodeAnalysisContext c, TypeDeclarationSyntax declaration, IEnumerable<ISymbol> typeMembers)
+        private void CheckInstanceMembers(SonarSyntaxNodeReportingContext c, TypeDeclarationSyntax declaration, IEnumerable<ISymbol> typeMembers)
         {
             var typeInitializers = typeMembers.OfType<IMethodSymbol>().Where(x => x is { MethodKind: MethodKind.Constructor, IsStatic: false, IsImplicitlyDeclared: false }).ToList();
             if (typeInitializers.Count == 0)
@@ -104,7 +104,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void CheckStaticMembers(SonarSyntaxNodeAnalysisContext c, TypeDeclarationSyntax declaration, IEnumerable<ISymbol> typeMembers)
+        private void CheckStaticMembers(SonarSyntaxNodeReportingContext c, TypeDeclarationSyntax declaration, IEnumerable<ISymbol> typeMembers)
         {
             var typeInitializers = typeMembers.OfType<IMethodSymbol>().Where(method => method.MethodKind == MethodKind.StaticConstructor || method.IsModuleInitializer()).ToList();
             if (typeInitializers.Count == 0)
@@ -177,7 +177,7 @@ namespace SonarAnalyzer.Rules.CSharp
             return allMembers;
         }
 
-        private static List<NodeSymbolAndModel<TSyntax, IMethodSymbol>> GetInitializerDeclarations<TSyntax>(SonarSyntaxNodeAnalysisContext context, List<IMethodSymbol> constructorSymbols)
+        private static List<NodeSymbolAndModel<TSyntax, IMethodSymbol>> GetInitializerDeclarations<TSyntax>(SonarSyntaxNodeReportingContext context, List<IMethodSymbol> constructorSymbols)
             where TSyntax : SyntaxNode =>
             constructorSymbols
                 .Select(x => new NodeSymbolAndModel<TSyntax, IMethodSymbol>(null, x.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() as TSyntax, x))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShadowsOuterStaticMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShadowsOuterStaticMember.cs
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 },
                 SymbolKind.NamedType);
 
-        private static void CheckNamedType(SonarSymbolAnalysisContext context, IReadOnlyList<ISymbol> outerMembersOfSameName, INamedTypeSymbol namedType)
+        private static void CheckNamedType(SonarSymbolReportingContext context, IReadOnlyList<ISymbol> outerMembersOfSameName, INamedTypeSymbol namedType)
         {
             if (outerMembersOfSameName.Any(x => x is INamedTypeSymbol { TypeKind: TypeKind.Class or TypeKind.Struct or TypeKind.Delegate or TypeKind.Enum or TypeKind.Interface }))
             {
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckMember(SonarSymbolAnalysisContext context, IReadOnlyList<ISymbol> outerMembersOfSameName, ISymbol member)
+        private static void CheckMember(SonarSymbolReportingContext context, IReadOnlyList<ISymbol> outerMembersOfSameName, ISymbol member)
         {
             if (outerMembersOfSameName.Any(x => (x.IsStatic && !x.IsAbstract && !x.IsVirtual) || x is IFieldSymbol { IsConst: true })
                 && member.FirstDeclaringReferenceIdentifier() is { } identifier

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldBeStatic.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldBeStatic.cs
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 ? methodDeclaration.Body?.DescendantNodes()
                 : methodDeclaration.ExpressionBody.DescendantNodes();
 
-        private static void CheckIssue<TDeclarationSyntax>(SonarSyntaxNodeAnalysisContext context,
+        private static void CheckIssue<TDeclarationSyntax>(SonarSyntaxNodeReportingContext context,
                                                            Func<TDeclarationSyntax, IEnumerable<SyntaxNode>> getDescendants,
                                                            Func<TDeclarationSyntax, SyntaxToken> getIdentifier,
                                                            string memberKind)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldNotHaveConflictingTransparencyAttributes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldNotHaveConflictingTransparencyAttributes.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     csac.RegisterCompilationEndAction(cac => ReportOnConflictingTransparencyAttributes(cac, nodesWithSecuritySafeCritical, nodesWithSecurityCritical));
                 });
 
-        private static void CollectSecurityAttributes(SonarSyntaxNodeAnalysisContext syntaxNodeAnalysisContext,
+        private static void CollectSecurityAttributes(SonarSyntaxNodeReportingContext syntaxNodeAnalysisContext,
                                                       Dictionary<SyntaxNode, AttributeSyntax> nodesWithSecuritySafeCritical,
                                                       Dictionary<SyntaxNode, AttributeSyntax> nodesWithSecurityCritical)
         {
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportOnConflictingTransparencyAttributes(SonarCompilationAnalysisContext compilationContext,
+        private static void ReportOnConflictingTransparencyAttributes(SonarCompilationReportingContext compilationContext,
                                                                       Dictionary<SyntaxNode, AttributeSyntax> nodesWithSecuritySafeCritical,
                                                                       Dictionary<SyntaxNode, AttributeSyntax> nodesWithSecurityCritical)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverloadsShouldBeGrouped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverloadsShouldBeGrouped.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKindEx.RecordStructDeclaration,
         };
 
-        protected override MemberInfo CreateMemberInfo(SonarSyntaxNodeAnalysisContext c, MemberDeclarationSyntax member) =>
+        protected override MemberInfo CreateMemberInfo(SonarSyntaxNodeReportingContext c, MemberDeclarationSyntax member) =>
             member switch
             {
                 ConstructorDeclarationSyntax constructor => new MemberInfo(c, member, constructor.Identifier, constructor.IsStatic(), false, true),

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideChangedDefaultValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideChangedDefaultValue.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.MethodDeclaration);
         }
 
-        private static void ReportParameterIfNeeded(SonarSyntaxNodeAnalysisContext context, IParameterSymbol overridingParameter, IParameterSymbol overriddenParameter,
+        private static void ReportParameterIfNeeded(SonarSyntaxNodeReportingContext context, IParameterSymbol overridingParameter, IParameterSymbol overriddenParameter,
             ParameterSyntax parameterSyntax, bool isExplicitImplementation)
         {
             if (isExplicitImplementation)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ConstructorDeclaration,
                 SyntaxKindEx.LocalFunctionStatement);
 
-        private static MethodContext CreateContext(SonarSyntaxNodeAnalysisContext c)
+        private static MethodContext CreateContext(SonarSyntaxNodeReportingContext c)
         {
             if (c.Node is BaseMethodDeclarationSyntax method)
             {
@@ -254,19 +254,19 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private class MethodContext
         {
-            public readonly SonarSyntaxNodeAnalysisContext Context;
+            public readonly SonarSyntaxNodeReportingContext Context;
             public readonly IMethodSymbol Symbol;
             public readonly ParameterListSyntax ParameterList;
             public readonly BlockSyntax Body;
             public readonly ArrowExpressionClauseSyntax ExpressionBody;
 
-            public MethodContext(SonarSyntaxNodeAnalysisContext context, BaseMethodDeclarationSyntax declaration)
+            public MethodContext(SonarSyntaxNodeReportingContext context, BaseMethodDeclarationSyntax declaration)
                 : this(context, declaration.ParameterList, declaration.Body, declaration.ExpressionBody()) { }
 
-            public MethodContext(SonarSyntaxNodeAnalysisContext context, LocalFunctionStatementSyntaxWrapper declaration)
+            public MethodContext(SonarSyntaxNodeReportingContext context, LocalFunctionStatementSyntaxWrapper declaration)
                 : this(context, declaration.ParameterList, declaration.Body, declaration.ExpressionBody) { }
 
-            private MethodContext(SonarSyntaxNodeAnalysisContext context, ParameterListSyntax parameterList, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody)
+            private MethodContext(SonarSyntaxNodeReportingContext context, ParameterListSyntax parameterList, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody)
             {
                 Context = context;
                 Symbol = context.SemanticModel.GetDeclaredSymbol(context.Node) as IMethodSymbol;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveIdenticalImplementations.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveIdenticalImplementations.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override SyntaxToken GetMethodIdentifier(IMethodDeclaration method) =>
             method.Identifier;
 
-        protected override bool IsExcludedFromBeingExamined(SonarSyntaxNodeAnalysisContext context) =>
+        protected override bool IsExcludedFromBeingExamined(SonarSyntaxNodeReportingContext context) =>
             base.IsExcludedFromBeingExamined(context)
             && !context.IsTopLevelMain();
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MultilineBlocksWithoutBrace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MultilineBlocksWithoutBrace.cs
@@ -50,7 +50,7 @@ public sealed class MultilineBlocksWithoutBrace : SonarDiagnosticAnalyzer
             SyntaxKind.IfStatement);
     }
 
-    private static void CheckLoop(SonarSyntaxNodeAnalysisContext context, StatementSyntax statement)
+    private static void CheckLoop(SonarSyntaxNodeReportingContext context, StatementSyntax statement)
     {
         if (!IsNestedStatement(statement))
         {
@@ -58,7 +58,7 @@ public sealed class MultilineBlocksWithoutBrace : SonarDiagnosticAnalyzer
         }
     }
 
-    private static void CheckIf(SonarSyntaxNodeAnalysisContext context, IfStatementSyntax ifStatement)
+    private static void CheckIf(SonarSyntaxNodeReportingContext context, IfStatementSyntax ifStatement)
     {
         if (!ifStatement.GetPrecedingIfsInConditionChain().Any()
             && !IsNestedStatement(ifStatement.Statement)
@@ -85,7 +85,7 @@ public sealed class MultilineBlocksWithoutBrace : SonarDiagnosticAnalyzer
         return statement;
     }
 
-    private static void CheckStatement(SonarSyntaxNodeAnalysisContext context, StatementSyntax first, string executed, string execute)
+    private static void CheckStatement(SonarSyntaxNodeReportingContext context, StatementSyntax first, string executed, string execute)
     {
         if (IsNotEmpty(first)
             && SecondStatement(context.Node, first) is { } second

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NameOfShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NameOfShouldBeUsed.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 : paramGroups.Select(g => g.First().Identifier.ValueText);
         }
 
-        protected override bool LeastLanguageVersionMatches(SonarSyntaxNodeAnalysisContext context) =>
+        protected override bool LeastLanguageVersionMatches(SonarSyntaxNodeReportingContext context) =>
             context.Compilation.IsAtLeastLanguageVersion(LanguageVersion.CSharp6);
 
         protected override bool IsArgumentExceptionCallingNameOf(SyntaxNode node, IEnumerable<string> arguments) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(ReportTrivialWrappers, SyntaxKind.MethodDeclaration);
         }
 
-        private static void ReportPublicExternalMethods(SonarSymbolAnalysisContext c)
+        private static void ReportPublicExternalMethods(SonarSymbolReportingContext c)
         {
             var methodSymbol = (IMethodSymbol)c.Symbol;
             if (methodSymbol.IsExtern
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportTrivialWrappers(SonarSyntaxNodeAnalysisContext c)
+        private static void ReportTrivialWrappers(SonarSyntaxNodeReportingContext c)
         {
             var methodDeclaration = (MethodDeclarationSyntax)c.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NoExceptionsInFinally.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NoExceptionsInFinally.cs
@@ -32,10 +32,10 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private sealed class ThrowInFinallyWalker : SafeCSharpSyntaxWalker
         {
-            private readonly SonarSyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeReportingContext context;
             private readonly DiagnosticDescriptor rule;
 
-            public ThrowInFinallyWalker(SonarSyntaxNodeAnalysisContext context, DiagnosticDescriptor rule)
+            public ThrowInFinallyWalker(SonarSyntaxNodeReportingContext context, DiagnosticDescriptor rule)
             {
                 this.context = context;
                 this.rule = rule;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NonFlagsEnumInBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NonFlagsEnumInBitwiseOperation.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ExclusiveOrAssignmentExpression);
         }
 
-        private static void CheckExpressionWithOperator<T>(SonarSyntaxNodeAnalysisContext context, Func<T, SyntaxToken> operatorSelector)
+        private static void CheckExpressionWithOperator<T>(SonarSyntaxNodeReportingContext context, Func<T, SyntaxToken> operatorSelector)
             where T : SyntaxNode
         {
             if (context.SemanticModel.GetSymbolInfo(context.Node).Symbol is not IMethodSymbol { MethodKind: MethodKind.BuiltinOperator, ReturnType.TypeKind: TypeKind.Enum } operation

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterNamesShouldNotDuplicateMethodNames.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterNamesShouldNotDuplicateMethodNames.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKindEx.LocalFunctionStatement);
         }
 
-        private static void CheckMethodParameters(SonarSyntaxNodeAnalysisContext context, SyntaxToken identifier, ParameterListSyntax parameterList)
+        private static void CheckMethodParameters(SonarSyntaxNodeReportingContext context, SyntaxToken identifier, ParameterListSyntax parameterList)
         {
             var methodName = identifier.ToString();
             foreach (var parameter in parameterList.Parameters.Select(p => p.Identifier))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }, SyntaxKind.ObjectCreationExpression);
         }
 
-        private void AnalyzeArguments(SonarSyntaxNodeAnalysisContext analysisContext, ArgumentListSyntax argumentList,
+        private void AnalyzeArguments(SonarSyntaxNodeReportingContext analysisContext, ArgumentListSyntax argumentList,
             Func<Location> getLocation)
         {
             if (argumentList == null)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PartialMethodNoImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PartialMethodNoImplementation.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(CheckForCandidatePartialInvocation, SyntaxKind.InvocationExpression);
         }
 
-        private static void CheckForCandidatePartialDeclaration(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckForCandidatePartialDeclaration(SonarSyntaxNodeReportingContext context)
         {
             var declaration = (MethodDeclarationSyntax)context.Node;
             var partialKeyword = declaration.Modifiers.FirstOrDefault(m => m.IsKind(SyntaxKind.PartialKeyword));
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckForCandidatePartialInvocation(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckForCandidatePartialInvocation(SonarSyntaxNodeReportingContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PreferJaggedArraysOverMultidimensional.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PreferJaggedArraysOverMultidimensional.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PropertyDeclaration);
         }
 
-        private static void AnalyzeNode<TSyntax>(SonarSyntaxNodeAnalysisContext context,
+        private static void AnalyzeNode<TSyntax>(SonarSyntaxNodeReportingContext context,
             Func<SemanticModel, TSyntax, ITypeSymbol> getTypeSymbol, Func<TSyntax, Location> getLocation)
             where TSyntax : SyntaxNode
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundancyInConstructorDestructorDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundancyInConstructorDestructorDeclaration.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(CheckDestructorDeclaration, SyntaxKind.DestructorDeclaration);
         }
 
-        private static void CheckDestructorDeclaration(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckDestructorDeclaration(SonarSyntaxNodeReportingContext context)
         {
             var destructorDeclaration = (DestructorDeclarationSyntax)context.Node;
 
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckConstructorDeclaration(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckConstructorDeclaration(SonarSyntaxNodeReportingContext context)
         {
             var constructorDeclaration = (ConstructorDeclarationSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantCast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantCast.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.InvocationExpression);
         }
 
-        private static void CheckCastExpression(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax expression, ExpressionSyntax type, Location location)
+        private static void CheckCastExpression(SonarSyntaxNodeReportingContext context, ExpressionSyntax expression, ExpressionSyntax type, Location location)
         {
             if (expression.IsKind(SyntaxKindEx.DefaultLiteralExpression))
             {
@@ -83,7 +83,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckExtensionMethodInvocation(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckExtensionMethodInvocation(SonarSyntaxNodeReportingContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if (GetEnumerableExtensionSymbol(invocation, context.SemanticModel) is { } methodSymbol)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(UselessConditionSwitchExpression, SyntaxKindEx.SwitchExpression);
         }
 
-        private static void UselessConditionIfStatement(SonarSyntaxNodeAnalysisContext c)
+        private static void UselessConditionIfStatement(SonarSyntaxNodeReportingContext c)
         {
             var ifStatement = (IfStatementSyntax)c.Node;
 
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void UselessConditionSwitchExpression(SonarSyntaxNodeAnalysisContext c)
+        private static void UselessConditionSwitchExpression(SonarSyntaxNodeReportingContext c)
         {
             var switchExpression = (SwitchExpressionSyntaxWrapper)c.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantDeclaration.cs
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKind.OutKeyword
         };
 
-        private static void VisitParenthesizedLambdaExpression(SonarSyntaxNodeAnalysisContext context)
+        private static void VisitParenthesizedLambdaExpression(SonarSyntaxNodeReportingContext context)
         {
             var lambda = (ParenthesizedLambdaExpressionSyntax)context.Node;
 
@@ -81,7 +81,7 @@ namespace SonarAnalyzer.Rules.CSharp
             CheckTypeSpecifications(context, lambda);
         }
 
-        private static void CheckTypeSpecifications(SonarSyntaxNodeAnalysisContext context, ParenthesizedLambdaExpressionSyntax lambda)
+        private static void CheckTypeSpecifications(SonarSyntaxNodeReportingContext context, ParenthesizedLambdaExpressionSyntax lambda)
         {
             if (!IsParameterListModifiable(lambda))
             {
@@ -113,7 +113,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckUnusedParameters(SonarSyntaxNodeAnalysisContext context, ParenthesizedLambdaExpressionSyntax lambda)
+        private static void CheckUnusedParameters(SonarSyntaxNodeReportingContext context, ParenthesizedLambdaExpressionSyntax lambda)
         {
             if (context.Compilation.IsLambdaDiscardParameterSupported())
             {
@@ -156,7 +156,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #region Nullable constructor call
 
-        private static void ReportRedundantNullableConstructorCall(SonarSyntaxNodeAnalysisContext context)
+        private static void ReportRedundantNullableConstructorCall(SonarSyntaxNodeReportingContext context)
         {
             var objectCreation = ObjectCreationFactory.Create(context.Node);
             if (!IsNullableCreation(objectCreation, context.SemanticModel))
@@ -196,14 +196,14 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #region Array (creation, size, type)
 
-        private static void ReportRedundancyInArrayCreation(SonarSyntaxNodeAnalysisContext context)
+        private static void ReportRedundancyInArrayCreation(SonarSyntaxNodeReportingContext context)
         {
             var array = (ArrayCreationExpressionSyntax)context.Node;
             ReportRedundantArraySizeSpecifier(context, array);
             ReportRedundantArrayTypeSpecifier(context, array);
         }
 
-        private static void ReportRedundantArraySizeSpecifier(SonarSyntaxNodeAnalysisContext context, ArrayCreationExpressionSyntax array)
+        private static void ReportRedundantArraySizeSpecifier(SonarSyntaxNodeReportingContext context, ArrayCreationExpressionSyntax array)
         {
             if (array.Initializer == null || array.Type == null)
             {
@@ -223,7 +223,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportRedundantArrayTypeSpecifier(SonarSyntaxNodeAnalysisContext context, ArrayCreationExpressionSyntax array)
+        private static void ReportRedundantArrayTypeSpecifier(SonarSyntaxNodeReportingContext context, ArrayCreationExpressionSyntax array)
         {
             if (array.Initializer == null
                 || !array.Initializer.Expressions.Any()
@@ -264,7 +264,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #region Object initializer
 
-        private static void ReportOnRedundantObjectInitializer(SonarSyntaxNodeAnalysisContext context)
+        private static void ReportOnRedundantObjectInitializer(SonarSyntaxNodeReportingContext context)
         {
             var objectCreation = ObjectCreationFactory.Create(context.Node);
 
@@ -280,7 +280,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #region Explicit delegate creation
 
-        private static void ReportOnExplicitDelegateCreation(SonarSyntaxNodeAnalysisContext context)
+        private static void ReportOnExplicitDelegateCreation(SonarSyntaxNodeReportingContext context)
         {
             var objectCreation = ObjectCreationFactory.Create(context.Node);
             var argumentExpression = objectCreation.ArgumentList?.Arguments.FirstOrDefault()?.Expression;
@@ -361,7 +361,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         #region Parameter list
 
-        private static void ReportOnRedundantParameterList(SonarSyntaxNodeAnalysisContext context)
+        private static void ReportOnRedundantParameterList(SonarSyntaxNodeReportingContext context)
         {
             var anonymousMethod = (AnonymousMethodExpressionSyntax)context.Node;
             if (anonymousMethod.ParameterList == null)
@@ -426,7 +426,7 @@ namespace SonarAnalyzer.Rules.CSharp
                    && methodSymbol.ToDisplayString() == newMethodSymbol.ToDisplayString();
         }
 
-        private static void ReportIssueOnRedundantObjectCreation(SonarSyntaxNodeAnalysisContext context, SyntaxNode node, string message, RedundancyType redundancyType)
+        private static void ReportIssueOnRedundantObjectCreation(SonarSyntaxNodeReportingContext context, SyntaxNode node, string message, RedundancyType redundancyType)
         {
             var location = node is ObjectCreationExpressionSyntax objectCreation
                 ? objectCreation.CreateLocation(objectCreation.Type)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantInheritanceList.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKindEx.RecordClassDeclaration,
             SyntaxKindEx.RecordStructDeclaration);
 
-        private static void ReportRedundantBaseType(SonarSyntaxNodeAnalysisContext context, BaseTypeDeclarationSyntax typeDeclaration, KnownType redundantType, string message)
+        private static void ReportRedundantBaseType(SonarSyntaxNodeReportingContext context, BaseTypeDeclarationSyntax typeDeclaration, KnownType redundantType, string message)
         {
             var baseTypeSyntax = typeDeclaration.BaseList.Types.First().Type;
             if (context.SemanticModel.GetSymbolInfo(baseTypeSyntax).Symbol is ITypeSymbol baseTypeSymbol
@@ -75,7 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportRedundantInterfaces(SonarSyntaxNodeAnalysisContext context, BaseTypeDeclarationSyntax typeDeclaration)
+        private static void ReportRedundantInterfaces(SonarSyntaxNodeReportingContext context, BaseTypeDeclarationSyntax typeDeclaration)
         {
             var declaredType = context.SemanticModel.GetDeclaredSymbol(typeDeclaration);
             if (declaredType is null)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ParenthesizedLambdaExpression);
         }
 
-        private static void CheckForRedundantJumps(SonarSyntaxNodeAnalysisContext context, CSharpSyntaxNode node)
+        private static void CheckForRedundantJumps(SonarSyntaxNodeReportingContext context, CSharpSyntaxNode node)
         {
             if (!CSharpControlFlowGraph.TryGet(node, context.SemanticModel, out var cfg))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantModifier.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantModifier.cs
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.UncheckedStatement);
         }
 
-        private static void CheckForUnnecessaryUnsafeBlocks(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckForUnnecessaryUnsafeBlocks(SonarSyntaxNodeReportingContext context)
         {
             var typeDeclaration = (TypeDeclarationSyntax)context.Node;
             if (typeDeclaration.Parent is TypeDeclarationSyntax || context.IsRedundantPositionalRecordContext())
@@ -91,7 +91,7 @@ namespace SonarAnalyzer.Rules.CSharp
             CheckForUnnecessaryUnsafeBlocksBelow(context, typeDeclaration);
         }
 
-        private static void CheckForUnnecessaryUnsafeBlocksBelow(SonarSyntaxNodeAnalysisContext context, TypeDeclarationSyntax typeDeclaration)
+        private static void CheckForUnnecessaryUnsafeBlocksBelow(SonarSyntaxNodeReportingContext context, TypeDeclarationSyntax typeDeclaration)
         {
             var unsafeKeyword = FindUnsafeKeyword(typeDeclaration);
             if (unsafeKeyword == default)
@@ -111,7 +111,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckForUnnecessaryUnsafeBlocksInMember(SonarSyntaxNodeAnalysisContext context, MemberDeclarationSyntax member)
+        private static void CheckForUnnecessaryUnsafeBlocksInMember(SonarSyntaxNodeReportingContext context, MemberDeclarationSyntax member)
         {
             var unsafeKeyword = FindUnsafeKeyword(member);
             if (unsafeKeyword != default)
@@ -175,7 +175,7 @@ namespace SonarAnalyzer.Rules.CSharp
             && (type.TypeKind == TypeKind.Pointer
                 || (type.TypeKind == TypeKind.Array && IsUnsafe(((IArrayTypeSymbol)type).ElementType)));
 
-        private static void MarkAllUnsafeBlockInside(SonarSyntaxNodeAnalysisContext context, SyntaxNode container)
+        private static void MarkAllUnsafeBlockInside(SonarSyntaxNodeReportingContext context, SyntaxNode container)
         {
             foreach (var @unsafe in container.DescendantNodes().SelectMany(x => x.ChildTokens()).Where(x => x.IsKind(SyntaxKind.UnsafeKeyword)))
             {
@@ -183,13 +183,13 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportOnUnsafeBlock(SonarSyntaxNodeAnalysisContext context, Location issueLocation) =>
+        private static void ReportOnUnsafeBlock(SonarSyntaxNodeReportingContext context, Location issueLocation) =>
             context.ReportIssue(Diagnostic.Create(Rule, issueLocation, "unsafe", "redundant"));
 
         private static SyntaxToken FindUnsafeKeyword(MemberDeclarationSyntax memberDeclaration) =>
             Modifiers(memberDeclaration).FirstOrDefault(x => x.IsKind(SyntaxKind.UnsafeKeyword));
 
-        private static void CheckTypeDeclarationForRedundantPartial(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckTypeDeclarationForRedundantPartial(SonarSyntaxNodeReportingContext context)
         {
             var typeDeclaration = (TypeDeclarationSyntax)context.Node;
             if (!context.IsRedundantPositionalRecordContext()
@@ -212,7 +212,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 _ => default
             };
 
-        private static void CheckSealedMemberInSealedClass(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckSealedMemberInSealedClass(SonarSyntaxNodeReportingContext context)
         {
             if (Modifiers((MemberDeclarationSyntax)context.Node) is var modifiers
                 && modifiers.Any(SyntaxKind.SealedKeyword)
@@ -250,11 +250,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PreIncrementExpression
             };
 
-            private readonly SonarSyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeReportingContext context;
             private bool isCurrentContextChecked;
             private bool currentContextHasIntegralOperation;
 
-            public CheckedWalker(SonarSyntaxNodeAnalysisContext context)
+            public CheckedWalker(SonarSyntaxNodeReportingContext context)
             {
                 this.context = context;
                 isCurrentContextChecked = context.Node switch

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
@@ -93,7 +93,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override bool AreEquivalent(SyntaxNode node1, SyntaxNode node2) => CSharpEquivalenceChecker.AreEquivalent(node1, node2);
 
-        private static void CheckAndPattern(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckAndPattern(SonarSyntaxNodeReportingContext context)
         {
             var binaryPatternNode = (BinaryPatternSyntaxWrapper)context.Node;
             var left = binaryPatternNode.Left.SyntaxNode.RemoveParentheses();
@@ -122,7 +122,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && !isPatternWrapper.IsNull();
         }
 
-        private static void CheckOrPattern(SonarSyntaxNodeAnalysisContext context)
+        private static void CheckOrPattern(SonarSyntaxNodeReportingContext context)
         {
             var binaryPatternNode = (BinaryPatternSyntaxWrapper)context.Node;
             var left = binaryPatternNode.Left.SyntaxNode.RemoveParentheses();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullableTypeComparison.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullableTypeComparison.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.NotEqualsExpression);
         }
 
-        private static void CheckGetTypeAndTypeOfEquality(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax sideA, ExpressionSyntax sideB, Location location)
+        private static void CheckGetTypeAndTypeOfEquality(SonarSyntaxNodeReportingContext context, ExpressionSyntax sideA, ExpressionSyntax sideB, Location location)
         {
             if (!(sideA as InvocationExpressionSyntax).IsGetTypeCall(context.SemanticModel))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToArrayCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToArrayCall.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 },
                 SyntaxKind.InvocationExpression);
 
-        private static MemberAccessExpressionSyntax GetRedundantMemberAccess(SonarSyntaxNodeAnalysisContext context, string targetMethodName, KnownType targetKnownType)
+        private static MemberAccessExpressionSyntax GetRedundantMemberAccess(SonarSyntaxNodeReportingContext context, string targetMethodName, KnownType targetKnownType)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToStringCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToStringCall.cs
@@ -117,23 +117,23 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.InvocationExpression);
         }
 
-        private static void CheckLeftExpressionForRemovableToStringCall(SonarSyntaxNodeAnalysisContext context,
+        private static void CheckLeftExpressionForRemovableToStringCall(SonarSyntaxNodeReportingContext context,
             BinaryExpressionSyntax binary)
         {
             CheckExpressionForRemovableToStringCall(context, binary.Left, binary.Right, 0);
         }
-        private static void CheckRightExpressionForRemovableToStringCall(SonarSyntaxNodeAnalysisContext context,
+        private static void CheckRightExpressionForRemovableToStringCall(SonarSyntaxNodeReportingContext context,
             BinaryExpressionSyntax binary)
         {
             CheckExpressionForRemovableToStringCall(context, binary.Right, binary.Left, 1);
         }
-        private static void CheckRightExpressionForRemovableToStringCall(SonarSyntaxNodeAnalysisContext context,
+        private static void CheckRightExpressionForRemovableToStringCall(SonarSyntaxNodeReportingContext context,
             AssignmentExpressionSyntax assignment)
         {
             CheckExpressionForRemovableToStringCall(context, assignment.Right, assignment.Left, 1);
         }
 
-        private static void CheckExpressionForRemovableToStringCall(SonarSyntaxNodeAnalysisContext context,
+        private static void CheckExpressionForRemovableToStringCall(SonarSyntaxNodeReportingContext context,
             ExpressionSyntax expressionWithToStringCall, ExpressionSyntax otherOperandOfAddition, int checkedSideIndex)
         {
             if (!IsArgumentlessToStringCallNotOnBaseExpression(expressionWithToStringCall, context.SemanticModel, out var location, out var methodSymbol) ||

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PropertyDeclaration,
                 SyntaxKind.OperatorDeclaration);
 
-        private static void ReportIfReturnsNullOrDefault(SonarSyntaxNodeAnalysisContext context)
+        private static void ReportIfReturnsNullOrDefault(SonarSyntaxNodeReportingContext context)
         {
             if (GetExpressionBody(context.Node) is { } expressionBody)
             {
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static bool IsReturningCollection(SonarSyntaxNodeAnalysisContext context)
+        private static bool IsReturningCollection(SonarSyntaxNodeReportingContext context)
         {
             var symbol = context.SemanticModel.GetDeclaredSymbol(context.Node);
             var methodSymbol = (symbol as IPropertySymbol)?.GetMethod ?? symbol as IMethodSymbol;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnValueIgnored.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnValueIgnored.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.SimpleLambdaExpression);
         }
 
-        private static void CheckExpressionForPureMethod(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax expression)
+        private static void CheckExpressionForPureMethod(SonarSyntaxNodeReportingContext context, ExpressionSyntax expression)
         {
             if (expression is InvocationExpressionSyntax invocation
                 && context.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol { ReturnsVoid: false } invokedMethodSymbol

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(FindPossibleViolations, SyntaxKind.ConstructorDeclaration);
         }
 
-        private static void FindPossibleViolations(SonarSyntaxNodeAnalysisContext c)
+        private static void FindPossibleViolations(SonarSyntaxNodeReportingContext c)
         {
             var constructorSyntax = (ConstructorDeclarationSyntax)c.Node;
             var reportLocation = constructorSyntax?.Identifier.GetLocation();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SetLocaleForDataTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SetLocaleForDataTypes.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     compilationStartContext.RegisterCompilationEndAction(c => ProcessCollectedSymbols(c, symbolsWhereTypeIsCreated, symbolsWhereLocaleIsSet));
                 });
 
-        private static void ProcessObjectCreations(SonarSyntaxNodeAnalysisContext c, IDictionary<ISymbol, SyntaxNode> symbolsWhereTypeIsCreated)
+        private static void ProcessObjectCreations(SonarSyntaxNodeReportingContext c, IDictionary<ISymbol, SyntaxNode> symbolsWhereTypeIsCreated)
         {
             if (GetSymbolFromConstructorInvocation(c.Node, c.SemanticModel) is ITypeSymbol objectType
                 && objectType.IsAny(CheckedTypes)
@@ -71,7 +71,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ProcessSimpleAssignments(SonarSyntaxNodeAnalysisContext c, ISet<ISymbol> symbolsWhereLocaleIsSet)
+        private static void ProcessSimpleAssignments(SonarSyntaxNodeReportingContext c, ISet<ISymbol> symbolsWhereLocaleIsSet)
         {
             var assignmentExpression = (AssignmentExpressionSyntax)c.Node;
             var variableSymbols = assignmentExpression.AssignmentTargets()
@@ -83,7 +83,7 @@ namespace SonarAnalyzer.Rules.CSharp
             symbolsWhereLocaleIsSet.UnionWith(variableSymbols);
         }
 
-        private static void ProcessCollectedSymbols(SonarCompilationAnalysisContext c, IDictionary<ISymbol, SyntaxNode> symbolsWhereTypeIsCreated, ISet<ISymbol> symbolsWhereLocaleIsSet)
+        private static void ProcessCollectedSymbols(SonarCompilationReportingContext c, IDictionary<ISymbol, SyntaxNode> symbolsWhereTypeIsCreated, ISet<ISymbol> symbolsWhereLocaleIsSet)
         {
             foreach (var invalidCreation in symbolsWhereTypeIsCreated.Where(x => !symbolsWhereLocaleIsSet.Contains(x.Key)))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SillyBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SillyBitwiseOperation.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.ExclusiveOrAssignmentExpression);
         }
 
-        private void CheckAssignment(SonarSyntaxNodeAnalysisContext context, int constValueToLookFor)
+        private void CheckAssignment(SonarSyntaxNodeReportingContext context, int constValueToLookFor)
         {
             var assignment = (AssignmentExpressionSyntax)context.Node;
             if (FindIntConstant(context.SemanticModel, assignment.Right) is { } constValue
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void CheckBinary(SonarSyntaxNodeAnalysisContext context, int constValueToLookFor)
+        private void CheckBinary(SonarSyntaxNodeReportingContext context, int constValueToLookFor)
         {
             var binary = (BinaryExpressionSyntax)context.Node;
             CheckBinary(context, binary.Left, binary.OperatorToken, binary.Right, constValueToLookFor);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SqlKeywordsDelimitedBySpace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SqlKeywordsDelimitedBySpace.cs
@@ -97,9 +97,9 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private sealed class StringConcatenationWalker : SafeCSharpSyntaxWalker
         {
-            private readonly SonarSyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeReportingContext context;
 
-            public StringConcatenationWalker(SonarSyntaxNodeAnalysisContext context) =>
+            public StringConcatenationWalker(SonarSyntaxNodeReportingContext context) =>
                 this.context = context;
 
             public override void VisitInterpolatedStringExpression(InterpolatedStringExpressionSyntax node)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInGenericClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInGenericClass.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKindEx.RecordStructDeclaration,
                 SyntaxKind.StructDeclaration);
 
-        private static void CheckMember(SonarSyntaxNodeAnalysisContext context, SyntaxNode root, Location location, string[] typeParameterNames)
+        private static void CheckMember(SonarSyntaxNodeReportingContext context, SyntaxNode root, Location location, string[] typeParameterNames)
         {
             if (!HasGenericType(context, root, typeParameterNames))
             {
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static bool HasGenericType(SonarSyntaxNodeAnalysisContext context, SyntaxNode root, string[] typeParameterNames) =>
+        private static bool HasGenericType(SonarSyntaxNodeReportingContext context, SyntaxNode root, string[] typeParameterNames) =>
             root.DescendantNodesAndSelf()
                 .OfType<IdentifierNameSyntax>()
                 .Any(x => typeParameterNames.Contains(x.Identifier.Value) && context.SemanticModel.GetSymbolInfo(x).Symbol is { Kind: SymbolKind.TypeParameter });

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticSealedClassProtectedMembers.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticSealedClassProtectedMembers.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKind.EventFieldDeclaration);
         }
 
-        private static void ReportDiagnostics(SonarSyntaxNodeAnalysisContext context, SyntaxNode declaration, IEnumerable<SyntaxToken> modifiers)
+        private static void ReportDiagnostics(SonarSyntaxNodeReportingContext context, SyntaxNode declaration, IEnumerable<SyntaxToken> modifiers)
         {
             var symbol = context.SemanticModel.GetDeclaredSymbol(declaration);
             if (symbol == null || symbol.IsOverride || !symbol.ContainingType.IsSealed)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringFormatValidator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringFormatValidator.cs
@@ -80,7 +80,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(CheckForFormatStringIssues, SyntaxKind.InvocationExpression);
 
-        private static void CheckForFormatStringIssues(SonarSyntaxNodeAnalysisContext analysisContext)
+        private static void CheckForFormatStringIssues(SonarSyntaxNodeReportingContext analysisContext)
         {
             var invocation = (InvocationExpressionSyntax)analysisContext.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringLiteralShouldNotBeDuplicated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringLiteralShouldNotBeDuplicated.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 .Any(p => p.Identifier.ValueText == literalExpression.Token.ValueText)
             ?? false;
 
-        protected override bool IsInnerInstance(SonarSyntaxNodeAnalysisContext context) =>
+        protected override bool IsInnerInstance(SonarSyntaxNodeReportingContext context) =>
             context.Node.Ancestors().Any(x =>
                 x.IsAnyKind(TypeDeclarationSyntaxKinds)
                 || (x.IsKind(SyntaxKind.CompilationUnit) && x.ChildNodes().Any(y => y.IsKind(SyntaxKind.GlobalStatement))));
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override SyntaxToken LiteralToken(LiteralExpressionSyntax literal) =>
             literal.Token;
 
-        protected override bool IsNamedTypeOrTopLevelMain(SonarSyntaxNodeAnalysisContext context) =>
+        protected override bool IsNamedTypeOrTopLevelMain(SonarSyntaxNodeReportingContext context) =>
             IsNamedType(context) || context.IsTopLevelMain();
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.InvocationExpression);
         }
 
-        private static void ReportOnViolation(SonarSyntaxNodeAnalysisContext context)
+        private static void ReportOnViolation(SonarSyntaxNodeReportingContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override ControlFlowGraph CreateCfg(SemanticModel model, SyntaxNode node, CancellationToken cancel) =>
             node.CreateCfg(model, cancel);
 
-        protected override void AnalyzeSonar(SonarSyntaxNodeAnalysisContext context, SyntaxNode body, ISymbol symbol)
+        protected override void AnalyzeSonar(SonarSyntaxNodeReportingContext context, SyntaxNode body, ISymbol symbol)
         {
             var enabledAnalyzers = AllRules.Select(x => x.Value.CreateSonarFallback(Configuration))
                                            .WhereNotNull()
@@ -140,7 +140,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportDiagnosticsSonar(SonarSyntaxNodeAnalysisContext context, IEnumerable<ISymbolicExecutionAnalysisContext> analyzerContexts, bool supportsPartialResults)
+        private static void ReportDiagnosticsSonar(SonarSyntaxNodeReportingContext context, IEnumerable<ISymbolicExecutionAnalysisContext> analyzerContexts, bool supportsPartialResults)
         {
             foreach (var analyzerContext in analyzerContexts.Where(x => x.SupportsPartialResults == supportsPartialResults))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration, SyntaxKindEx.LocalFunctionStatement);
 
-        private static void AnalyzeMethod(SonarSyntaxNodeAnalysisContext c)
+        private static void AnalyzeMethod(SonarSyntaxNodeReportingContext c)
         {
             if (HasAttributes(c.Node) && c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol methodSymbol)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
                  SyntaxKindEx.ThrowExpression);
         }
 
-        private static void ReportDiagnostic(SonarSyntaxNodeAnalysisContext c, ExpressionSyntax newExceptionExpression, SyntaxNode throwExpression)
+        private static void ReportDiagnostic(SonarSyntaxNodeReportingContext c, ExpressionSyntax newExceptionExpression, SyntaxNode throwExpression)
         {
             if (c.SemanticModel.GetTypeInfo(newExceptionExpression).Type.Is(KnownType.System_NotImplementedException))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeExaminationOnSystemType.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeExaminationOnSystemType.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
                },
                SyntaxKind.InvocationExpression);
 
-        private static void CheckIsInstanceOfTypeCallWithTypeArgument(SonarSyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation, ISymbol methodSymbol)
+        private static void CheckIsInstanceOfTypeCallWithTypeArgument(SonarSyntaxNodeReportingContext context, InvocationExpressionSyntax invocation, ISymbol methodSymbol)
         {
             if (methodSymbol.Name != nameof(Type.IsInstanceOfType) || !methodSymbol.ContainingType.Is(KnownType.System_Type))
             {
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.ReportIssue(Diagnostic.Create(Rule, argument.GetLocation(), message));
         }
 
-        private static void CheckGetTypeCallOnType(SonarSyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation, IMethodSymbol invokedMethod)
+        private static void CheckGetTypeCallOnType(SonarSyntaxNodeReportingContext context, InvocationExpressionSyntax invocation, IMethodSymbol invokedMethod)
         {
             if (!(invocation.Expression is MemberAccessExpressionSyntax memberCall)
                 || IsException(memberCall, context.SemanticModel)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
@@ -169,7 +169,7 @@ public sealed class UnchangedLocalVariablesShouldBeConst : SonarDiagnosticAnalyz
         declaratorSyntax is { Initializer.Value: { } initializer }
             && initializer.DescendantNodesAndSelf().Any(x => x.IsKind(SyntaxKind.Interpolation));
 
-    private static void Report(SonarSyntaxNodeAnalysisContext c, VariableDeclaratorSyntax declaratorSyntax) =>
+    private static void Report(SonarSyntaxNodeReportingContext c, VariableDeclaratorSyntax declaratorSyntax) =>
         c.ReportIssue(Diagnostic.Create(Rule,
             declaratorSyntax.Identifier.GetLocation(),
             declaratorSyntax.Identifier.ValueText,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnconditionalJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnconditionalJumpStatement.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
             SyntaxKind.DoStatement
         };
 
-        protected override LoopWalkerBase<StatementSyntax, SyntaxKind> GetWalker(SonarSyntaxNodeAnalysisContext context)
+        protected override LoopWalkerBase<StatementSyntax, SyntaxKind> GetWalker(SonarSyntaxNodeReportingContext context)
             => new LoopWalker(context, LoopStatements);
 
         private class LoopWalker : LoopWalkerBase<StatementSyntax, SyntaxKind>
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
-            public LoopWalker(SonarSyntaxNodeAnalysisContext context, ISet<SyntaxKind> loopStatements) : base(context, loopStatements) { }
+            public LoopWalker(SonarSyntaxNodeReportingContext context, ISet<SyntaxKind> loopStatements) : base(context, loopStatements) { }
 
             public override void Visit()
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterSymbolAction(RaiseOnUninvokedEventDeclaration, SymbolKind.NamedType);
 
-        private void RaiseOnUninvokedEventDeclaration(SonarSymbolAnalysisContext context)
+        private void RaiseOnUninvokedEventDeclaration(SonarSymbolReportingContext context)
         {
             var namedType = (INamedTypeSymbol)context.Symbol;
             if (!namedType.IsClassOrStruct() || namedType.ContainingType != null)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryUsings.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryUsings.cs
@@ -69,7 +69,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void CheckUnnecessaryUsings(SonarSyntaxNodeAnalysisContext context, IEnumerable<UsingDirectiveSyntax> usingDirectives, ISet<INamespaceSymbol> necessaryNamespaces)
+        private static void CheckUnnecessaryUsings(SonarSyntaxNodeReportingContext context, IEnumerable<UsingDirectiveSyntax> usingDirectives, ISet<INamespaceSymbol> necessaryNamespaces)
         {
             foreach (var usingDirective in usingDirectives)
             {
@@ -91,12 +91,12 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             public readonly HashSet<INamespaceSymbol> NecessaryNamespaces = new();
 
-            private readonly SonarSyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeReportingContext context;
             private readonly IImmutableSet<EquivalentNameSyntax> usingDirectivesFromParent;
             private readonly INamespaceSymbol currentNamespace;
             private bool linqQueryVisited;
 
-            public CSharpRemovableUsingWalker(SonarSyntaxNodeAnalysisContext context, IImmutableSet<EquivalentNameSyntax> usingDirectivesFromParent, INamespaceSymbol currentNamespace)
+            public CSharpRemovableUsingWalker(SonarSyntaxNodeReportingContext context, IImmutableSet<EquivalentNameSyntax> usingDirectivesFromParent, INamespaceSymbol currentNamespace)
             {
                 this.context = context;
                 this.usingDirectivesFromParent = usingDirectivesFromParent;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -75,7 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         });
                 });
 
-        private static void NamedSymbolAction(SonarSymbolAnalysisContext context, HashSet<ISymbol> removableInternalTypes)
+        private static void NamedSymbolAction(SonarSymbolReportingContext context, HashSet<ISymbol> removableInternalTypes)
         {
             var namedType = (INamedTypeSymbol)context.Symbol;
             var privateSymbols = new HashSet<ISymbol>();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(AnalyzeLocalFunctionStatements, SyntaxKindEx.LocalFunctionStatement);
         }
 
-        private static void AnalyzeNamedTypes(SonarSymbolAnalysisContext context)
+        private static void AnalyzeNamedTypes(SonarSymbolReportingContext context)
         {
             var namedType = (INamedTypeSymbol)context.Symbol;
             if (!namedType.IsClassOrStruct() || namedType.ContainingType != null)
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void AnalyzeLocalFunctionStatements(SonarSyntaxNodeAnalysisContext context)
+        private static void AnalyzeLocalFunctionStatements(SonarSyntaxNodeReportingContext context)
         {
             var localFunctionSyntax = (LocalFunctionStatementSyntaxWrapper)context.Node;
             var topMostContainingMethod = localFunctionSyntax.IsTopLevel()

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericEventHandlerInstances.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericEventHandlerInstances.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
                }, SyntaxKind.EventDeclaration);
         }
 
-        private static void AnalyzeEventType(SonarSyntaxNodeAnalysisContext analysisContext, SyntaxNode eventNode,
+        private static void AnalyzeEventType(SonarSyntaxNodeReportingContext analysisContext, SyntaxNode eventNode,
             Func<Location> getLocationToReportOn)
         {
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKindEx.RecordStructDeclaration);
         }
 
-        private static void VerifyMethodDeclaration(SonarSyntaxNodeAnalysisContext context)
+        private static void VerifyMethodDeclaration(SonarSyntaxNodeReportingContext context)
         {
             var methodDeclaration = (BaseMethodDeclarationSyntax)context.Node;
             var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodDeclaration);
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void VerifyPropertyDeclaration(SonarSyntaxNodeAnalysisContext context)
+        private static void VerifyPropertyDeclaration(SonarSyntaxNodeReportingContext context)
         {
             var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
             var propertySymbol = context.SemanticModel.GetDeclaredSymbol(propertyDeclaration);
@@ -107,7 +107,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void VerifyRecordDeclaration(SonarSyntaxNodeAnalysisContext context)
+        private static void VerifyRecordDeclaration(SonarSyntaxNodeReportingContext context)
         {
             var declaration = (RecordDeclarationSyntaxWrapper)context.Node;
             if (!context.IsRedundantPositionalRecordContext() && HasStringUriParams(declaration.ParameterList, context.SemanticModel))
@@ -120,7 +120,7 @@ namespace SonarAnalyzer.Rules.CSharp
             parameterList != null
             && parameterList.Parameters.Any(x => NameContainsUri(x.Identifier.Text) && model.GetDeclaredSymbol(x).IsType(KnownType.System_String));
 
-        private static void VerifyInvocationAndCreation(SonarSyntaxNodeAnalysisContext context)
+        private static void VerifyInvocationAndCreation(SonarSyntaxNodeReportingContext context)
         {
             if (context.SemanticModel.GetSymbolInfo(context.Node).Symbol is IMethodSymbol invokedMethodSymbol
                 && !invokedMethodSymbol.IsInType(KnownType.System_Uri)
@@ -131,7 +131,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void VerifyReturnType(SonarSyntaxNodeAnalysisContext context, BaseMethodDeclarationSyntax methodDeclaration, IMethodSymbol methodSymbol)
+        private static void VerifyReturnType(SonarSyntaxNodeReportingContext context, BaseMethodDeclarationSyntax methodDeclaration, IMethodSymbol methodSymbol)
         {
             if ((methodDeclaration as MethodDeclarationSyntax)?.ReturnType?.GetLocation() is { } returnTypeLocation
                 && methodSymbol.ReturnType.Is(KnownType.System_String)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ValuesUselesslyIncremented.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ValuesUselesslyIncremented.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PostIncrementExpression,
                 SyntaxKind.PostDecrementExpression);
 
-        private static void VisitParent(SonarSyntaxNodeAnalysisContext context, PostfixUnaryExpressionSyntax increment)
+        private static void VisitParent(SonarSyntaxNodeReportingContext context, PostfixUnaryExpressionSyntax increment)
         {
             switch (increment.Parent)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(c => ProcessVariableDesignation(c, ((ListPatternSyntaxWrapper)c.Node).Designation), SyntaxKindEx.ListPattern);
         }
 
-        private static void ProcessVariableDesignation(SonarSyntaxNodeAnalysisContext context, VariableDesignationSyntaxWrapper variableDesignation)
+        private static void ProcessVariableDesignation(SonarSyntaxNodeReportingContext context, VariableDesignationSyntaxWrapper variableDesignation)
         {
             if (variableDesignation.AllVariables() is { Length: > 0 } variables
                 && context.ContainingSymbol.ContainingType is { } containingType
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ProcessVariableDeclaration(SonarSyntaxNodeAnalysisContext context, VariableDeclarationSyntax variableDeclaration)
+        private static void ProcessVariableDeclaration(SonarSyntaxNodeReportingContext context, VariableDeclarationSyntax variableDeclaration)
         {
             if (variableDeclaration is { Variables: { Count: > 0 } variables }
                 && context.ContainingSymbol.ContainingType is { } containingType
@@ -86,7 +86,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private static void ReportOnVariableMatchingField(SonarSyntaxNodeAnalysisContext context, IEnumerable<ISymbol> members, SyntaxToken identifier)
+        private static void ReportOnVariableMatchingField(SonarSyntaxNodeReportingContext context, IEnumerable<ISymbol> members, SyntaxToken identifier)
         {
             if (members.FirstOrDefault(m => m.Name == identifier.ValueText) is { } matchingMember)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfMissingContractAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfMissingContractAttribute.cs
@@ -84,7 +84,7 @@ namespace SonarAnalyzer.Rules.CSharp
                      .OfType<IMethodSymbol>()
                      .Any(m => m.HasAttribute(KnownType.System_ServiceModel_OperationContractAttribute));
 
-        private static TypeDeclarationSyntax GetTypeDeclaration(SonarSymbolAnalysisContext context, ISymbol namedType) =>
+        private static TypeDeclarationSyntax GetTypeDeclaration(SonarSymbolReportingContext context, ISymbol namedType) =>
             namedType.DeclaringSyntaxReferences
                      .Where(x => context.ShouldAnalyzeTree(x.SyntaxTree, CSharpGeneratedCodeRecognizer.Instance))
                      .Select(x => x.GetSyntax() as TypeDeclarationSyntax)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
@@ -84,7 +84,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     ccc.RegisterNodeAction(VerifyXmlReaderInvocations, SyntaxKind.InvocationExpression);
                 });
 
-        private void VerifyXmlReaderInvocations(SonarSyntaxNodeAnalysisContext context)
+        private void VerifyXmlReaderInvocations(SonarSyntaxNodeReportingContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if (!invocation.IsMemberAccessOnKnownType("Create", KnownType.System_Xml_XmlReader, context.SemanticModel))
@@ -105,7 +105,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void VerifyXPathDocumentConstructor(SonarSyntaxNodeAnalysisContext context, IObjectCreation objectCreation)
+        private void VerifyXPathDocumentConstructor(SonarSyntaxNodeReportingContext context, IObjectCreation objectCreation)
         {
             if (!context.SemanticModel.GetTypeInfo(objectCreation.Expression).Type.Is(KnownType.System_Xml_XPath_XPathDocument)
                 // If a XmlReader is provided in the constructor, XPathDocument will be as safe as the received reader.

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ConditionEvaluatesToConstant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ConditionEvaluatesToConstant.cs
@@ -89,12 +89,12 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S2583, S2589);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(context, explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext
         {
-            private readonly SonarSyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeReportingContext context;
             private readonly SonarExplodedGraph explodedGraph;
 
             private readonly HashSet<SyntaxNode> conditionTrue = new HashSet<SyntaxNode>();
@@ -105,7 +105,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
             private bool hasYieldStatement;
 
-            public AnalysisContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph)
+            public AnalysisContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph)
             {
                 this.context = context;
                 this.explodedGraph = explodedGraph;

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -74,7 +74,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S4158);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyNullableValueAccess.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyNullableValueAccess.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S3655);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/HashesShouldHaveUnpredictableSalt.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/HashesShouldHaveUnpredictableSalt.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S2053);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(explodedGraph);
 
         internal sealed class LocationContext

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InitializationVectorShouldBeRandom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InitializationVectorShouldBeRandom.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(S3329);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : DefaultAnalysisContext<Location>

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InvalidCastToInterfaceSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InvalidCastToInterfaceSymbolicExecution.cs
@@ -31,19 +31,19 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S1944);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(context, explodedGraph);
 
         internal sealed class NullableCastCheck : ExplodedGraphCheck
         {
-            private readonly SonarSyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeReportingContext context;
 
             public NullableCastCheck(SonarExplodedGraph explodedGraph)
                 : base(explodedGraph)
             {
             }
 
-            public NullableCastCheck(SonarExplodedGraph explodedGraph, SonarSyntaxNodeAnalysisContext context)
+            public NullableCastCheck(SonarExplodedGraph explodedGraph, SonarSyntaxNodeReportingContext context)
                 : this(explodedGraph)
             {
                 this.context = context;
@@ -90,7 +90,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
         {
             public bool SupportsPartialResults => true;
 
-            public AnalysisContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+            public AnalysisContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph) =>
                 explodedGraph.AddExplodedGraphCheck(new NullableCastCheck(explodedGraph, context));
 
             public void Dispose()

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/NullPointerDereference.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/NullPointerDereference.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S2259);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(context, explodedGraph);
 
         internal sealed class NullPointerCheck : ExplodedGraphCheck
@@ -192,11 +192,11 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext
         {
-            private readonly SonarSyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeReportingContext context;
             private readonly HashSet<IdentifierNameSyntax> nullIdentifiers = new();
             private readonly NullPointerCheck nullPointerCheck;
 
-            public AnalysisContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph)
+            public AnalysisContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph)
             {
                 this.context = context;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ObjectsShouldNotBeDisposedMoreThanOnce.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ObjectsShouldNotBeDisposedMoreThanOnce.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(S3966);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(S3900);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(context, explodedGraph);
 
         private static void CollectMemberAccesses(MemberAccessingEventArgs args, ISet<IdentifierNameSyntax> identifiers, SemanticModel semanticModel)
@@ -51,11 +51,11 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
         {
             public bool SupportsPartialResults => true;
 
-            private readonly SonarSyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeReportingContext context;
             private readonly HashSet<IdentifierNameSyntax> identifiers = new();
             private readonly NullPointerDereference.NullPointerCheck nullPointerCheck;
 
-            public AnalysisContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph)
+            public AnalysisContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph)
             {
                 if (!GetMethodSymbol(context).IsPubliclyAccessible())
                 {
@@ -89,7 +89,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
             private static bool IsArgumentOfConstructorInitializer(SyntaxNode identifier) =>
                 identifier.FirstAncestorOrSelf<ConstructorInitializerSyntax>() != null;
 
-            private static ISymbol GetMethodSymbol(SonarSyntaxNodeAnalysisContext context) =>
+            private static ISymbol GetMethodSymbol(SonarSyntaxNodeReportingContext context) =>
                 context.SemanticModel.GetSymbolInfo(context.Node).Symbol ?? context.SemanticModel.GetDeclaredSymbol(context.Node);
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/RestrictDeserializedTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/RestrictDeserializedTypes.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
         public IEnumerable<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(S5773);
 
-        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph) =>
+        public ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph) =>
             new AnalysisContext(explodedGraph);
 
         private sealed class AnalysisContext : ISymbolicExecutionAnalysisContext

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ISymbolicExecutionAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ISymbolicExecutionAnalyzer.cs
@@ -24,6 +24,6 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar
     {
         IEnumerable<DiagnosticDescriptor> SupportedDiagnostics { get; }
 
-        ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeAnalysisContext context, SonarExplodedGraph explodedGraph);
+        ISymbolicExecutionAnalysisContext CreateContext(SonarSyntaxNodeReportingContext context, SonarExplodedGraph explodedGraph);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -77,24 +77,24 @@ public sealed class SonarAnalysisContext
         analysisContext.RegisterCodeBlockStartAction<TSyntaxKind>(
             c => Execute<SonarCodeBlockStartAnalysisContext<TSyntaxKind>, CodeBlockStartAnalysisContext<TSyntaxKind>>(new(this, c), action, c.CodeBlock.SyntaxTree, generatedCodeRecognizer));
 
-    public void RegisterCompilationAction(Action<SonarCompilationAnalysisContext> action) =>
+    public void RegisterCompilationAction(Action<SonarCompilationReportingContext> action) =>
         analysisContext.RegisterCompilationAction(
-            c => Execute<SonarCompilationAnalysisContext, CompilationAnalysisContext>(new(this, c), action, null));
+            c => Execute<SonarCompilationReportingContext, CompilationAnalysisContext>(new(this, c), action, null));
 
     public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
         analysisContext.RegisterCompilationStartAction(
             c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action, null));
 
-    public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
+    public void RegisterSymbolAction(Action<SonarSymbolReportingContext> action, params SymbolKind[] symbolKinds) =>
         analysisContext.RegisterSymbolAction(
-            c => Execute<SonarSymbolAnalysisContext, SymbolAnalysisContext>(new(this, c), action, null), symbolKinds);
+            c => Execute<SonarSymbolReportingContext, SymbolAnalysisContext>(new(this, c), action, null), symbolKinds);
 
-    public void RegisterNodeAction<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds)
+    public void RegisterNodeAction<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeReportingContext> action, params TSyntaxKind[] syntaxKinds)
         where TSyntaxKind : struct =>
         analysisContext.RegisterSyntaxNodeAction(
-            c => Execute<SonarSyntaxNodeAnalysisContext, SyntaxNodeAnalysisContext>(new(this, c), action, c.Node.SyntaxTree, generatedCodeRecognizer), syntaxKinds);
+            c => Execute<SonarSyntaxNodeReportingContext, SyntaxNodeAnalysisContext>(new(this, c), action, c.Node.SyntaxTree, generatedCodeRecognizer), syntaxKinds);
 
-    public void RegisterTreeAction(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxTreeAnalysisContext> action) =>
+    public void RegisterTreeAction(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxTreeReportingContext> action) =>
         analysisContext.RegisterCompilationStartAction(WrapTreeAction(action, generatedCodeRecognizer));
 
     /// <summary>
@@ -104,12 +104,12 @@ public sealed class SonarAnalysisContext
     /// * For all unchanged files under PR analysis.
     /// This should NOT be used for actions that report issues.
     /// </summary>
-    public void RegisterNodeActionInAllFiles<TSyntaxKind>(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
+    public void RegisterNodeActionInAllFiles<TSyntaxKind>(Action<SonarSyntaxNodeReportingContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
         analysisContext.RegisterSyntaxNodeAction(c => action(new(this, c)), syntaxKinds);
 
-    public Action<CompilationStartAnalysisContext> WrapTreeAction(Action<SonarSyntaxTreeAnalysisContext> action, GeneratedCodeRecognizer generatedCodeRecognizer = null) =>
+    public Action<CompilationStartAnalysisContext> WrapTreeAction(Action<SonarSyntaxTreeReportingContext> action, GeneratedCodeRecognizer generatedCodeRecognizer = null) =>
         c => c.RegisterSyntaxTreeAction(
-            treeContext => Execute<SonarSyntaxTreeAnalysisContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action, treeContext.Tree, generatedCodeRecognizer));
+            treeContext => Execute<SonarSyntaxTreeReportingContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action, treeContext.Tree, generatedCodeRecognizer));
 
     /// <param name="sourceTree">Tree that is definitely known to be analyzed. Pass 'null' if the context doesn't know a specific tree to be analyzed, like a CompilationContext.</param>
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action, SyntaxTree sourceTree, GeneratedCodeRecognizer generatedCodeRecognizer = null)

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCodeBlockReportingContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCodeBlockReportingContext.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.AnalysisContext;
 
-public sealed class SonarCodeBlockAnalysisContext : SonarTreeReportingContextBase<CodeBlockAnalysisContext>
+public sealed class SonarCodeBlockReportingContext : SonarTreeReportingContextBase<CodeBlockAnalysisContext>
 {
     public override SyntaxTree Tree => Context.CodeBlock.SyntaxTree;
     public override Compilation Compilation => Context.SemanticModel.Compilation;
@@ -30,7 +30,7 @@ public sealed class SonarCodeBlockAnalysisContext : SonarTreeReportingContextBas
     public ISymbol OwningSymbol => Context.OwningSymbol;
     public SemanticModel SemanticModel => Context.SemanticModel;
 
-    internal SonarCodeBlockAnalysisContext(SonarAnalysisContext analysisContext, CodeBlockAnalysisContext context) : base(analysisContext, context) { }
+    internal SonarCodeBlockReportingContext(SonarAnalysisContext analysisContext, CodeBlockAnalysisContext context) : base(analysisContext, context) { }
 
     private protected override ReportingContext CreateReportingContext(Diagnostic diagnostic) =>
         new(this, diagnostic);

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCodeBlockStartAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCodeBlockStartAnalysisContext.cs
@@ -32,9 +32,9 @@ public sealed class SonarCodeBlockStartAnalysisContext<TSyntaxKind> : SonarAnaly
 
     internal SonarCodeBlockStartAnalysisContext(SonarAnalysisContext analysisContext, CodeBlockStartAnalysisContext<TSyntaxKind> context) : base(analysisContext, context) { }
 
-    public void RegisterNodeAction(Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] symbolKinds) =>
+    public void RegisterNodeAction(Action<SonarSyntaxNodeReportingContext> action, params TSyntaxKind[] symbolKinds) =>
         Context.RegisterSyntaxNodeAction(x => action(new(AnalysisContext, x)), symbolKinds);
 
-    public void RegisterCodeBlockEndAction(Action<SonarCodeBlockAnalysisContext> action) =>
+    public void RegisterCodeBlockEndAction(Action<SonarCodeBlockReportingContext> action) =>
         Context.RegisterCodeBlockEndAction(x => action(new(AnalysisContext, x)));
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationReportingContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationReportingContext.cs
@@ -23,7 +23,7 @@ using System.Text.RegularExpressions;
 
 namespace SonarAnalyzer.AnalysisContext;
 
-public sealed class SonarCompilationAnalysisContext : SonarCompilationReportingContextBase<CompilationAnalysisContext>
+public sealed class SonarCompilationReportingContext : SonarCompilationReportingContextBase<CompilationAnalysisContext>
 {
     private static readonly TimeSpan FileNameTimeout = TimeSpan.FromMilliseconds(100);
     private static readonly Regex WebConfigRegex = new(@"[\\\/]web\.([^\\\/]+\.)?config$", RegexOptions.IgnoreCase, FileNameTimeout);
@@ -34,7 +34,7 @@ public sealed class SonarCompilationAnalysisContext : SonarCompilationReportingC
     public override AnalyzerOptions Options => Context.Options;
     public override CancellationToken Cancel => Context.CancellationToken;
 
-    internal SonarCompilationAnalysisContext(SonarAnalysisContext analysisContext, CompilationAnalysisContext context) : base(analysisContext, context) { }
+    internal SonarCompilationReportingContext(SonarAnalysisContext analysisContext, CompilationAnalysisContext context) : base(analysisContext, context) { }
 
     public IEnumerable<string> WebConfigFiles()
     {

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
@@ -29,13 +29,13 @@ public sealed class SonarCompilationStartAnalysisContext : SonarAnalysisContextB
 
     internal SonarCompilationStartAnalysisContext(SonarAnalysisContext analysisContext, CompilationStartAnalysisContext context) : base(analysisContext, context) { }
 
-    public void RegisterSymbolAction(Action<SonarSymbolAnalysisContext> action, params SymbolKind[] symbolKinds) =>
+    public void RegisterSymbolAction(Action<SonarSymbolReportingContext> action, params SymbolKind[] symbolKinds) =>
         Context.RegisterSymbolAction(x => action(new(AnalysisContext, x)), symbolKinds);
 
-    public void RegisterCompilationEndAction(Action<SonarCompilationAnalysisContext> action) =>
+    public void RegisterCompilationEndAction(Action<SonarCompilationReportingContext> action) =>
         Context.RegisterCompilationEndAction(x => action(new(AnalysisContext, x)));
 
-    public void RegisterNodeAction<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds)
+    public void RegisterNodeAction<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeReportingContext> action, params TSyntaxKind[] syntaxKinds)
         where TSyntaxKind : struct =>
         AnalysisContext.RegisterNodeAction(generatedCodeRecognizer, action, syntaxKinds);
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarParametrizedAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarParametrizedAnalysisContext.cs
@@ -29,11 +29,11 @@ public sealed class SonarParametrizedAnalysisContext
     internal SonarParametrizedAnalysisContext(SonarAnalysisContext context) =>
         Context = context;
 
-    public void RegisterNodeAction<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeAnalysisContext> action, params TSyntaxKind[] syntaxKinds)
+    public void RegisterNodeAction<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeReportingContext> action, params TSyntaxKind[] syntaxKinds)
         where TSyntaxKind : struct =>
         Context.RegisterNodeAction(generatedCodeRecognizer, action, syntaxKinds);
 
-    public void RegisterTreeAction(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxTreeAnalysisContext> action)
+    public void RegisterTreeAction(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxTreeReportingContext> action)
     {
         // This is tricky. SyntaxTree actions do not have compilation. So we register them in CompilationStart.
         // ParametrizedAnalyzer postpones CompilationStartActions to enforce that parameters are already set when the postponed action is executed.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSymbolReportingContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSymbolReportingContext.cs
@@ -20,15 +20,15 @@
 
 namespace SonarAnalyzer.AnalysisContext;
 
-public sealed class SonarSyntaxTreeAnalysisContext : SonarTreeReportingContextBase<SyntaxTreeAnalysisContext>
+public sealed class SonarSymbolReportingContext : SonarCompilationReportingContextBase<SymbolAnalysisContext>
 {
-    public override SyntaxTree Tree => Context.Tree;
-    public override Compilation Compilation { get; }    // SyntaxTreeAnalysisContext doesn't hold a Compilation reference, we need to provide it from CompilationStart context via constructor
+    public override SyntaxTree Tree => Context.Symbol.Locations.Select(x => x.SourceTree).FirstOrDefault(x => x is not null);
+    public override Compilation Compilation => Context.Compilation;
     public override AnalyzerOptions Options => Context.Options;
     public override CancellationToken Cancel => Context.CancellationToken;
+    public ISymbol Symbol => Context.Symbol;
 
-    internal SonarSyntaxTreeAnalysisContext(SonarAnalysisContext analysisContext, SyntaxTreeAnalysisContext context, Compilation compilation) : base(analysisContext, context) =>
-        Compilation = compilation ?? throw new ArgumentNullException(nameof(compilation));
+    internal SonarSymbolReportingContext(SonarAnalysisContext analysisContext, SymbolAnalysisContext context) : base(analysisContext, context) { }
 
     private protected override ReportingContext CreateReportingContext(Diagnostic diagnostic) =>
         new(this, diagnostic);

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxNodeReportingContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxNodeReportingContext.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.AnalysisContext;
 
-public sealed class SonarSyntaxNodeAnalysisContext : SonarTreeReportingContextBase<SyntaxNodeAnalysisContext>
+public sealed class SonarSyntaxNodeReportingContext : SonarTreeReportingContextBase<SyntaxNodeAnalysisContext>
 {
     public override SyntaxTree Tree => Context.Node.SyntaxTree;
     public override Compilation Compilation => Context.Compilation;
@@ -30,7 +30,7 @@ public sealed class SonarSyntaxNodeAnalysisContext : SonarTreeReportingContextBa
     public SemanticModel SemanticModel => Context.SemanticModel;
     public ISymbol ContainingSymbol => Context.ContainingSymbol;
 
-    internal SonarSyntaxNodeAnalysisContext(SonarAnalysisContext analysisContext, SyntaxNodeAnalysisContext context) : base(analysisContext, context) { }
+    internal SonarSyntaxNodeReportingContext(SonarAnalysisContext analysisContext, SyntaxNodeAnalysisContext context) : base(analysisContext, context) { }
 
     /// <summary>
     /// Roslyn invokes the analyzer twice for positional records. The first invocation is for the class declaration and the second for the ctor represented by the positional parameter list.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxTreeReportingContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxTreeReportingContext.cs
@@ -20,15 +20,15 @@
 
 namespace SonarAnalyzer.AnalysisContext;
 
-public sealed class SonarSymbolAnalysisContext : SonarCompilationReportingContextBase<SymbolAnalysisContext>
+public sealed class SonarSyntaxTreeReportingContext : SonarTreeReportingContextBase<SyntaxTreeAnalysisContext>
 {
-    public override SyntaxTree Tree => Context.Symbol.Locations.Select(x => x.SourceTree).FirstOrDefault(x => x is not null);
-    public override Compilation Compilation => Context.Compilation;
+    public override SyntaxTree Tree => Context.Tree;
+    public override Compilation Compilation { get; }    // SyntaxTreeAnalysisContext doesn't hold a Compilation reference, we need to provide it from CompilationStart context via constructor
     public override AnalyzerOptions Options => Context.Options;
     public override CancellationToken Cancel => Context.CancellationToken;
-    public ISymbol Symbol => Context.Symbol;
 
-    internal SonarSymbolAnalysisContext(SonarAnalysisContext analysisContext, SymbolAnalysisContext context) : base(analysisContext, context) { }
+    internal SonarSyntaxTreeReportingContext(SonarAnalysisContext analysisContext, SyntaxTreeAnalysisContext context, Compilation compilation) : base(analysisContext, context) =>
+        Compilation = compilation ?? throw new ArgumentNullException(nameof(compilation));
 
     private protected override ReportingContext CreateReportingContext(Diagnostic diagnostic) =>
         new(this, diagnostic);

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/ReportingContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/ReportingContext.cs
@@ -28,19 +28,19 @@ namespace SonarAnalyzer.Helpers
         public Diagnostic Diagnostic { get; }
         public Compilation Compilation { get; }
 
-        public ReportingContext(SonarSyntaxNodeAnalysisContext context, Diagnostic diagnostic)
+        public ReportingContext(SonarSyntaxNodeReportingContext context, Diagnostic diagnostic)
             : this(diagnostic, context.Context.ReportDiagnostic, context.Compilation, context.Tree) { }
 
-        public ReportingContext(SonarSyntaxTreeAnalysisContext context, Diagnostic diagnostic)
+        public ReportingContext(SonarSyntaxTreeReportingContext context, Diagnostic diagnostic)
             : this(diagnostic, context.Context.ReportDiagnostic, context.Compilation, context.Tree) { }
 
-        public ReportingContext(SonarCompilationAnalysisContext context, Diagnostic diagnostic)
+        public ReportingContext(SonarCompilationReportingContext context, Diagnostic diagnostic)
             : this(diagnostic, context.Context.ReportDiagnostic, context.Compilation, diagnostic.Location?.SourceTree ?? context.Tree) { }
 
-        public ReportingContext(SonarSymbolAnalysisContext context, Diagnostic diagnostic)
+        public ReportingContext(SonarSymbolReportingContext context, Diagnostic diagnostic)
             : this(diagnostic, context.Context.ReportDiagnostic, context.Compilation, diagnostic.Location?.SourceTree ?? context.Tree) { }
 
-        public ReportingContext(SonarCodeBlockAnalysisContext context, Diagnostic diagnostic)
+        public ReportingContext(SonarCodeBlockReportingContext context, Diagnostic diagnostic)
             : this(diagnostic, context.Context.ReportDiagnostic, context.Compilation, context.Tree) { }
 
         private ReportingContext(Diagnostic diagnostic,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AllBranchesShouldNotHaveSameImplementationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AllBranchesShouldNotHaveSameImplementationBase.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules
 
             protected abstract Location GetLocation(TIfSyntax topLevelIf);
 
-            public Action<SonarSyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
+            public Action<SonarSyntaxNodeReportingContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
                 context =>
                 {
                     var elseSyntax = (TElseSyntax)context.Node;
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules
 
             protected abstract Location GetLocation(TTernaryStatement ternaryStatement);
 
-            public Action<SonarSyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
+            public Action<SonarSyntaxNodeReportingContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
                 context =>
                 {
                     var ternaryStatement = (TTernaryStatement)context.Node;
@@ -104,7 +104,7 @@ namespace SonarAnalyzer.Rules
 
             protected abstract Location GetLocation(TSwitchStatement switchStatement);
 
-            public Action<SonarSyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
+            public Action<SonarSyntaxNodeReportingContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
                 context =>
                 {
                     var switchStatement = (TSwitchStatement)context.Node;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/BooleanCheckInvertedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/BooleanCheckInvertedBase.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract bool IsIgnoredNullableOperation(TBinaryExpression expression, SemanticModel semanticModel);
 
-        protected Action<SonarSyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule)
+        protected Action<SonarSyntaxNodeReportingContext> GetAnalysisAction(DiagnosticDescriptor rule)
         {
             return c =>
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/BooleanLiteralUnnecessaryBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/BooleanLiteralUnnecessaryBase.cs
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Rules
         protected BooleanLiteralUnnecessaryBase() : base(DiagnosticId) { }
 
         // LogicalAnd (C#) / AndAlso (VB)
-        protected void CheckAndExpression(SonarSyntaxNodeAnalysisContext context)
+        protected void CheckAndExpression(SonarSyntaxNodeReportingContext context)
         {
             var binary = (TBinaryExpression)context.Node;
             if (IsInsideTernaryWithThrowExpression(binary) || CheckForNullabilityAndBooleanConstantsReport(context, binary, reportOnTrue: true))
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules
         }
 
         // LogicalOr (C#) / OrElse (VB)
-        protected void CheckOrExpression(SonarSyntaxNodeAnalysisContext context)
+        protected void CheckOrExpression(SonarSyntaxNodeReportingContext context)
         {
             var binary = (TBinaryExpression)context.Node;
             if (IsInsideTernaryWithThrowExpression(binary) || CheckForNullabilityAndBooleanConstantsReport(context, binary, reportOnTrue: false))
@@ -90,7 +90,7 @@ namespace SonarAnalyzer.Rules
             CheckForBooleanConstantOnRight(context, binary, IsTrueLiteralKind, ErrorLocation.NonBoolLiteralExpression);
         }
 
-        protected void CheckEquals(SonarSyntaxNodeAnalysisContext context)
+        protected void CheckEquals(SonarSyntaxNodeReportingContext context)
         {
             var binary = (TBinaryExpression)context.Node;
             if (IsInsideTernaryWithThrowExpression(binary)
@@ -106,7 +106,7 @@ namespace SonarAnalyzer.Rules
             CheckForBooleanConstantOnRight(context, binary, IsFalseLiteralKind, ErrorLocation.BoolLiteral);
         }
 
-        protected void CheckNotEquals(SonarSyntaxNodeAnalysisContext context)
+        protected void CheckNotEquals(SonarSyntaxNodeReportingContext context)
         {
             var binary = (TBinaryExpression)context.Node;
             if (IsInsideTernaryWithThrowExpression(binary) || CheckForNullabilityAndBooleanConstantsReport(context, binary, reportOnTrue: false))
@@ -121,7 +121,7 @@ namespace SonarAnalyzer.Rules
             CheckForBooleanConstantOnRight(context, binary, IsTrueLiteralKind, ErrorLocation.BoolLiteral);
         }
 
-        protected void CheckTernaryExpressionBranches(SonarSyntaxNodeAnalysisContext context, SyntaxTree ternaryTree, SyntaxNode thenBranch, SyntaxNode elseBranch)
+        protected void CheckTernaryExpressionBranches(SonarSyntaxNodeReportingContext context, SyntaxTree ternaryTree, SyntaxNode thenBranch, SyntaxNode elseBranch)
         {
             var thenNoParantheses = Language.Syntax.RemoveParentheses(thenBranch);
             var elseNoParantheses = Language.Syntax.RemoveParentheses(elseBranch);
@@ -146,7 +146,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private bool CheckForNullabilityAndBooleanConstantsReport(SonarSyntaxNodeAnalysisContext context, TBinaryExpression binary, bool reportOnTrue)
+        private bool CheckForNullabilityAndBooleanConstantsReport(SonarSyntaxNodeReportingContext context, TBinaryExpression binary, bool reportOnTrue)
         {
             var binaryExpressionLeft = Language.Syntax.RemoveParentheses(GetLeftNode(binary));
             var binaryExpressionRight = Language.Syntax.RemoveParentheses(GetRightNode(binary));
@@ -179,13 +179,13 @@ namespace SonarAnalyzer.Rules
             return false;
         }
 
-        private void CheckForBooleanConstantOnLeft(SonarSyntaxNodeAnalysisContext context, TBinaryExpression binary, IsBooleanLiteralKind isBooleanLiteralKind, ErrorLocation errorLocation) =>
+        private void CheckForBooleanConstantOnLeft(SonarSyntaxNodeReportingContext context, TBinaryExpression binary, IsBooleanLiteralKind isBooleanLiteralKind, ErrorLocation errorLocation) =>
             CheckForBooleanConstant(context, binary, isBooleanLiteralKind, errorLocation, isLeftSide: true);
 
-        private void CheckForBooleanConstantOnRight(SonarSyntaxNodeAnalysisContext context, TBinaryExpression binary, IsBooleanLiteralKind isBooleanLiteralKind, ErrorLocation errorLocation) =>
+        private void CheckForBooleanConstantOnRight(SonarSyntaxNodeReportingContext context, TBinaryExpression binary, IsBooleanLiteralKind isBooleanLiteralKind, ErrorLocation errorLocation) =>
             CheckForBooleanConstant(context, binary, isBooleanLiteralKind, errorLocation, isLeftSide: false);
 
-        private void CheckForBooleanConstant(SonarSyntaxNodeAnalysisContext context,
+        private void CheckForBooleanConstant(SonarSyntaxNodeReportingContext context,
                                              TBinaryExpression binary,
                                              IsBooleanLiteralKind isBooleanLiteralKind,
                                              ErrorLocation errorLocation,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CatchRethrowBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CatchRethrowBase.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract SyntaxNode GetDeclarationType(TCatchClause catchClause);
 
-        protected void RaiseOnInvalidCatch(SonarSyntaxNodeAnalysisContext context)
+        protected void RaiseOnInvalidCatch(SonarSyntaxNodeReportingContext context)
         {
             var catches = GetCatches(context.Node);
             var caughtExceptionTypes = new Lazy<List<INamedTypeSymbol>>(() =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules
 
         protected CertificateValidationCheckBase() : base(DiagnosticId) { }
 
-        protected void CheckAssignmentSyntax(SonarSyntaxNodeAnalysisContext c)
+        protected void CheckAssignmentSyntax(SonarSyntaxNodeReportingContext c)
         {
             SplitAssignment((TAssignmentExpressionSyntax)c.Node, out var leftIdentifier, out var right);
             if (leftIdentifier != null && right != null
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        protected void CheckConstructorParameterSyntax(SonarSyntaxNodeAnalysisContext c)
+        protected void CheckConstructorParameterSyntax(SonarSyntaxNodeReportingContext c)
         {
             if (c.SemanticModel.GetSymbolInfo(c.Node).Symbol is IMethodSymbol ctor)
             {
@@ -290,7 +290,7 @@ namespace SonarAnalyzer.Rules
             return lst;
         }
 
-        private ImmutableArray<TInvocationExpressionSyntax> FindInvocationList(SonarSyntaxNodeAnalysisContext c, SyntaxNode root, IMethodSymbol method)
+        private ImmutableArray<TInvocationExpressionSyntax> FindInvocationList(SonarSyntaxNodeReportingContext c, SyntaxNode root, IMethodSymbol method)
         {
             if (root == null || method == null)
             {
@@ -312,10 +312,10 @@ namespace SonarAnalyzer.Rules
 
         protected readonly struct InspectionContext
         {
-            public readonly SonarSyntaxNodeAnalysisContext Context;
+            public readonly SonarSyntaxNodeReportingContext Context;
             public readonly HashSet<SyntaxNode> VisitedMethods;
 
-            public InspectionContext(SonarSyntaxNodeAnalysisContext context)
+            public InspectionContext(SonarSyntaxNodeReportingContext context)
             {
                 Context = context;
                 VisitedMethods = new HashSet<SyntaxNode>();

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ClassNotInstantiatableBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ClassNotInstantiatableBase.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules
                     IsAnyConstructorToCurrentType(descendants.DescendantNodes, namedType, descendants.Model)
                     || IsAnyNestedTypeExtendingCurrentType(descendants.DescendantNodes, namedType, descendants.Model));
 
-        private void CheckClassWithOnlyUnusedPrivateConstructors(SonarSymbolAnalysisContext context)
+        private void CheckClassWithOnlyUnusedPrivateConstructors(SonarSymbolReportingContext context)
         {
             var namedType = (INamedTypeSymbol)context.Symbol;
             if (!IsNonStaticClassWithNoAttributes(namedType) || DerivesFromSafeHandle(namedType))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CognitiveComplexityBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CognitiveComplexityBase.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules
         protected CognitiveComplexityBase() =>
             rule = Language.CreateDescriptor(DiagnosticId, MessageFormat, isEnabledByDefault: false);
 
-        protected void CheckComplexity<TSyntax>(SonarSyntaxNodeAnalysisContext context,
+        protected void CheckComplexity<TSyntax>(SonarSyntaxNodeReportingContext context,
                                                 Func<TSyntax, SyntaxNode> nodeSelector,
                                                 Func<TSyntax, Location> getLocationToReport,
                                                 Func<SyntaxNode, CognitiveComplexity> getComplexity,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CollectionEmptinessCheckingBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CollectionEmptinessCheckingBase.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules
                 },
                 Language.SyntaxKind.ComparisonKinds);
 
-        private void CheckExpression(SonarSyntaxNodeAnalysisContext context, SyntaxNode expression, int constant, ComparisonKind comparison)
+        private void CheckExpression(SonarSyntaxNodeReportingContext context, SyntaxNode expression, int constant, ComparisonKind comparison)
         {
             if (comparison.Compare(constant).IsEmptyOrNotEmpty()
                 && TryGetCountCall(expression, context.SemanticModel, out var location, out var typeArgument))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ConstructorArgumentValueShouldExistBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ConstructorArgumentValueShouldExistBase.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules
                 : null;
         }
 
-        protected void CheckConstructorArgumentProperty(SonarSyntaxNodeAnalysisContext c, SyntaxNode propertyDeclaration, IPropertySymbol propertySymbol)
+        protected void CheckConstructorArgumentProperty(SonarSyntaxNodeReportingContext c, SyntaxNode propertyDeclaration, IPropertySymbol propertySymbol)
         {
             if (propertySymbol == null)
             {
@@ -57,6 +57,6 @@ namespace SonarAnalyzer.Rules
         }
 
         protected abstract IEnumerable<string> GetAllParentClassConstructorArgumentNames(SyntaxNode propertyDeclaration);
-        protected abstract void ReportIssue(SonarSyntaxNodeAnalysisContext c, AttributeData constructorArgumentAttribute);
+        protected abstract void ReportIssue(SonarSyntaxNodeReportingContext c, AttributeData constructorArgumentAttribute);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallInsecureSecurityAlgorithmBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallInsecureSecurityAlgorithmBase.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules
             context.RegisterNodeAction(Language.GeneratedCodeRecognizer, CheckInvocation, Language.SyntaxKind.InvocationExpression);
         }
 
-        private void CheckInvocation(SonarSyntaxNodeAnalysisContext context)
+        private void CheckInvocation(SonarSyntaxNodeReportingContext context)
         {
             var invocation = (TInvocationExpressionSyntax)context.Node;
 
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void CheckObjectCreation(SonarSyntaxNodeAnalysisContext context)
+        private void CheckObjectCreation(SonarSyntaxNodeReportingContext context)
         {
             var objectCreation = context.Node;
 
@@ -102,7 +102,7 @@ namespace SonarAnalyzer.Rules
             return FactoryParameterNames.Any(alg => alg.Equals(StringLiteralValue(Arguments(argumentList).First()), StringComparison.Ordinal));
         }
 
-        private void ReportAllDiagnostics(SonarSyntaxNodeAnalysisContext context, Location location)
+        private void ReportAllDiagnostics(SonarSyntaxNodeReportingContext context, Location location)
         {
             foreach (var supportedDiagnostic in SupportedDiagnostics)
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallMethodsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallMethodsBase.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(Language.GeneratedCodeRecognizer, AnalyzeInvocation, Language.SyntaxKind.InvocationExpression);
 
-        private void AnalyzeInvocation(SonarSyntaxNodeAnalysisContext analysisContext)
+        private void AnalyzeInvocation(SonarSyntaxNodeReportingContext analysisContext)
         {
             if ((TInvocationExpressionSyntax)analysisContext.Node is var invocation
                 && Language.Syntax.InvocationIdentifier(invocation) is { } identifier

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCheckZeroSizeCollectionBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCheckZeroSizeCollectionBase.cs
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Rules
                 },
                 Language.SyntaxKind.ComparisonKinds);
 
-        protected void CheckExpression(SonarSyntaxNodeAnalysisContext context, SyntaxNode issue, SyntaxNode expression, int constant, ComparisonKind comparison)
+        protected void CheckExpression(SonarSyntaxNodeReportingContext context, SyntaxNode issue, SyntaxNode expression, int constant, ComparisonKind comparison)
         {
             expression = Language.Syntax.RemoveConditionalAccess(expression);
             var result = comparison.Compare(constant);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotOverwriteCollectionElementsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotOverwriteCollectionElementsBase.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules
 
         protected DoNotOverwriteCollectionElementsBase() : base(DiagnosticId) { }
 
-        protected void AnalysisAction(SonarSyntaxNodeAnalysisContext context)
+        protected void AnalysisAction(SonarSyntaxNodeReportingContext context)
         {
             var statement = (TStatementSyntax)context.Node;
             var collectionIdentifier = GetCollectionIdentifier(statement);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/EmptyMethodBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/EmptyMethodBase.cs
@@ -26,7 +26,7 @@ namespace SonarAnalyzer.Rules
         internal const string DiagnosticId = "S1186";
 
         protected abstract TSyntaxKind[] SyntaxKinds { get; }
-        protected abstract void CheckMethod(SonarSyntaxNodeAnalysisContext context);
+        protected abstract void CheckMethod(SonarSyntaxNodeReportingContext context);
 
         protected override string MessageFormat => "Add a nested comment explaining why this method is empty, throw a 'NotSupportedException' or complete the implementation.";
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FunctionComplexityBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FunctionComplexityBase.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract override void Initialize(SonarParametrizedAnalysisContext context);
 
-        protected void CheckComplexity<TSyntax>(SonarSyntaxNodeAnalysisContext context, Func<TSyntax, SyntaxNode> nodeSelector, Func<TSyntax, Location> location,
+        protected void CheckComplexity<TSyntax>(SonarSyntaxNodeReportingContext context, Func<TSyntax, SyntaxNode> nodeSelector, Func<TSyntax, Location> location,
             string declarationType)
             where TSyntax : SyntaxNode
         {
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        protected void CheckComplexity<TSyntax>(SonarSyntaxNodeAnalysisContext context, Func<TSyntax, Location> location,
+        protected void CheckComplexity<TSyntax>(SonarSyntaxNodeReportingContext context, Func<TSyntax, Location> location,
             string declarationType)
             where TSyntax : SyntaxNode
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DisablingRequestValidationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DisablingRequestValidationBase.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules
             context.RegisterCompilationAction(CheckWebConfig);
         }
 
-        private void CheckController(SonarSymbolAnalysisContext context)
+        private void CheckController(SonarSymbolReportingContext context)
         {
             if (!IsEnabled(context.Options))
             {
@@ -74,7 +74,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void CheckWebConfig(SonarCompilationAnalysisContext context)
+        private void CheckWebConfig(SonarCompilationReportingContext context)
         {
             if (!IsEnabled(context.Options))
             {
@@ -92,7 +92,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void ReportValidateRequest(SonarCompilationAnalysisContext context, XDocument doc, string webConfigPath)
+        private void ReportValidateRequest(SonarCompilationReportingContext context, XDocument doc, string webConfigPath)
         {
             foreach (var pages in doc.XPathSelectElements("configuration/system.web/pages"))
             {
@@ -104,7 +104,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void ReportRequestValidationMode(SonarCompilationAnalysisContext context, XDocument doc, string webConfigPath)
+        private void ReportRequestValidationMode(SonarCompilationReportingContext context, XDocument doc, string webConfigPath)
         {
             foreach (var httpRuntime in doc.XPathSelectElements("configuration/system.web/httpRuntime"))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -117,7 +117,7 @@ namespace SonarAnalyzer.Rules
             return configuration.IsEnabled(DiagnosticId);
         }
 
-        private void CheckWebConfig(SonarCompilationAnalysisContext context)
+        private void CheckWebConfig(SonarCompilationReportingContext context)
         {
             foreach (var path in context.WebConfigFiles())
             {
@@ -128,7 +128,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void CheckWebConfig(SonarCompilationAnalysisContext context, string path, IEnumerable<XElement> elements)
+        private void CheckWebConfig(SonarCompilationReportingContext context, string path, IEnumerable<XElement> elements)
         {
             foreach (var element in elements)
             {
@@ -146,7 +146,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void CheckAppSettings(SonarCompilationAnalysisContext context)
+        private void CheckAppSettings(SonarCompilationReportingContext context)
         {
             foreach (var path in context.AppSettingsFiles())
             {
@@ -229,7 +229,7 @@ namespace SonarAnalyzer.Rules
             protected CredentialWordsFinderBase(DoNotHardcodeCredentialsBase<TSyntaxKind> analyzer) =>
                 this.analyzer = analyzer;
 
-            public Action<SonarSyntaxNodeAnalysisContext> AnalysisAction() =>
+            public Action<SonarSyntaxNodeReportingContext> AnalysisAction() =>
                 context =>
                 {
                     var declarator = (TSyntaxNode)context.Node;
@@ -245,10 +245,10 @@ namespace SonarAnalyzer.Rules
         private sealed class CredentialWordsJsonWalker : JsonWalker
         {
             private readonly DoNotHardcodeCredentialsBase<TSyntaxKind> analyzer;
-            private readonly SonarCompilationAnalysisContext context;
+            private readonly SonarCompilationReportingContext context;
             private readonly string path;
 
-            public CredentialWordsJsonWalker(DoNotHardcodeCredentialsBase<TSyntaxKind> analyzer, SonarCompilationAnalysisContext context, string path)
+            public CredentialWordsJsonWalker(DoNotHardcodeCredentialsBase<TSyntaxKind> analyzer, SonarCompilationReportingContext context, string path)
             {
                 this.analyzer = analyzer;
                 this.context = context;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/HardcodedIpAddressBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/HardcodedIpAddressBase.cs
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules
             && !IsIgnoredVariableName(node)
             && !HasAttributes(node);
 
-        private void CheckForHardcodedIpAddressesInStringLiteral(SonarSyntaxNodeAnalysisContext context)
+        private void CheckForHardcodedIpAddressesInStringLiteral(SonarSyntaxNodeReportingContext context)
         {
             if (IsEnabled(context.Options)
                 && (TLiteralExpression)context.Node is var stringLiteral
@@ -90,7 +90,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void CheckForHardcodedIpAddressesInStringInterpolation(SonarSyntaxNodeAnalysisContext context)
+        private void CheckForHardcodedIpAddressesInStringInterpolation(SonarSyntaxNodeReportingContext context)
         {
             if (IsEnabled(context.Options)
                 && Language.Syntax.TryGetGetInterpolatedTextValue(context.Node, context.SemanticModel, out var stringContent)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/LooseFilePermissionsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/LooseFilePermissionsBase.cs
@@ -31,8 +31,8 @@ namespace SonarAnalyzer.Rules
         protected readonly DiagnosticDescriptor Rule;
 
         protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
-        protected abstract void VisitAssignments(SonarSyntaxNodeAnalysisContext context);
-        protected abstract void VisitInvocations(SonarSyntaxNodeAnalysisContext context);
+        protected abstract void VisitAssignments(SonarSyntaxNodeReportingContext context);
+        protected abstract void VisitInvocations(SonarSyntaxNodeReportingContext context);
 
         protected LooseFilePermissionsBase(IAnalyzerConfiguration configuration) : base(configuration) =>
             Rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
@@ -88,7 +88,7 @@ namespace SonarAnalyzer.Rules
             attributeName.Equals(RequestSizeLimit, Language.NameComparison)
             || attributeName.Equals(RequestSizeLimitAttribute, Language.NameComparison);
 
-        private void CollectAttributesOverTheLimit(SonarSyntaxNodeAnalysisContext context, IDictionary<SyntaxNode, Attributes> attributesOverTheLimit)
+        private void CollectAttributesOverTheLimit(SonarSyntaxNodeReportingContext context, IDictionary<SyntaxNode, Attributes> attributesOverTheLimit)
         {
             if (!IsEnabled(context.Options))
             {
@@ -116,7 +116,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void ReportOnCollectedAttributes(SonarCompilationAnalysisContext context, IDictionary<SyntaxNode, Attributes> attributesOverTheLimit)
+        private void ReportOnCollectedAttributes(SonarCompilationReportingContext context, IDictionary<SyntaxNode, Attributes> attributesOverTheLimit)
         {
             foreach (var invalidAttributes in attributesOverTheLimit.Values)
             {
@@ -138,7 +138,7 @@ namespace SonarAnalyzer.Rules
             return SupportedDiagnostics.Any(d => analyzerConfiguration.IsEnabled(d.Id));
         }
 
-        private void CheckWebConfig(SonarCompilationAnalysisContext c)
+        private void CheckWebConfig(SonarCompilationReportingContext c)
         {
             foreach (var fullPath in c.WebConfigFiles())
             {
@@ -150,7 +150,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void ReportRequestLengthViolation(SonarCompilationAnalysisContext c, XDocument doc, string webConfigPath)
+        private void ReportRequestLengthViolation(SonarCompilationReportingContext c, XDocument doc, string webConfigPath)
         {
             foreach (var httpRuntime in doc.XPathSelectElements("configuration/system.web/httpRuntime"))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/IfChainWithoutElseBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/IfChainWithoutElseBase.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules
         protected abstract string ElseClause { get; }
 
         protected abstract bool IsElseIfWithoutElse(TIfSyntax ifSyntax);
-        protected abstract Location IssueLocation(SonarSyntaxNodeAnalysisContext context, TIfSyntax ifSyntax);
+        protected abstract Location IssueLocation(SonarSyntaxNodeReportingContext context, TIfSyntax ifSyntax);
 
         protected override string MessageFormat => "Add the missing '{0}' clause with either the appropriate action or a suitable comment as to why no action is taken.";
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/InsecureTemporaryFilesCreationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/InsecureTemporaryFilesCreationBase.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(Language.GeneratedCodeRecognizer, Visit, Language.SyntaxKind.SimpleMemberAccessExpression);
 
-        private void Visit(SonarSyntaxNodeAnalysisContext context)
+        private void Visit(SonarSyntaxNodeReportingContext context)
         {
             var memberAccess = (TMemberAccessSyntax)context.Node;
             if (IsMemberAccessOnKnownType(memberAccess, VulnerableApiName, KnownType.System_IO_Path, context.SemanticModel))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MarkWindowsFormsMainWithStaThreadBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MarkWindowsFormsMainWithStaThreadBase.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(Language.GeneratedCodeRecognizer, Action, SyntaxKinds);
 
-        private void Action(SonarSyntaxNodeAnalysisContext c)
+        private void Action(SonarSyntaxNodeReportingContext c)
         {
             var methodDeclaration = (TMethodSyntax)c.Node;
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MethodOverloadsShouldBeGroupedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MethodOverloadsShouldBeGroupedBase.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules
         protected abstract TSyntaxKind[] SyntaxKinds { get; }
 
         protected abstract IEnumerable<TMemberDeclarationSyntax> GetMemberDeclarations(SyntaxNode node);
-        protected abstract MemberInfo CreateMemberInfo(SonarSyntaxNodeAnalysisContext c, TMemberDeclarationSyntax member);
+        protected abstract MemberInfo CreateMemberInfo(SonarSyntaxNodeReportingContext c, TMemberDeclarationSyntax member);
 
         protected override string MessageFormat => "All '{0}' method overloads should be adjacent.";
 
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules
             },
             SyntaxKinds);
 
-        protected List<MemberInfo>[] GetMisplacedOverloads(SonarSyntaxNodeAnalysisContext c, IEnumerable<TMemberDeclarationSyntax> members)
+        protected List<MemberInfo>[] GetMisplacedOverloads(SonarSyntaxNodeReportingContext c, IEnumerable<TMemberDeclarationSyntax> members)
         {
             var misplacedOverloads = new Dictionary<MemberInfo, List<MemberInfo>>();
             var membersGroupedByInterface = MembersGroupedByInterface(c, members);
@@ -104,7 +104,7 @@ namespace SonarAnalyzer.Rules
         /// Returned ImmutableArray of interfaces for each member is used to determine whether overloads of the same interface should be grouped by name.
         /// If all methods of the class implement single interface, we want the overloads to be placed together within interface group.
         /// </summary>
-        private static Dictionary<TMemberDeclarationSyntax, ImmutableArray<INamedTypeSymbol>> MembersGroupedByInterface(SonarSyntaxNodeAnalysisContext c, IEnumerable<TMemberDeclarationSyntax> members)
+        private static Dictionary<TMemberDeclarationSyntax, ImmutableArray<INamedTypeSymbol>> MembersGroupedByInterface(SonarSyntaxNodeReportingContext c, IEnumerable<TMemberDeclarationSyntax> members)
         {
             var ret = new Dictionary<TMemberDeclarationSyntax, ImmutableArray<INamedTypeSymbol>>();
             ImmutableArray<INamedTypeSymbol> currentInterfaces, previousInterfaces = ImmutableArray<INamedTypeSymbol>.Empty;
@@ -163,7 +163,7 @@ namespace SonarAnalyzer.Rules
             public TMemberDeclarationSyntax Member { get; }
             public SyntaxToken NameSyntax { get; }
 
-            public MemberInfo(SonarSyntaxNodeAnalysisContext context, TMemberDeclarationSyntax member, SyntaxToken nameSyntax, bool isStatic, bool isAbstract, bool isCaseSensitive)
+            public MemberInfo(SonarSyntaxNodeReportingContext context, TMemberDeclarationSyntax member, SyntaxToken nameSyntax, bool isStatic, bool isAbstract, bool isCaseSensitive)
             {
                 Member = member;
                 accessibility = context.SemanticModel.GetDeclaredSymbol(member)?.DeclaredAccessibility.ToString();

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MethodsShouldNotHaveIdenticalImplementationsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MethodsShouldNotHaveIdenticalImplementationsBase.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules
                 },
                 SyntaxKinds);
 
-        protected virtual bool IsExcludedFromBeingExamined(SonarSyntaxNodeAnalysisContext context) =>
+        protected virtual bool IsExcludedFromBeingExamined(SonarSyntaxNodeReportingContext context) =>
             context.ContainingSymbol.Kind != SymbolKind.NamedType;
 
         protected static bool HaveSameParameters<TSyntax>(SeparatedSyntaxList<TSyntax>? leftParameters, SeparatedSyntaxList<TSyntax>? rightParameters)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MultipleVariableDeclarationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MultipleVariableDeclarationBase.cs
@@ -51,7 +51,7 @@ public abstract class MultipleVariableDeclarationBase<TSyntaxKind> : SonarDiagno
             Language.SyntaxKind.FieldDeclaration);
     }
 
-    private static void CheckAndReportVariables(SonarSyntaxNodeAnalysisContext context, DiagnosticDescriptor rule, ICollection<SyntaxToken> variables)
+    private static void CheckAndReportVariables(SonarSyntaxNodeReportingContext context, DiagnosticDescriptor rule, ICollection<SyntaxToken> variables)
     {
         if (variables.Count <= 1)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/NameOfShouldBeUsedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/NameOfShouldBeUsedBase.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract IEnumerable<string> GetParameterNames(TMethodSyntax method); // Handle parameters with the same name (in the IDE it can happen)
         protected abstract bool IsStringLiteral(SyntaxToken t);
-        protected abstract bool LeastLanguageVersionMatches(SonarSyntaxNodeAnalysisContext context);
+        protected abstract bool LeastLanguageVersionMatches(SonarSyntaxNodeReportingContext context);
         protected abstract bool IsArgumentExceptionCallingNameOf(SyntaxNode node, IEnumerable<string> arguments);
         protected abstract TMethodSyntax MethodSyntax(SyntaxNode node);
 
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void ReportIssues(SonarSyntaxNodeAnalysisContext context)
+        private void ReportIssues(SonarSyntaxNodeReportingContext context)
         {
             if (!LeastLanguageVersionMatches(context))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/OptionalParameterNotPassedToBaseCallBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/OptionalParameterNotPassedToBaseCallBase.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.Rules
         protected const string DiagnosticId = "S3466";
         protected const string MessageFormat = "Pass the missing user-supplied parameter value{0} to this 'base' call.";
 
-        protected void ReportOptionalParameterNotPassedToBase(SonarSyntaxNodeAnalysisContext c, TInvocationExpressionSyntax invocation)
+        protected void ReportOptionalParameterNotPassedToBase(SonarSyntaxNodeReportingContext c, TInvocationExpressionSyntax invocation)
         {
             if (!(c.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol calledMethod))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParameterNameMatchesOriginalBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParameterNameMatchesOriginalBase.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules
                 },
                 SyntaxKinds);
 
-        private void VerifyParameters(SonarSyntaxNodeAnalysisContext context, TMethodDeclarationSyntax methodSyntax, IList<IParameterSymbol> expectedParameters, string expectedLocation)
+        private void VerifyParameters(SonarSyntaxNodeReportingContext context, TMethodDeclarationSyntax methodSyntax, IList<IParameterSymbol> expectedParameters, string expectedLocation)
         {
             foreach (var item in ParameterIdentifiers(methodSyntax)
                                     .Zip(expectedParameters, (actual, expected) => new { actual, expected })
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void VerifyGenericParameters(SonarSyntaxNodeAnalysisContext context,
+        private void VerifyGenericParameters(SonarSyntaxNodeReportingContext context,
                                              TMethodDeclarationSyntax methodSyntax,
                                              IList<IParameterSymbol> actualParameters,
                                              IList<IParameterSymbol> expectedParameters,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules
         protected abstract SyntaxToken? GetArgumentIdentifier(TArgumentSyntax argument);
         protected abstract SyntaxToken? GetNameColonArgumentIdentifier(TArgumentSyntax argument);
 
-        internal void ReportIncorrectlyOrderedParameters(SonarSyntaxNodeAnalysisContext analysisContext,
+        internal void ReportIncorrectlyOrderedParameters(SonarSyntaxNodeReportingContext analysisContext,
             MethodParameterLookupBase<TArgumentSyntax> methodParameterLookup, SeparatedSyntaxList<TArgumentSyntax> argumentList,
             Func<Location> getLocationToReport)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PartCreationPolicyShouldBeUsedWithExportAttributeBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PartCreationPolicyShouldBeUsedWithExportAttributeBase.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract TDeclarationSyntax GetTypeDeclaration(TAttributeSyntax attribute);
 
-        protected void AnalyzeNode(SonarSyntaxNodeAnalysisContext c)
+        protected void AnalyzeNode(SonarSyntaxNodeReportingContext c)
         {
             var attribute = (TAttributeSyntax)c.Node;
             if (!IsPartCreationPolicyAttribute(attribute))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertiesAccessCorrectFieldBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertiesAccessCorrectFieldBase.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules
             ? invokedMethod
             : null;
 
-        private void CheckType(SonarSymbolAnalysisContext context)
+        private void CheckType(SonarSymbolReportingContext context)
         {
             var symbol = (INamedTypeSymbol)context.Symbol;
             if (!symbol.TypeKind.Equals(TypeKind.Class)
@@ -113,7 +113,7 @@ namespace SonarAnalyzer.Rules
                   .OfType<IPropertySymbol>()
                   .Where(ImplementsExplicitGetterOrSetter);
 
-        private void CheckExpectedFieldIsUsed(SonarSymbolAnalysisContext context, IMethodSymbol methodSymbol, IFieldSymbol expectedField, ImmutableArray<FieldData> actualFields)
+        private void CheckExpectedFieldIsUsed(SonarSymbolReportingContext context, IMethodSymbol methodSymbol, IFieldSymbol expectedField, ImmutableArray<FieldData> actualFields)
         {
             var expectedFieldIsUsed = actualFields.Any(a => a.Field.Equals(expectedField));
             if (!expectedFieldIsUsed || !actualFields.Any())

--- a/analyzers/src/SonarAnalyzer.Common/Rules/RedundantNullCheckBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/RedundantNullCheckBase.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules
         protected abstract bool AreEquivalent(SyntaxNode node1, SyntaxNode node2);
 
         // LogicalAnd (C#) / AndAlso (VB)
-        protected void CheckAndExpression(SonarSyntaxNodeAnalysisContext context)
+        protected void CheckAndExpression(SonarSyntaxNodeReportingContext context)
         {
             var binaryExpression = (TBinaryExpression)context.Node;
             var binaryExpressionLeft = GetLeftNode(binaryExpression);
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules
         }
 
         // LogicalOr (C#) / OrElse (VB)
-        protected void CheckOrExpression(SonarSyntaxNodeAnalysisContext context)
+        protected void CheckOrExpression(SonarSyntaxNodeReportingContext context)
         {
             var binaryExpression = (TBinaryExpression)context.Node;
             var binaryExpressionLeft = GetLeftNode(binaryExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ReversedOperatorsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ReversedOperatorsBase.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules
         private static bool TiedTogether(FileLinePositionSpan left, FileLinePositionSpan right) =>
             left.EndLinePosition == right.StartLinePosition;
 
-        protected Action<SonarSyntaxNodeAnalysisContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
+        protected Action<SonarSyntaxNodeReportingContext> GetAnalysisAction(DiagnosticDescriptor rule) =>
             c =>
             {
                 var unaryExpression = (TUnaryExpressionSyntax)c.Node;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SecurityPInvokeMethodShouldNotBeCalledBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SecurityPInvokeMethodShouldNotBeCalledBase.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules
             dllName.Equals(InteropName, StringComparison.OrdinalIgnoreCase)
             || dllName.Equals(InteropDllName, StringComparison.OrdinalIgnoreCase);
 
-        private void CheckForIssue(SonarSyntaxNodeAnalysisContext analysisContext)
+        private void CheckForIssue(SonarSyntaxNodeReportingContext analysisContext)
         {
             if (analysisContext.Node is TInvocationExpressionSyntax invocation
                 && Language.Syntax.NodeExpression(invocation) is { } directMethodCall

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ShiftDynamicNotIntegerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ShiftDynamicNotIntegerBase.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules
                 Language.SyntaxKind.RightShiftAssignmentStatement);
         }
 
-        protected void CheckExpressionWithTwoParts(SonarSyntaxNodeAnalysisContext context, Func<SyntaxNode, SyntaxNode> getLeft, Func<SyntaxNode, SyntaxNode> getRight)
+        protected void CheckExpressionWithTwoParts(SonarSyntaxNodeReportingContext context, Func<SyntaxNode, SyntaxNode> getLeft, Func<SyntaxNode, SyntaxNode> getRight)
         {
             var expression = context.Node;
             var left = getLeft(expression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SillyBitwiseOperationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SillyBitwiseOperationBase.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules
         protected SillyBitwiseOperationBase() =>
             Rule = Language.CreateDescriptor(DiagnosticId, MessageFormat, fadeOutCode: true);
 
-        protected void CheckBinary(SonarSyntaxNodeAnalysisContext context, SyntaxNode left, SyntaxToken @operator, SyntaxNode right, int constValueToLookFor)
+        protected void CheckBinary(SonarSyntaxNodeReportingContext context, SyntaxNode left, SyntaxToken @operator, SyntaxNode right, int constValueToLookFor)
         {
             Location location;
             bool isReportingOnLeftKey;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/StringConcatenationInLoopBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/StringConcatenationInLoopBase.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules
                 SimpleAssignmentKinds.ToArray());
         }
 
-        private void CheckSimpleAssignment(SonarSyntaxNodeAnalysisContext context)
+        private void CheckSimpleAssignment(SonarSyntaxNodeReportingContext context)
         {
             var assignment = (TAssignmentExpression)context.Node;
             if (!IsString(GetLeft(assignment), context.SemanticModel))
@@ -97,7 +97,7 @@ namespace SonarAnalyzer.Rules
             return nestedLeft;
         }
 
-        private void CheckCompoundAssignment(SonarSyntaxNodeAnalysisContext context)
+        private void CheckCompoundAssignment(SonarSyntaxNodeReportingContext context)
         {
             var addAssignment = (TAssignmentExpression)context.Node;
             if (!IsString(GetLeft(addAssignment), context.SemanticModel))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/StringLiteralShouldNotBeDuplicatedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/StringLiteralShouldNotBeDuplicatedBase.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules
         protected abstract TSyntaxKind[] SyntaxKinds { get; }
 
         protected abstract bool IsMatchingMethodParameterName(TLiteralExpressionSyntax literalExpression);
-        protected abstract bool IsInnerInstance(SonarSyntaxNodeAnalysisContext context);
+        protected abstract bool IsInnerInstance(SonarSyntaxNodeReportingContext context);
         protected abstract IEnumerable<TLiteralExpressionSyntax> FindLiteralExpressions(SyntaxNode node);
         protected abstract SyntaxToken LiteralToken(TLiteralExpressionSyntax literal);
 
@@ -54,13 +54,13 @@ namespace SonarAnalyzer.Rules
             // Hence the decision to do like other languages, at class-level
             context.RegisterNodeAction(Language.GeneratedCodeRecognizer, ReportOnViolation, SyntaxKinds);
 
-        protected virtual bool IsNamedTypeOrTopLevelMain(SonarSyntaxNodeAnalysisContext context) =>
+        protected virtual bool IsNamedTypeOrTopLevelMain(SonarSyntaxNodeReportingContext context) =>
             IsNamedType(context);
 
-        protected static bool IsNamedType(SonarSyntaxNodeAnalysisContext context) =>
+        protected static bool IsNamedType(SonarSyntaxNodeReportingContext context) =>
             context.ContainingSymbol.Kind == SymbolKind.NamedType;
 
-        private void ReportOnViolation(SonarSyntaxNodeAnalysisContext context)
+        private void ReportOnViolation(SonarSyntaxNodeReportingContext context)
         {
             if (!IsNamedTypeOrTopLevelMain(context) || IsInnerInstance(context))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules
     {
         protected abstract ImmutableDictionary<DiagnosticDescriptor, RuleFactory> AllRules { get; }
         protected abstract ControlFlowGraph CreateCfg(SemanticModel model, SyntaxNode node, CancellationToken cancel);
-        protected abstract void AnalyzeSonar(SonarSyntaxNodeAnalysisContext context, SyntaxNode body, ISymbol symbol);
+        protected abstract void AnalyzeSonar(SonarSyntaxNodeReportingContext context, SyntaxNode body, ISymbol symbol);
 
         protected IAnalyzerConfiguration Configuration { get; }
 
@@ -47,10 +47,10 @@ namespace SonarAnalyzer.Rules
             new RuleFactory<TRuleCheck, TSonarFallback>();
 
         // We need to rewrite this https://github.com/SonarSource/sonar-dotnet/issues/4824
-        protected static bool IsEnabled(SonarSyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor) =>
+        protected static bool IsEnabled(SonarSyntaxNodeReportingContext context, DiagnosticDescriptor descriptor) =>
             context.HasMatchingScope(descriptor) && descriptor.GetEffectiveSeverity(context.Compilation.Options) != ReportDiagnostic.Suppress;
 
-        protected void Analyze<TNode>(SonarAnalysisContext analysisContext, SonarSyntaxNodeAnalysisContext context, Func<TNode, SyntaxNode> getBody) where TNode : SyntaxNode
+        protected void Analyze<TNode>(SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext context, Func<TNode, SyntaxNode> getBody) where TNode : SyntaxNode
         {
             if (getBody((TNode)context.Node) is { } body && context.SemanticModel.GetDeclaredSymbol(context.Node) is { } symbol)
             {
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        protected void Analyze(SonarAnalysisContext analysisContext, SonarSyntaxNodeAnalysisContext nodeContext, SyntaxNode body, ISymbol symbol)
+        protected void Analyze(SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext nodeContext, SyntaxNode body, ISymbol symbol)
         {
             if (body is { ContainsDiagnostics: false })
             {
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        private void AnalyzeRoslyn(SonarAnalysisContext analysisContext, SonarSyntaxNodeAnalysisContext nodeContext, SyntaxNode body, ISymbol symbol)
+        private void AnalyzeRoslyn(SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext nodeContext, SyntaxNode body, ISymbol symbol)
         {
             var checks = AllRules
                 .Where(x => IsEnabled(nodeContext, x.Key))
@@ -109,7 +109,7 @@ namespace SonarAnalyzer.Rules
                 this.createSonarFallbackInstance = createSonarFallbackInstance;
             }
 
-            public SymbolicRuleCheck CreateInstance(IAnalyzerConfiguration configuration, SonarAnalysisContext analysisContext, SonarSyntaxNodeAnalysisContext nodeContext)
+            public SymbolicRuleCheck CreateInstance(IAnalyzerConfiguration configuration, SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext nodeContext)
             {
                 if (configuration.ForceSonarCfg && createSonarFallbackInstance is not null)
                 {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ThrowReservedExceptionsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ThrowReservedExceptionsBase.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules
                 KnownType.System_OutOfMemoryException
             );
 
-        protected void ReportReservedExceptionCreation(SonarSyntaxNodeAnalysisContext context,
+        protected void ReportReservedExceptionCreation(SonarSyntaxNodeReportingContext context,
             SyntaxNode throwStatementExpression)
         {
             if (throwStatementExpression == null ||

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ToStringShouldNotReturnNullBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ToStringShouldNotReturnNullBase.cs
@@ -41,7 +41,7 @@ public abstract class ToStringShouldNotReturnNullBase<TSyntaxKind> : SonarDiagno
             c => ToStringReturnsNull(c, c.Node),
             Language.SyntaxKind.ReturnStatement);
 
-    protected void ToStringReturnsNull(SonarSyntaxNodeAnalysisContext context, SyntaxNode node)
+    protected void ToStringReturnsNull(SonarSyntaxNodeReportingContext context, SyntaxNode node)
     {
         if (node is not null && ReturnsNull(Language.Syntax.NodeExpression(node)) && WithinToString(node))
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UnconditionalJumpStatementBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UnconditionalJumpStatementBase.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract ISet<TSyntaxKind> LoopStatements { get; }
 
-        protected abstract LoopWalkerBase<TStatementSyntax, TSyntaxKind> GetWalker(SonarSyntaxNodeAnalysisContext context);
+        protected abstract LoopWalkerBase<TStatementSyntax, TSyntaxKind> GetWalker(SonarSyntaxNodeReportingContext context);
 
         protected override string MessageFormat => "Refactor the containing loop to do more than one iteration.";
 
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules
         protected List<TStatementSyntax> UnconditionalContinues { get; } = new List<TStatementSyntax>();
         protected List<TStatementSyntax> UnconditionalTerminates { get; } = new List<TStatementSyntax>();
 
-        protected LoopWalkerBase(SonarSyntaxNodeAnalysisContext context, ISet<TLanguageKindEnum> loopStatements)
+        protected LoopWalkerBase(SonarSyntaxNodeReportingContext context, ISet<TLanguageKindEnum> loopStatements)
         {
             rootExpression = context.Node;
             semanticModel = context.SemanticModel;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/LogAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/LogAnalyzerBase.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules
 
         protected LogAnalyzerBase() : base(DiagnosticId, Title) { }
 
-        protected sealed override IEnumerable<LogInfo> CreateAnalysisMessages(SonarCompilationAnalysisContext c) =>
+        protected sealed override IEnumerable<LogInfo> CreateAnalysisMessages(SonarCompilationReportingContext c) =>
             new[]
             {
                 new LogInfo { Severity = LogSeverity.Info, Text = "Roslyn version: " + typeof(SyntaxNode).Assembly.GetName().Version },

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules
                 EndOffset = lineSpan.EndLinePosition.Character
             };
 
-        protected void ReadParameters(SonarCompilationAnalysisContext c)
+        protected void ReadParameters(SonarCompilationReportingContext c)
         {
             var settings = c.Options.ParseSonarLintXmlSettings();
             var outPath = c.ProjectConfiguration().OutPath;
@@ -82,7 +82,7 @@ namespace SonarAnalyzer.Rules
 
         protected virtual bool AnalyzeUnchangedFiles => false;
 
-        protected virtual IEnumerable<TMessage> CreateAnalysisMessages(SonarCompilationAnalysisContext c) => Enumerable.Empty<TMessage>();
+        protected virtual IEnumerable<TMessage> CreateAnalysisMessages(SonarCompilationReportingContext c) => Enumerable.Empty<TMessage>();
 
         protected UtilityAnalyzerBase(string diagnosticId, string title) : base(diagnosticId, title) { }
 
@@ -119,7 +119,7 @@ namespace SonarAnalyzer.Rules
             && FileExtensionWhitelist.Contains(Path.GetExtension(tree.FilePath))
             && (AnalyzeGeneratedCode || !Language.GeneratedCodeRecognizer.IsGenerated(tree));
 
-        private bool ShouldGenerateMetrics(SonarCompilationAnalysisContext context, SyntaxTree tree) =>
+        private bool ShouldGenerateMetrics(SonarCompilationReportingContext context, SyntaxTree tree) =>
             (AnalyzeUnchangedFiles || !context.IsUnchanged(tree))
             && ShouldGenerateMetrics(tree);
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/VariableUnusedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/VariableUnusedBase.cs
@@ -33,16 +33,16 @@ namespace SonarAnalyzer.Rules
 
             protected abstract IEnumerable<SyntaxNode> GetDeclaredVariables(TLocalDeclaration localDeclaration);
 
-            public void CollectDeclarations(SonarSyntaxNodeAnalysisContext c) =>
+            public void CollectDeclarations(SonarSyntaxNodeReportingContext c) =>
                 declaredLocals.UnionWith(
                     GetDeclaredVariables((TLocalDeclaration)c.Node)
                         .Select(variable => c.SemanticModel.GetDeclaredSymbol(variable) ?? c.SemanticModel.GetSymbolInfo(variable).Symbol)
                         .WhereNotNull());
 
-            public void CollectUsages(SonarSyntaxNodeAnalysisContext c) =>
+            public void CollectUsages(SonarSyntaxNodeReportingContext c) =>
                 usedLocals.UnionWith(GetUsedSymbols(c.Node, c.SemanticModel));
 
-            public void ReportUnusedVariables(SonarCodeBlockAnalysisContext c, DiagnosticDescriptor rule)
+            public void ReportUnusedVariables(SonarCodeBlockReportingContext c, DiagnosticDescriptor rule)
             {
                 foreach (var unused in declaredLocals.Except(usedLocals))
                 {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicRuleCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicRuleCheck.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         protected SemanticModel SemanticModel => context.SemanticModel;
 
         private readonly HashSet<Location> reportedDiagnostics = new();
-        private SonarSyntaxNodeAnalysisContext context;
+        private SonarSyntaxNodeReportingContext context;
 
         protected abstract DiagnosticDescriptor Rule { get; }
 
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         /// </remarks>
         public abstract bool ShouldExecute();
 
-        public void Init(SonarAnalysisContext sonarContext, SonarSyntaxNodeAnalysisContext nodeContext)
+        public void Init(SonarAnalysisContext sonarContext, SonarSyntaxNodeReportingContext nodeContext)
         {
             SonarContext = sonarContext;
             context = nodeContext;

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/BaseTypeContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/BaseTypeContext.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Helpers
         /// </summary>
         public IEnumerable<SyntaxNode> AllBaseTypeNodes { get; }
 
-        public BaseTypeContext(SonarSyntaxNodeAnalysisContext context, IEnumerable<SyntaxNode> allBaseTypeNodes) : base(context) =>
+        public BaseTypeContext(SonarSyntaxNodeReportingContext context, IEnumerable<SyntaxNode> allBaseTypeNodes) : base(context) =>
             AllBaseTypeNodes = allBaseTypeNodes ?? Enumerable.Empty<SyntaxNode>();
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/BaseTypeTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/BaseTypeTracker.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Helpers.Trackers
             };
         }
 
-        protected override BaseTypeContext CreateContext(SonarSyntaxNodeAnalysisContext context) =>
+        protected override BaseTypeContext CreateContext(SonarSyntaxNodeReportingContext context) =>
             GetBaseTypeNodes(context.Node) is { } baseTypeList
             && baseTypeList.Any()
             ? new BaseTypeContext(context, baseTypeList)

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/ElementAccessContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/ElementAccessContext.cs
@@ -24,7 +24,7 @@ namespace SonarAnalyzer.Helpers
     {
         public Lazy<IPropertySymbol> InvokedPropertySymbol { get; }
 
-        public ElementAccessContext(SonarSyntaxNodeAnalysisContext context) : base(context) =>
+        public ElementAccessContext(SonarSyntaxNodeReportingContext context) : base(context) =>
             InvokedPropertySymbol = new Lazy<IPropertySymbol>(() => context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IPropertySymbol);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/ElementAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/ElementAccessTracker.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Helpers.Trackers
             context => context.InvokedPropertySymbol.Value != null
                        && context.InvokedPropertySymbol.Value.ContainingType.DerivesOrImplementsAny(types.ToImmutableArray());
 
-        protected override ElementAccessContext CreateContext(SonarSyntaxNodeAnalysisContext context) =>
+        protected override ElementAccessContext CreateContext(SonarSyntaxNodeReportingContext context) =>
             new ElementAccessContext(context);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/FieldAccessContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/FieldAccessContext.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.Helpers
         public string FieldName { get; }
         public Lazy<IFieldSymbol> InvokedFieldSymbol { get; }
 
-        public FieldAccessContext(SonarSyntaxNodeAnalysisContext context, string fieldName) : base(context)
+        public FieldAccessContext(SonarSyntaxNodeReportingContext context, string fieldName) : base(context)
         {
             FieldName = fieldName;
             InvokedFieldSymbol = new Lazy<IFieldSymbol>(() => SemanticModel.GetSymbolInfo(Node).Symbol as IFieldSymbol);

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/FieldAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/FieldAccessTracker.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Helpers.Trackers
         public Condition MatchField(params MemberDescriptor[] fields) =>
             context => MemberDescriptor.MatchesAny(context.FieldName, context.InvokedFieldSymbol, false, Language.NameComparison, fields);
 
-        protected override FieldAccessContext CreateContext(SonarSyntaxNodeAnalysisContext context)
+        protected override FieldAccessContext CreateContext(SonarSyntaxNodeReportingContext context)
         {
             // We register for both MemberAccess and IdentifierName and we want to avoid raising two times for the same identifier.
             if (IsIdentifierWithinMemberAccess(context.Node))

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/InvocationContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/InvocationContext.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.Helpers
         public string MethodName { get; }
         public Lazy<IMethodSymbol> MethodSymbol { get; }
 
-        public InvocationContext(SonarSyntaxNodeAnalysisContext context, string methodName) : this(context.Node, methodName, context.SemanticModel) { }
+        public InvocationContext(SonarSyntaxNodeReportingContext context, string methodName) : this(context.Node, methodName, context.SemanticModel) { }
 
         public InvocationContext(SyntaxNode node, string methodName, SemanticModel semanticModel) : base(node, semanticModel)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/InvocationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/InvocationTracker.cs
@@ -82,7 +82,7 @@ namespace SonarAnalyzer.Helpers.Trackers
                        && containingType.TypeArguments[1].Is(KnownType.Microsoft_Extensions_Primitives_StringValues);
             };
 
-        protected override InvocationContext CreateContext(SonarSyntaxNodeAnalysisContext context) =>
+        protected override InvocationContext CreateContext(SonarSyntaxNodeReportingContext context) =>
             Language.Syntax.NodeExpression(context.Node) is { } expression
             && ExpectedExpressionIdentifier(expression) is { } identifier
                 ? new InvocationContext(context, identifier.ValueText) : null;

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/MethodDeclarationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/MethodDeclarationTracker.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Helpers.Trackers
                     }
                 });
 
-            void TrackMethodDeclaration(SonarSymbolAnalysisContext c)
+            void TrackMethodDeclaration(SonarSymbolReportingContext c)
             {
                 if (!IsTrackedMethod((IMethodSymbol)c.Symbol, c.Compilation))
                 {

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/ObjectCreationContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/ObjectCreationContext.cs
@@ -24,7 +24,7 @@ namespace SonarAnalyzer.Helpers
     {
         public Lazy<IMethodSymbol> InvokedConstructorSymbol { get; }
 
-        public ObjectCreationContext(SonarSyntaxNodeAnalysisContext context) : base(context) =>
+        public ObjectCreationContext(SonarSyntaxNodeReportingContext context) : base(context) =>
             InvokedConstructorSymbol = new Lazy<IMethodSymbol>(() => context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IMethodSymbol);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/ObjectCreationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/ObjectCreationTracker.cs
@@ -71,7 +71,7 @@ namespace SonarAnalyzer.Helpers.Trackers
                        && context.InvokedConstructorSymbol.Value.IsConstructor()
                        && context.InvokedConstructorSymbol.Value.ContainingType.Implements(baseType);
 
-        protected override ObjectCreationContext CreateContext(SonarSyntaxNodeAnalysisContext context) =>
+        protected override ObjectCreationContext CreateContext(SonarSyntaxNodeReportingContext context) =>
             new ObjectCreationContext(context);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessContext.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.Helpers
         public string PropertyName { get; }
         public Lazy<IPropertySymbol> PropertySymbol { get; }
 
-        public PropertyAccessContext(SonarSyntaxNodeAnalysisContext context, string propertyName) : base(context)
+        public PropertyAccessContext(SonarSyntaxNodeReportingContext context, string propertyName) : base(context)
         {
             PropertyName = propertyName;
             PropertySymbol = new Lazy<IPropertySymbol>(() => context.SemanticModel.GetSymbolInfo(context.Node).Symbol as IPropertySymbol);

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/PropertyAccessTracker.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Helpers.Trackers
         public Condition Or(Condition condition1, Condition condition2, Condition condition3) =>
             value => condition1(value) || condition2(value) || condition3(value);
 
-        protected override PropertyAccessContext CreateContext(SonarSyntaxNodeAnalysisContext context)
+        protected override PropertyAccessContext CreateContext(SonarSyntaxNodeReportingContext context)
         {
             // We register for both MemberAccess and IdentifierName and we want to
             // avoid raising two times for the same identifier.

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/SyntaxBaseContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/SyntaxBaseContext.cs
@@ -26,7 +26,7 @@ namespace SonarAnalyzer.Helpers
         public SyntaxNode Node { get; }
         public Location PrimaryLocation { get; set; }
 
-        public SyntaxBaseContext(SonarSyntaxNodeAnalysisContext context) : this(context.Node, context.SemanticModel) { }
+        public SyntaxBaseContext(SonarSyntaxNodeReportingContext context) : this(context.Node, context.SemanticModel) { }
 
         public SyntaxBaseContext(SyntaxNode node, SemanticModel semanticModel)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/SyntaxTrackerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/SyntaxTrackerBase.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.Helpers
         where TContext : SyntaxBaseContext
     {
         protected abstract TSyntaxKind[] TrackedSyntaxKinds { get; }
-        protected abstract TContext CreateContext(SonarSyntaxNodeAnalysisContext context);
+        protected abstract TContext CreateContext(SonarSyntaxNodeReportingContext context);
 
         public void Track(TrackerInput input, params Condition[] conditions) =>
             Track(input, Array.Empty<object>(), conditions);
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Helpers
                   }
               });
 
-            void TrackAndReportIfNecessary(SonarSyntaxNodeAnalysisContext c)
+            void TrackAndReportIfNecessary(SonarSyntaxNodeReportingContext c)
             {
                 if (CreateContext(c) is { } trackingContext
                     && conditions.All(c => c(trackingContext))

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarAnalysisContextExtensions.cs
@@ -23,34 +23,34 @@ namespace SonarAnalyzer.Extensions
     public static class SonarAnalysisContextExtensions
     {
         public static void RegisterNodeAction<TSyntaxKind>(this SonarAnalysisContext context,
-                                                                               Action<SonarSyntaxNodeAnalysisContext> action,
+                                                                               Action<SonarSyntaxNodeReportingContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterNodeAction(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
         public static void RegisterNodeAction<TSyntaxKind>(this SonarParametrizedAnalysisContext context,
-                                                                               Action<SonarSyntaxNodeAnalysisContext> action,
+                                                                               Action<SonarSyntaxNodeReportingContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterNodeAction(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
         public static void RegisterNodeAction<TSyntaxKind>(this SonarCompilationStartAnalysisContext context,
-                                                                               Action<SonarSyntaxNodeAnalysisContext> action,
+                                                                               Action<SonarSyntaxNodeReportingContext> action,
                                                                                params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
             context.RegisterNodeAction(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterTreeAction(this SonarAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
+        public static void RegisterTreeAction(this SonarAnalysisContext context, Action<SonarSyntaxTreeReportingContext> action) =>
             context.RegisterTreeAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterTreeAction(this SonarParametrizedAnalysisContext context, Action<SonarSyntaxTreeAnalysisContext> action) =>
+        public static void RegisterTreeAction(this SonarParametrizedAnalysisContext context, Action<SonarSyntaxTreeReportingContext> action) =>
             context.RegisterTreeAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
         public static void RegisterCodeBlockStartAction<TSyntaxKind>(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action)
             where TSyntaxKind : struct =>
             context.RegisterCodeBlockStartAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-        public static void ReportIssue(this SonarCompilationAnalysisContext context, Diagnostic diagnostic) =>
+        public static void ReportIssue(this SonarCompilationReportingContext context, Diagnostic diagnostic) =>
             context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic);
 
-        public static void ReportIssue(this SonarSymbolAnalysisContext context, Diagnostic diagnostic) =>
+        public static void ReportIssue(this SonarSymbolReportingContext context, Diagnostic diagnostic) =>
             context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic);
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarSyntaxNodeAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarSyntaxNodeAnalysisContextExtensions.cs
@@ -22,6 +22,6 @@ namespace SonarAnalyzer.Extensions;
 
 public static class SonarSyntaxNodeAnalysisContextExtensions
 {
-    public static bool IsInExpressionTree(this SonarSyntaxNodeAnalysisContext context) =>
+    public static bool IsInExpressionTree(this SonarSyntaxNodeReportingContext context) =>
         context.Node.IsInExpressionTree(context.SemanticModel);
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BinaryOperationWithIdenticalExpressions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BinaryOperationWithIdenticalExpressions.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 SyntaxKindsToCheckAssignment);
         }
 
-        private static void ReportIfExpressionsMatch(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax left, ExpressionSyntax right,
+        private static void ReportIfExpressionsMatch(SonarSyntaxNodeReportingContext context, ExpressionSyntax left, ExpressionSyntax right,
             SyntaxToken operatorToken)
         {
             if (VisualBasicEquivalenceChecker.AreEquivalent(left.RemoveParentheses(), right.RemoveParentheses()))

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanLiteralUnnecessary.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanLiteralUnnecessary.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             context.RegisterNodeAction(CheckConditional, SyntaxKind.TernaryConditionalExpression);
         }
 
-        private void CheckLogicalNot(SonarSyntaxNodeAnalysisContext context)
+        private void CheckLogicalNot(SonarSyntaxNodeReportingContext context)
         {
             var logicalNot = (UnaryExpressionSyntax)context.Node;
             var logicalNotOperand = logicalNot.Operand.RemoveParentheses();
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             }
         }
 
-        private void CheckConditional(SonarSyntaxNodeAnalysisContext context)
+        private void CheckConditional(SonarSyntaxNodeReportingContext context)
         {
             var conditional = (TernaryConditionalExpressionSyntax)context.Node;
             var whenTrue = conditional.WhenTrue;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CommentLineEnd.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/CommentLineEnd.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 });
         }
 
-        private void CheckTokenComments(SonarSyntaxTreeAnalysisContext context, SyntaxToken token)
+        private void CheckTokenComments(SonarSyntaxTreeReportingContext context, SyntaxToken token)
         {
             var tokenLine = token.GetLocation().GetLineSpan().StartLinePosition.Line;
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameCondition.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 },
                 SyntaxKind.MultiLineIfBlock);
 
-        private void CheckConditionAt(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax[] conditions, int currentIndex)
+        private void CheckConditionAt(SonarSyntaxNodeReportingContext context, ExpressionSyntax[] conditions, int currentIndex)
         {
             for (var i = 0; i < currentIndex; i++)
             {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameImplementation.cs
@@ -80,7 +80,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 SyntaxKind.SelectBlock);
         }
 
-        private static void CheckStatementsAt(SonarSyntaxNodeAnalysisContext context, List<SyntaxList<StatementSyntax>> statements, int currentIndex, string constructType)
+        private static void CheckStatementsAt(SonarSyntaxNodeReportingContext context, List<SyntaxList<StatementSyntax>> statements, int currentIndex, string constructType)
         {
             var currentBlockStatements = statements[currentIndex];
             if (currentBlockStatements.Count(IsApprovedStatement) < 2)
@@ -98,7 +98,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             }
         }
 
-        private static void ReportIssue(SonarSyntaxNodeAnalysisContext context, SyntaxList<StatementSyntax> statementsToReport, SyntaxList<StatementSyntax> locationProvider, string constructType)
+        private static void ReportIssue(SonarSyntaxNodeReportingContext context, SyntaxList<StatementSyntax> statementsToReport, SyntaxList<StatementSyntax> locationProvider, string constructType)
         {
             var firstStatement = statementsToReport.FirstOrDefault();
             if (firstStatement == null)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConstructorArgumentValueShouldExist.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConstructorArgumentValueShouldExist.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 .Select(x => x.Identifier.Identifier.ValueText);
         }
 
-        protected override void ReportIssue(SonarSyntaxNodeAnalysisContext c, AttributeData constructorArgumentAttribute)
+        protected override void ReportIssue(SonarSyntaxNodeReportingContext c, AttributeData constructorArgumentAttribute)
         {
             var attributeSyntax =
                 (AttributeSyntax)constructorArgumentAttribute.ApplicationSyntaxReference.GetSyntax();

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyMethod.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyMethod.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             SyntaxKind.SubBlock
         };
 
-        protected override void CheckMethod(SonarSyntaxNodeAnalysisContext context)
+        protected override void CheckMethod(SonarSyntaxNodeReportingContext context)
         {
             var methodBlock = (MethodBlockSyntax)context.Node;
             if (methodBlock.Statements.Count == 0
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         private static bool ContainsComments(IEnumerable<SyntaxTrivia> trivias) =>
             trivias.Any(s => s.IsKind(SyntaxKind.CommentTrivia));
 
-        private static bool ShouldMethodBeExcluded(SonarSyntaxNodeAnalysisContext context, MethodStatementSyntax methodStatement)
+        private static bool ShouldMethodBeExcluded(SonarSyntaxNodeReportingContext context, MethodStatementSyntax methodStatement)
         {
             if (methodStatement.Modifiers.Any(SyntaxKind.MustOverrideKeyword)
                 || methodStatement.Modifiers.Any(SyntaxKind.OverridableKeyword)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IfChainWithoutElse.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IfChainWithoutElse.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             ifSyntax.ElseIfBlocks.Any()
             && (ifSyntax.ElseBlock == null || IsEmptyBlock(ifSyntax));
 
-        protected override Location IssueLocation(SonarSyntaxNodeAnalysisContext context, MultiLineIfBlockSyntax ifSyntax) =>
+        protected override Location IssueLocation(SonarSyntaxNodeReportingContext context, MultiLineIfBlockSyntax ifSyntax) =>
             ifSyntax.ElseIfBlocks.Last().ElseIfStatement.ElseIfKeyword.GetLocation();
 
         private static bool IsEmptyBlock(MultiLineIfBlockSyntax multiLineIfBlock) =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LooseFilePermissions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LooseFilePermissions.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         internal LooseFilePermissions(IAnalyzerConfiguration configuration) : base(configuration) { }
 
-        protected override void VisitAssignments(SonarSyntaxNodeAnalysisContext context)
+        protected override void VisitAssignments(SonarSyntaxNodeReportingContext context)
         {
             var node = context.Node;
             if (IsFileAccessPermissions(node, context.SemanticModel) && !node.IsPartOfBinaryNegationOrCondition())
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             }
         }
 
-        protected override void VisitInvocations(SonarSyntaxNodeAnalysisContext context)
+        protected override void VisitInvocations(SonarSyntaxNodeReportingContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
             if ((IsSetAccessRule(invocation, context.SemanticModel) || IsAddAccessRule(invocation, context.SemanticModel))

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodOverloadsShouldBeGrouped.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodOverloadsShouldBeGrouped.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             SyntaxKind.StructureBlock
         };
 
-        protected override MemberInfo CreateMemberInfo(SonarSyntaxNodeAnalysisContext c, StatementSyntax member)
+        protected override MemberInfo CreateMemberInfo(SonarSyntaxNodeReportingContext c, StatementSyntax member)
         {
             if (member is ConstructorBlockSyntax constructor)
             {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NameOfShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NameOfShouldBeUsed.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 : paramGroups.Select(x => x.First().Identifier.Identifier.ValueText);
         }
 
-        protected override bool LeastLanguageVersionMatches(SonarSyntaxNodeAnalysisContext context) =>
+        protected override bool LeastLanguageVersionMatches(SonarSyntaxNodeReportingContext context) =>
             context.Compilation.IsAtLeastLanguageVersion(LanguageVersion.VisualBasic14);
 
         protected override bool IsArgumentExceptionCallingNameOf(SyntaxNode node, IEnumerable<string> arguments) =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 SyntaxKind.ForEachStatement);
         }
 
-        private void ProcessLoop<T>(SonarSyntaxNodeAnalysisContext context, T loop, Func<T, VisualBasicSyntaxNode> GetControlVariable, Func<ILocalSymbol, bool> isDeclaredInLoop)
+        private void ProcessLoop<T>(SonarSyntaxNodeReportingContext context, T loop, Func<T, VisualBasicSyntaxNode> GetControlVariable, Func<ILocalSymbol, bool> isDeclaredInLoop)
         {
             var controlVar = GetControlVariable(loop);
             if (!(controlVar is IdentifierNameSyntax))
@@ -68,7 +68,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             context.ReportIssue(Diagnostic.Create(rule, controlVar.GetLocation(), Pattern));
         }
 
-        private void ProcessVariableDeclarator(SonarSyntaxNodeAnalysisContext context)
+        private void ProcessVariableDeclarator(SonarSyntaxNodeReportingContext context)
         {
             var declarator = (VariableDeclaratorSyntax)context.Node;
             if (declarator.Parent is FieldDeclarationSyntax)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NoExceptionsInFinally.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NoExceptionsInFinally.cs
@@ -37,10 +37,10 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         private class ThrowInFinallyWalker : SafeVisualBasicSyntaxWalker
         {
-            private readonly SonarSyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeReportingContext context;
             private readonly DiagnosticDescriptor rule;
 
-            public ThrowInFinallyWalker(SonarSyntaxNodeAnalysisContext context, DiagnosticDescriptor rule)
+            public ThrowInFinallyWalker(SonarSyntaxNodeReportingContext context, DiagnosticDescriptor rule)
             {
                 this.context = context;
                 this.rule = rule;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 }, SyntaxKind.ObjectCreationExpression);
         }
 
-        private void AnalyzeArguments(SonarSyntaxNodeAnalysisContext analysisContext, ArgumentListSyntax argumentList,
+        private void AnalyzeArguments(SonarSyntaxNodeReportingContext analysisContext, ArgumentListSyntax argumentList,
             Func<Location> getLocation)
         {
             if (argumentList == null)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SillyBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SillyBitwiseOperation.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 SyntaxKind.ExclusiveOrExpression);
         }
 
-        private void CheckBinary(SonarSyntaxNodeAnalysisContext context, int constValueToLookFor)
+        private void CheckBinary(SonarSyntaxNodeReportingContext context, int constValueToLookFor)
         {
             var binary = (BinaryExpressionSyntax)context.Node;
             CheckBinary(context, binary.Left, binary.OperatorToken, binary.Right, constValueToLookFor);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringLiteralShouldNotBeDuplicated.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringLiteralShouldNotBeDuplicated.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 .Any(p => p.Identifier.Identifier.ValueText.Equals(literalExpression.Token.ValueText, StringComparison.OrdinalIgnoreCase))
                 ?? false;
 
-        protected override bool IsInnerInstance(SonarSyntaxNodeAnalysisContext context) =>
+        protected override bool IsInnerInstance(SonarSyntaxNodeReportingContext context) =>
             context.Node.Ancestors().Any(x => x is ClassBlockSyntax || x is StructureBlockSyntax);
 
         protected override IEnumerable<LiteralExpressionSyntax> FindLiteralExpressions(SyntaxNode node) =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         protected override ControlFlowGraph CreateCfg(SemanticModel model, SyntaxNode node, CancellationToken cancel) =>
             node.CreateCfg(model, cancel);
 
-        protected override void AnalyzeSonar(SonarSyntaxNodeAnalysisContext context, SyntaxNode body, ISymbol symbol)
+        protected override void AnalyzeSonar(SonarSyntaxNodeReportingContext context, SyntaxNode body, ISymbol symbol)
         {
             // There are no old Sonar rules in VB.NET
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnconditionalJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnconditionalJumpStatement.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             SyntaxKind.SimpleDoLoopBlock
         };
 
-        protected override LoopWalkerBase<StatementSyntax, SyntaxKind> GetWalker(SonarSyntaxNodeAnalysisContext context)
+        protected override LoopWalkerBase<StatementSyntax, SyntaxKind> GetWalker(SonarSyntaxNodeReportingContext context)
             => new LoopWalker(context, LoopStatements);
 
         private class LoopWalker : LoopWalkerBase<StatementSyntax, SyntaxKind>
@@ -71,7 +71,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
             protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
-            public LoopWalker(SonarSyntaxNodeAnalysisContext context, ISet<SyntaxKind> loopStatements) : base(context, loopStatements) { }
+            public LoopWalker(SonarSyntaxNodeReportingContext context, ISet<SyntaxKind> loopStatements) : base(context, loopStatements) { }
 
             public override void Visit()
             {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseReturnStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseReturnStatement.cs
@@ -41,10 +41,10 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         private class IdentifierWalker : SafeVisualBasicSyntaxWalker
         {
-            private readonly SonarSyntaxNodeAnalysisContext context;
+            private readonly SonarSyntaxNodeReportingContext context;
             private readonly string name;
 
-            public IdentifierWalker(SonarSyntaxNodeAnalysisContext context, string name)
+            public IdentifierWalker(SonarSyntaxNodeReportingContext context, string name)
             {
                 this.context = context;
                 this.name = name;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
@@ -74,7 +74,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 SyntaxKind.SimpleMemberAccessExpression);
         }
 
-        private bool CheckExpression(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax expression)
+        private bool CheckExpression(SonarSyntaxNodeReportingContext context, ExpressionSyntax expression)
         {
             if (!IsCandidateForExtraction(context, expression))
             {
@@ -115,7 +115,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             return false;
         }
 
-        private static bool IsCandidateForExtraction(SonarSyntaxNodeAnalysisContext context, ExpressionSyntax currentMemberExpression)
+        private static bool IsCandidateForExtraction(SonarSyntaxNodeReportingContext context, ExpressionSyntax currentMemberExpression)
         {
             return currentMemberExpression != null &&
                 !currentMemberExpression.IsKind(SyntaxKind.IdentifierName) &&

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextBaseTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextBaseTest.cs
@@ -170,13 +170,13 @@ public partial class SonarAnalysisContextBaseTest
            .WithMessage("File 'SonarProjectConfig.xml' has been added as an AdditionalFile but could not be read and parsed.");
     }
 
-    private SonarCompilationAnalysisContext CreateSut(ProjectType projectType, bool isScannerRun) =>
+    private SonarCompilationReportingContext CreateSut(ProjectType projectType, bool isScannerRun) =>
         CreateSut(AnalysisScaffolding.CreateOptions(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, projectType, isScannerRun)));
 
-    private static SonarCompilationAnalysisContext CreateSut(AnalyzerOptions options) =>
+    private static SonarCompilationReportingContext CreateSut(AnalyzerOptions options) =>
         CreateSut(new SnippetCompiler("// Nothing to see here").SemanticModel.Compilation, options);
 
-    private static SonarCompilationAnalysisContext CreateSut(Compilation compilation, AnalyzerOptions options)
+    private static SonarCompilationReportingContext CreateSut(Compilation compilation, AnalyzerOptions options)
     {
         var compilationContext = new CompilationAnalysisContext(compilation, options, _ => { }, _ => true, default);
         return new(AnalysisScaffolding.CreateSonarAnalysisContext(), compilationContext);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.cs
@@ -278,7 +278,7 @@ public partial class SonarAnalysisContextTest
     {
         var compilation = new SnippetCompiler("// Nothing to see here", TestHelper.ProjectTypeReference(projectType)).SemanticModel.Compilation;
         var context = new CompilationAnalysisContext(compilation, AnalysisScaffolding.CreateOptions(), null, null, default);
-        var sut = new SonarCompilationAnalysisContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);
+        var sut = new SonarCompilationReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);
 
         sut.IsTestProject().Should().Be(expectedResult);
     }
@@ -290,7 +290,7 @@ public partial class SonarAnalysisContextTest
     {
         var configPath = AnalysisScaffolding.CreateSonarProjectConfig(TestContext, projectType);
         var context = new CompilationAnalysisContext(null, AnalysisScaffolding.CreateOptions(configPath), null, null, default);
-        var sut = new SonarCompilationAnalysisContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);
+        var sut = new SonarCompilationReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);
 
         sut.IsTestProject().Should().Be(expectedResult);
     }
@@ -305,7 +305,7 @@ public partial class SonarAnalysisContextTest
         var location = context.Tree.GetRoot().GetLocation();
         var symbol = Mock.Of<ISymbol>(x => x.Locations == ImmutableArray.Create(location));
         var symbolContext = new SymbolAnalysisContext(symbol, context.Model.Compilation, context.Options, _ => wasReported = true, _ => true, default);
-        var sut = new SonarSymbolAnalysisContext(new SonarAnalysisContext(context, DummyMainDescriptor), symbolContext);
+        var sut = new SonarSymbolReportingContext(new SonarAnalysisContext(context, DummyMainDescriptor), symbolContext);
         sut.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, Mock.Of<Diagnostic>(x => x.Id == "Sxxx" && x.Location == location && x.Descriptor == DummyMainDescriptor[0]));
 
         wasReported.Should().Be(expected);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarCodeBlockReportingContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarCodeBlockReportingContextTest.cs
@@ -18,25 +18,32 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis.CSharp;
+using Moq;
 using SonarAnalyzer.AnalysisContext;
 
 namespace SonarAnalyzer.UnitTest.AnalysisContext;
 
 [TestClass]
-public class SonarCompilationAnalysisContextTest
+public class SonarCodeBlockReportingContextTest
 {
     [TestMethod]
     public void Properties_ArePropagated()
     {
         var cancel = new CancellationToken(true);
-        var (tree, model) = TestHelper.CompileCS("// Nothing to see here");
+        var codeBlock = SyntaxFactory.Block();
+        var owningSymbol = Mock.Of<ISymbol>();
+        var model = Mock.Of<SemanticModel>();
         var options = AnalysisScaffolding.CreateOptions();
-        var context = new CompilationAnalysisContext(model.Compilation, options, _ => { }, _ => true, cancel);
-        var sut = new SonarCompilationAnalysisContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);
+        var context = new CodeBlockAnalysisContext(codeBlock, owningSymbol, model, options, _ => { }, _ => true, cancel);
+        var sut = new SonarCodeBlockReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);
 
-        sut.Tree.Should().Be(tree);
+        sut.Tree.Should().Be(codeBlock.SyntaxTree);
         sut.Compilation.Should().Be(model.Compilation);
         sut.Options.Should().Be(options);
         sut.Cancel.Should().Be(cancel);
+        sut.CodeBlock.Should().Be(codeBlock);
+        sut.OwningSymbol.Should().Be(owningSymbol);
+        sut.SemanticModel.Should().Be(model);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarCompilationReportingContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarCompilationReportingContextTest.cs
@@ -18,32 +18,25 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.CodeAnalysis.CSharp;
-using Moq;
 using SonarAnalyzer.AnalysisContext;
 
 namespace SonarAnalyzer.UnitTest.AnalysisContext;
 
 [TestClass]
-public class SonarCodeBlockAnalysisContextTest
+public class SonarCompilationReportingContextTest
 {
     [TestMethod]
     public void Properties_ArePropagated()
     {
         var cancel = new CancellationToken(true);
-        var codeBlock = SyntaxFactory.Block();
-        var owningSymbol = Mock.Of<ISymbol>();
-        var model = Mock.Of<SemanticModel>();
+        var (tree, model) = TestHelper.CompileCS("// Nothing to see here");
         var options = AnalysisScaffolding.CreateOptions();
-        var context = new CodeBlockAnalysisContext(codeBlock, owningSymbol, model, options, _ => { }, _ => true, cancel);
-        var sut = new SonarCodeBlockAnalysisContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);
+        var context = new CompilationAnalysisContext(model.Compilation, options, _ => { }, _ => true, cancel);
+        var sut = new SonarCompilationReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);
 
-        sut.Tree.Should().Be(codeBlock.SyntaxTree);
+        sut.Tree.Should().Be(tree);
         sut.Compilation.Should().Be(model.Compilation);
         sut.Options.Should().Be(options);
         sut.Cancel.Should().Be(cancel);
-        sut.CodeBlock.Should().Be(codeBlock);
-        sut.OwningSymbol.Should().Be(owningSymbol);
-        sut.SemanticModel.Should().Be(model);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarSyntaxNodeReportingContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarSyntaxNodeReportingContextTest.cs
@@ -24,7 +24,7 @@ using SonarAnalyzer.AnalysisContext;
 namespace SonarAnalyzer.UnitTest.AnalysisContext;
 
 [TestClass]
-public class SonarSyntaxNodeAnalysisContextTest
+public class SonarSyntaxNodeReportingContextTest
 {
     [TestMethod]
     public void Properties_ArePropagated()
@@ -35,7 +35,7 @@ public class SonarSyntaxNodeAnalysisContextTest
         var options = AnalysisScaffolding.CreateOptions();
         var containingSymbol = Mock.Of<ISymbol>();
         var context = new SyntaxNodeAnalysisContext(node, containingSymbol, model, options, _ => { }, _ => true, cancel);
-        var sut = new SonarSyntaxNodeAnalysisContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);
+        var sut = new SonarSyntaxNodeReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);
 
         sut.Tree.Should().Be(tree);
         sut.Compilation.Should().Be(model.Compilation);
@@ -61,7 +61,7 @@ public class SonarSyntaxNodeAnalysisContextTest
         var node = tree.GetRoot();
         var wasReported = false;
         var context = new SyntaxNodeAnalysisContext(node, model, AnalysisScaffolding.CreateOptions(), _ => wasReported = true, _ => true, default);
-        var sut = new SonarSyntaxNodeAnalysisContext(analysisContext, context);
+        var sut = new SonarSyntaxNodeReportingContext(analysisContext, context);
         try
         {
             sut.ReportIssue(Diagnostic.Create(rule, (reportOnCorrectTree ? nodeFromCorrectCompilation : nodeFromAnotherCompilation).GetLocation()));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SonarAnalysisContextExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SonarAnalysisContextExtensionsTest.cs
@@ -44,7 +44,7 @@ public class SonarAnalysisContextExtensions
                 """);
         var wasReported = false;
         var symbolContext = new SymbolAnalysisContext(Mock.Of<ISymbol>(), model.Compilation, AnalysisScaffolding.CreateOptions(), _ => wasReported = true, _ => true, default);
-        var context = new SonarSymbolAnalysisContext(AnalysisScaffolding.CreateSonarAnalysisContext(), symbolContext);
+        var context = new SonarSymbolReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), symbolContext);
         CS.ReportIssue(context, Diagnostic.Create(DummyMainDescriptor, tree.GetRoot().GetLocation()));
 
         wasReported.Should().Be(expected);
@@ -62,7 +62,7 @@ public class SonarAnalysisContextExtensions
                 """);
         var wasReported = false;
         var symbolContext = new SymbolAnalysisContext(Mock.Of<ISymbol>(), model.Compilation, AnalysisScaffolding.CreateOptions(), _ => wasReported = true, _ => true, default);
-        var context = new SonarSymbolAnalysisContext(AnalysisScaffolding.CreateSonarAnalysisContext(), symbolContext);
+        var context = new SonarSymbolReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), symbolContext);
         VB.ReportIssue(context, Diagnostic.Create(DummyMainDescriptor, tree.GetRoot().GetLocation()));
 
         wasReported.Should().Be(expected);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SnippetCompiler.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SnippetCompiler.cs
@@ -140,7 +140,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public INamedTypeSymbol GetTypeByMetadataName(string metadataName) =>
             SemanticModel.Compilation.GetTypeByMetadataName(metadataName);
 
-        public SonarSyntaxNodeAnalysisContext CreateAnalysisContext(SyntaxNode node)
+        public SonarSyntaxNodeReportingContext CreateAnalysisContext(SyntaxNode node)
         {
             var nodeContext =  new SyntaxNodeAnalysisContext(node, SemanticModel, null, null, null, default);
             return new(AnalysisScaffolding.CreateSonarAnalysisContext(), nodeContext);


### PR DESCRIPTION
Part of #6532

Rename analysis context inheriting reporting base class to be `*ReportingContext`.

Original comment: https://github.com/SonarSource/sonar-dotnet/pull/6555#discussion_r1060035670