### PR TITLE
Java ITs CSharp: Start orchestrator only once

### DIFF
--- a/its/src/test/java/com/sonar/it/csharp/AnalysisWarningsTest.java
+++ b/its/src/test/java/com/sonar/it/csharp/AnalysisWarningsTest.java
@@ -20,19 +20,17 @@
 package com.sonar.it.csharp;
 
 import com.sonar.it.shared.TestUtils;
-import com.sonar.it.shared.Tests;
 import com.sonar.orchestrator.build.BuildResult;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sonarqube.ws.Ce;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import static com.sonar.it.shared.Tests.ORCHESTRATOR;
+import static com.sonar.it.csharp.Tests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AnalysisWarningsTest {


### PR DESCRIPTION
All C# ITs references and starts `com.sonar.it.csharp.Tests.ORCHESTRATOR`. And are executed in `Tests: Java ITs CSharp` CI step.

`AnalysisWarningsTest` was referencing `com.sonar.it.shared.Tests.ORCHESTRATOR`, a separate orchestrator instance that started a 2nd instance of SQ of the same CI step.

`com.sonar.it.shared.Tests.ORCHESTRATOR` should be used only by `shared` integration tests that are executed in `Tests: Java ITs Others` step.