### PR TITLE
Refactor SonarAnalysisContext - Cleanup TestHelper

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarCompilationStartAnalysisContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarCompilationStartAnalysisContextTest.cs
@@ -31,7 +31,7 @@ public class SonarCompilationStartAnalysisContextTest
     {
         var cancel = new CancellationToken(true);
         var (tree, model) = TestHelper.CompileCS("// Nothing to see here");
-        var options = AnalysisScaffolding.CreateOptions(null);   // FIXME: Remove null argument in #6590
+        var options = AnalysisScaffolding.CreateOptions();
         var context = new Mock<CompilationStartAnalysisContext>(model.Compilation, options, cancel).Object;
         var sut = new SonarCompilationStartAnalysisContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarSymbolReportingContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarSymbolReportingContextTest.cs
@@ -33,7 +33,7 @@ public class SonarSymbolReportingContextTest
         var cancel = new CancellationToken(true);
         var (tree, model) = TestHelper.CompileCS("public class Sample { }");
         var options = AnalysisScaffolding.CreateOptions(null);   // FIXME: Remove null argument in #6590
-        var symbol = model.GetDeclaredSymbol(tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().Single());
+        var symbol = model.GetDeclaredSymbol(tree.Single<ClassDeclarationSyntax>());
         var context = new SymbolAnalysisContext(symbol, model.Compilation, options, _ => { }, _ => true, cancel);
         var sut = new SonarSymbolReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarSymbolReportingContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarSymbolReportingContextTest.cs
@@ -32,7 +32,7 @@ public class SonarSymbolReportingContextTest
     {
         var cancel = new CancellationToken(true);
         var (tree, model) = TestHelper.CompileCS("public class Sample { }");
-        var options = AnalysisScaffolding.CreateOptions(null);   // FIXME: Remove null argument in #6590
+        var options = AnalysisScaffolding.CreateOptions();
         var symbol = model.GetDeclaredSymbol(tree.Single<ClassDeclarationSyntax>());
         var context = new SymbolAnalysisContext(symbol, model.Compilation, options, _ => { }, _ => true, cancel);
         var sut = new SonarSymbolReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarSyntaxTreeReportingContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarSyntaxTreeReportingContextTest.cs
@@ -41,7 +41,7 @@ public class SonarSyntaxTreeReportingContextTest
     {
         var cancel = new CancellationToken(true);
         var (tree, model) = TestHelper.CompileCS("// Nothing to see here");
-        var options = AnalysisScaffolding.CreateOptions(null);   // FIXME: Remove null argument in #6590
+        var options = AnalysisScaffolding.CreateOptions();
         var context = new SyntaxTreeAnalysisContext(tree, options, _ => { }, _ => true, cancel);
         var sut = new SonarSyntaxTreeReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context, model.Compilation);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CBDE/MlirTestUtilities.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CBDE/MlirTestUtilities.cs
@@ -78,15 +78,6 @@ namespace SonarAnalyzer.UnitTest.CBDE
             Assert.AreEqual(trimmedExpected.Trim(), trimmedActual.Trim());
         }
 
-        public static IControlFlowGraph GetCfgForMethod(string code, string methodName)
-        {
-            (var method, var semanticModel) = TestHelper.CompileCS(code).GetMethod(methodName);
-            return CSharpControlFlowGraph.Create(method.Body, semanticModel);
-        }
-
-        public static string GetCfgGraph(string code, string methodName) =>
-            CfgSerializer.Serialize(GetCfgForMethod(code, methodName), methodName);
-
         public static void ExportAllMethods(string code, TextWriter writer, bool withLoc)
         {
             var (tree, model) = TestHelper.CompileIgnoreErrorsCS(code);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarCfgSerializerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarCfgSerializerTest.cs
@@ -384,7 +384,7 @@ internal class Test
         private static IControlFlowGraph CreateMethodCfg(string code)
         {
             var (tree, model) = TestHelper.CompileIgnoreErrorsCS(code);
-            return CSharpControlFlowGraph.Create(tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().First().Body, model);
+            return CSharpControlFlowGraph.Create(tree.First<MethodDeclarationSyntax>().Body, model);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarCfgSerializerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarCfgSerializerTest.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SonarAnalyzer.CFG;
 using SonarAnalyzer.CFG.Sonar;
 using SonarAnalyzer.UnitTest.Helpers;
@@ -38,7 +39,7 @@ class C
     }
 }
 ";
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "Foo"), "Foo");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "Foo");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{EXIT}""]
@@ -103,7 +104,7 @@ class C
     void Bar() { }
 }
 ";
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "Foo"), "Foo");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "Foo");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{BINARY:TrueLiteralExpression|true}""]
@@ -131,7 +132,7 @@ class C
     }
 }
 ";
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "Foo"), "Foo");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "Foo");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{FOREACH:ForEachStatement|items}""]
@@ -165,7 +166,7 @@ namespace Namespace
         }
     };";
 
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "ForEach"), "ForEach");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "ForEach");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""ForEach"" {
 0 [shape=record label=""{FOREACH:ForEachVariableStatement|values}""]
@@ -195,7 +196,7 @@ class C
     }
 }
 ";
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "Foo"), "Foo");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "Foo");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{FOR:ForStatement|0|i = 0}""]
@@ -227,7 +228,7 @@ class C
     }
 }
 ";
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "Foo"), "Foo");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "Foo");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{JUMP:UsingStatement|x}""]
@@ -254,7 +255,7 @@ class C
     }
 }
 ";
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "Foo"), "Foo");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "Foo");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{LOCK:LockStatement|x}""]
@@ -281,7 +282,7 @@ class C
     }
 }
 ";
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "Foo"), "Foo");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "Foo");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{SIMPLE|Bar|x =\>\n        \{\n            return 1 + 1;\n        \}|Bar(x =\>\n        \{\n            return 1 + 1;\n        \})}""]
@@ -303,7 +304,7 @@ internal class Test
     }
 }
 ";
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "Range"), "Range");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "Range");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Range"" {
 0 [shape=record label=""{SIMPLE|1..4|r = 1..4}""]
@@ -325,7 +326,7 @@ internal class Test
     }
 }
 ";
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "Index"), "Index");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "Index");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Index"" {
 0 [shape=record label=""{SIMPLE|^1|index = ^1}""]
@@ -347,7 +348,7 @@ internal class Test
     }
 }
 ";
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "Range"), "Range");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "Range");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Range"" {
 0 [shape=record label=""{SIMPLE|^2..^0|range = ^2..^0}""]
@@ -370,7 +371,7 @@ internal class Test
     }
 }
 ";
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "Range"), "Range");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "Range");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Range"" {
 0 [shape=record label=""{SIMPLE|new[] \{ 1, 2 \}|1|2|\{ 1, 2 \}|ints = new[] \{ 1, 2 \}|ints|^2..^1|ints[^2..^1]|lastTwo = ints[^2..^1]}""]
@@ -380,10 +381,10 @@ internal class Test
 ");
         }
 
-        private static IControlFlowGraph GetCfgForMethod(string code, string methodName)
+        private static IControlFlowGraph CreateMethodCfg(string code)
         {
-            var (method, model) = TestHelper.CompileIgnoreErrorsCS(code).GetMethod(methodName);
-            return CSharpControlFlowGraph.Create(method.Body, model);
+            var (tree, model) = TestHelper.CompileIgnoreErrorsCS(code);
+            return CSharpControlFlowGraph.Create(tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().First().Body, model);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarCfgSerializerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarCfgSerializerTest.cs
@@ -68,7 +68,7 @@ class C
     }
 }
 ";
