### PR TITLE
Dependabot: Use Analyzers directory for NuGet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
     labels: [ ]     # Do not add default "dependency" label
 
   - package-ecosystem: "nuget"
-    directory: "/"
+    directory: "/analyzers"
     schedule:
       interval: "daily"
     labels: [ ]     # Do not add default "dependency" label


### PR DESCRIPTION
I've noticed that we're not getting NuGet updates on this repo. 

This changes directory to the one with SLN file.