### PR TITLE
FP on S4487: Null-coalescing assignment is not recognized

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/UnusedPrivateMember.CSharp8.cs
@@ -82,3 +82,13 @@ namespace Repro1144
         }
     }
 }
+
+class NullCoalescingAssignment
+{
+    private object field;
+
+    public void SetIfNull()
+    {
+        field ??= new object(); // Noncompliant FP
+    }
+}


### PR DESCRIPTION
As reported #6653, null-coalescing assignments are not recognized as the usage of a field.