-            var dot = CfgSerializer.Serialize(GetCfgForMethod(code, "Foo"), "Foo");
+            var dot = CfgSerializer.Serialize(CreateMethodCfg(code), "Foo");
 
             dot.Should().BeIgnoringLineEndings(@"digraph ""Foo"" {
 0 [shape=record label=""{BRANCH:SwitchStatement|a}""]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
@@ -80,8 +80,8 @@ namespace NS
         public Foo(int i) {}
     }
 }";
-            var (ctor, semanticModel) = TestHelper.CompileCS(input).GetConstructor("Foo");
-            var cfg = CSharpControlFlowGraph.Create(ctor.Body, semanticModel);
+            var (tree, semanticModel) = TestHelper.CompileCS(input);
+            var cfg = CSharpControlFlowGraph.Create(FirstConstructorBody(tree), semanticModel);
 
             VerifyCfg(cfg, 5);
 
@@ -120,8 +120,8 @@ namespace NS
         public Foo(int i) {}
     }
 }";
-            var (ctor, semanticModel) = TestHelper.CompileCS(input).GetConstructor("Foo");
-            var cfg = CSharpControlFlowGraph.Create(ctor.Body, semanticModel);
+            var (tree, semanticModel) = TestHelper.CompileCS(input);
+            var cfg = CSharpControlFlowGraph.Create(FirstConstructorBody(tree), semanticModel);
 
             VerifyCfg(cfg, 2);
 
@@ -152,8 +152,8 @@ namespace NS
         public Bar(int i) {}
     }
 }";
-            var (ctor, semanticModel) = TestHelper.CompileCS(input).GetConstructor("Foo");
-            var cfg = CSharpControlFlowGraph.Create(ctor.Body, semanticModel);
+            var (tree, semanticModel) = TestHelper.CompileCS(input);
+            var cfg = CSharpControlFlowGraph.Create(FirstConstructorBody(tree), semanticModel);
 
             VerifyCfg(cfg, 2);
 
@@ -5078,6 +5078,9 @@ namespace NS
 
             return cfg;
         }
+
+        private static SyntaxNode FirstConstructorBody(SyntaxTree tree) =>
+            tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().First().Body;
 
         #endregion
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
@@ -56,7 +56,7 @@ namespace NS
     public int Bar() => 4 + 5;
   }
 }";
-            var (method, model) = CompileWithMethodBody(input, "Bar");
+            var (method, model) = CompileWithMethodBody(input);
             var expression = method.ExpressionBody.Expression;
             var cfg = CSharpControlFlowGraph.Create(expression, model);
             VerifyMinimalCfg(cfg);
@@ -172,7 +172,7 @@ namespace NS
         [TestMethod]
         public void Cfg_ExtremelyNestedExpression_NotSupported_FromExpression()
         {
-            var (method, model) = CompileWithMethodBody(string.Format(TestInput, $"var x = {ExtremelyNestedExpression()};"), "Bar");
+            var (method, model) = CompileWithMethodBody(string.Format(TestInput, $"var x = {ExtremelyNestedExpression()};"));
             var equalsValueSyntax = method.DescendantNodes(x => !(x is ExpressionSyntax)).OfType<EqualsValueClauseSyntax>().Single();
             Action a = () => CSharpControlFlowGraph.Create(equalsValueSyntax.Value, model);
 
@@ -191,7 +191,8 @@ public class Sample
         return {ExtremelyNestedExpression()};
     }}
 }}";
-            var (method, semanticModel) = TestHelper.CompileCS(input).GetMethod("Main");
+            var (tree, semanticModel) = TestHelper.CompileCS(input);
+            var method = FirstMethod(tree);
             Action a = () => CSharpControlFlowGraph.Create(method.Body, semanticModel);
 
             a.Should().Throw<NotSupportedException>().WithMessage("Too complex expression");
@@ -206,7 +207,8 @@ public class Sample
 {{
     public string Main() =>{ExtremelyNestedExpression()};
 }}";
-            var (method, semanticModel) = TestHelper.CompileCS(input).GetMethod("Main");
+            var (tree, semanticModel) = TestHelper.CompileCS(input);
+            var method = FirstMethod(tree);
             Action a = () => CSharpControlFlowGraph.Create(method.ExpressionBody, semanticModel);
 
             a.Should().Throw<NotSupportedException>().WithMessage("Too complex expression");
@@ -223,7 +225,8 @@ public class Sample
 
     public void Go(System.Func<string, string> arg) {{ }}
 }}";
-            var (method, semanticModel) = TestHelper.CompileCS(input).GetMethod("Main");
+            var (tree, semanticModel) = TestHelper.CompileCS(input);
+            var method = FirstMethod(tree);
             CSharpControlFlowGraph.Create(method.ExpressionBody, semanticModel).Should().NotBeNull();
             CSharpControlFlowGraph.TryGet(method.ExpressionBody, semanticModel, out _).Should().BeTrue();
         }
@@ -238,7 +241,8 @@ public class Sample
 
     public void Go(System.Func<string> arg) {{ }}
 }}";
-            var (method, semanticModel) = TestHelper.CompileCS(input).GetMethod("Main");
+            var (tree, semanticModel) = TestHelper.CompileCS(input);
+            var method = FirstMethod(tree);
             CSharpControlFlowGraph.Create(method.ExpressionBody, semanticModel).Should().NotBeNull();
             CSharpControlFlowGraph.TryGet(method.ExpressionBody, semanticModel, out _).Should().BeTrue();
         }
@@ -5057,8 +5061,11 @@ namespace NS
   }}
 }}";
 
