### PR TITLE
Report deprecation analysis warning for MsBuild 14/15

### DIFF
--- a/analyzers/its/expected/Roslyn.1.3.1/Roslyn.1.3.1--net452-S1450.json
+++ b/analyzers/its/expected/Roslyn.1.3.1/Roslyn.1.3.1--net452-S1450.json
@@ -6,9 +6,9 @@
 "location":  {
 "uri":  "sources\Roslyn.1.3.1\OldRoslyn.cs",
 "region":  {
-"startLine":  11,
+"startLine":  10,
 "startColumn":  24,
-"endLine":  11,
+"endLine":  10,
 "endColumn":  29
 }
 }

--- a/analyzers/its/expected/Roslyn.1.3.1/Roslyn.1.3.1--net452-S2221.json
+++ b/analyzers/its/expected/Roslyn.1.3.1/Roslyn.1.3.1--net452-S2221.json
@@ -6,9 +6,9 @@
 "location":  {
 "uri":  "sources\Roslyn.1.3.1\OldRoslyn.cs",
 "region":  {
-"startLine":  39,
+"startLine":  38,
 "startColumn":  13,
-"endLine":  39,
+"endLine":  38,
 "endColumn":  18
 }
 }

--- a/analyzers/its/expected/Roslyn.1.3.1/Roslyn.1.3.1--net452-S2259.json
+++ b/analyzers/its/expected/Roslyn.1.3.1/Roslyn.1.3.1--net452-S2259.json
@@ -6,9 +6,9 @@
 "location":  {
 "uri":  "sources\Roslyn.1.3.1\OldRoslyn.cs",
 "region":  {
-"startLine":  16,
+"startLine":  15,
 "startColumn":  19,
-"endLine":  16,
+"endLine":  15,
 "endColumn":  24
 }
 }
@@ -19,9 +19,9 @@
 "location":  {
 "uri":  "sources\Roslyn.1.3.1\OldRoslyn.cs",
 "region":  {
-"startLine":  23,
+"startLine":  22,
 "startColumn":  20,
-"endLine":  23,
+"endLine":  22,
 "endColumn":  28
 }
 }
@@ -32,9 +32,9 @@
 "location":  {
 "uri":  "sources\Roslyn.1.3.1\OldRoslyn.cs",
 "region":  {
-"startLine":  37,
+"startLine":  36,
 "startColumn":  24,
-"endLine":  37,
+"endLine":  36,
 "endColumn":  27
 }
 }

--- a/analyzers/its/expected/Roslyn.1.3.1/Roslyn.1.3.1--net452-S2325.json
+++ b/analyzers/its/expected/Roslyn.1.3.1/Roslyn.1.3.1--net452-S2325.json
@@ -6,9 +6,9 @@
 "location":  {
 "uri":  "sources\Roslyn.1.3.1\OldRoslyn.cs",
 "region":  {
-"startLine":  19,
+"startLine":  18,
 "startColumn":  23,
-"endLine":  19,
+"endLine":  18,
 "endColumn":  34
 }
 }
@@ -19,9 +19,9 @@
 "location":  {
 "uri":  "sources\Roslyn.1.3.1\OldRoslyn.cs",
 "region":  {
-"startLine":  26,
+"startLine":  25,
 "startColumn":  23,
-"endLine":  26,
+"endLine":  25,
 "endColumn":  31
 }
 }

--- a/analyzers/its/expected/Roslyn.1.3.1/Roslyn.1.3.1--net452-S3353.json
+++ b/analyzers/its/expected/Roslyn.1.3.1/Roslyn.1.3.1--net452-S3353.json
@@ -6,9 +6,9 @@
 "location":  {
 "uri":  "sources\Roslyn.1.3.1\OldRoslyn.cs",
 "region":  {
-"startLine":  21,
+"startLine":  20,
 "startColumn":  20,
-"endLine":  21,
+"endLine":  20,
 "endColumn":  28
 }
 }

