### PR TITLE
Fail Java build when RuleDescriptorGeneratorFails

### DIFF
--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -260,6 +260,7 @@
                   </fileset>
                 </copy>
                 <exec executable="dotnet"
+                      failonerror="true"
                       dir="${analyzers.directory}/packaging/binaries/RuleDescriptorGenerator">
                   <arg value="SonarAnalyzer.RuleDescriptorGenerator.dll"/>
                   <arg value="${analyzers.directory}/packaging/binaries/SonarAnalyzer.CSharp.dll"/>

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -261,6 +261,7 @@
                   </fileset>
                 </copy>
                 <exec executable="dotnet"
+                      failonerror="true"
                       dir="${analyzers.directory}/packaging/binaries/RuleDescriptorGenerator">
                   <arg value="SonarAnalyzer.RuleDescriptorGenerator.dll"/>
                   <arg value="${analyzers.directory}/packaging/binaries/SonarAnalyzer.VisualBasic.dll"/>


### PR DESCRIPTION
Without this, the "exec" task of `maven-antrun-lugin` reports `[ERROR]` and happily continues. The build succeeds and the SQ startup fails due to runtime error because of some missing resources.

We need to fail the Java build when this `exec` task fails.

Remark:
`failonerror` defaults to `true` when used at maven-antrun-plugin level (c.p. https://maven.apache.org/plugins/maven-antrun-plugin/run-mojo.html), but defaults to `false` when used in a `exec` task under `target` (c.p. https://ant.apache.org/manual/Tasks/exec.html).