-        internal static (MethodDeclarationSyntax, SemanticModel) CompileWithMethodBody(string input, string methodName) =>
-            TestHelper.CompileIgnoreErrorsCS(input).GetMethod(methodName);
+        internal static (MethodDeclarationSyntax Method, SemanticModel Model) CompileWithMethodBody(string input)
+        {
+            var (tree, semanticModel) = TestHelper.CompileIgnoreErrorsCS(input);
+            return (tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().First(), semanticModel);
+        }
 
         internal static string ExtremelyNestedExpression()
         {
@@ -5069,7 +5076,7 @@ namespace NS
 
         private static IControlFlowGraph Build(string methodBody)
         {
-            var (method, model) = CompileWithMethodBody(string.Format(TestInput, methodBody), "Bar");
+            var (method, model) = CompileWithMethodBody(string.Format(TestInput, methodBody));
             var cfg = CSharpControlFlowGraph.Create(method.Body, model);
 
             // when debugging the CFG, it is useful to visualize the CFG
@@ -5081,6 +5088,9 @@ namespace NS
 
         private static SyntaxNode FirstConstructorBody(SyntaxTree tree) =>
             tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().First().Body;
+
+        private static MethodDeclarationSyntax FirstMethod(SyntaxTree tree) =>
+            tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().First();
 
         #endregion
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
@@ -5064,7 +5064,7 @@ namespace NS
         internal static (MethodDeclarationSyntax Method, SemanticModel Model) CompileWithMethodBody(string input)
         {
             var (tree, semanticModel) = TestHelper.CompileIgnoreErrorsCS(input);
-            return (tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().First(), semanticModel);
+            return (tree.First<MethodDeclarationSyntax>(), semanticModel);
         }
 
         internal static string ExtremelyNestedExpression()
@@ -5087,10 +5087,10 @@ namespace NS
         }
 
         private static SyntaxNode FirstConstructorBody(SyntaxTree tree) =>
-            tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().First().Body;
+            tree.First<ConstructorDeclarationSyntax>().Body;
 
         private static MethodDeclarationSyntax FirstMethod(SyntaxTree tree) =>
-            tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+            tree.First<MethodDeclarationSyntax>();
 
         #endregion
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AttributeSyntaxExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/AttributeSyntaxExtensionsTest.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
         {
             var compilation = CreateCompilation(code);
             var syntaxTree = compilation.SyntaxTrees.First();
-            var attribute = syntaxTree.GetRoot().DescendantNodes().OfType<AttributeSyntax>().First();
+            var attribute = syntaxTree.First<AttributeSyntax>();
 
             attribute.IsKnownType(KnownType.System_ObsoleteAttribute, compilation.GetSemanticModel(syntaxTree)).Should().Be(isKnownType);
         }
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
         {
             var compilation = CreateCompilation("[System.ObsoleteAttribute] public class X{}");
             var syntaxTree = compilation.SyntaxTrees.First();
-            var attribute = syntaxTree.GetRoot().DescendantNodes().OfType<AttributeSyntax>().First();
+            var attribute = syntaxTree.First<AttributeSyntax>();
 
             attribute.IsKnownType(KnownType.System_String, compilation.GetSemanticModel(syntaxTree)).Should().Be(false);
         }
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
         {
             var compilation = CreateCompilation("[System.ObsoleteAttribute] public class X{}");
             var syntaxTree = compilation.SyntaxTrees.First();
-            var attribute = syntaxTree.GetRoot().DescendantNodes().OfType<AttributeSyntax>().First();
+            var attribute = syntaxTree.First<AttributeSyntax>();
 
             attribute.IsKnownType(ImmutableArray<KnownType>.Empty, compilation.GetSemanticModel(syntaxTree)).Should().Be(false);
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/ControlFlowGraphExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/ControlFlowGraphExtensionsTests.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SonarAnalyzer.CFG.Roslyn;
 using SonarAnalyzer.Extensions;
 
@@ -35,7 +36,7 @@ public class Sample
     public void Method() { }
 }";
             var (tree, semanticModel) = TestHelper.CompileCS(code);
-            var method = tree.GetMethod("Method");
+            var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
             var symbol = semanticModel.GetDeclaredSymbol(method) as IMethodSymbol;
             var cfg = ControlFlowGraph.Create(method, semanticModel, default);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/ControlFlowGraphExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/ControlFlowGraphExtensionsTests.cs
@@ -36,7 +36,7 @@ public class Sample
     public void Method() { }
 }";
             var (tree, semanticModel) = TestHelper.CompileCS(code);
-            var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+            var method = tree.Single<MethodDeclarationSyntax>();
             var symbol = semanticModel.GetDeclaredSymbol(method) as IMethodSymbol;
             var cfg = ControlFlowGraph.Create(method, semanticModel, default);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/ExpressionSyntaxExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/ExpressionSyntaxExtensionsTest.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
 
             var semanticModel = compilation.GetSemanticModel(tree);
 
-            return (tree.GetRoot().DescendantNodes().OfType<ExpressionSyntax>().First(), semanticModel);
+            return (tree.First<ExpressionSyntax>(), semanticModel);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/InterpolatedStringExpressionSyntaxExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/InterpolatedStringExpressionSyntaxExtensionsTests.cs
@@ -92,7 +92,7 @@ public class C
 
             var semanticModel = compilation.GetSemanticModel(tree);
 
-            return (tree.GetRoot().DescendantNodes().OfType<InterpolatedStringExpressionSyntax>().First(), semanticModel);
+            return (tree.First<InterpolatedStringExpressionSyntax>(), semanticModel);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/ObjectCreationExpressionSyntaxExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/ObjectCreationExpressionSyntaxExtensionsTest.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
         {
             var compilation = CreateCompilation(code);
             var syntaxTree = compilation.SyntaxTrees.First();
-            var objectCreation = syntaxTree.GetRoot().DescendantNodes().OfType<ObjectCreationExpressionSyntax>().First();
+            var objectCreation = syntaxTree.First<ObjectCreationExpressionSyntax>();
 
             objectCreation.IsKnownType(KnownType.System_DateTime, compilation.GetSemanticModel(syntaxTree)).Should().Be(expectedResult);
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -181,7 +181,7 @@ public class Sample
     }
 }";
             var (tree, semanticModel) = TestHelper.CompileCS(code);
-            var node = tree.GetRoot().DescendantNodes().OfType<CS.MethodDeclarationSyntax>().Single();
+            var node = tree.Single<CS.MethodDeclarationSyntax>();
 
             SyntaxNodeExtensionsCS.CreateCfg(node.Body, semanticModel, default).Should().NotBeNull();
         }
@@ -196,7 +196,7 @@ Public Class Sample
     End Sub
 End Class";
             var (tree, semanticModel) = TestHelper.CompileVB(code);
-            var node = tree.GetRoot().DescendantNodes().OfType<VB.MethodBlockSyntax>().Single();
+            var node = tree.Single<VB.MethodBlockSyntax>();
 
             SyntaxNodeExtensionsVB.CreateCfg(node, semanticModel, default).Should().NotBeNull();
         }
@@ -213,7 +213,7 @@ public class Sample
     }
 }";
             var (tree, semanticModel) = TestHelper.CompileCS(code);
-            var node = tree.GetRoot().DescendantNodes().OfType<CS.InvocationExpressionSyntax>().Single();
+            var node = tree.Single<CS.InvocationExpressionSyntax>();
 
             SyntaxNodeExtensionsCS.CreateCfg(node, semanticModel, default).Should().NotBeNull();
         }
@@ -228,7 +228,7 @@ Public Class Sample
     End Sub
 End Class";
             var (tree, semanticModel) = TestHelper.CompileVB(code);
-            var node = tree.GetRoot().DescendantNodes().OfType<VB.InvocationExpressionSyntax>().Single();
+            var node = tree.Single<VB.InvocationExpressionSyntax>();
 
             SyntaxNodeExtensionsVB.CreateCfg(node, semanticModel, default).Should().NotBeNull();
         }
@@ -247,7 +247,7 @@ public class Sample
     }
 }";
             var (tree, semanticModel) = TestHelper.CompileCS(code);
-            var lambda = tree.GetRoot().DescendantNodes().OfType<CS.ParenthesizedLambdaExpressionSyntax>().Single();
+            var lambda = tree.Single<CS.ParenthesizedLambdaExpressionSyntax>();
 
             SyntaxNodeExtensionsCS.CreateCfg(lambda.Body, semanticModel, default).Should().NotBeNull();
         }
@@ -263,7 +263,7 @@ Public Class Sample
 End Class
 ";
             var (tree, semanticModel) = TestHelper.CompileVB(code);
-            var lambda = tree.GetRoot().DescendantNodes().OfType<VB.SingleLineLambdaExpressionSyntax>().Single();
+            var lambda = tree.Single<VB.SingleLineLambdaExpressionSyntax>();
 
             SyntaxNodeExtensionsVB.CreateCfg(lambda.Body, semanticModel, default).Should().NotBeNull();
         }
