### PR TITLE
Improve S1244: Add message to use "IsXInfinity()" instead of "== double.XInfinity"

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
@@ -85,11 +85,6 @@ public sealed class EqualityOnFloatingPoint : SonarDiagnosticAnalyzer
         }
     }
 
-    // Only checks for type and member accessed. No need to check that proposedMethod exists in type because:
-    // - both special members and corresponding `IsXXX()` methods exist in double and float since .NET 1.1
-    // - both special members and corresponding `IsXXX()` methods exist in Half since its introduction, in .NET 5
-    // - while NFloat has been introduced in .NET 6, special members and corresponding IsXXX() methods have been introduced at the same time, in .NET 7
-    // - no other floating point typeswith prevision issues exist before .NET 7, and any new type after has to conform to `IFloatingPointIeee754`
     private static string ProposedMessageForMemberAccess(SonarSyntaxNodeReportingContext context, ExpressionSyntax expression) =>
         expression is MemberAccessExpressionSyntax memberAccess
         && SpecialMembers.TryGetValue(memberAccess.GetName(), out var proposedMethod)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
@@ -30,6 +30,8 @@ public sealed class EqualityOnFloatingPoint : SonarDiagnosticAnalyzer
     private static readonly Dictionary<string, string> SpecialMembers = new()
     {
         { nameof(double.NaN), nameof(double.IsNaN) },
+        { nameof(double.PositiveInfinity), nameof(double.IsPositiveInfinity) },
+        { nameof(double.NegativeInfinity), nameof(double.IsNegativeInfinity) },
     };
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
@@ -83,6 +85,11 @@ public sealed class EqualityOnFloatingPoint : SonarDiagnosticAnalyzer
         }
     }
 
+    // Only checks for type and member accessed. No need to check that proposedMethod exists in type because:
+    // - both special members and corresponding `IsXXX()` methods exist in double and float since .NET 1.1
+    // - both special members and corresponding `IsXXX()` methods exist in Half since its introduction, in .NET 5
+    // - while NFloat has been introduced in .NET 6, special members and corresponding IsXXX() methods have been introduced at the same time, in .NET 7
+    // - no other floating point typeswith prevision issues exist before .NET 7, and any new type after has to conform to `IFloatingPointIeee754`
     private static string ProposedMessageForMemberAccess(SonarSyntaxNodeReportingContext context, ExpressionSyntax expression) =>
         expression is MemberAccessExpressionSyntax memberAccess
         && SpecialMembers.TryGetValue(memberAccess.GetName(), out var proposedMethod)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EqualityOnFloatingPoint.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EqualityOnFloatingPoint.CSharp11.cs