--- a/analyzers/its/expected/Roslyn.1.3.1/Roslyn.1.3.1--net452-S3900.json
+++ b/analyzers/its/expected/Roslyn.1.3.1/Roslyn.1.3.1--net452-S3900.json
@@ -6,9 +6,9 @@
 "location":  {
 "uri":  "sources\Roslyn.1.3.1\OldRoslyn.cs",
 "region":  {
-"startLine":  37,
+"startLine":  36,
 "startColumn":  24,
-"endLine":  37,
+"endLine":  36,
 "endColumn":  27
 }
 }

--- a/analyzers/its/sources/Roslyn.1.3.1/OldRoslyn.cs
+++ b/analyzers/its/sources/Roslyn.1.3.1/OldRoslyn.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Diagnostics;
 
 namespace Roslyn

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/AnalysisWarningAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/AnalysisWarningAnalyzer.cs
@@ -18,16 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.CFG.Helpers
-{
-    public static class RoslynHelper
-    {
-        public const int MinimalSupportedMajorVersion = 3;
+namespace SonarAnalyzer.Rules.CSharp;
 
-        public static bool IsRoslynCfgSupported(int minimalVersion = MinimalSupportedMajorVersion) =>
-            typeof(SemanticModel).Assembly.GetName().Version.Major >= minimalVersion;
-
-        public static Type FlowAnalysisType(string typeName) =>
-            typeof(SemanticModel).Assembly.GetType("Microsoft.CodeAnalysis.FlowAnalysis." + typeName);
-    }
-}
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class AnalysisWarningAnalyzer : AnalysisWarningAnalyzerBase { }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/AnalysisWarningAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/AnalysisWarningAnalyzerBase.cs
@@ -28,6 +28,8 @@ public abstract class AnalysisWarningAnalyzerBase : UtilityAnalyzerBase
     private const string DiagnosticId = "S9999-warning";
     private const string Title = "Analysis Warning generator";
 
+    private static readonly object FileWriteLock = new();
+
     protected virtual int MinimalSupportedRoslynVersion { get; } = RoslynHelper.MinimalSupportedMajorVersion;   // For testing
 
     protected AnalysisWarningAnalyzerBase() : base(DiagnosticId, Title) { }
@@ -40,9 +42,19 @@ public abstract class AnalysisWarningAnalyzerBase : UtilityAnalyzerBase
             {
                 // This can be removed after we bump Microsoft.CodeAnalysis references to 3.0 or higher.
                 var path = Path.GetFullPath(Path.Combine(OutPath, "../../AnalysisWarnings.MsBuild.json"));
-                if (!File.Exists(path))
+                lock (FileWriteLock)
                 {
-                    File.WriteAllText(path, @"[{""text"": ""Analysis using MsBuild 14 and 15 build tools is deprecated. Please update your pipeline to MsBuild 16 or higher.""}]");
+                    if (!File.Exists(path))
+                    {
+                        try
+                        {
+                            File.WriteAllText(path, @"[{""text"": ""Analysis using MsBuild 14 and 15 build tools is deprecated. Please update your pipeline to MsBuild 16 or higher.""}]");
+                        }
+                        catch
+                        {
+                            // Nothing to do here. Two compilations running on two different processes are unlikely to lock each other out on a small file write.
+                        }
+                    }
                 }
             }
         });

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/AnalysisWarningAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/AnalysisWarningAnalyzerBase.cs
@@ -30,7 +30,7 @@ public abstract class AnalysisWarningAnalyzerBase : UtilityAnalyzerBase
 
     private static readonly object FileWriteLock = new();
 
-    protected virtual int MinimalSupportedRoslynVersion { get; } = RoslynHelper.MinimalSupportedMajorVersion;   // For testing
+    protected virtual int MinimalSupportedRoslynVersion => RoslynHelper.MinimalSupportedMajorVersion;   // For testing
 
     protected AnalysisWarningAnalyzerBase() : base(DiagnosticId, Title) { }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/AnalysisWarningAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/AnalysisWarningAnalyzerBase.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.IO;