@@ -305,7 +305,7 @@ public class Sample
     }
 }";
             var (tree, semanticModel) = TestHelper.CompileCS(code);
-            var innerLambda = tree.GetRoot().DescendantNodes().OfType<CS.SimpleLambdaExpressionSyntax>().Single();
+            var innerLambda = tree.Single<CS.SimpleLambdaExpressionSyntax>();
             innerLambda.Parent.Parent.Should().BeOfType<CS.VariableDeclaratorSyntax>().Subject.Identifier.ValueText.Should().Be("innerLambda");
 
             var cfg = SyntaxNodeExtensionsCS.CreateCfg(innerLambda.Body, semanticModel, default);
@@ -341,7 +341,7 @@ Public Class Sample
     End Sub
 End Class";
             var (tree, semanticModel) = TestHelper.CompileVB(code);
-            var innerSub = tree.GetRoot().DescendantNodes().OfType<VB.InvocationExpressionSyntax>().Single().FirstAncestorOrSelf<VB.SingleLineLambdaExpressionSyntax>();
+            var innerSub = tree.Single<VB.InvocationExpressionSyntax>().FirstAncestorOrSelf<VB.SingleLineLambdaExpressionSyntax>();
             innerSub.Parent.Parent.Should().BeOfType<VB.VariableDeclaratorSyntax>().Subject.Names.Single().Identifier.ValueText.Should().Be("InnerSingleLineSub");
 
             var cfg = SyntaxNodeExtensionsVB.CreateCfg(innerSub, semanticModel, default);
@@ -368,7 +368,7 @@ public class Sample
     }
 }";
             var (tree, model) = TestHelper.CompileIgnoreErrorsCS(code);
-            var lambda = tree.GetRoot().DescendantNodes().OfType<CS.ParenthesizedLambdaExpressionSyntax>().Single();
+            var lambda = tree.Single<CS.ParenthesizedLambdaExpressionSyntax>();
             SyntaxNodeExtensionsCS.CreateCfg(lambda.Body, model, default).Should().NotBeNull();
         }
 
@@ -382,7 +382,7 @@ Public Class Sample
     End Sub
 End Class";
             var (tree, model) = TestHelper.CompileIgnoreErrorsVB(code);
-            var lambda = tree.GetRoot().DescendantNodes().OfType<VB.SingleLineLambdaExpressionSyntax>().Single();
+            var lambda = tree.Single<VB.SingleLineLambdaExpressionSyntax>();
             SyntaxNodeExtensionsVB.CreateCfg(lambda, model, default).Should().BeNull();
         }
 
@@ -394,7 +394,7 @@ End Class";
         public void CreateCfg_InvalidSyntax_ReturnsCfg_CS(string code)
         {
             var (tree, model) = TestHelper.CompileIgnoreErrorsCS(code);
-            var lambda = tree.GetRoot().DescendantNodes().OfType<CS.ParenthesizedLambdaExpressionSyntax>().Single();
+            var lambda = tree.Single<CS.ParenthesizedLambdaExpressionSyntax>();
 
             SyntaxNodeExtensionsCS.CreateCfg(lambda.Body, model, default).Should().NotBeNull();
         }
@@ -421,7 +421,7 @@ public class Sample
     }
 }";
             var (tree, model) = TestHelper.CompileCS(code);
-            var lambda = tree.GetRoot().DescendantNodes().OfType<CS.ParenthesizedLambdaExpressionSyntax>().Single();
+            var lambda = tree.Single<CS.ParenthesizedLambdaExpressionSyntax>();
             Action a = () =>
                 {
                     for (var i = 0; i < 10000; i++)
@@ -450,7 +450,7 @@ Public Class Sample
     End Sub
 End Class";
             var (tree, model) = TestHelper.CompileVB(code);
-            var lambda = tree.GetRoot().DescendantNodes().OfType<VB.SingleLineLambdaExpressionSyntax>().Single();
+            var lambda = tree.Single<VB.SingleLineLambdaExpressionSyntax>();
             Action a = () =>
             {
                 for (var i = 0; i < 10000; i++)
@@ -473,8 +473,8 @@ public class Sample
 }";
             var compilation1 = TestHelper.CompileCS(code).Model.Compilation;
             var compilation2 = compilation1.WithAssemblyName("Different-Compilation-Reusing-Same-Nodes");
-            var method1 = compilation1.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<CS.MethodDeclarationSyntax>().Single();
-            var method2 = compilation2.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<CS.MethodDeclarationSyntax>().Single();
+            var method1 = compilation1.SyntaxTrees.Single().Single<CS.MethodDeclarationSyntax>();
+            var method2 = compilation2.SyntaxTrees.Single().Single<CS.MethodDeclarationSyntax>();
             var cfg1 = SyntaxNodeExtensionsCS.CreateCfg(method1.Body, compilation1.GetSemanticModel(method1.SyntaxTree), default);
             var cfg2 = SyntaxNodeExtensionsCS.CreateCfg(method2.Body, compilation2.GetSemanticModel(method2.SyntaxTree), default);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/VisualBasic/ISymbolExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/VisualBasic/ISymbolExtensionsTest.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.UnitTest.Extensions.VisualBasic
         public void GetDescendantNodes_ForDifferentSyntaxTrees_ReturnsEmpty_VB()
         {
             var first = SyntaxFactory.ParseSyntaxTree("Dim a As String");
-            var identifier = first.GetRoot().DescendantNodes().OfType<ModifiedIdentifierSyntax>().First();
+            var identifier = first.Single<ModifiedIdentifierSyntax>();
 
             var second = SyntaxFactory.ParseSyntaxTree("Dim a As String");
             ISymbolExtensions_VB.GetDescendantNodes(identifier.GetLocation(), second.GetRoot()).Should().BeEmpty();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/VisualBasic/InterpolatedStringExpressionSyntaxExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/VisualBasic/InterpolatedStringExpressionSyntaxExtensionsTests.cs
@@ -84,14 +84,8 @@ End Class";
 
         private static (InterpolatedStringExpressionSyntax InterpolatedStringExpression, SemanticModel SemanticModel) Compile(string code)
         {
-            var tree = VisualBasicSyntaxTree.ParseText(code);
-            var compilation = VisualBasicCompilation.Create("TempAssembly.dll")
-                                                    .AddSyntaxTrees(tree)
-                                                    .AddReferences(MetadataReferenceFacade.ProjectDefaultReferences);
-
-            var semanticModel = compilation.GetSemanticModel(tree);
-
-            return (tree.GetRoot().DescendantNodes().OfType<InterpolatedStringExpressionSyntax>().First(), semanticModel);
+            var (tree, model) = TestHelper.CompileCS(code);
+            return (tree.First<InterpolatedStringExpressionSyntax>(), model);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/VisualBasic/InterpolatedStringExpressionSyntaxExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/VisualBasic/InterpolatedStringExpressionSyntaxExtensionsTests.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using SonarAnalyzer.Extensions;
 
@@ -47,10 +46,9 @@ End Class";
                    Dim mixConstantAndLiteral = $""TextValue {constant}""")]
         [DataRow(@"Const constant As Integer = 1
                    Dim mix = $""{constant}{$""{Foo()}""}{""{notConstant}""}""")]
-        public void TryGetGetInterpolatedTextValue_UnsupportedSyntaxKinds_ReturnsFalse(string code)
+        public void TryGetGetInterpolatedTextValue_UnsupportedSyntaxKinds_ReturnsFalse(string methodBody)
         {
-            var codeSnipet = string.Format(CodeSnipet, code);
-            var (expression, semanticModel) = Compile(codeSnipet);
+            var (expression, semanticModel) = Compile(methodBody);
             expression.TryGetGetInterpolatedTextValue(semanticModel, out var interpolatedValue).Should().Be(false);
             interpolatedValue.Should().BeNull();
         }
@@ -62,29 +60,28 @@ End Class";
                  "TextOnly")]
         [DataRow(@"
                     Const constantString As String = ""Foo""
-                    Const constantInterpolation As String = $""{constantString} with text.""
+                    Dim constantInterpolation As String = $""{constantString} with text.""
                  ",
                  "Foo with text.")]
         [DataRow(@"
                     Const constantString As String = ""Foo""
-                    Const constantInterpolation As String = $""{$""Nested {constantString}""} with text.""",
+                    Dim constantInterpolation As String = $""{$""Nested {constantString}""} with text.""",
                  "Nested Foo with text.")]
         [DataRow(@"
                     notConstantString = ""SomeValue""
                     Dim interpolatedString As String = $""{notConstantString}""
                  ",
                  "SomeValue")]
