### PR TITLE
Refactor SonarAnalysisContext - SonarParametrizedAnalysisContext inherits SonarAnalysisContext

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotHardcodeCredentials.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotHardcodeCredentials.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.CSharp
         internal /*for testing*/ DoNotHardcodeCredentials(IAnalyzerConfiguration configuration) : base(configuration) { }
 
         protected override void InitializeActions(SonarParametrizedAnalysisContext context) =>
-            context.RegisterPostponedAction(
+            context.RegisterCompilationStartAction(
                 c =>
                 {
                     if (!IsEnabled(c.Options))

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -97,7 +97,9 @@ public class SonarAnalysisContext
             c => Execute<SonarSyntaxNodeReportingContext, SyntaxNodeAnalysisContext>(new(this, c), action, c.Node.SyntaxTree, generatedCodeRecognizer), syntaxKinds);
 
     public void RegisterTreeAction(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxTreeReportingContext> action) =>
-        analysisContext.RegisterCompilationStartAction(WrapTreeAction(action, generatedCodeRecognizer));
+        analysisContext.RegisterCompilationStartAction(
+            c => c.RegisterSyntaxTreeAction(
+                treeContext => Execute<SonarSyntaxTreeReportingContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action, treeContext.Tree, generatedCodeRecognizer)));
 
     /// <summary>
     /// Register action for a SyntaxNode that is executed unconditionally:
@@ -108,10 +110,6 @@ public class SonarAnalysisContext
     /// </summary>
     public void RegisterNodeActionInAllFiles<TSyntaxKind>(Action<SonarSyntaxNodeReportingContext> action, params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
         analysisContext.RegisterSyntaxNodeAction(c => action(new(this, c)), syntaxKinds);
-
-    public Action<CompilationStartAnalysisContext> WrapTreeAction(Action<SonarSyntaxTreeReportingContext> action, GeneratedCodeRecognizer generatedCodeRecognizer = null) =>
-        c => c.RegisterSyntaxTreeAction(
-            treeContext => Execute<SonarSyntaxTreeReportingContext, SyntaxTreeAnalysisContext>(new(this, treeContext, c.Compilation), action, treeContext.Tree, generatedCodeRecognizer));
 
     /// <param name="sourceTree">Tree that is definitely known to be analyzed. Pass 'null' if the context doesn't know a specific tree to be analyzed, like a CompilationContext.</param>
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action, SyntaxTree sourceTree, GeneratedCodeRecognizer generatedCodeRecognizer = null)

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -23,7 +23,7 @@ using RoslynAnalysisContext = Microsoft.CodeAnalysis.Diagnostics.AnalysisContext
 
 namespace SonarAnalyzer.AnalysisContext;
 
-public sealed class SonarAnalysisContext
+public class SonarAnalysisContext
 {
     private readonly RoslynAnalysisContext analysisContext;
     private readonly IEnumerable<DiagnosticDescriptor> supportedDiagnostics;
@@ -63,6 +63,8 @@ public sealed class SonarAnalysisContext
         this.supportedDiagnostics = supportedDiagnostics ?? throw new ArgumentNullException(nameof(supportedDiagnostics));
     }
 
+    private protected SonarAnalysisContext(SonarAnalysisContext context) : this(context.analysisContext, context.supportedDiagnostics) { }
+
     public bool TryGetValue<TValue>(SourceText text, SourceTextValueProvider<TValue> valueProvider, out TValue value) =>
         analysisContext.TryGetValue(text, valueProvider, out value);
 
@@ -81,7 +83,7 @@ public sealed class SonarAnalysisContext
         analysisContext.RegisterCompilationAction(
             c => Execute<SonarCompilationReportingContext, CompilationAnalysisContext>(new(this, c), action, null));
 
-    public void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
+    public virtual void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
         analysisContext.RegisterCompilationStartAction(
             c => Execute<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action, null));
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarParametrizedAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarParametrizedAnalysisContext.cs
@@ -20,31 +20,16 @@
 
 namespace SonarAnalyzer.AnalysisContext;
 
-public sealed class SonarParametrizedAnalysisContext
+public sealed class SonarParametrizedAnalysisContext : SonarAnalysisContext
 {
     private readonly List<Action<SonarCompilationStartAnalysisContext>> postponedActions = new();
 
-    public SonarAnalysisContext Context { get; }
-
-    internal SonarParametrizedAnalysisContext(SonarAnalysisContext context) =>
-        Context = context;
-
-    public void RegisterNodeAction<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeReportingContext> action, params TSyntaxKind[] syntaxKinds)
-        where TSyntaxKind : struct =>
-        Context.RegisterNodeAction(generatedCodeRecognizer, action, syntaxKinds);
-
-    public void RegisterTreeAction(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxTreeReportingContext> action)
-    {
-        // This is tricky. SyntaxTree actions do not have compilation. So we register them in CompilationStart.
-        // ParametrizedAnalyzer postpones CompilationStartActions to enforce that parameters are already set when the postponed action is executed.
-        var wrappedAction = Context.WrapTreeAction(action, generatedCodeRecognizer);
-        RegisterPostponedAction(startContext => wrappedAction(startContext.Context));
-    }
+    internal SonarParametrizedAnalysisContext(SonarAnalysisContext context) : base(context) { }
 
     /// <summary>
     /// Register CompilationStart action that will be executed once rule parameters are set.
     /// </summary>