+using SonarAnalyzer.CFG.Helpers;
+
+namespace SonarAnalyzer.Rules;
+
+public abstract class AnalysisWarningAnalyzerBase : UtilityAnalyzerBase
+{
+    private const string DiagnosticId = "S9999-warning";
+    private const string Title = "Analysis Warning generator";
+
+    protected virtual int MinimalSupportedRoslynVersion { get; } = RoslynHelper.MinimalSupportedMajorVersion;   // For testing
+
+    protected AnalysisWarningAnalyzerBase() : base(DiagnosticId, Title) { }
+
+    protected sealed override void Initialize(SonarAnalysisContext context) =>
+        context.RegisterCompilationAction(c =>
+        {
+            ReadParameters(c);
+            if (IsAnalyzerEnabled && !RoslynHelper.IsRoslynCfgSupported(MinimalSupportedRoslynVersion))     // MsBuild 15 is bound with Roslyn 2.x, where Roslyn CFG is not available.
+            {
+                // This can be removed after we bump Microsoft.CodeAnalysis references to 3.0 or higher.
+                var path = Path.GetFullPath(Path.Combine(OutPath, "../../AnalysisWarnings.MsBuild.json"));
+                if (!File.Exists(path))
+                {
+                    File.WriteAllText(path, @"[{""text"": ""Analysis using MsBuild 14 and 15 build tools is deprecated. Please update your pipeline to MsBuild 16 or higher.""}]");
+                }
+            }
+        });
+}

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/AnalysisWarningAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/AnalysisWarningAnalyzerBase.cs
@@ -36,26 +36,26 @@ public abstract class AnalysisWarningAnalyzerBase : UtilityAnalyzerBase
 
     protected sealed override void Initialize(SonarAnalysisContext context) =>
         context.RegisterCompilationAction(c =>
-        {
-            ReadParameters(c);
-            if (IsAnalyzerEnabled && !RoslynHelper.IsRoslynCfgSupported(MinimalSupportedRoslynVersion))     // MsBuild 15 is bound with Roslyn 2.x, where Roslyn CFG is not available.
             {
-                // This can be removed after we bump Microsoft.CodeAnalysis references to 3.0 or higher.
-                var path = Path.GetFullPath(Path.Combine(OutPath, "../../AnalysisWarnings.MsBuild.json"));
-                lock (FileWriteLock)
+                ReadParameters(c);
+                if (IsAnalyzerEnabled && !RoslynHelper.IsRoslynCfgSupported(MinimalSupportedRoslynVersion))     // MsBuild 15 is bound with Roslyn 2.x, where Roslyn CFG is not available.
                 {
-                    if (!File.Exists(path))
+                    // This can be removed after we bump Microsoft.CodeAnalysis references to 3.0 or higher.
+                    var path = Path.GetFullPath(Path.Combine(OutPath, "../../AnalysisWarnings.MsBuild.json"));
+                    lock (FileWriteLock)
                     {
-                        try
+                        if (!File.Exists(path))
                         {
-                            File.WriteAllText(path, @"[{""text"": ""Analysis using MsBuild 14 and 15 build tools is deprecated. Please update your pipeline to MsBuild 16 or higher.""}]");
-                        }
-                        catch
-                        {
-                            // Nothing to do here. Two compilations running on two different processes are unlikely to lock each other out on a small file write.
+                            try
+                            {
+                                File.WriteAllText(path, """[{"text": "Analysis using MsBuild 14 and 15 build tools is deprecated. Please update your pipeline to MsBuild 16 or higher."}]""");
+                            }
+                            catch
+                            {
+                                // Nothing to do here. Two compilations running on two different processes are unlikely to lock each other out on a small file write.
+                            }
                         }
                     }
                 }
-            }
-        });
+            });
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/AnalysisWarningAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/AnalysisWarningAnalyzer.cs
@@ -18,16 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.CFG.Helpers
-{
-    public static class RoslynHelper
-    {
-        public const int MinimalSupportedMajorVersion = 3;
+namespace SonarAnalyzer.Rules.VisualBasic;
 
-        public static bool IsRoslynCfgSupported(int minimalVersion = MinimalSupportedMajorVersion) =>
-            typeof(SemanticModel).Assembly.GetName().Version.Major >= minimalVersion;
-
-        public static Type FlowAnalysisType(string typeName) =>
-            typeof(SemanticModel).Assembly.GetType("Microsoft.CodeAnalysis.FlowAnalysis." + typeName);
-    }
-}
+[DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+public class AnalysisWarningAnalyzer : AnalysisWarningAnalyzerBase { }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/AnalysisWarningAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/AnalysisWarningAnalyzerTest.cs
@@ -1,0 +1,95 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.IO;
+using SonarAnalyzer.CFG.Helpers;
+using SonarAnalyzer.Common;
+using SonarAnalyzer.Rules;
+using CS = SonarAnalyzer.Rules.CSharp;
+using VB = SonarAnalyzer.Rules.VisualBasic;
+
+namespace SonarAnalyzer.UnitTest.Rules
+{
+    [TestClass]
+    public class AnalysisWarningAnalyzerTest
+    {
+        public TestContext TestContext { get; set; }
+
+        [DataTestMethod]
+        [DataRow(LanguageNames.CSharp, true)]
+        [DataRow(LanguageNames.CSharp, false)]
+        [DataRow(LanguageNames.VisualBasic, true)]
+        [DataRow(LanguageNames.VisualBasic, false)]
+        public void SupportedRoslyn(string languageName, bool isAnalyzerEnabled)
+        {
+            var expectedPath = ExecuteAnalyzer(languageName, isAnalyzerEnabled, RoslynHelper.MinimalSupportedMajorVersion); // Using production value that is lower than our UT Roslyn version
+            File.Exists(expectedPath).Should().BeFalse("Analysis warning file should not be generated.");
+        }
+
+        [DataTestMethod]
+        [DataRow(LanguageNames.CSharp)]
+        [DataRow(LanguageNames.VisualBasic)]
+        public void OldRoslyn(string languageName)
+        {
+            var expectedPath = ExecuteAnalyzer(languageName, true, 1000);  // Requiring too high Roslyn version => we're under unsupported scenario
+            File.Exists(expectedPath).Should().BeTrue();
+            File.ReadAllText(expectedPath).Should().Be(@"[{""text"": ""Analysis using MsBuild 14 and 15 build tools is deprecated. Please update your pipeline to MsBuild 16 or higher.""}]");
+        }
+
+        private string ExecuteAnalyzer(string languageName, bool isAnalyzerEnabled, int minimalSupportedRoslynVersion)
+        {
+            var language = AnalyzerLanguage.FromName(languageName);
+            var outPath = TestHelper.TestPath(TestContext, @".sonarqube\out");
+            Directory.CreateDirectory(outPath);
+            UtilityAnalyzerBase analyzer = language.LanguageName switch
+            {
+                LanguageNames.CSharp => new TestAnalysisWarningAnalyzer_CS(isAnalyzerEnabled, minimalSupportedRoslynVersion, outPath),
+                LanguageNames.VisualBasic => new TestAnalysisWarningAnalyzer_VB(isAnalyzerEnabled, minimalSupportedRoslynVersion, outPath),
+                _ => throw new UnexpectedLanguageException(language)
+            };
+            new VerifierBuilder().AddAnalyzer(() => analyzer).AddSnippet(string.Empty).VerifyNoIssueReported(); // Nothing to analyze, just make it run
+            return Path.Combine(outPath, "AnalysisWarnings.MsBuild.json");
+        }
+
+        private sealed class TestAnalysisWarningAnalyzer_CS : CS.AnalysisWarningAnalyzer
+        {
+            protected override int MinimalSupportedRoslynVersion { get; }
+
+            public TestAnalysisWarningAnalyzer_CS(bool isAnalyzerEnabled, int minimalSupportedRoslynVersion, string outPath)
+            {
+                IsAnalyzerEnabled = isAnalyzerEnabled;
+                MinimalSupportedRoslynVersion = minimalSupportedRoslynVersion;
+                OutPath = Path.GetFullPath(Path.Combine(outPath, "0", "output-language"));
+            }
+        }
+
+        private sealed class TestAnalysisWarningAnalyzer_VB : VB.AnalysisWarningAnalyzer
+        {
+            protected override int MinimalSupportedRoslynVersion { get; }
+
+            public TestAnalysisWarningAnalyzer_VB(bool isAnalyzerEnabled, int minimalSupportedRoslynVersion, string outPath)
+            {
+                IsAnalyzerEnabled = isAnalyzerEnabled;
+                MinimalSupportedRoslynVersion = minimalSupportedRoslynVersion;
+                OutPath = outPath;
+            }
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/AnalysisWarningAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/AnalysisWarningAnalyzerTest.cs
@@ -70,19 +70,20 @@ public class AnalysisWarningAnalyzerTest
     private string ExecuteAnalyzer(string languageName, bool isAnalyzerEnabled, int minimalSupportedRoslynVersion, bool createDirectory = true)
     {
         var language = AnalyzerLanguage.FromName(languageName);
-        var outPath = TestHelper.TestPath(TestContext, @".sonarqube\out");
+        var analysisOutPath = TestHelper.TestPath(TestContext, @$"{languageName}\.sonarqube\out");
+        var projectOutPath = Path.GetFullPath(Path.Combine(analysisOutPath, "0", "output-language"));
         if (createDirectory)
         {
-            Directory.CreateDirectory(outPath);
+            Directory.CreateDirectory(analysisOutPath);
         }
         UtilityAnalyzerBase analyzer = language.LanguageName switch
         {
-            LanguageNames.CSharp => new TestAnalysisWarningAnalyzer_CS(isAnalyzerEnabled, minimalSupportedRoslynVersion, outPath),
-            LanguageNames.VisualBasic => new TestAnalysisWarningAnalyzer_VB(isAnalyzerEnabled, minimalSupportedRoslynVersion, outPath),
+            LanguageNames.CSharp => new TestAnalysisWarningAnalyzer_CS(isAnalyzerEnabled, minimalSupportedRoslynVersion, projectOutPath),
+            LanguageNames.VisualBasic => new TestAnalysisWarningAnalyzer_VB(isAnalyzerEnabled, minimalSupportedRoslynVersion, projectOutPath),
             _ => throw new UnexpectedLanguageException(language)
         };
         new VerifierBuilder().AddAnalyzer(() => analyzer).AddSnippet(string.Empty).VerifyNoIssueReported(); // Nothing to analyze, just make it run
-        return Path.Combine(outPath, "AnalysisWarnings.MsBuild.json");
+        return Path.Combine(analysisOutPath, "AnalysisWarnings.MsBuild.json");
     }
 
     private sealed class TestAnalysisWarningAnalyzer_CS : CS.AnalysisWarningAnalyzer
@@ -93,7 +94,7 @@ public class AnalysisWarningAnalyzerTest
         {
             IsAnalyzerEnabled = isAnalyzerEnabled;
             MinimalSupportedRoslynVersion = minimalSupportedRoslynVersion;
-            OutPath = Path.GetFullPath(Path.Combine(outPath, "0", "output-language"));
+            OutPath = outPath;
         }
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/AnalysisWarningAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/AnalysisWarningAnalyzerTest.cs
@@ -51,6 +51,10 @@ namespace SonarAnalyzer.UnitTest.Rules
             var expectedPath = ExecuteAnalyzer(languageName, true, 1000);  // Requiring too high Roslyn version => we're under unsupported scenario
             File.Exists(expectedPath).Should().BeTrue();
             File.ReadAllText(expectedPath).Should().Be(@"[{""text"": ""Analysis using MsBuild 14 and 15 build tools is deprecated. Please update your pipeline to MsBuild 16 or higher.""}]");
+
+            // Lock file and run it for 2nd time
+            using var lockedFile = new FileStream(expectedPath, FileMode.Open, FileAccess.Write, FileShare.None);
+            ExecuteAnalyzer(languageName, true, 1000).Should().Be(expectedPath, "path should be reused and analyzer should not fail");
         }
 
         private string ExecuteAnalyzer(string languageName, bool isAnalyzerEnabled, int minimalSupportedRoslynVersion)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/CopyPasteTokenAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/CopyPasteTokenAnalyzerTest.cs
@@ -19,7 +19,6 @@
  */
 
 using System.IO;
-using System.Runtime.CompilerServices;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Protobuf;
 using SonarAnalyzer.Rules;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/LogAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/LogAnalyzerTest.cs
@@ -18,11 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Runtime.CompilerServices;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Protobuf;
 using SonarAnalyzer.Rules;
-using SonarAnalyzer.UnitTest.Common;
 using SonarAnalyzer.UnitTest.Helpers;
 using CS = SonarAnalyzer.Rules.CSharp;
 using VB = SonarAnalyzer.Rules.VisualBasic;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
@@ -19,7 +19,6 @@
  */
 
 using System.IO;
-using System.Runtime.CompilerServices;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Protobuf;
 using SonarAnalyzer.Rules;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/TokenTypeAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/TokenTypeAnalyzerTest.cs
@@ -19,7 +19,6 @@
  */
 
 using System.IO;
-using System.Runtime.CompilerServices;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Protobuf;
 using SonarAnalyzer.Rules;

--- a/its/projects/Roslyn.1.3.1/OldRoslyn.cs
+++ b/its/projects/Roslyn.1.3.1/OldRoslyn.cs
@@ -1,5 +1,4 @@
-﻿
-namespace Roslyn
+﻿namespace Roslyn
 {
     public class OldRoslyn
     {

--- a/its/projects/Roslyn.1.3.1/OldRoslyn.cs
+++ b/its/projects/Roslyn.1.3.1/OldRoslyn.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Roslyn
+{
+    public class OldRoslyn
+    {
+        // Nothing to see here
+    }
+}

--- a/its/projects/Roslyn.1.3.1/Roslyn.1.3.1.csproj
+++ b/its/projects/Roslyn.1.3.1/Roslyn.1.3.1.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net452</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- This will enforce using Roslyn 1.3.1 -->
+    <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="1.0.8" />
+  </ItemGroup>
+</Project>

--- a/its/projects/Roslyn.1.3.1/Roslyn.1.3.1.sln
+++ b/its/projects/Roslyn.1.3.1/Roslyn.1.3.1.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32811.315
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Roslyn.1.3.1", "Roslyn.1.3.1.csproj", "{151E9036-31F1-481F-BBCE-6C663F21EB31}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{151E9036-31F1-481F-BBCE-6C663F21EB31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{151E9036-31F1-481F-BBCE-6C663F21EB31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{151E9036-31F1-481F-BBCE-6C663F21EB31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{151E9036-31F1-481F-BBCE-6C663F21EB31}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0E15ED11-FF3B-4CCE-8940-EFE27FCC42FD}
+	EndGlobalSection
+EndGlobal

--- a/its/projects/Roslyn.1.3.1/packages.lock.json
+++ b/its/projects/Roslyn.1.3.1/packages.lock.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.5.2": {
+      "Microsoft.CodeDom.Providers.DotNetCompilerPlatform": {
+        "type": "Direct",
+        "requested": "[1.0.8, )",
+        "resolved": "1.0.8",
+        "contentHash": "Mrl8R7fzrb4/TxsuqVeXxyuAp7j81MJTCHLWxsMAVeuPqjZ7Y/Zg52q0yAPfmrvA2Nx/gkAsWoed/rSToJuLFg==",
+        "dependencies": {
+          "Microsoft.Net.Compilers": "1.3.2"
+        }
+      },
+      "Microsoft.Net.Compilers": {
+        "type": "Transitive",
+        "resolved": "1.3.2",
+        "contentHash": "usbCzvNYmSWTdlsJM8FYm1NgGPdM+njnBzerAn3xKGy4/prztHcofq7CMiO7Lb0AK71jXKUzmUuW9Fc0cIzdbQ=="
+      }
+    }
+  }
+}

--- a/its/src/test/java/com/sonar/it/csharp/AnalysisWarningsTest.java
+++ b/its/src/test/java/com/sonar/it/csharp/AnalysisWarningsTest.java
@@ -20,19 +20,17 @@
 package com.sonar.it.csharp;
 
 import com.sonar.it.shared.TestUtils;
-import com.sonar.it.shared.Tests;
 import com.sonar.orchestrator.build.BuildResult;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sonarqube.ws.Ce;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import static com.sonar.it.shared.Tests.ORCHESTRATOR;
+import static com.sonar.it.csharp.Tests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AnalysisWarningsTest {
@@ -59,5 +57,14 @@ public class AnalysisWarningsTest {
     Ce.Task task = TestUtils.getAnalysisWarningsTask(ORCHESTRATOR, buildResult);
     assertThat(task.getStatus()).isEqualTo(Ce.TaskStatus.SUCCESS);
     assertThat(task.getWarningsList()).containsExactly("First message", "Second message");
+  }
+
+  @Test
+  public void analysisWarnings_OldRoslyn() throws IOException {
+    BuildResult buildResult = Tests.analyzeProject(temp, "Roslyn.1.3.1", null);
+
+    Ce.Task task = TestUtils.getAnalysisWarningsTask(ORCHESTRATOR, buildResult);
+    assertThat(task.getStatus()).isEqualTo(Ce.TaskStatus.SUCCESS);
+    assertThat(task.getWarningsList()).containsExactly("Analysis using MsBuild 14 and 15 build tools is deprecated. Please update your pipeline to MsBuild 16 or higher.");
   }
 }


### PR DESCRIPTION
Fixes #6678

MsBuild 14 is bound with Roslyn 1.x
MsBuild 15 is bound with Roslyn 2.x
We're fine with MsBuild 16+ and Roslyn 3.x+
https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022

While it is possible to have MsBuild 16+ and use Roslyn 1.x with it (see the trick in ITs), it's a corner case that we'll ignore as we can't detect MsBuild version from within Roslyn without help of Scanner for .NET.

The analyzer complains when old Roslyn is used and that's also correct behavior. As bumping Roslyn dependency will make it stop working on that Roslyn, no matter what MsBuild is used.

---

### How this works:

SQ plugin (the java part) already has a [mechanism](https://github.com/SonarSource/sonar-dotnet/blob/master/sonar-dotnet-shared-library/src/main/java/org/sonarsource/dotnet/shared/plugins/AnalysisWarningsSensor.java#L54), that picks up all JSON files from predefined location with predefined name. And will report them as analysis warnings in UI. This is used for scanner and autoscan (other applications dropping files around to report issues).

So all we need to do is to drop one file per analysis (per solution) onto a disk.

Sample file: https://github.com/SonarSource/sonar-dotnet/blob/master/sonar-dotnet-shared-library/src/test/resources/analysisWarnings/AnalysisWarnings.AutoScan.json