### PR TITLE
Revert release.yml 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5.0.1
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5 #uses the latest v5.x.y version rather than a specific version
     with:
       publishToBinaries: true
       mavenCentralSync: true


### PR DESCRIPTION
Revert release.yml to automatically use the latest minor version (v5).
