### PR TITLE
Fix S3220 FP: Rule does not take into account access modifier of the members

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
@@ -105,7 +105,7 @@ public sealed class InvocationResolvesToOverrideWithParams : SonarDiagnosticAnal
 
     private static bool MethodAccessibleWithinType(IMethodSymbol method, ITypeSymbol type) =>
         IsInTypeOrNested(method, type)
-        || method.DeclaredAccessibility switch // FIXME: Null check for top-level statements?
+        || method.DeclaredAccessibility switch
             {
                 Accessibility.Private => false,
                 // ProtectedAndInternal corresponds to `private protected`.

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
@@ -18,144 +18,88 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Rules.CSharp
+namespace SonarAnalyzer.Rules.CSharp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvocationResolvesToOverrideWithParams : SonarDiagnosticAnalyzer
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class InvocationResolvesToOverrideWithParams : SonarDiagnosticAnalyzer
+    private const string DiagnosticId = "S3220";
+    private const string MessageFormat = "Review this call, which partially matches an overload without 'params'. The partial match is '{0}'.";
+
+    private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+    protected override void Initialize(SonarAnalysisContext context)
     {
-        private const string DiagnosticId = "S3220";
-        private const string MessageFormat = "Review this call, which partially matches an overload without 'params'. The partial match is '{0}'.";
+        context.RegisterNodeAction(
+            c =>
+            {
+                var invocation = (InvocationExpressionSyntax)c.Node;
+                CheckCall(c, invocation, invocation.ArgumentList);
+            },
+            SyntaxKind.InvocationExpression);
 
-        private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+        context.RegisterNodeAction(
+            c =>
+            {
+                var objectCreation = (ObjectCreationExpressionSyntax)c.Node;
+                CheckCall(c, objectCreation, objectCreation.ArgumentList);
+            },
+            SyntaxKind.ObjectCreationExpression);
+    }
 
-        protected override void Initialize(SonarAnalysisContext context)
+    private static void CheckCall(SonarSyntaxNodeReportingContext context, SyntaxNode node, ArgumentListSyntax argumentList)
+    {
+        if (argumentList is { Arguments.Count: > 0 }
+            && context.SemanticModel.GetSymbolInfo(node).Symbol is IMethodSymbol method
+            && method.Parameters.LastOrDefault() is { IsParams: true }
+            && !IsInvocationWithExplicitArray(argumentList, method, context.SemanticModel)
+            && ArgumentTypes(context, argumentList) is var argumentTypes
+            && argumentTypes.All(x => x is not IErrorTypeSymbol)
+            && OtherOverloadsOf(method)
+                .FirstOrDefault(x => ArgumentsMatchParameters(argumentList, argumentTypes, x, context.SemanticModel))
+                    is { } otherMethod)
         {
-            context.RegisterNodeAction(
-                c =>
-                {
-                    var invocation = (InvocationExpressionSyntax)c.Node;
-                    CheckCall(c, invocation, invocation.ArgumentList);
-                },
-                SyntaxKind.InvocationExpression);
-
-            context.RegisterNodeAction(
-                c =>
-                {
-                    var objectCreation = (ObjectCreationExpressionSyntax)c.Node;
-                    CheckCall(c, objectCreation, objectCreation.ArgumentList);
-                },
-                SyntaxKind.ObjectCreationExpression);
+            context.ReportIssue(Diagnostic.Create(Rule, node.GetLocation(), otherMethod.ToMinimalDisplayString(context.SemanticModel, node.SpanStart)));
         }
+    }
 
-        private static void CheckCall(SonarSyntaxNodeReportingContext context, SyntaxNode node, ArgumentListSyntax argumentList)
-        {
-            if (argumentList == null
-                || argumentList.Arguments.Count == 0
-                || context.SemanticModel.GetSymbolInfo(node).Symbol is not IMethodSymbol invokedMethodSymbol
-                || !invokedMethodSymbol.Parameters.Any()
-                || !invokedMethodSymbol.Parameters.Last().IsParams
-                || IsInvocationWithExplicitArray(argumentList, invokedMethodSymbol, context.SemanticModel))
-            {
-                return;
-            }
+    private static List<ITypeSymbol> ArgumentTypes(SonarSyntaxNodeReportingContext context, ArgumentListSyntax argumentList) =>
+        argumentList.Arguments
+            .Select(x => context.SemanticModel.GetTypeInfo(x.Expression))
+            .Select(x => x.Type ?? x.ConvertedType) // Action and Func won't always resolve properly with Type
+            .ToList();
 
-            var argumentTypes = argumentList.Arguments
-                .Select(arg => context.SemanticModel.GetTypeInfo(arg.Expression))
-                .Select(typeInfo => typeInfo.Type ?? typeInfo.ConvertedType) // Action and Func won't always resolve properly with Type
-                .ToList();
-            if (argumentTypes.Any(type => type is IErrorTypeSymbol))
-            {
-                return;
-            }
+    private static IEnumerable<IMethodSymbol> OtherOverloadsOf(IMethodSymbol method) =>
+        method.ContainingType
+            .GetMembers(method.Name)
+            .OfType<IMethodSymbol>()
+            .Where(x => !x.IsVararg && x.MethodKind == method.MethodKind && !method.Equals(x) && x.Parameters.Any() && !x.Parameters.Last().IsParams);
 
-            var possibleOtherMethods = invokedMethodSymbol.ContainingType.GetMembers(invokedMethodSymbol.Name)
-                .OfType<IMethodSymbol>()
-                .Where(m => !m.IsVararg)
-                .Where(m => m.MethodKind == invokedMethodSymbol.MethodKind)
-                .Where(m => !invokedMethodSymbol.Equals(m))
-                .Where(m => m.Parameters.Any() && !m.Parameters.Last().IsParams);
+    private static bool IsInvocationWithExplicitArray(ArgumentListSyntax argumentList, IMethodSymbol invokedMethodSymbol, SemanticModel semanticModel)
+    {
+        var lookup = new CSharpMethodParameterLookup(argumentList, invokedMethodSymbol);
+        var parameters = argumentList.Arguments.Select(Valid).ToList();
+        return parameters.All(x => x != null) && parameters.Count(x => x.IsParams) == 1;
 
-            var otherMethod = possibleOtherMethods.FirstOrDefault(possibleOtherMethod =>
-                    ArgumentsMatchParameters(
-                        argumentList,
-                        argumentTypes.Select(t => t as INamedTypeSymbol).ToList(),
-                        possibleOtherMethod,
-                        context.SemanticModel));
+        IParameterSymbol Valid(ArgumentSyntax argument) =>
+            lookup.TryGetSymbol(argument, out var parameter)
+            && (!parameter.IsParams || semanticModel.GetTypeInfo(argument.Expression).Type is IArrayTypeSymbol)
+                ? parameter
+                : null;
+    }
 
-            if (otherMethod != null)
-            {
-                context.ReportIssue(Diagnostic.Create(
-                    Rule,
-                    node.GetLocation(),
-                    otherMethod.ToMinimalDisplayString(context.SemanticModel, node.SpanStart)));
-            }
-        }
+    private static bool ArgumentsMatchParameters(ArgumentListSyntax argumentList, List<ITypeSymbol> argumentTypes, IMethodSymbol possibleOtherMethod, SemanticModel semanticModel)
+    {
+        var lookup = new CSharpMethodParameterLookup(argumentList, possibleOtherMethod);
+        var parameters = argumentList.Arguments.Select((argument, index) => Valid(argument, argumentTypes[index])).ToList();
+        return parameters.All(x => x != null) && possibleOtherMethod.Parameters.Except(parameters).All(x => x.HasExplicitDefaultValue);
 
-        private static bool IsInvocationWithExplicitArray(ArgumentListSyntax argumentList, IMethodSymbol invokedMethodSymbol, SemanticModel semanticModel)
-        {
-            var methodParameterLookup = new CSharpMethodParameterLookup(argumentList, invokedMethodSymbol);
-
-            var allParameterMatches = new List<IParameterSymbol>();
-            foreach (var argument in argumentList.Arguments)
-            {
-                if (!methodParameterLookup.TryGetSymbol(argument, out var parameter))
-                {
-                    return false;
-                }
-
-                allParameterMatches.Add(parameter);
-
-                if (!parameter.IsParams)
-                {
-                    continue;
-                }
-
-                var argType = semanticModel.GetTypeInfo(argument.Expression).Type;
-                if (argType is not IArrayTypeSymbol)
-                {
-                    return false;
-                }
-            }
-
-            return allParameterMatches.Count(p => p.IsParams) == 1;
-        }
-
-        private static bool ArgumentsMatchParameters(ArgumentListSyntax argumentList, List<INamedTypeSymbol> argumentTypes, IMethodSymbol possibleOtherMethod, SemanticModel semanticModel)
-        {
-            var methodParameterLookup = new CSharpMethodParameterLookup(argumentList, possibleOtherMethod);
-
-            var matchedParameters = new List<IParameterSymbol>();
-            for (var i = 0; i < argumentList.Arguments.Count; i++)
-            {
-                var argument = argumentList.Arguments[i];
-                var argumentType = argumentTypes[i];
-                if (!methodParameterLookup.TryGetSymbol(argument, out var parameter))
-                {
-                    return false;
-                }
-
-                if (argumentType == null)
-                {
-                    if (!parameter.Type.IsReferenceType)
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    var conversion = semanticModel.ClassifyConversion(argument.Expression, parameter.Type);
-                    if (!conversion.IsImplicit)
-                    {
-                        return false;
-                    }
-                }
-
-                matchedParameters.Add(parameter);
-            }
-
-            var nonMatchedParameters = possibleOtherMethod.Parameters.Except(matchedParameters);
-            return nonMatchedParameters.All(p => p.HasExplicitDefaultValue);
-        }
+        IParameterSymbol Valid(ArgumentSyntax argument, ITypeSymbol type) =>
+            lookup.TryGetSymbol(argument, out var parameter)
+            && ((type is INamedTypeSymbol && semanticModel.ClassifyConversion(argument.Expression, parameter.Type).IsImplicit)
+                || (type is not INamedTypeSymbol && parameter.Type.IsReferenceType))
+                ? parameter
+                : null;
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/ISymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/ISymbolExtensions.cs
@@ -36,5 +36,8 @@ namespace SonarAnalyzer.Helpers
 
         public static bool IsGlobalNamespace(this ISymbol symbol) =>
             symbol is INamespaceSymbol { Name: "" };
+
+        public static bool IsInSameAssembly(this ISymbol symbol, ISymbol anotherSymbol) =>
+            symbol.ContainingAssembly.Equals(anotherSymbol.ContainingAssembly);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/InvocationResolvesToOverrideWithParamsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/InvocationResolvesToOverrideWithParamsTest.cs
@@ -60,6 +60,12 @@ namespace SonarAnalyzer.UnitTest.Rules
                 .WithOptions(ParseOptionsHelper.FromCSharp11)
                 .Verify();
 
+        [TestMethod]
+        public void InvocationResolvesToOverrideWithParams_TopLevelStatements() =>
+            builder.AddPaths("InvocationResolvesToOverrideWithParams.TopLevelStatements.cs")
+                .WithTopLevelStatements()
+                .Verify();
+
 #endif
 
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/InvocationResolvesToOverrideWithParamsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/InvocationResolvesToOverrideWithParamsTest.cs
@@ -33,17 +33,17 @@ namespace SonarAnalyzer.UnitTest.Rules
             var anotherAssembly = TestHelper.CompileCS("""
                 public class FromAnotherAssembly
                 {
-                    protected int ProtectedOverload(object a, string b) => 1493;
-                    public int ProtectedOverload(string a, params string[] bs) => 1607;
+                    protected int ProtectedOverload(object a, string b) => 42;
+                    public int ProtectedOverload(string a, params string[] bs) => 42;
 
-                    private protected int PrivateProtectedOverload(object a, string b) => 1494;
-                    public int PrivateProtectedOverload(string a, params string[] bs) => 1608;
+                    private protected int PrivateProtectedOverload(object a, string b) => 42;
+                    public int PrivateProtectedOverload(string a, params string[] bs) => 42;
 
-                    protected internal int ProtectedInternalOverload(object a, string b) => 1495;
-                    public int ProtectedInternalOverload(string a, params string[] bs) => 1609;
+                    protected internal int ProtectedInternalOverload(object a, string b) => 42;
+                    public int ProtectedInternalOverload(string a, params string[] bs) => 42;
 
-                    internal int InternalOverload(object a, string b) => 1496;
-                    public int InternalOverload(string a, params string[] bs) => 1610;
+                    internal int InternalOverload(object a, string b) => 42;
+                    public int InternalOverload(string a, params string[] bs) => 42;
                 }
                 """).Model.Compilation.ToMetadataReference();
             builder.AddPaths("InvocationResolvesToOverrideWithParams.cs")

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/InvocationResolvesToOverrideWithParamsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/InvocationResolvesToOverrideWithParamsTest.cs
@@ -28,10 +28,29 @@ namespace SonarAnalyzer.UnitTest.Rules
         private readonly VerifierBuilder builder = new VerifierBuilder<InvocationResolvesToOverrideWithParams>();
 
         [TestMethod]
-        public void InvocationResolvesToOverrideWithParams() =>
+        public void InvocationResolvesToOverrideWithParams()
+        {
+            var anotherAssembly = TestHelper.CompileCS("""
+                public class FromAnotherAssembly
+                {
+                    protected int ProtectedOverload(object a, string b) => 1493;
+                    public int ProtectedOverload(string a, params string[] bs) => 1607;
+
+                    private protected int PrivateProtectedOverload(object a, string b) => 1494;
+                    public int PrivateProtectedOverload(string a, params string[] bs) => 1608;
+
+                    protected internal int ProtectedInternalOverload(object a, string b) => 1495;
+                    public int ProtectedInternalOverload(string a, params string[] bs) => 1609;
+
+                    internal int InternalOverload(object a, string b) => 1496;
+                    public int InternalOverload(string a, params string[] bs) => 1610;
+                }
+                """).Model.Compilation.ToMetadataReference();
             builder.AddPaths("InvocationResolvesToOverrideWithParams.cs")
+                .AddReferences(new[] { anotherAssembly })
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
+        }
 
 #if NET
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.CSharp11.cs
@@ -1,24 +1,21 @@
 ﻿using System;
 
-namespace Tests.Diagnostics
+interface IMyInterface
 {
-    interface IMyInterface
+    static virtual void Test(int foo, params object[] p) => Console.WriteLine("Test1");
+
+    static virtual void Test(double foo, object p1) => Console.WriteLine("Test2");
+
+    static virtual void InterfaceStaticAbstractMethod<T>() where T : IMyInterface
     {
-        static virtual void Test(int foo, params object[] p) => Console.WriteLine("Test1");
-
-        static virtual void Test(double foo, object p1) => Console.WriteLine("Test2");
-
-        static virtual void InterfaceStaticAbstractMethod<T>() where T : IMyInterface
-        {
-            T.Test(42, null); // Noncompliant {{Review this call, which partially matches an overload without 'params'. The partial match is 'void IMyInterface.Test(double foo, object p1)'.}}
-        }
+        T.Test(42, null); // Noncompliant {{Review this call, which partially matches an overload without 'params'. The partial match is 'void IMyInterface.Test(double foo, object p1)'.}}
     }
+}
 
-    class MyClass
+class MyClass
+{
+    void ClassMethod<T>() where T : IMyInterface
     {
-        void ClassMethod<T>() where T : IMyInterface
-        {
-            T.Test(42, null); // Noncompliant
-        }
+        T.Test(42, null); // Noncompliant
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.TopLevelStatements.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.TopLevelStatements.cs
@@ -59,9 +59,9 @@ public class SomeClass
     protected virtual int OverriddenAsProtected(object a, string b) => 42;
     public int OverriddenAsProtected(string a, params string[] bs) => 42;
 
-    protected int ShadowedAsPublic(object a, string b) => 1498;
-    public int ShadowedAsPublic(string a, params string[] bs) => 1612;
+    protected int ShadowedAsPublic(object a, string b) => 42;
+    public int ShadowedAsPublic(string a, params string[] bs) => 42;
 
-    protected int ShadowedAsProtectedInternal(object a, string b) => 1499;
-    public int ShadowedAsProtectedInternal(string a, params string[] bs) => 1613;
+    protected int ShadowedAsProtectedInternal(object a, string b) => 42;
+    public int ShadowedAsProtectedInternal(string a, params string[] bs) => 42;
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.TopLevelStatements.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.TopLevelStatements.cs
@@ -1,4 +1,4 @@
-﻿Repro5430.SomeClass x;
+﻿SomeClass x;
 x = new ("1");              // Compliant, can't see non-param overload
 x = new ("1", "s1");        // Compliant, can't see non-param overload
 x = new (null, "s1");       // Compliant, can't see non-param overload
@@ -35,37 +35,33 @@ x.InternalOverload(null, "s2");                    // Noncompliant
 x.InternalOverload(null, new[] { "s2" });          // Compliant
 x.InternalOverload("42", "s1", "s2");              // Compliant
 
-// Reproducer for https://github.com/SonarSource/sonar-dotnet/issues/5430
-namespace Repro5430
+public class SomeClass
 {
-    public class SomeClass
-    {
-        private SomeClass(object a, string b) { }
-        private SomeClass(string a, string b) { }
-        public SomeClass(string a, params string[] bs) { }
+    private SomeClass(object a, string b) { }
+    private SomeClass(string a, string b) { }
+    public SomeClass(string a, params string[] bs) { }
 
-        private int PrivateOverload(object a, string b) => 1492;
-        public int PrivateOverload(string a, params string[] bs) => 1606;
+    private int PrivateOverload(object a, string b) => 42;
+    public int PrivateOverload(string a, params string[] bs) => 42;
 
-        protected int ProtectedOverload(object a, string b) => 1493;
-        public int ProtectedOverload(string a, params string[] bs) => 1607;
+    protected int ProtectedOverload(object a, string b) => 42;
+    public int ProtectedOverload(string a, params string[] bs) => 42;
 
-        private protected int PrivateProtectedOverload(object a, string b) => 1494;
-        public int PrivateProtectedOverload(string a, params string[] bs) => 1608;
+    private protected int PrivateProtectedOverload(object a, string b) => 42;
+    public int PrivateProtectedOverload(string a, params string[] bs) => 42;
 
-        protected internal int ProtectedInternalOverload(object a, string b) => 1495;
-        public int ProtectedInternalOverload(string a, params string[] bs) => 1609;
+    protected internal int ProtectedInternalOverload(object a, string b) => 42;
+    public int ProtectedInternalOverload(string a, params string[] bs) => 42;
 
-        internal int InternalOverload(object a, string b) => 1496;
-        public int InternalOverload(string a, params string[] bs) => 1610;
+    internal int InternalOverload(object a, string b) => 42;
+    public int InternalOverload(string a, params string[] bs) => 42;
 
-        protected virtual int OverriddenAsProtected(object a, string b) => 1497;
-        public int OverriddenAsProtected(string a, params string[] bs) => 1611;
+    protected virtual int OverriddenAsProtected(object a, string b) => 42;
+    public int OverriddenAsProtected(string a, params string[] bs) => 42;
 
-        protected int ShadowedAsPublic(object a, string b) => 1498;
-        public int ShadowedAsPublic(string a, params string[] bs) => 1612;
+    protected int ShadowedAsPublic(object a, string b) => 1498;
+    public int ShadowedAsPublic(string a, params string[] bs) => 1612;
 
-        protected int ShadowedAsProtectedInternal(object a, string b) => 1499;
-        public int ShadowedAsProtectedInternal(string a, params string[] bs) => 1613;
-    }
+    protected int ShadowedAsProtectedInternal(object a, string b) => 1499;
+    public int ShadowedAsProtectedInternal(string a, params string[] bs) => 1613;
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.TopLevelStatements.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.TopLevelStatements.cs
@@ -1,0 +1,71 @@
+﻿Repro5430.SomeClass x;
+x = new ("1");              // Compliant, can't see non-param overload
+x = new ("1", "s1");        // Compliant, can't see non-param overload
+x = new (null, "s1");       // Compliant, can't see non-param overload
+x = new ("1", "s1", "s2");  // Compliant, can't see non-param overload
+x = new (null, "s1", "s2"); // Compliant, can't see non-param overload
+
+x.PrivateOverload("42");                           // Compliant
+x.PrivateOverload("42", "s1");                     // Compliant
+x.PrivateOverload(null, "s1");                     // Compliant
+x.PrivateOverload(null, new[] { "s2" });           // Compliant
+x.PrivateOverload("42", "s1", "s2");               // Compliant
+
+x.ProtectedOverload("s1");                         // Compliant
+x.ProtectedOverload("s1", "s2");                   // Compliant
+x.ProtectedOverload(null, "s2");                   // Compliant
+x.ProtectedOverload(null, new[] { "s2" });         // Compliant
+x.ProtectedOverload("42", "s1", "s2");             // Compliant
+
+x.PrivateProtectedOverload("s1");                  // Compliant
+x.PrivateProtectedOverload("s1", "s2");            // Compliant
+x.PrivateProtectedOverload(null, "s2");            // Compliant
+x.PrivateProtectedOverload(null, new[] { "s2" });  // Compliant
+x.PrivateProtectedOverload("42", "s1", "s2");      // Compliant
+
+x.ProtectedInternalOverload("s1");                 // Compliant
+x.ProtectedInternalOverload("s1", "s2");           // Noncompliant
+x.ProtectedInternalOverload(null, "s2");           // Noncompliant
+x.ProtectedInternalOverload(null, new[] { "s2" }); // Compliant
+x.ProtectedInternalOverload("42", "s1", "s2");     // Compliant
+
+x.InternalOverload("s1");                          // Compliant
+x.InternalOverload("s1", "s2");                    // Noncompliant
+x.InternalOverload(null, "s2");                    // Noncompliant
+x.InternalOverload(null, new[] { "s2" });          // Compliant
+x.InternalOverload("42", "s1", "s2");              // Compliant
+
+// Reproducer for https://github.com/SonarSource/sonar-dotnet/issues/5430
+namespace Repro5430
+{
+    public class SomeClass
+    {
+        private SomeClass(object a, string b) { }
+        private SomeClass(string a, string b) { }
+        public SomeClass(string a, params string[] bs) { }
+
+        private int PrivateOverload(object a, string b) => 1492;
+        public int PrivateOverload(string a, params string[] bs) => 1606;
+
+        protected int ProtectedOverload(object a, string b) => 1493;
+        public int ProtectedOverload(string a, params string[] bs) => 1607;
+
+        private protected int PrivateProtectedOverload(object a, string b) => 1494;
+        public int PrivateProtectedOverload(string a, params string[] bs) => 1608;
+
+        protected internal int ProtectedInternalOverload(object a, string b) => 1495;
+        public int ProtectedInternalOverload(string a, params string[] bs) => 1609;
+
+        internal int InternalOverload(object a, string b) => 1496;
+        public int InternalOverload(string a, params string[] bs) => 1610;
+
+        protected virtual int OverriddenAsProtected(object a, string b) => 1497;
+        public int OverriddenAsProtected(string a, params string[] bs) => 1611;
+
+        protected int ShadowedAsPublic(object a, string b) => 1498;
+        public int ShadowedAsPublic(string a, params string[] bs) => 1612;
+
+        protected int ShadowedAsProtectedInternal(object a, string b) => 1499;
+        public int ShadowedAsProtectedInternal(string a, params string[] bs) => 1613;
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.cs
@@ -141,17 +141,17 @@ namespace Repro5430
 {
     public class SomeClass
     {
-        private int InlineInitializedField11 = new SomeClass().PrivateOverload("s1");                  // Compliant
-        private int InlineInitializedField12 = new SomeClass().PrivateOverload("s1", "s2");            // Noncompliant
-        private int InlineInitializedField13 = new SomeClass().PrivateOverload(null, "s2");            // Noncompliant
-        private int InlineInitializedField14 = new SomeClass().PrivateOverload(null, new[] { "s2" });  // Compliant
-        private int InlineInitializedField15 = new SomeClass().PrivateOverload("42", "s1", "s2");      // Compliant
+        private int Field11 = new SomeClass().PrivateOverload("s1");                  // Compliant
+        private int Field12 = new SomeClass().PrivateOverload("s1", "s2");            // Noncompliant
+        private int Field13 = new SomeClass().PrivateOverload(null, "s2");            // Noncompliant
+        private int Field14 = new SomeClass().PrivateOverload(null, new[] { "s2" });  // Compliant
+        private int Field15 = new SomeClass().PrivateOverload("42", "s1", "s2");      // Compliant
 
-        private int InlineInitializedField21 = new SomeClass().InternalOverload("s1");                 // Compliant
-        private int InlineInitializedField22 = new SomeClass().InternalOverload("s1", "s2");           // Noncompliant
-        private int InlineInitializedField23 = new SomeClass().InternalOverload(null, "s2");           // Noncompliant
-        private int InlineInitializedField24 = new SomeClass().InternalOverload(null, new[] { "s2" }); // Compliant
-        private int InlineInitializedField25 = new SomeClass().InternalOverload("42", "s1", "s2");     // Compliant
+        private int Field21 = new SomeClass().InternalOverload("s1");                 // Compliant
+        private int Field22 = new SomeClass().InternalOverload("s1", "s2");           // Noncompliant
+        private int Field23 = new SomeClass().InternalOverload(null, "s2");           // Noncompliant
+        private int Field24 = new SomeClass().InternalOverload(null, new[] { "s2" }); // Compliant
+        private int Field25 = new SomeClass().InternalOverload("42", "s1", "s2");     // Compliant
 
         public SomeClass() { }
         private SomeClass(object a, string b) { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.cs
@@ -141,131 +141,269 @@ namespace Repro5430
 {
     public class SomeClass
     {
-        private SomeClass(int a, string b) { }
-        public SomeClass(int a, params string[] bs) { }
+        private int InlineInitializedField11 = new SomeClass("1", "s1").PrivateOverload("s1");                  // Compliant
+        private int InlineInitializedField12 = new SomeClass("1", "s1").PrivateOverload("s1", "s2");            // Noncompliant
+        private int InlineInitializedField13 = new SomeClass("1", "s1").PrivateOverload(null, "s2");            // Noncompliant
+        private int InlineInitializedField14 = new SomeClass("1", "s1").PrivateOverload(null, new[] { "s2" });  // Compliant
+        private int InlineInitializedField15 = new SomeClass("1", "s1").PrivateOverload("42", "s1", "s2");      // Compliant
 
-        private void PrivateOverloadOtherParams(int a, string b) { }
-        public void PrivateOverloadOtherParams(int a, params string[] bs) { }
+        private int InlineInitializedField21 = new SomeClass("1", "s1").InternalOverload("s1");                 // Compliant
+        private int InlineInitializedField22 = new SomeClass("1", "s1").InternalOverload("s1", "s2");           // Noncompliant
+        private int InlineInitializedField23 = new SomeClass("1", "s1").InternalOverload(null, "s2");           // Noncompliant
+        private int InlineInitializedField24 = new SomeClass("1", "s1").InternalOverload(null, new[] { "s2" }); // Compliant
+        private int InlineInitializedField25 = new SomeClass("1", "s1").InternalOverload("42", "s1", "s2");     // Compliant
 
-        private void PrivateOverloadOnlyParams() { }
-        public void PrivateOverloadOnlyParams(params string[] bs) { }
+        private SomeClass(object a, string b) { }
+        private SomeClass(string a, string b) { }
+        public SomeClass(string a, params string[] bs) { }
 
-        protected void ProtectedOverload() { }
-        public void ProtectedOverload(params string[] bs) { }
+        private int PrivateOverload(object a, string b) => 1492;
+        public int PrivateOverload(string a, params string[] bs) => 1606;
 
-        private protected void PrivateProtectedOverload() { }
-        public void PrivateProtectedOverload(params string[] bs) { }
+        protected int ProtectedOverload(object a, string b) => 1493;
+        public int ProtectedOverload(string a, params string[] bs) => 1607;
 
-        protected internal void ProtectedInternalOverload() { }
-        public void ProtectedInternalOverload(params string[] bs) { }
+        private protected int PrivateProtectedOverload(object a, string b) => 1494;
+        public int PrivateProtectedOverload(string a, params string[] bs) => 1608;
 
-        internal void InternalOverload() { }
-        public void InternalOverload(params string[] bs) { }
+        protected internal int ProtectedInternalOverload(object a, string b) => 1495;
+        public int ProtectedInternalOverload(string a, params string[] bs) => 1609;
 
-        protected virtual void OverriddenAsProtected() { }
-        public void OverriddenAsProtected(params string[] bs) { }
+        internal int InternalOverload(object a, string b) => 1496;
+        public int InternalOverload(string a, params string[] bs) => 1610;
 
-        protected void ShadowedAsPublic() { }
-        public void ShadowedAsPublic(params string[] bs) { }
+        protected virtual int OverriddenAsProtected(object a, string b) => 1497;
+        public int OverriddenAsProtected(string a, params string[] bs) => 1611;
 
-        protected void ShadowedAsProtectedInternal() { }
-        public void ShadowedAsProtectedInternal(params string[] bs) { }
+        protected int ShadowedAsPublic(object a, string b) => 1498;
+        public int ShadowedAsPublic(string a, params string[] bs) => 1612;
+
+        protected int ShadowedAsProtectedInternal(object a, string b) => 1499;
+        public int ShadowedAsProtectedInternal(string a, params string[] bs) => 1613;
+
+        public void AllOverloadsVisibleFromSameClass()
+        {
+            SomeClass x;
+            x = new SomeClass("1");                          // Compliant, can't resolve to non-param overload
+            x = new SomeClass("1", "s1");                    // Compliant, resolves to non-param overload
+            x = new SomeClass(null, "s1");                   // Compliant, resolves to non-param overload
+            x = new SomeClass("1", "s1", "s2");              // Compliant, can't resolve to non-param overload
+            x = new SomeClass(null, "s1", "s2");             // Compliant, can't resolve to non-param overload
+
+            PrivateOverload("42");                           // Compliant
+            PrivateOverload("42", "s1");                     // Noncompliant
+            PrivateOverload(null, "s1");                     // Noncompliant
+            PrivateOverload(null, new[] { "s2" });           // Compliant
+            PrivateOverload("42", "s1", "s2");               // Compliant
+
+            ProtectedOverload("s1");                         // Compliant
+            ProtectedOverload("s1", "s2");                   // Noncompliant
+            ProtectedOverload(null, "s2");                   // Noncompliant
+            ProtectedOverload(null, new[] { "s2" });         // Compliant
+            ProtectedOverload("42", "s1", "s2");             // Compliant
+
+            PrivateProtectedOverload("s1");                  // Compliant
+            PrivateProtectedOverload("s1", "s2");            // Noncompliant
+            PrivateProtectedOverload(null, "s2");            // Noncompliant
+            PrivateProtectedOverload(null, new[] { "s2" });  // Compliant
+            PrivateProtectedOverload("42", "s1", "s2");      // Compliant
+
+            ProtectedInternalOverload("s1");                 // Compliant
+            ProtectedInternalOverload("s1", "s2");           // Noncompliant
+            ProtectedInternalOverload(null, "s2");           // Noncompliant
+            ProtectedInternalOverload(null, new[] { "s2" }); // Compliant
+            ProtectedInternalOverload("42", "s1", "s2");     // Compliant
+
+            InternalOverload("s1");                          // Compliant
+            InternalOverload("s1", "s2");                    // Noncompliant
+            InternalOverload(null, "s2");                    // Noncompliant
+            InternalOverload(null, new[] { "s2" });          // Compliant
+            InternalOverload("42", "s1", "s2");              // Compliant
+        }
 
         public class NestedClass
         {
-            public void Basics()
+            public void AllOverloadsVisibleFromWithinNestedClass()
             {
-                SomeClass x;
-                x = new SomeClass(1);                         // Noncompliant
-                x = new SomeClass(1, "s1");                   // Noncompliant
-                x = new SomeClass(1, "s1", "s2");             // Noncompliant
-
-                x.PrivateOverloadOtherParams(42);             // Noncompliant
-                x.PrivateOverloadOtherParams(42, "s1");       // Noncompliant
-                x.PrivateOverloadOtherParams(42, "s1", "s2"); // Noncompliant
-
-                x.PrivateOverloadOnlyParams();                // Noncompliant
-                x.PrivateOverloadOnlyParams("s1");            // Noncompliant
-                x.PrivateOverloadOnlyParams("s1", "s2");      // Noncompliant
-
-                x.ProtectedOverload();                        // Noncompliant
-                x.ProtectedOverload("s1");                    // Noncompliant
-                x.ProtectedOverload("s1", "s2");              // Noncompliant
-
-                x.PrivateProtectedOverload();                 // Noncompliant
-                x.PrivateProtectedOverload("s1");             // Noncompliant
-                x.PrivateProtectedOverload("s1", "s2");       // Noncompliant
-
-                x.ProtectedInternalOverload();                // Noncompliant
-                x.ProtectedInternalOverload("s1");            // Noncompliant
-                x.ProtectedInternalOverload("s1", "s2");      // Noncompliant
-
-                x.InternalOverload();                         // Noncompliant
-                x.InternalOverload("s1");                     // Noncompliant
-                x.InternalOverload("s1", "s2");               // Noncompliant
+                var x = new SomeClass("1", "s1");
+                x.PrivateOverload("42");                 // Compliant
+                x.PrivateOverload("42", "s1");           // Noncompliant
+                x.PrivateOverload(null, "s1");           // Noncompliant
+                x.PrivateOverload(null, new[] { "s2" }); // Compliant
+                x.PrivateOverload("42", "s1", "s2");     // Compliant
             }
+
+            public struct Nested2ndLevel
+            {
+                public void AllOverloadsVisibleFromWithinNested2ndLevel()
+                {
+                    var x = new SomeClass("1", "s1");
+                    x.PrivateOverload("42");                 // Compliant
+                    x.PrivateOverload("42", "s1");           // Noncompliant
+                    x.PrivateOverload(null, "s1");           // Noncompliant
+                    x.PrivateOverload(null, new[] { "s2" }); // Compliant
+                    x.PrivateOverload("42", "s1", "s2");     // Compliant
+                }
+            }
+        }
+    }
+
+    public class OtherClass
+    {
+        private int InlineInitializedField11 = new SomeClass("1", "s1").PrivateOverload("s1");                  // Compliant
+        private int InlineInitializedField12 = new SomeClass("1", "s1").PrivateOverload("s1", "s2");            // Compliant
+        private int InlineInitializedField13 = new SomeClass("1", "s1").PrivateOverload(null, "s2");            // Compliant
+        private int InlineInitializedField14 = new SomeClass("1", "s1").PrivateOverload(null, new[] { "s2" });  // Compliant
+        private int InlineInitializedField15 = new SomeClass("1", "s1").PrivateOverload("42", "s1", "s2");      // Compliant
+
+        private int InlineInitializedField21 = new SomeClass("1", "s1").InternalOverload("s1");                 // Compliant
+        private int InlineInitializedField22 = new SomeClass("1", "s1").InternalOverload("s1", "s2");           // Noncompliant
+        private int InlineInitializedField23 = new SomeClass("1", "s1").InternalOverload(null, "s2");           // Noncompliant
+        private int InlineInitializedField24 = new SomeClass("1", "s1").InternalOverload(null, new[] { "s2" }); // Compliant
+        private int InlineInitializedField25 = new SomeClass("1", "s1").InternalOverload("42", "s1", "s2");     // Compliant
+
+        public int this[int i]
+        {
+            get
+            {
+                var x = new SomeClass("1", "s1");
+                x.InternalOverload("s1");                      // Compliant
+                x.InternalOverload("s1", "s2");                // Noncompliant
+                x.InternalOverload(null, "s2");                // Noncompliant
+                x.InternalOverload(null, new[] { "s2" });      // Compliant
+                x.InternalOverload("42", "s1", "s2");          // Compliant
+                return 42;
+            }
+        }
+
+        public int CheckAccessibilityInProperty
+        {
+            get
+            {
+                var x = new SomeClass("1", "s1");
+                x.InternalOverload("s1");                      // Compliant
+                x.InternalOverload("s1", "s2");                // Noncompliant
+                x.InternalOverload(null, "s2");                // Noncompliant
+                x.InternalOverload(null, new[] { "s2" });      // Compliant
+                x.InternalOverload("42", "s1", "s2");          // Compliant
+                return 42;
+            }
+        }
+
+        public void CheckAccessibilityInMethod()
+        {
+            SomeClass x;
+            x = new SomeClass("1");                            // Compliant, can't see non-param overload
+            x = new SomeClass("1", "s1");                      // Compliant, can't see non-param overload
+            x = new SomeClass(null, "s1");                     // Compliant, can't see non-param overload
+            x = new SomeClass("1", "s1", "s2");                // Compliant, can't see non-param overload
+            x = new SomeClass(null, "s1", "s2");               // Compliant, can't see non-param overload
+
+            x.PrivateOverload("42");                           // Compliant
+            x.PrivateOverload("42", "s1");                     // Compliant
+            x.PrivateOverload(null, "s1");                     // Compliant
+            x.PrivateOverload(null, new[] { "s2" });           // Compliant
+            x.PrivateOverload("42", "s1", "s2");               // Compliant
+
+            x.ProtectedOverload("s1");                         // Compliant
+            x.ProtectedOverload("s1", "s2");                   // Compliant
+            x.ProtectedOverload(null, "s2");                   // Compliant
+            x.ProtectedOverload(null, new[] { "s2" });         // Compliant
+            x.ProtectedOverload("42", "s1", "s2");             // Compliant
+
+            x.PrivateProtectedOverload("s1");                  // Compliant
+            x.PrivateProtectedOverload("s1", "s2");            // Compliant
+            x.PrivateProtectedOverload(null, "s2");            // Compliant
+            x.PrivateProtectedOverload(null, new[] { "s2" });  // Compliant
+            x.PrivateProtectedOverload("42", "s1", "s2");      // Compliant
+
+            x.ProtectedInternalOverload("s1");                 // Compliant
+            x.ProtectedInternalOverload("s1", "s2");           // Noncompliant
+            x.ProtectedInternalOverload(null, "s2");           // Noncompliant
+            x.ProtectedInternalOverload(null, new[] { "s2" }); // Compliant
+            x.ProtectedInternalOverload("42", "s1", "s2");     // Compliant
+
+            x.InternalOverload("s1");                          // Compliant
+            x.InternalOverload("s1", "s2");                    // Noncompliant
+            x.InternalOverload(null, "s2");                    // Noncompliant
+            x.InternalOverload(null, new[] { "s2" });          // Compliant
+            x.InternalOverload("42", "s1", "s2");              // Compliant
         }
     }
 
     public class SubClass : SomeClass
     {
-        public SubClass(int a, params string[] bs) : base(a, bs) { }
+        public SubClass(string a, params string[] bs) : base(a, bs) { }
 
-        protected override void OverriddenAsProtected() { }
+        protected override int OverriddenAsProtected(object a, string b) => 2494;
 
-        public new void ShadowedAsPublic() { }
+        public new int ShadowedAsPublic(object a, string b) => 2498;
 
-        protected internal new void ShadowedAsProtectedInternal() { }
-    }
+        protected internal new int ShadowedAsProtectedInternal(object a, string b) => 2499;
 
-    public class OtherClass
-    {
-        public void Basics()
+        public void OverridenAndShadowedAccessibility()
         {
-            SomeClass x;
-            x = new SomeClass(2);                         // Compliant
-            x = new SomeClass(2, "s1");                   // Compliant
-            x = new SomeClass(2, "s1", "s2");             // Compliant
+            var x = new SubClass("3");
+            x.OverriddenAsProtected("42");                       // Compliant
+            x.OverriddenAsProtected("42", "s1");                 // Noncompliant, overrides doesn't change priority
+            x.OverriddenAsProtected(null, "s1");                 // Noncompliant, overrides doesn't change priority
+            x.OverriddenAsProtected(null, new[] { "s2" });       // Compliant
+            x.OverriddenAsProtected("42", "s1", "s2");           // Compliant
 
-            x.PrivateOverloadOtherParams(42);             // Compliant
-            x.PrivateOverloadOtherParams(42, "s1");       // Compliant
-            x.PrivateOverloadOtherParams(42, "s1", "s2"); // Compliant
+            x.ShadowedAsPublic("s1");                            // Compliant
+            x.ShadowedAsPublic("s1", "s2");                      // Compliant, shadowing method takes priority
+            x.ShadowedAsPublic(null, "s1");                      // Compliant, shadowing method takes priority
+            x.ShadowedAsPublic(null, new[] { "s2" });            // Compliant
+            x.ShadowedAsPublic("42", "s1", "s2");                // Compliant
 
-            x.PrivateOverloadOnlyParams();                // Compliant
-            x.PrivateOverloadOnlyParams("s1");            // Compliant
-            x.PrivateOverloadOnlyParams("s1", "s2");      // Compliant
-
-            x.ProtectedOverload();                        // Compliant
-            x.ProtectedOverload("s1");                    // Compliant
-            x.ProtectedOverload("s1", "s2");              // Compliant
-
-            x.PrivateProtectedOverload();                 // Compliant
-            x.PrivateProtectedOverload("s1");             // Compliant
-            x.PrivateProtectedOverload("s1", "s2");       // Compliant
-
-            x.ProtectedInternalOverload();                // Noncompliant
-            x.ProtectedInternalOverload("s1");            // Noncompliant
-            x.ProtectedInternalOverload("s1", "s2");      // Noncompliant
-
-            x.InternalOverload();                         // Noncompliant
-            x.InternalOverload("s1");                     // Noncompliant
-            x.InternalOverload("s1", "s2");               // Noncompliant
+            x.ShadowedAsProtectedInternal("s1");                 // Compliant
+            x.ShadowedAsProtectedInternal("s1", "s2");           // Compliant, shadowing method takes priority
+            x.ShadowedAsProtectedInternal(null, "s1");           // Compliant, shadowing method takes priority
+            x.ShadowedAsProtectedInternal(null, new[] { "s2" }); // Compliant
+            x.ShadowedAsProtectedInternal("42", "s1", "s2");     // Compliant
         }
 
-        public void Overrides()
+        public class NestedClass
         {
-            var x = new SubClass(3);
-            x.OverriddenAsProtected();                 // Compliant
-            x.OverriddenAsProtected("s1");             // Compliant
-            x.OverriddenAsProtected("s1", "s2");       // Compliant
+            public void AllOverloadsVisibleFromWithinNestedClass()
+            {
+                var x = new SomeClass("1", "s1");
+                x.PrivateOverload("42");                 // Compliant
+                x.PrivateOverload("42", "s1");           // Compliant
+                x.PrivateOverload(null, "s1");           // Compliant
+                x.PrivateOverload(null, new[] { "s2" }); // Compliant
+                x.PrivateOverload("42", "s1", "s2");     // Compliant
+            }
+        }
+    }
 
-            x.ShadowedAsPublic();                      // Noncompliant
-            x.ShadowedAsPublic("s1");                  // Noncompliant
-            x.ShadowedAsPublic("s1", "s2");            // Noncompliant
+    public class SubClassOfClassFromAnotherAssembly : FromAnotherAssembly
+    {
+        public void AccessibilityAcrossAssemblies()
+        {
+            ProtectedOverload("42");                         // Compliant
+            ProtectedOverload("42", "s1");                   // Noncompliant, protected visible across assemblies
+            ProtectedOverload(null, "s1");                   // Noncompliant, protected visible across assemblies
+            ProtectedOverload(null, new[] { "s2" });         // Compliant
+            ProtectedOverload("42", "s1", "s2");             // Compliant
 
-            x.ShadowedAsProtectedInternal();           // Noncompliant
-            x.ShadowedAsProtectedInternal("s1");       // Noncompliant
-            x.ShadowedAsProtectedInternal("s1", "s2"); // Noncompliant
+            PrivateProtectedOverload("42");                  // Compliant
+            PrivateProtectedOverload("42", "s1");            // Compliant, private protected not visible across assemblies
+            PrivateProtectedOverload(null, "s1");            // Compliant, private protected not visible across assemblies
+            PrivateProtectedOverload(null, new[] { "s2" });  // Compliant
+            PrivateProtectedOverload("42", "s1", "s2");      // Compliant
+
+            ProtectedInternalOverload("42");                 // Compliant
+            ProtectedInternalOverload("42", "s1");           // Noncompliant, protected internal visible across assemblies
+            ProtectedInternalOverload(null, "s1");           // Noncompliant, protected internal visible across assemblies
+            ProtectedInternalOverload(null, new[] { "s2" }); // Compliant
+            ProtectedInternalOverload("42", "s1", "s2");     // Compliant
+
+            InternalOverload("42");                          // Compliant
+            InternalOverload("42", "s1");                    // Compliant, internal not visible across assemblies
+            InternalOverload(null, "s1");                    // Compliant, internal not visible across assemblies
+            InternalOverload(null, new[] { "s2" });          // Compliant
+            InternalOverload("42", "s1", "s2");              // Compliant
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.cs
@@ -2,139 +2,136 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace Tests.Diagnostics
+class InvocationResolvesToOverrideWithParams
 {
-    class InvocationResolvesToOverrideWithParams
+    public static void Test(int foo, params object[] p)
     {
-        public static void Test(int foo, params object[] p)
-        {
-            Console.WriteLine("test1");
-        }
-
-        public static void Test(double foo, object p1)
-        {
-            Console.WriteLine("test2");
-        }
-
-        static void Main(string[] args)
-        {
-            Test(42, null); // Noncompliant {{Review this call, which partially matches an overload without 'params'. The partial match is 'void InvocationResolvesToOverrideWithParams.Test(double foo, object p1)'.}}
-//          ^^^^^^^^^^^^^^
-        }
-
-        public InvocationResolvesToOverrideWithParams(string a, params object[] b)
-        {
-
-        }
-        public InvocationResolvesToOverrideWithParams(object a, object b, object c)
-        {
-
-        }
-
-        private void Format(string a, params object[] b) { }
-
-        private void Format(object a, object b, object c, object d = null) { }
-
-        private void Format2(string a, params object[] b) { }
-
-        private void Format2(int a, object b, object c) { }
-
-        private void Format3(params int[] a) { }
-
-        private void Format3(IEnumerable<int> a) { }
-
-        private void Format4(params object[] a) { }
-
-        private void Format4(object o, IEnumerable<object> a) { }
-
-        private void m()
-        {
-            Format("", null, null); //Noncompliant
-            Format(new object(), null, null);
-            Format("", new object[0]);
-
-            Format2("", null, null); //Compliant
-
-            new InvocationResolvesToOverrideWithParams("", null, null); //Noncompliant
-            new InvocationResolvesToOverrideWithParams(new object(), null, null);
-
-            Format3(new int[0]); //Compliant, although it is also an IEnumerable<int>
-
-            Format4(new object(), new int[0]); //Noncompliant
-
-            Format3(null); //Noncompliant, maybe it could be compliant
-            string.Concat("aaaa"); //Noncompliant, resolves to params, but there's a single object version too.
-
-            Console.WriteLine("format", 0, 1, "", ""); //Compliant
-        }
+        Console.WriteLine("test1");
     }
 
-    public class MyClass
+    public static void Test(double foo, object p1)
     {
-        public void Format(string a, params object[] b) { }
-        public void Format() { } // The presence of this method causes the issue
-
-        public void Test()
-        {
-            Format("", null, null);
-        }
+        Console.WriteLine("test2");
     }
 
-    public class Test
+    static void Main(string[] args)
     {
-        public void MyMethod(params string[] s) { }
-        public void MyMethod(Test s) { }
-
-        public Test()
-        {
-            MyMethod(""); // Compliant
-        }
+        Test(42, null); // Noncompliant {{Review this call, which partially matches an overload without 'params'. The partial match is 'void InvocationResolvesToOverrideWithParams.Test(double foo, object p1)'.}}
+//      ^^^^^^^^^^^^^^
     }
 
-    public class Test2
+    public InvocationResolvesToOverrideWithParams(string a, params object[] b)
     {
-        public static implicit operator Test2(string s) { return null; }
 
-        public void MyMethod(params string[] s) { }
-        public void MyMethod(Test2 s) { }
+    }
+    public InvocationResolvesToOverrideWithParams(object a, object b, object c)
+    {
 
-        public Test2()
-        {
-            MyMethod(""); // Noncompliant
-        }
     }
 
-    // See https://github.com/SonarSource/sonar-dotnet/issues/2234
-    public class FuncAndActionCases
-    {
-        static void Main(string[] args)
-        {
-            M1(() => Console.WriteLine("hi"));
-        }
+    private void Format(string a, params object[] b) { }
 
-        public static void M1(params Action[] a) { }
-        public static void M1<T>(Func<T> f) { }
-        public static void M1(Func<Task> f) { }
+    private void Format(object a, object b, object c, object d = null) { }
+
+    private void Format2(string a, params object[] b) { }
+
+    private void Format2(int a, object b, object c) { }
+
+    private void Format3(params int[] a) { }
+
+    private void Format3(IEnumerable<int> a) { }
+
+    private void Format4(params object[] a) { }
+
+    private void Format4(object o, IEnumerable<object> a) { }
+
+    private void m()
+    {
+        Format("", null, null); // Noncompliant
+        Format(new object(), null, null);
+        Format("", new object[0]);
+
+        Format2("", null, null); // Compliant
+
+        new InvocationResolvesToOverrideWithParams("", null, null); //Noncompliant
+        new InvocationResolvesToOverrideWithParams(new object(), null, null);
+
+        Format3(new int[0]); //Compliant, although it is also an IEnumerable<int>
+
+        Format4(new object(), new int[0]); // Noncompliant
+
+        Format3(null); // Noncompliant, maybe it could be compliant
+        string.Concat("aaaa"); // Noncompliant, resolves to params, but there's a single object version too.
+
+        Console.WriteLine("format", 0, 1, "", ""); // Compliant
+    }
+}
+
+public class MyClass
+{
+    public void Format(string a, params object[] b) { }
+    public void Format() { } // The presence of this method causes the issue
+
+    public void Test()
+    {
+        Format("", null, null);
+    }
+}
+
+public class Test
+{
+    public void MyMethod(params string[] s) { }
+    public void MyMethod(Test s) { }
+
+    public Test()
+    {
+        MyMethod(""); // Compliant
+    }
+}
+
+public class Test2
+{
+    public static implicit operator Test2(string s) { return null; }
+
+    public void MyMethod(params string[] s) { }
+    public void MyMethod(Test2 s) { }
+
+    public Test2()
+    {
+        MyMethod(""); // Noncompliant
+    }
+}
+
+// See https://github.com/SonarSource/sonar-dotnet/issues/2234
+public class FuncAndActionCases
+{
+    static void Main(string[] args)
+    {
+        M1(() => Console.WriteLine("hi"));
     }
 
-    public class WithLocalFunctions
+    public static void M1(params Action[] a) { }
+    public static void M1<T>(Func<T> f) { }
+    public static void M1(Func<Task> f) { }
+}
+
+public class WithLocalFunctions
+{
+    public static void Test(int foo, params object[] p)
     {
-        public static void Test(int foo, params object[] p)
-        {
-            Console.WriteLine("test1");
-        }
+        Console.WriteLine("test1");
+    }
 
-        public static void Test(double foo, object p1)
-        {
-            Console.WriteLine("test2");
-        }
+    public static void Test(double foo, object p1)
+    {
+        Console.WriteLine("test2");
+    }
 
-        public void Method()
+    public void Method()
+    {
+        static void Call()
         {
-            static void Call()
-            {
-                Test(42, null); // Noncompliant {{Review this call, which partially matches an overload without 'params'. The partial match is 'void WithLocalFunctions.Test(double foo, object p1)'.}}
-            }
+            Test(42, null); // Noncompliant {{Review this call, which partially matches an overload without 'params'. The partial match is 'void WithLocalFunctions.Test(double foo, object p1)'.}}
         }
     }
 }
@@ -147,16 +144,128 @@ namespace Repro5430
         private SomeClass(int a, string b) { }
         public SomeClass(int a, params string[] bs) { }
 
-        private void SomeMethod(int a, string b) { }
-        public void SomeMethod(int a, params string[] bs) { }
+        private void PrivateOverloadOtherParams(int a, string b) { }
+        public void PrivateOverloadOtherParams(int a, params string[] bs) { }
+
+        private void PrivateOverloadOnlyParams() { }
+        public void PrivateOverloadOnlyParams(params string[] bs) { }
+
+        protected void ProtectedOverload() { }
+        public void ProtectedOverload(params string[] bs) { }
+
+        private protected void PrivateProtectedOverload() { }
+        public void PrivateProtectedOverload(params string[] bs) { }
+
+        protected internal void ProtectedInternalOverload() { }
+        public void ProtectedInternalOverload(params string[] bs) { }
+
+        internal void InternalOverload() { }
+        public void InternalOverload(params string[] bs) { }
+
+        protected virtual void OverriddenAsProtected() { }
+        public void OverriddenAsProtected(params string[] bs) { }
+
+        protected void ShadowedAsPublic() { }
+        public void ShadowedAsPublic(params string[] bs) { }
+
+        protected void ShadowedAsProtectedInternal() { }
+        public void ShadowedAsProtectedInternal(params string[] bs) { }
+
+        public class NestedClass
+        {
+            public void Basics()
+            {
+                SomeClass x;
+                x = new SomeClass(1);                         // Noncompliant
+                x = new SomeClass(1, "s1");                   // Noncompliant
+                x = new SomeClass(1, "s1", "s2");             // Noncompliant
+
+                x.PrivateOverloadOtherParams(42);             // Noncompliant
+                x.PrivateOverloadOtherParams(42, "s1");       // Noncompliant
+                x.PrivateOverloadOtherParams(42, "s1", "s2"); // Noncompliant
+
+                x.PrivateOverloadOnlyParams();                // Noncompliant
+                x.PrivateOverloadOnlyParams("s1");            // Noncompliant
+                x.PrivateOverloadOnlyParams("s1", "s2");      // Noncompliant
+
+                x.ProtectedOverload();                        // Noncompliant
+                x.ProtectedOverload("s1");                    // Noncompliant
+                x.ProtectedOverload("s1", "s2");              // Noncompliant
+
+                x.PrivateProtectedOverload();                 // Noncompliant
+                x.PrivateProtectedOverload("s1");             // Noncompliant
+                x.PrivateProtectedOverload("s1", "s2");       // Noncompliant
+
+                x.ProtectedInternalOverload();                // Noncompliant
+                x.ProtectedInternalOverload("s1");            // Noncompliant
+                x.ProtectedInternalOverload("s1", "s2");      // Noncompliant
+
+                x.InternalOverload();                         // Noncompliant
+                x.InternalOverload("s1");                     // Noncompliant
+                x.InternalOverload("s1", "s2");               // Noncompliant
+            }
+        }
+    }
+
+    public class SubClass : SomeClass
+    {
+        public SubClass(int a, params string[] bs) : base(a, bs) { }
+
+        protected override void OverriddenAsProtected() { }
+
+        public new void ShadowedAsPublic() { }
+
+        protected internal new void ShadowedAsProtectedInternal() { }
     }
 
     public class OtherClass
     {
-        public void SomeOtherMethod()
+        public void Basics()
         {
-            var x = new SomeClass(42, "SomeString"); // Noncompliant FP
-            x.SomeMethod(42, "SomeString"); // Noncompliant FP
+            SomeClass x;
+            x = new SomeClass(2);                         // Compliant
+            x = new SomeClass(2, "s1");                   // Compliant
+            x = new SomeClass(2, "s1", "s2");             // Compliant
+
+            x.PrivateOverloadOtherParams(42);             // Compliant
+            x.PrivateOverloadOtherParams(42, "s1");       // Compliant
+            x.PrivateOverloadOtherParams(42, "s1", "s2"); // Compliant
+
+            x.PrivateOverloadOnlyParams();                // Compliant
+            x.PrivateOverloadOnlyParams("s1");            // Compliant
+            x.PrivateOverloadOnlyParams("s1", "s2");      // Compliant
+
+            x.ProtectedOverload();                        // Compliant
+            x.ProtectedOverload("s1");                    // Compliant
+            x.ProtectedOverload("s1", "s2");              // Compliant
+
+            x.PrivateProtectedOverload();                 // Compliant
+            x.PrivateProtectedOverload("s1");             // Compliant
+            x.PrivateProtectedOverload("s1", "s2");       // Compliant
+
+            x.ProtectedInternalOverload();                // Noncompliant
+            x.ProtectedInternalOverload("s1");            // Noncompliant
+            x.ProtectedInternalOverload("s1", "s2");      // Noncompliant
+
+            x.InternalOverload();                         // Noncompliant
+            x.InternalOverload("s1");                     // Noncompliant
+            x.InternalOverload("s1", "s2");               // Noncompliant
+        }
+
+        public void Overrides()
+        {
+            var x = new SubClass(3);
+            x.OverriddenAsProtected();                 // Compliant
+            x.OverriddenAsProtected("s1");             // Compliant
+            x.OverriddenAsProtected("s1", "s2");       // Compliant
+
+            x.ShadowedAsPublic();                      // Noncompliant
+            x.ShadowedAsPublic("s1");                  // Noncompliant
+            x.ShadowedAsPublic("s1", "s2");            // Noncompliant
+
+            x.ShadowedAsProtectedInternal();           // Noncompliant
+            x.ShadowedAsProtectedInternal("s1");       // Noncompliant
+            x.ShadowedAsProtectedInternal("s1", "s2"); // Noncompliant
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.cs
@@ -136,50 +136,51 @@ public class WithLocalFunctions
     }
 }
 
-// Reproducer for https://github.com/SonarSource/sonar-dotnet/issues/5430
+// https://github.com/SonarSource/sonar-dotnet/issues/5430
 namespace Repro5430
 {
     public class SomeClass
     {
-        private int InlineInitializedField11 = new SomeClass("1", "s1").PrivateOverload("s1");                  // Compliant
-        private int InlineInitializedField12 = new SomeClass("1", "s1").PrivateOverload("s1", "s2");            // Noncompliant
-        private int InlineInitializedField13 = new SomeClass("1", "s1").PrivateOverload(null, "s2");            // Noncompliant
-        private int InlineInitializedField14 = new SomeClass("1", "s1").PrivateOverload(null, new[] { "s2" });  // Compliant
-        private int InlineInitializedField15 = new SomeClass("1", "s1").PrivateOverload("42", "s1", "s2");      // Compliant
+        private int InlineInitializedField11 = new SomeClass().PrivateOverload("s1");                  // Compliant
+        private int InlineInitializedField12 = new SomeClass().PrivateOverload("s1", "s2");            // Noncompliant
+        private int InlineInitializedField13 = new SomeClass().PrivateOverload(null, "s2");            // Noncompliant
+        private int InlineInitializedField14 = new SomeClass().PrivateOverload(null, new[] { "s2" });  // Compliant
+        private int InlineInitializedField15 = new SomeClass().PrivateOverload("42", "s1", "s2");      // Compliant
 
-        private int InlineInitializedField21 = new SomeClass("1", "s1").InternalOverload("s1");                 // Compliant
-        private int InlineInitializedField22 = new SomeClass("1", "s1").InternalOverload("s1", "s2");           // Noncompliant
-        private int InlineInitializedField23 = new SomeClass("1", "s1").InternalOverload(null, "s2");           // Noncompliant
-        private int InlineInitializedField24 = new SomeClass("1", "s1").InternalOverload(null, new[] { "s2" }); // Compliant
-        private int InlineInitializedField25 = new SomeClass("1", "s1").InternalOverload("42", "s1", "s2");     // Compliant
+        private int InlineInitializedField21 = new SomeClass().InternalOverload("s1");                 // Compliant
+        private int InlineInitializedField22 = new SomeClass().InternalOverload("s1", "s2");           // Noncompliant
+        private int InlineInitializedField23 = new SomeClass().InternalOverload(null, "s2");           // Noncompliant
+        private int InlineInitializedField24 = new SomeClass().InternalOverload(null, new[] { "s2" }); // Compliant
+        private int InlineInitializedField25 = new SomeClass().InternalOverload("42", "s1", "s2");     // Compliant
 
+        public SomeClass() { }
         private SomeClass(object a, string b) { }
         private SomeClass(string a, string b) { }
         public SomeClass(string a, params string[] bs) { }
 
-        private int PrivateOverload(object a, string b) => 1492;
-        public int PrivateOverload(string a, params string[] bs) => 1606;
+        private int PrivateOverload(object a, string b) => 42;
+        public int PrivateOverload(string a, params string[] bs) => 42;
 
-        protected int ProtectedOverload(object a, string b) => 1493;
-        public int ProtectedOverload(string a, params string[] bs) => 1607;
+        protected int ProtectedOverload(object a, string b) => 42;
+        public int ProtectedOverload(string a, params string[] bs) => 42;
 
-        private protected int PrivateProtectedOverload(object a, string b) => 1494;
-        public int PrivateProtectedOverload(string a, params string[] bs) => 1608;
+        private protected int PrivateProtectedOverload(object a, string b) => 42;
+        public int PrivateProtectedOverload(string a, params string[] bs) => 42;
 
-        protected internal int ProtectedInternalOverload(object a, string b) => 1495;
-        public int ProtectedInternalOverload(string a, params string[] bs) => 1609;
+        protected internal int ProtectedInternalOverload(object a, string b) => 42;
+        public int ProtectedInternalOverload(string a, params string[] bs) => 42;
 
-        internal int InternalOverload(object a, string b) => 1496;
-        public int InternalOverload(string a, params string[] bs) => 1610;
+        internal int InternalOverload(object a, string b) => 42;
+        public int InternalOverload(string a, params string[] bs) => 42;
 
-        protected virtual int OverriddenAsProtected(object a, string b) => 1497;
-        public int OverriddenAsProtected(string a, params string[] bs) => 1611;
+        protected virtual int OverriddenAsProtected(object a, string b) => 42;
+        public int OverriddenAsProtected(string a, params string[] bs) => 42;
 
-        protected int ShadowedAsPublic(object a, string b) => 1498;
-        public int ShadowedAsPublic(string a, params string[] bs) => 1612;
+        protected int ShadowedAsPublic(object a, string b) => 42;
+        public int ShadowedAsPublic(string a, params string[] bs) => 42;
 
-        protected int ShadowedAsProtectedInternal(object a, string b) => 1499;
-        public int ShadowedAsProtectedInternal(string a, params string[] bs) => 1613;
+        protected int ShadowedAsProtectedInternal(object a, string b) => 42;
+        public int ShadowedAsProtectedInternal(string a, params string[] bs) => 42;
 
         public void AllOverloadsVisibleFromSameClass()
         {
@@ -225,7 +226,7 @@ namespace Repro5430
         {
             public void AllOverloadsVisibleFromWithinNestedClass()
             {
-                var x = new SomeClass("1", "s1");
+                var x = new SomeClass();
                 x.PrivateOverload("42");                 // Compliant
                 x.PrivateOverload("42", "s1");           // Noncompliant
                 x.PrivateOverload(null, "s1");           // Noncompliant
@@ -237,7 +238,7 @@ namespace Repro5430
             {
                 public void AllOverloadsVisibleFromWithinNested2ndLevel()
                 {
-                    var x = new SomeClass("1", "s1");
+                    var x = new SomeClass();
                     x.PrivateOverload("42");                 // Compliant
                     x.PrivateOverload("42", "s1");           // Noncompliant
                     x.PrivateOverload(null, "s1");           // Noncompliant
@@ -250,23 +251,23 @@ namespace Repro5430
 
     public class OtherClass
     {
-        private int InlineInitializedField11 = new SomeClass("1", "s1").PrivateOverload("s1");                  // Compliant
-        private int InlineInitializedField12 = new SomeClass("1", "s1").PrivateOverload("s1", "s2");            // Compliant
-        private int InlineInitializedField13 = new SomeClass("1", "s1").PrivateOverload(null, "s2");            // Compliant
-        private int InlineInitializedField14 = new SomeClass("1", "s1").PrivateOverload(null, new[] { "s2" });  // Compliant
-        private int InlineInitializedField15 = new SomeClass("1", "s1").PrivateOverload("42", "s1", "s2");      // Compliant
+        private int InlineInitializedField11 = new SomeClass().PrivateOverload("s1");                  // Compliant
+        private int InlineInitializedField12 = new SomeClass().PrivateOverload("s1", "s2");            // Compliant
+        private int InlineInitializedField13 = new SomeClass().PrivateOverload(null, "s2");            // Compliant
+        private int InlineInitializedField14 = new SomeClass().PrivateOverload(null, new[] { "s2" });  // Compliant
+        private int InlineInitializedField15 = new SomeClass().PrivateOverload("42", "s1", "s2");      // Compliant
 
-        private int InlineInitializedField21 = new SomeClass("1", "s1").InternalOverload("s1");                 // Compliant
-        private int InlineInitializedField22 = new SomeClass("1", "s1").InternalOverload("s1", "s2");           // Noncompliant
-        private int InlineInitializedField23 = new SomeClass("1", "s1").InternalOverload(null, "s2");           // Noncompliant
-        private int InlineInitializedField24 = new SomeClass("1", "s1").InternalOverload(null, new[] { "s2" }); // Compliant
-        private int InlineInitializedField25 = new SomeClass("1", "s1").InternalOverload("42", "s1", "s2");     // Compliant
+        private int InlineInitializedField21 = new SomeClass().InternalOverload("s1");                 // Compliant
+        private int InlineInitializedField22 = new SomeClass().InternalOverload("s1", "s2");           // Noncompliant
+        private int InlineInitializedField23 = new SomeClass().InternalOverload(null, "s2");           // Noncompliant
+        private int InlineInitializedField24 = new SomeClass().InternalOverload(null, new[] { "s2" }); // Compliant
+        private int InlineInitializedField25 = new SomeClass().InternalOverload("42", "s1", "s2");     // Compliant
 
         public int this[int i]
         {
             get
             {
-                var x = new SomeClass("1", "s1");
+                var x = new SomeClass();
                 x.InternalOverload("s1");                      // Compliant
                 x.InternalOverload("s1", "s2");                // Noncompliant
                 x.InternalOverload(null, "s2");                // Noncompliant
@@ -280,7 +281,7 @@ namespace Repro5430
         {
             get
             {
-                var x = new SomeClass("1", "s1");
+                var x = new SomeClass();
                 x.InternalOverload("s1");                      // Compliant
                 x.InternalOverload("s1", "s2");                // Noncompliant
                 x.InternalOverload(null, "s2");                // Noncompliant
@@ -293,11 +294,11 @@ namespace Repro5430
         public void CheckAccessibilityInMethod()
         {
             SomeClass x;
-            x = new SomeClass("1");                            // Compliant, can't see non-param overload
-            x = new SomeClass("1", "s1");                      // Compliant, can't see non-param overload
-            x = new SomeClass(null, "s1");                     // Compliant, can't see non-param overload
-            x = new SomeClass("1", "s1", "s2");                // Compliant, can't see non-param overload
-            x = new SomeClass(null, "s1", "s2");               // Compliant, can't see non-param overload
+            x = new SomeClass("1");                            // Compliant, can't see non-param overload because it's private
+            x = new SomeClass("1", "s1");                      // Compliant
+            x = new SomeClass(null, "s1");                     // Compliant
+            x = new SomeClass("1", "s1", "s2");                // Compliant
+            x = new SomeClass(null, "s1", "s2");               // Compliant
 
             x.PrivateOverload("42");                           // Compliant
             x.PrivateOverload("42", "s1");                     // Compliant
@@ -333,17 +334,18 @@ namespace Repro5430
 
     public class SubClass : SomeClass
     {
+        public SubClass(): base() { }
         public SubClass(string a, params string[] bs) : base(a, bs) { }
 
-        protected override int OverriddenAsProtected(object a, string b) => 2494;
+        protected override int OverriddenAsProtected(object a, string b) => 42;
 
-        public new int ShadowedAsPublic(object a, string b) => 2498;
+        public new int ShadowedAsPublic(object a, string b) => 42;
 
-        protected internal new int ShadowedAsProtectedInternal(object a, string b) => 2499;
+        protected internal new int ShadowedAsProtectedInternal(object a, string b) => 42;
 
         public void OverridenAndShadowedAccessibility()
         {
-            var x = new SubClass("3");
+            var x = new SubClass();
             x.OverriddenAsProtected("42");                       // Compliant
             x.OverriddenAsProtected("42", "s1");                 // Noncompliant, overrides doesn't change priority
             x.OverriddenAsProtected(null, "s1");                 // Noncompliant, overrides doesn't change priority
@@ -367,7 +369,7 @@ namespace Repro5430
         {
             public void AllOverloadsVisibleFromWithinNestedClass()
             {
-                var x = new SomeClass("1", "s1");
+                var x = new SomeClass();
                 x.PrivateOverload("42");                 // Compliant
                 x.PrivateOverload("42", "s1");           // Compliant
                 x.PrivateOverload(null, "s1");           // Compliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/InvocationResolvesToOverrideWithParams.cs
@@ -251,17 +251,17 @@ namespace Repro5430
 
     public class OtherClass
     {
-        private int InlineInitializedField11 = new SomeClass().PrivateOverload("s1");                  // Compliant
-        private int InlineInitializedField12 = new SomeClass().PrivateOverload("s1", "s2");            // Compliant
-        private int InlineInitializedField13 = new SomeClass().PrivateOverload(null, "s2");            // Compliant
-        private int InlineInitializedField14 = new SomeClass().PrivateOverload(null, new[] { "s2" });  // Compliant
-        private int InlineInitializedField15 = new SomeClass().PrivateOverload("42", "s1", "s2");      // Compliant
+        private int Field11 = new SomeClass().PrivateOverload("s1");                  // Compliant
+        private int Field12 = new SomeClass().PrivateOverload("s1", "s2");            // Compliant
+        private int Field13 = new SomeClass().PrivateOverload(null, "s2");            // Compliant
+        private int Field14 = new SomeClass().PrivateOverload(null, new[] { "s2" });  // Compliant
+        private int Field15 = new SomeClass().PrivateOverload("42", "s1", "s2");      // Compliant
 
-        private int InlineInitializedField21 = new SomeClass().InternalOverload("s1");                 // Compliant
-        private int InlineInitializedField22 = new SomeClass().InternalOverload("s1", "s2");           // Noncompliant
-        private int InlineInitializedField23 = new SomeClass().InternalOverload(null, "s2");           // Noncompliant
-        private int InlineInitializedField24 = new SomeClass().InternalOverload(null, new[] { "s2" }); // Compliant
-        private int InlineInitializedField25 = new SomeClass().InternalOverload("42", "s1", "s2");     // Compliant
+        private int Field21 = new SomeClass().InternalOverload("s1");                 // Compliant
+        private int Field22 = new SomeClass().InternalOverload("s1", "s2");           // Noncompliant
+        private int Field23 = new SomeClass().InternalOverload(null, "s2");           // Noncompliant
+        private int Field24 = new SomeClass().InternalOverload(null, new[] { "s2" }); // Compliant
+        private int Field25 = new SomeClass().InternalOverload("42", "s1", "s2");     // Compliant
 
         public int this[int i]
         {


### PR DESCRIPTION
Fixes #5430

~~Made into a draft because it should be merged after the release.~~

Remarks:
An API has been introduced in Roslyin API to check whether a symbol is accessible from within another symbol: https://github.com/dotnet/roslyn/issues/23842

The API is not yet available for the .NET Analyzer, and quite heavy (as it also for any type of symbol).
For those reasons, a tailored way of checking visibility of a method overload `M` of a type `T` from a (potentially different) type `U` has been implemented, exploiting the fact that, for rule 3220 to be triggered, `T`, as well as at least one of the overloads of `M `(with `params`) are visible from `U`.

A false negative would be produced in the case: 
- `InternalsVisibleToAttribute("A2")` is used on an assembly `A1`
- assembly `A2` contains a class `C2` deriving from a class `C1` in `A1`
- `C1` contains a public overload method `M1` with `params` and an `internal` overload `M1` without params
- `C2` contains a method `M2` which calls `M1`
- Signatures of `M1` are such that invocation `M1` resolves to the `params` version, but the `non-params` one would be valid as well (as per rule https://sonarsource.github.io/rspec/#/rspec/S3220/csharp). 