### PR TITLE
Refactor SonarAnalysisContext - Rename SyntaxTreeExtensionsTest

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxTreeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxTreeExtensionsTest.cs
@@ -21,10 +21,10 @@
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Extensions;
 
-namespace SonarAnalyzer.UnitTest.AnalysisContext;
+namespace SonarAnalyzer.UnitTest.Extensions;
 
 [TestClass]
-public class SyntaxTreeContextExtensionsTest
+public class SyntaxTreeExtensionsTest
 {
     public TestContext TestContext { get; set; }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxTreeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxTreeExtensionsTest.cs
@@ -26,8 +26,6 @@ namespace SonarAnalyzer.UnitTest.Extensions;
 [TestClass]
 public class SyntaxTreeExtensionsTest
 {
-    public TestContext TestContext { get; set; }
-
     [TestMethod]
     public void IsGenerated_On_GeneratedTree()
     {


### PR DESCRIPTION
Part of #6532

File `SyntaxTreeContextExtensionsTest.cs` should not have `Context` in the name and should be in `Extensions` directory.