@@ -4,25 +4,6 @@ using System.Runtime.InteropServices;
 
 public class EqualityOnFloatingPoint
 {
-    void HalfNaN(Half h)
-    {
-        _ = h == Half.NaN; // Noncompliant {{Do not check floating point equality with exact values, use 'Half.IsNaN()' instead.}}
-        //    ^^
-        h = Half.NaN;      // Compliant, not a comparison
-    }
-
-    void NFloatNaN(NFloat nf)
-    {
-        _ = nf == System.Runtime.InteropServices.NFloat.NaN; // Noncompliant {{Do not check floating point equality with exact values, use 'NFloat.IsNaN()' instead.}}
-        _ = nf == NFloat.NaN;                                // Noncompliant {{Do not check floating point equality with exact values, use 'NFloat.IsNaN()' instead.}}
-    }
-
-    public void M<T>(T t) where T : IFloatingPointIeee754<T>
-    {
-        if (t == T.NaN) { } // Noncompliant {{Do not check floating point equality with exact values, use 'T.IsNaN()' instead.}}
-        if (T.IsNaN(t)) { } // Compliant
-    }
-
     bool HalfEqual(Half first, Half second)
         => first == second;    // Noncompliant {{Do not check floating point equality with exact values, use a range instead.}}
     //           ^^
@@ -44,4 +25,58 @@ public class EqualityOnFloatingPoint
 
     bool Equal<T>(T first, T second) where T : IBinaryFloatingPointIeee754<T>
         => first == second;    // Noncompliant
+}
+
+public class ReportSpecificMessage_NaN
+{
+    void HalfNaN(Half h)
+    {
+        _ = h == Half.NaN; // Noncompliant {{Do not check floating point equality with exact values, use 'Half.IsNaN()' instead.}}
+        //    ^^
+        h = Half.NaN;      // Compliant, not a comparison
+    }
+
+    void NFloatNaN(NFloat nf)
+    {
+        _ = nf == System.Runtime.InteropServices.NFloat.NaN; // Noncompliant {{Do not check floating point equality with exact values, use 'NFloat.IsNaN()' instead.}}
+        _ = nf == NFloat.NaN;                                // Noncompliant {{Do not check floating point equality with exact values, use 'NFloat.IsNaN()' instead.}}
+    }
+
+    public void M<T>(T t) where T : IFloatingPointIeee754<T>
+    {
+        if (t == T.NaN) { } // Noncompliant {{Do not check floating point equality with exact values, use 'T.IsNaN()' instead.}}
+        if (T.IsNaN(t)) { } // Compliant
+    }
+}
+
+public class ReportSpecificMessage_Infinities
+{
+    void HalfInfinities(Half h)
+    {
+        _ = h == Half.PositiveInfinity; // Noncompliant {{Do not check floating point equality with exact values, use 'Half.IsPositiveInfinity()' instead.}}
+        _ = Half.NegativeInfinity == h; // Noncompliant {{Do not check floating point equality with exact values, use 'Half.IsNegativeInfinity()' instead.}}
+    }
+
+    void NFloatInfinities(NFloat nf)
+    {
+        _ = nf == NFloat.PositiveInfinity; // Noncompliant {{Do not check floating point equality with exact values, use 'NFloat.IsPositiveInfinity()' instead.}}
+        _ = NFloat.NegativeInfinity == nf; // Noncompliant {{Do not check floating point equality with exact values, use 'NFloat.IsNegativeInfinity()' instead.}}
+    }
+}
+
+namespace TestWithUsingStatic
+{
+    using static System.Runtime.InteropServices.NFloat;
+
+    public class ReportSpecificMessage
+    {
+        public void WithUsingStatic(double d)
+        {
+            _ = d == NaN;          // Noncompliant {{Do not check floating point equality with exact values, use 'IsNaN()' instead.}}
+            _ = NaN == d;          // Noncompliant {{Do not check floating point equality with exact values, use 'IsNaN()' instead.}}
+            _ = NaN == NaN;        // Noncompliant {{Do not check floating point equality with exact values, use 'IsNaN()' instead.}}
+            _ = NaN == float.NaN;  // Noncompliant {{Do not check floating point equality with exact values, use 'NFloat.IsNaN()' instead.}}
+            _ = double.NaN == NaN; // Noncompliant {{Do not check floating point equality with exact values, use 'double.IsNaN()' instead.}}
+        }
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EqualityOnFloatingPoint.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EqualityOnFloatingPoint.CSharp11.cs
@@ -4,27 +4,27 @@ using System.Runtime.InteropServices;
 
 public class EqualityOnFloatingPoint
 {
-    bool HalfEqual(Half first, Half second)
-        => first == second;    // Noncompliant {{Do not check floating point equality with exact values, use a range instead.}}
-    //           ^^
+    bool HalfEqual(Half first, Half second) =>
+        first == second;    // Noncompliant {{Do not check floating point equality with exact values, use a range instead.}}
+    //        ^^
 
-    bool NFloatEqual(NFloat first, NFloat second)
-        => first == second;    // Noncompliant
+    bool NFloatEqual(NFloat first, NFloat second) =>
+        first == second; // Noncompliant
 
-    bool IsEpsilon<T>(T value) where T : IFloatingPointIeee754<T>
-        => value == T.Epsilon; // Noncompliant
+    bool IsEpsilon<T>(T value) where T : IFloatingPointIeee754<T> =>
+        value == T.Epsilon; // Noncompliant
 
-    bool IsPi<T>(T value) where T : IFloatingPointIeee754<T>
-        => value <= T.Pi && ((value >= T.Pi)); // Noncompliant
+    bool IsPi<T>(T value) where T : IFloatingPointIeee754<T> =>
+        value <= T.Pi && ((value >= T.Pi)); // Noncompliant
 
-    bool IsNotE<T>(T value) where T : IFloatingPointIeee754<T>
-        => value > T.E || ((value < T.E)); // Noncompliant
+    bool IsNotE<T>(T value) where T : IFloatingPointIeee754<T> =>
+        value > T.E || ((value < T.E)); // Noncompliant
 
-    bool AreEqual<T>(T first, T second) where T : IFloatingPointIeee754<T>
-        => first == second;    // Noncompliant
+    bool AreEqual<T>(T first, T second) where T : IFloatingPointIeee754<T> =>
+        first == second; // Noncompliant
 
-    bool Equal<T>(T first, T second) where T : IBinaryFloatingPointIeee754<T>
-        => first == second;    // Noncompliant
+    bool Equal<T>(T first, T second) where T : IBinaryFloatingPointIeee754<T> =>
+        first == second; // Noncompliant
 }
 
 public class ReportSpecificMessage_NaN

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EqualityOnFloatingPoint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/EqualityOnFloatingPoint.cs
@@ -100,6 +100,37 @@ public class ReportSpecificMessage_NaN
     }
 }
 