-        public void TryGetGetInterpolatedTextValue_SupportedSyntaxKinds_ReturnsTrue(string code, string expectedTextValue)
+        public void TryGetGetInterpolatedTextValue_SupportedSyntaxKinds_ReturnsTrue(string methodBody, string expectedTextValue)
         {
-            var codeSnipet = string.Format(CodeSnipet, code);
-            var (expression, semanticModel) = Compile(codeSnipet);
+            var (expression, semanticModel) = Compile(methodBody);
             expression.TryGetGetInterpolatedTextValue(semanticModel, out var interpolatedValue).Should().Be(true);
             interpolatedValue.Should().Be(expectedTextValue);
         }
 
-        private static (InterpolatedStringExpressionSyntax InterpolatedStringExpression, SemanticModel SemanticModel) Compile(string code)
+        private static (InterpolatedStringExpressionSyntax InterpolatedStringExpression, SemanticModel SemanticModel) Compile(string methodBody)
         {
-            var (tree, model) = TestHelper.CompileCS(code);
+            var (tree, model) = TestHelper.CompileVB(string.Format(CodeSnipet, methodBody));
             return (tree.First<InterpolatedStringExpressionSyntax>(), model);
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/AspNetMvcHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/AspNetMvcHelperTest.cs
@@ -44,13 +44,13 @@ public class Foo : System.Web.Mvc.Controller
     [System.Web.Mvc.NonActionAttribute]
     public void PublicNonAction() { }
 }";
-            var compilation = TestHelper.CompileCS(code, NuGetMetadataReference.MicrosoftAspNetMvc(aspNetMvcVersion).ToArray());
-            var publicFoo = compilation.GetMethodSymbol("PublicFoo");
-            var protectedFoo = compilation.GetMethodSymbol("ProtectedFoo");
-            var internalFoo = compilation.GetMethodSymbol("InternalFoo");
-            var privateFoo = compilation.GetMethodSymbol("PrivateFoo");
-            var innerFoo = compilation.GetMethodSymbol("InnerFoo");
-            var publicNonAction = compilation.GetMethodSymbol("PublicNonAction");
+            var compilation = TestHelper.CompileCS(code, NuGetMetadataReference.MicrosoftAspNetMvc(aspNetMvcVersion).ToArray()).Model.Compilation;
+            var publicFoo = GetMethodSymbol(compilation, "PublicFoo");
+            var protectedFoo = GetMethodSymbol(compilation, "ProtectedFoo");
+            var internalFoo = GetMethodSymbol(compilation, "InternalFoo");
+            var privateFoo = GetMethodSymbol(compilation, "PrivateFoo");
+            var innerFoo = GetMethodSymbol(compilation, "InnerFoo");
+            var publicNonAction = GetMethodSymbol(compilation, "PublicNonAction");
 
             AspNetMvcHelper.IsControllerMethod(publicFoo).Should().Be(true);
             AspNetMvcHelper.IsControllerMethod(protectedFoo).Should().Be(false);
@@ -80,11 +80,11 @@ public class MyController : Controller
 {
     public void PublicDiz() { }
 }";
-            var compilation = TestHelper.CompileCS(code, NuGetMetadataReference.MicrosoftAspNetMvc(aspNetMvcVersion).ToArray());
-            var publicFoo = compilation.GetMethodSymbol("PublicFoo");
-            var publicBar = compilation.GetMethodSymbol("PublicBar");
-            var publicDiz = compilation.GetMethodSymbol("PublicDiz");
-            var publicNonAction = compilation.GetMethodSymbol("PublicNonAction");
+            var compilation = TestHelper.CompileCS(code, NuGetMetadataReference.MicrosoftAspNetMvc(aspNetMvcVersion).ToArray()).Model.Compilation;
+            var publicFoo = GetMethodSymbol(compilation, "PublicFoo");
+            var publicBar = GetMethodSymbol(compilation, "PublicBar");
+            var publicDiz = GetMethodSymbol(compilation, "PublicDiz");
+            var publicNonAction = GetMethodSymbol(compilation, "PublicNonAction");
 
             AspNetMvcHelper.IsControllerMethod(publicFoo).Should().Be(true);
             AspNetMvcHelper.IsControllerMethod(publicBar).Should().Be(false);
@@ -105,9 +105,11 @@ public class Foo
     [Microsoft.AspNetCore.Mvc.NonActionAttribute]
     public void PublicNonAction() { }
 }";
-            var compilation = TestHelper.CompileCS(code, NetStandardMetadataReference.Netstandard.Union(NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(aspNetMvcVersion)).ToArray());
-            var publicFoo = compilation.GetMethodSymbol("PublicFoo");
-            var publicNonAction = compilation.GetMethodSymbol("PublicNonAction");
+            var compilation = TestHelper.CompileCS(code, NetStandardMetadataReference.Netstandard.Union(NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(aspNetMvcVersion)).ToArray())
+                .Model
+                .Compilation;
+            var publicFoo = GetMethodSymbol(compilation, "PublicFoo");
+            var publicNonAction = GetMethodSymbol(compilation, "PublicNonAction");
 
             AspNetMvcHelper.IsControllerMethod(publicFoo).Should().Be(true);
             AspNetMvcHelper.IsControllerMethod(publicNonAction).Should().Be(false);
@@ -124,8 +126,10 @@ public class Foo : Microsoft.AspNetCore.Mvc.ControllerBase
 {
     public void PublicFoo() { }
 }";
-            var compilation = TestHelper.CompileCS(code, NetStandardMetadataReference.Netstandard.Union(NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(aspNetMvcVersion)).ToArray());
-            var publicFoo = compilation.GetMethodSymbol("PublicFoo");
+            var compilation = TestHelper.CompileCS(code, NetStandardMetadataReference.Netstandard.Union(NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(aspNetMvcVersion)).ToArray())
+                .Model
+                .Compilation;
+            var publicFoo = GetMethodSymbol(compilation, "PublicFoo");
 
             AspNetMvcHelper.IsControllerMethod(publicFoo).Should().Be(false);
         }
@@ -145,5 +149,8 @@ public class Foo : Microsoft.AspNetCore.Mvc.ControllerBase
             var methodSymbol = semanticModel.GetDeclaredSymbol(tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single()) as IMethodSymbol;
             methodSymbol.IsControllerMethod().Should().Be(false);
         }