-    public void RegisterPostponedAction(Action<SonarCompilationStartAnalysisContext> action) =>
+    public override void RegisterCompilationStartAction(Action<SonarCompilationStartAnalysisContext> action) =>
         postponedActions.Add(action);
 
     /// <summary>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -87,7 +87,7 @@ namespace SonarAnalyzer.Rules
 
         protected sealed override void Initialize(SonarParametrizedAnalysisContext context)
         {
-            var input = new TrackerInput(context.Context, configuration, rule);
+            var input = new TrackerInput(context, configuration, rule);
 
             var oc = Language.Tracker.ObjectCreation;
             oc.Track(input, new object[] { MessageHardcodedPassword },
@@ -107,8 +107,8 @@ namespace SonarAnalyzer.Rules
                pa.MatchProperty(new MemberDescriptor(KnownType.System_Net_NetworkCredential, "Password")));
 
             InitializeActions(context);
-            context.Context.RegisterCompilationAction(CheckWebConfig);
-            context.Context.RegisterCompilationAction(CheckAppSettings);
+            context.RegisterCompilationAction(CheckWebConfig);
+            context.RegisterCompilationAction(CheckAppSettings);
         }
 
         protected bool IsEnabled(AnalyzerOptions options)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules
 
         protected override void Initialize(SonarParametrizedAnalysisContext context)
         {
-            context.RegisterPostponedAction(
+            context.RegisterCompilationStartAction(
                 c =>
                 {
                     var attributesOverTheLimit = new Dictionary<SyntaxNode, Attributes>();
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules
 
                     c.RegisterCompilationEndAction(cc => ReportOnCollectedAttributes(cc, attributesOverTheLimit));
                 });
-            context.Context.RegisterCompilationAction(CheckWebConfig);
+            context.RegisterCompilationAction(CheckWebConfig);
         }
 
         protected bool IsRequestFormLimits(string attributeName) =>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DoNotHardcodeCredentials.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Hotspots/DoNotHardcodeCredentials.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         internal /*for testing*/ DoNotHardcodeCredentials(IAnalyzerConfiguration configuration) : base(configuration) { }
 
         protected override void InitializeActions(SonarParametrizedAnalysisContext context) =>
-            context.RegisterPostponedAction(
+            context.RegisterCompilationStartAction(
                 c =>
                 {
                     if (!IsEnabled(c.Options))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.Register.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.Register.cs
@@ -93,7 +93,7 @@ public partial class SonarAnalysisContextTest
         var context = new DummyAnalysisContext(TestContext, unchangedFileName);
         var sut = new SonarParametrizedAnalysisContext(new(context, DummyMainDescriptor));
         sut.RegisterTreeAction(CSharpGeneratedCodeRecognizer.Instance, context.DelegateAction);
-        sut.ExecutePostponedActions(new(sut.Context, MockCompilationStartAnalysisContext(context)));  // Manual invocation, because SonarParametrizedAnalysisContext stores actions separately
+        sut.ExecutePostponedActions(new(sut, MockCompilationStartAnalysisContext(context)));  // Manual invocation, because SonarParametrizedAnalysisContext stores actions separately
 
         context.AssertDelegateInvoked(expected);
     }
@@ -104,7 +104,7 @@ public partial class SonarAnalysisContextTest
         var context = new DummyAnalysisContext(TestContext);
         var self = new SonarParametrizedAnalysisContext(new(context, DummyMainDescriptor));
         CS.RegisterTreeAction(self, context.DelegateAction);
-        self.ExecutePostponedActions(new(self.Context, MockCompilationStartAnalysisContext(context)));  // Manual invocation, because SonarParametrizedAnalysisContext stores actions separately
+        self.ExecutePostponedActions(new(self, MockCompilationStartAnalysisContext(context)));  // Manual invocation, because SonarParametrizedAnalysisContext stores actions separately
 
         context.AssertDelegateInvoked(true);
     }
@@ -115,7 +115,7 @@ public partial class SonarAnalysisContextTest
         var context = new DummyAnalysisContext(TestContext);
         var self = new SonarParametrizedAnalysisContext(new(context, DummyMainDescriptor));
         VB.RegisterTreeAction(self, context.DelegateAction);
-        self.ExecutePostponedActions(new(self.Context, MockCompilationStartAnalysisContext(context)));  // Manual invocation, because SonarParametrizedAnalysisContext stores actions separately
+        self.ExecutePostponedActions(new(self, MockCompilationStartAnalysisContext(context)));  // Manual invocation, because SonarParametrizedAnalysisContext stores actions separately
 
         context.AssertDelegateInvoked(true);
     }


### PR DESCRIPTION
Part of #6532

`SonarParametrizedAnalysisContext` should inherit `SonarAnalysisContext` because it is meant to be it's in-place alternation. And override that single method that has different behavior instead of trying to duplicate everything from it.