+public class ReportSpecificMessage_Infinities
+{
+    public void WithDouble(double d)
+    {
+        _ = d == double.PositiveInfinity; // Noncompliant {{Do not check floating point equality with exact values, use 'double.IsPositiveInfinity()' instead.}}
+        _ = double.PositiveInfinity != d; // Noncompliant {{Do not check floating point inequality with exact values, use 'double.IsPositiveInfinity()' instead.}}
+        _ = d == double.NegativeInfinity; // Noncompliant {{Do not check floating point equality with exact values, use 'double.IsNegativeInfinity()' instead.}}
+        _ = double.NegativeInfinity != d; // Noncompliant {{Do not check floating point inequality with exact values, use 'double.IsNegativeInfinity()' instead.}}
+    }
+
+    public void WithFloat(float f)
+    {
+        _ = f == float.PositiveInfinity; // Noncompliant {{Do not check floating point equality with exact values, use 'float.IsPositiveInfinity()' instead.}}
+        _ = float.PositiveInfinity != f; // Noncompliant {{Do not check floating point inequality with exact values, use 'float.IsPositiveInfinity()' instead.}}
+        _ = f == float.NegativeInfinity; // Noncompliant {{Do not check floating point equality with exact values, use 'float.IsNegativeInfinity()' instead.}}
+        _ = float.NegativeInfinity != f; // Noncompliant {{Do not check floating point inequality with exact values, use 'float.IsNegativeInfinity()' instead.}}
+    }
+
+    public void WithDoublePascalCase(Double d)
+    {
+        _ = Double.PositiveInfinity == d;        // Noncompliant {{Do not check floating point equality with exact values, use 'double.IsPositiveInfinity()' instead.}}
+        _ = d == System.Double.NegativeInfinity; // Noncompliant {{Do not check floating point equality with exact values, use 'double.IsNegativeInfinity()' instead.}}
+    }
+
+    public void WithSingle(Single f)
+    {
+        _ = Single.PositiveInfinity == f;        // Noncompliant {{Do not check floating point equality with exact values, use 'float.IsPositiveInfinity()' instead.}}
+        _ = f == System.Single.NegativeInfinity; // Noncompliant {{Do not check floating point equality with exact values, use 'float.IsNegativeInfinity()' instead.}}
+    }
+}
+
 namespace TestsWithTypeAliases
 {
     using DoubleAlias = Double;


### PR DESCRIPTION
Follows #6664
Fixes #6521 

~~Made into a draft because it should be merged after the release.~~

RSPEC update to be merged with this:
https://github.com/SonarSource/rspec/pull/1509