+
+        private static IMethodSymbol GetMethodSymbol(Compilation compilation, string name) =>
+            (IMethodSymbol)compilation.GetSymbolsWithName(name).Single();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/AspNetMvcHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/AspNetMvcHelperTest.cs
@@ -146,7 +146,7 @@ public class Foo : Microsoft.AspNetCore.Mvc.ControllerBase
         public Foo() { }
 }";
             var (tree, semanticModel) = TestHelper.CompileCS(code, NetStandardMetadataReference.Netstandard.Union(NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(aspNetMvcVersion)).ToArray());
-            var methodSymbol = semanticModel.GetDeclaredSymbol(tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single()) as IMethodSymbol;
+            var methodSymbol = semanticModel.GetDeclaredSymbol(tree.Single<ConstructorDeclarationSyntax>()) as IMethodSymbol;
             methodSymbol.IsControllerMethod().Should().Be(false);
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/AspNetMvcHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/AspNetMvcHelperTest.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 namespace SonarAnalyzer.UnitTest.Helpers
 {
     [TestClass]
@@ -139,9 +141,8 @@ public class Foo : Microsoft.AspNetCore.Mvc.ControllerBase
 {
         public Foo() { }
 }";
-            var compilation = TestHelper.CompileCS(code, NetStandardMetadataReference.Netstandard.Union(NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(aspNetMvcVersion)).ToArray());
-            var (ctor, semanticModel) = compilation.GetConstructor("Foo");
-            var methodSymbol = semanticModel.GetDeclaredSymbol(ctor) as IMethodSymbol;
+            var (tree, semanticModel) = TestHelper.CompileCS(code, NetStandardMetadataReference.Netstandard.Union(NuGetMetadataReference.MicrosoftAspNetCoreMvcCore(aspNetMvcVersion)).ToArray());
+            var methodSymbol = semanticModel.GetDeclaredSymbol(tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single()) as IMethodSymbol;
             methodSymbol.IsControllerMethod().Should().Be(false);
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/BuilderPatternDescriptorTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/BuilderPatternDescriptorTest.cs
@@ -80,7 +80,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
         {
             const string source = @"class X{void Foo(object x){x.ToString()}};";
             var snippet = new SnippetCompiler(source, true, AnalyzerLanguage.CSharp);
-            return new InvocationContext(snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single(), "ToString", snippet.SemanticModel);
+            return new InvocationContext(snippet.SyntaxTree.Single<InvocationExpressionSyntax>(), "ToString", snippet.SemanticModel);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/CSharpSymbolUsageCollectorTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/CSharpSymbolUsageCollectorTest.cs
@@ -56,7 +56,7 @@ public class Bar
                 .GetCompilation();
 
             var firstTree = firstCompilation.SyntaxTrees.Single();
-            var fooMethod = firstTree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+            var fooMethod = firstTree.Single<MethodDeclarationSyntax>();
             var firstCompilationSemanticModel = firstCompilation.GetSemanticModel(firstTree);
             var firstCompilationFieldSymbol = firstCompilationSemanticModel.GetSymbolInfo(fooMethod.DescendantNodes().OfType<ReturnStatementSyntax>().Single().Expression).Symbol;
             var firstCompilationKnownSymbols = new List<ISymbol> { firstCompilationFieldSymbol };
@@ -69,7 +69,7 @@ public class Bar
 
             // compilation doesn't match syntax node, since it belongs to another compilation
             var secondTree = secondCompilation.SyntaxTrees.Single();
-            var barMethod = secondTree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+            var barMethod = secondTree.Single<MethodDeclarationSyntax>();
             firstCompilationUsageCollector.Visit(barMethod);
             firstCompilationUsageCollector.UsedSymbols.Should().BeEquivalentTo(firstCompilationUsedSymbols);
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/KnownTypeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/KnownTypeTest.cs
@@ -83,14 +83,14 @@ public class KnownTypeTest
         var (tree, model) = TestHelper.CompileCS($@"
 namespace Exceptions {{ public class Exception {{ }} }}
 public class Test<T, T1, T2, T3> {{ public {type} Value; }}");
-        var expression = tree.GetRoot().DescendantNodes().OfType<CS.VariableDeclaratorSyntax>().Single();
+        var expression = tree.Single<CS.VariableDeclaratorSyntax>();
         return model.GetDeclaredSymbol(expression).GetSymbolType();
     }
 
     private static ITypeSymbol GetSymbol_VB(string type)
     {
         var (tree, model) = TestHelper.CompileVB($"Public Class Test(Of TKey, TValue) : Public Value As {type} : End Class");
-        var expression = tree.GetRoot().DescendantNodes().OfType<VB.ModifiedIdentifierSyntax>().Single();
+        var expression = tree.Single<VB.ModifiedIdentifierSyntax>();
         return model.GetDeclaredSymbol(expression).GetSymbolType();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/OperationExecutionOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/OperationExecutionOrderTest.cs
@@ -146,7 +146,7 @@ public class Sample
     public int Nested(params int[] values) => 0;
 }}";
             var (tree, semanticModel) = TestHelper.CompileCS(code);
-            var body = tree.GetRoot().DescendantNodes().OfType<BlockSyntax>().First();
+            var body = tree.First<BlockSyntax>();
             var rootOperation = new IOperationWrapperSonar(semanticModel.GetOperation(body));
             return new OperationExecutionOrder(rootOperation.Children, reverseOrder);
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/TypeDeclarationSyntaxExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/TypeDeclarationSyntaxExtensionsTest.cs
@@ -48,9 +48,7 @@ namespace Test
 }
 ";
             var snippet = new SnippetCompiler(code);
-
-            var typeDeclaration = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<TypeDeclarationSyntax>().Single();
-
+            var typeDeclaration = snippet.SyntaxTree.Single<TypeDeclarationSyntax>();
             typeDeclaration.GetMethodDeclarations().Single().Identifier.Text.Should().Be("WriteLine");
         }
 
@@ -79,9 +77,7 @@ namespace Test
 }
 ";
             var snippet = new SnippetCompiler(code);
-
-            var typeDeclaration = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<TypeDeclarationSyntax>().Single();
-
+            var typeDeclaration = snippet.SyntaxTree.Single<TypeDeclarationSyntax>();
             typeDeclaration
                 .GetMethodDeclarations()
                 .Select(methodDeclaration => methodDeclaration.Identifier.Text)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/LiveVariableAnalysis/SonarLiveVariableAnalysisTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/LiveVariableAnalysis/SonarLiveVariableAnalysisTest.cs
@@ -629,7 +629,7 @@ public class Sample
     private bool IsMethod(params bool[] args) => true;
     private void Capturing(System.Func<int> f) {{ }}
 }}";
-                var (method, model) = SonarControlFlowGraphTest.CompileWithMethodBody(code, "Main");
+                var (method, model) = SonarControlFlowGraphTest.CompileWithMethodBody(code);
                 IMethodSymbol symbol;
                 CSharpSyntaxNode body;
                 if (localFunctionName == null)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SonarExplodedGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SonarExplodedGraphTest.cs
@@ -1525,7 +1525,7 @@ namespace Namespace
             public int NumberOfProcessedInstructions;
 
             public ExplodedGraphContext(string methodBody)
-                : this(SonarControlFlowGraphTest.CompileWithMethodBody(string.Format(TestInput, methodBody), "Main"))
+                : this(SonarControlFlowGraphTest.CompileWithMethodBody(string.Format(TestInput, methodBody)))
             { }
 
             public ExplodedGraphContext((SyntaxTree tree, SemanticModel semanticModel) compilation)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SonarProgramStateTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SonarProgramStateTest.cs
@@ -139,7 +139,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Sonar
         private static ISymbol GetSymbol()
         {
             var testInput = "var a = true; var b = false; b = !b; a = (b);";
-            var (method, model) = SonarControlFlowGraphTest.CompileWithMethodBody(string.Format(SonarControlFlowGraphTest.TestInput, testInput), "Bar");
+            var (method, model) = SonarControlFlowGraphTest.CompileWithMethodBody(string.Format(SonarControlFlowGraphTest.TestInput, testInput));
             return model.GetDeclaredSymbol(method);
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SyntaxTreeExtensions.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SyntaxTreeExtensions.cs
@@ -18,30 +18,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+namespace SonarAnalyzer.UnitTest;
 
-namespace SonarAnalyzer.UnitTest.Helpers
+internal static class SyntaxTreeExtensions
 {
-    [TestClass]
-    public class DiagnosticReportHelperTest
-    {
-        private const string Source =
-@"namespace Test
-{
-    class TestClass
-    {
-    }
-}";
-        [TestMethod]
-        public void GetLineNumberToReport()
-        {
-            var syntaxTree = CSharpSyntaxTree.ParseText(Source);
-            var method = syntaxTree.Single<ClassDeclarationSyntax>();
-            method.GetLineNumberToReport()
-                .Should().Be(3);
-            method.GetLocation().GetLineSpan().StartLinePosition.GetLineNumberToReport()
-                .Should().Be(3);
-        }
-    }
+    public static T First<T>(this SyntaxTree tree) where T : SyntaxNode =>
+        tree.GetRoot().DescendantNodes().OfType<T>().First();
+
+    public static T Single<T>(this SyntaxTree tree) where T : SyntaxNode =>
+        tree.GetRoot().DescendantNodes().OfType<T>().Single();
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/TestHelper.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/TestHelper.cs
@@ -110,26 +110,6 @@ End Class", AnalyzerLanguage.VisualBasic);
                     : node.RawKind == (int)VB.SyntaxKind.FunctionBlock || node.RawKind == (int)VB.SyntaxKind.SubBlock;
         }
 
-        private static MethodDeclarationSyntax GetMethod(this SyntaxTree syntaxTree, string name, int skip = 0) =>
-            syntaxTree.GetRoot()
-                .DescendantNodes()
-                .OfType<MethodDeclarationSyntax>()
-                .Where(m => m.Identifier.ValueText == name)
-                .Skip(skip)
-                .First();
-
-        private static (MethodDeclarationSyntax, SemanticModel) GetMethod(this (SyntaxTree, SemanticModel) tuple, string name)
-        {
-            var (syntaxTree, semanticModel) = tuple;
-            return (syntaxTree.GetMethod(name), semanticModel);
-        }
-
-        public static IMethodSymbol GetMethodSymbol(this (SyntaxTree, SemanticModel) tuple, string name, int skip = 0)
-        {
-            var (syntaxTree, semanticModel) = tuple;
-            return semanticModel.GetDeclaredSymbol(syntaxTree.GetMethod(name, skip));
-        }
-
         public static bool IsSecurityHotspot(DiagnosticDescriptor diagnostic)
         {
             var type = RuleTypeMappingCS.Rules.GetValueOrDefault(diagnostic.Id) ?? RuleTypeMappingVB.Rules.GetValueOrDefault(diagnostic.Id);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/TestHelper.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/TestHelper.cs
@@ -19,7 +19,6 @@
  */
 
 using System.IO;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SonarAnalyzer.CFG;
 using SonarAnalyzer.CFG.Roslyn;
@@ -28,7 +27,6 @@ using SonarAnalyzer.Extensions;
 using SonarAnalyzer.UnitTest.PackagingTests;
 using StyleCop.Analyzers.Lightup;
 using CS = Microsoft.CodeAnalysis.CSharp;
-using RoslynAnalysisContext = Microsoft.CodeAnalysis.Diagnostics.AnalysisContext;
 using VB = Microsoft.CodeAnalysis.VisualBasic;
 
 namespace SonarAnalyzer.UnitTest
@@ -112,7 +110,7 @@ End Class", AnalyzerLanguage.VisualBasic);
                     : node.RawKind == (int)VB.SyntaxKind.FunctionBlock || node.RawKind == (int)VB.SyntaxKind.SubBlock;
         }
 
-        public static MethodDeclarationSyntax GetMethod(this SyntaxTree syntaxTree, string name, int skip = 0) =>
+        private static MethodDeclarationSyntax GetMethod(this SyntaxTree syntaxTree, string name, int skip = 0) =>
             syntaxTree.GetRoot()
                 .DescendantNodes()
                 .OfType<MethodDeclarationSyntax>()
@@ -120,7 +118,7 @@ End Class", AnalyzerLanguage.VisualBasic);
                 .Skip(skip)
                 .First();
 
-        public static (MethodDeclarationSyntax, SemanticModel) GetMethod(this (SyntaxTree, SemanticModel) tuple, string name)
+        private static (MethodDeclarationSyntax, SemanticModel) GetMethod(this (SyntaxTree, SemanticModel) tuple, string name)
         {
             var (syntaxTree, semanticModel) = tuple;
             return (syntaxTree.GetMethod(name), semanticModel);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/TestHelper.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/TestHelper.cs
@@ -126,20 +126,6 @@ End Class", AnalyzerLanguage.VisualBasic);
             return (syntaxTree.GetMethod(name), semanticModel);
         }
 
-        public static ConstructorDeclarationSyntax GetConstructor(this SyntaxTree syntaxTree, string name, int skip = 0) =>
-            syntaxTree.GetRoot()
-                .DescendantNodes()
-                .OfType<ConstructorDeclarationSyntax>()
-                .Where(m => m.Identifier.ValueText == name)
-                .Skip(skip)
-                .First();
-
-        public static (ConstructorDeclarationSyntax, SemanticModel) GetConstructor(this (SyntaxTree, SemanticModel) tuple, string name)
-        {
-            var (syntaxTree, semanticModel) = tuple;
-            return (syntaxTree.GetConstructor(name), semanticModel);
-        }
-
         public static IMethodSymbol GetMethodSymbol(this (SyntaxTree, SemanticModel) tuple, string name, int skip = 0)
         {
             var (syntaxTree, semanticModel) = tuple;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/ConstantValueFinderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Trackers/ConstantValueFinderTest.cs
@@ -45,7 +45,7 @@ public partial class Sample
 }";
             var compilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.CSharp, createExtraEmptyFile: false).AddSnippets(code1, code2).GetCompilation();
             var tree = compilation.SyntaxTrees.Single(x => x.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Any());
-            var returnExpression = tree.GetRoot().DescendantNodes().OfType<ReturnStatementSyntax>().Single().Expression;
+            var returnExpression = tree.Single<ReturnStatementSyntax>().Expression;
             var finder = new CSharpConstantValueFinder(compilation.GetSemanticModel(tree));
             finder.FindConstant(returnExpression).Should().Be(42);
         }
@@ -70,7 +70,7 @@ public class Bar
 }";
             var firstCompilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.CSharp, createExtraEmptyFile: false).AddSnippet(firstSnippet).GetCompilation();
             var secondCompilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.CSharp, createExtraEmptyFile: false).AddSnippet(secondSnippet).GetCompilation();
-            var secondCompilationReturnExpression = secondCompilation.SyntaxTrees.Single().GetRoot().DescendantNodes().OfType<ReturnStatementSyntax>().Single().Expression;
+            var secondCompilationReturnExpression = secondCompilation.SyntaxTrees.Single().Single<ReturnStatementSyntax>().Expression;
             var firstCompilationFinder = new CSharpConstantValueFinder(firstCompilation.GetSemanticModel(firstCompilation.SyntaxTrees.Single()));
             firstCompilationFinder.FindConstant(secondCompilationReturnExpression).Should().BeNull();
             var secondCompilationFinder = new CSharpConstantValueFinder(secondCompilation.GetSemanticModel(secondCompilation.SyntaxTrees.Single()));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/IOperationWrapperSonarTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/IOperationWrapperSonarTest.cs
@@ -92,7 +92,7 @@ public class Sample
     }
 }";
             var (tree, model) = TestHelper.CompileCS(code);
-            var declaration = tree.GetRoot().DescendantNodes().OfType<EqualsValueClauseSyntax>().Single();
+            var declaration = tree.Single<EqualsValueClauseSyntax>();
             semanticModel = model;
             return new IOperationWrapperSonar(model.GetOperation(declaration));
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/MethodDeclarationFactoryTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/MethodDeclarationFactoryTest.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.UnitTest.Wrappers
                     public void Bar(int y) { }
                 }";
             var snippet = new SnippetCompiler(code);
-            var method = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+            var method = snippet.SyntaxTree.Single<MethodDeclarationSyntax>();
             var wrapper = MethodDeclarationFactory.Create(method);
             wrapper.Body.Should().BeEquivalentTo(method.Body);
             wrapper.ExpressionBody.Should().BeEquivalentTo(method.ExpressionBody);
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.UnitTest.Wrappers
                     }
                 }";
             var snippet = new SnippetCompiler(code);
-            var method = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().First();
+            var method = snippet.SyntaxTree.Single<LocalFunctionStatementSyntax>();
             var wrapper = MethodDeclarationFactory.Create(method);
             wrapper.Body.Should().BeEquivalentTo(method.Body);
             wrapper.ExpressionBody.Should().BeEquivalentTo(method.ExpressionBody);
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.UnitTest.Wrappers
                     partial void Bar(int a);
                 }";
             var snippet = new SnippetCompiler(code);
-            var method = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+            var method = snippet.SyntaxTree.Single<MethodDeclarationSyntax>();
             var wrapper = MethodDeclarationFactory.Create(method);
             wrapper.HasImplementation.Should().BeFalse();
         }
@@ -97,7 +97,7 @@ namespace SonarAnalyzer.UnitTest.Wrappers
                 {
                 }";
             var snippet = new SnippetCompiler(code);
-            var method = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First();
+            var method = snippet.SyntaxTree.Single<ClassDeclarationSyntax>();
             Action a = () => MethodDeclarationFactory.Create(method);
             a.Should().Throw<InvalidOperationException>().WithMessage("Unexpected type: ClassDeclarationSyntax");
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/ObjectCreationFactoryTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/ObjectCreationFactoryTest.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.UnitTest.Wrappers
                     }
                 }";
             var snippet = new SnippetCompiler(code);
-            var objectCreation = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<ObjectCreationExpressionSyntax>().First();
+            var objectCreation = snippet.SyntaxTree.Single<ObjectCreationExpressionSyntax>();
             var wrapper = ObjectCreationFactory.Create(objectCreation);
             wrapper.Expression.Should().BeEquivalentTo(objectCreation);
             wrapper.Initializer.Should().BeEquivalentTo(objectCreation.Initializer);
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.UnitTest.Wrappers
                     }
                 }";
             var snippet = new SnippetCompiler(code);
-            var objectCreation = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<ObjectCreationExpressionSyntax>().First();
+            var objectCreation = snippet.SyntaxTree.Single<ObjectCreationExpressionSyntax>();
             var wrapper = ObjectCreationFactory.Create(objectCreation);
             wrapper.Initializer.Should().BeNull();
             wrapper.InitializerExpressions.Should().BeNull();
@@ -97,7 +97,7 @@ namespace SonarAnalyzer.UnitTest.Wrappers
                 }";
             var snippet = new SnippetCompiler(code);
             var syntaxTree = snippet.SyntaxTree;
-            var objectCreation = (ImplicitObjectCreationExpressionSyntaxWrapper)syntaxTree.GetRoot().DescendantNodes().First((node => node.IsKind(SyntaxKindEx.ImplicitObjectCreationExpression)));
+            var objectCreation = (ImplicitObjectCreationExpressionSyntaxWrapper)syntaxTree.GetRoot().DescendantNodes().First(node => node.IsKind(SyntaxKindEx.ImplicitObjectCreationExpression));
             var wrapper = ObjectCreationFactory.Create(objectCreation);
             wrapper.Expression.Should().BeEquivalentTo(objectCreation.SyntaxNode);
             wrapper.Initializer.Should().BeEquivalentTo(objectCreation.Initializer);
@@ -125,7 +125,7 @@ namespace SonarAnalyzer.UnitTest.Wrappers
                     }
                 }";
             var snippet = new SnippetCompiler(code);
-            var objectCreation = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<ImplicitObjectCreationExpressionSyntax>().First();
+            var objectCreation = snippet.SyntaxTree.Single<ImplicitObjectCreationExpressionSyntax>();
             var wrapper = ObjectCreationFactory.Create(objectCreation);
             wrapper.Initializer.Should().BeNull();
             wrapper.InitializerExpressions.Should().BeNull();
@@ -144,7 +144,7 @@ namespace SonarAnalyzer.UnitTest.Wrappers
                 }";
             var snippet = new SnippetCompiler(code, true, AnalyzerLanguage.CSharp);
             var syntaxTree = snippet.SyntaxTree;
-            var objectCreation = (ImplicitObjectCreationExpressionSyntaxWrapper)syntaxTree.GetRoot().DescendantNodes().First((node => node.IsKind(SyntaxKindEx.ImplicitObjectCreationExpression)));
+            var objectCreation = (ImplicitObjectCreationExpressionSyntaxWrapper)syntaxTree.GetRoot().DescendantNodes().First(node => node.IsKind(SyntaxKindEx.ImplicitObjectCreationExpression));
             var wrapper = ObjectCreationFactory.Create(objectCreation);
             wrapper.TypeAsString(snippet.SemanticModel).Should().BeEmpty();
         }
@@ -160,7 +160,7 @@ namespace SonarAnalyzer.UnitTest.Wrappers
         public void GivenNonConstructor_ThrowsException()
         {
             var snippet = new SnippetCompiler("public class A{}");
-            var classDeclaration = snippet.SyntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First();
+            var classDeclaration = snippet.SyntaxTree.Single<ClassDeclarationSyntax>();
             Action action = () => { ObjectCreationFactory.Create(classDeclaration); };
             action.Should().Throw<InvalidOperationException>().WithMessage("Unexpected type: ClassDeclarationSyntax");
         }


### PR DESCRIPTION
Follow up of #6532 

Remove `Get*` methods from TestHelper. They where mostly not needed or used by classes that are about to be deleted.
Extract `tree.First<T>` and `tree.Single<T>` where `T:SyntaxNode` in UTs instead.