### PR TITLE
S4663: Fix highlighting to remove underlying whitespaces

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/CommentsShouldNotBeEmptyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CommentsShouldNotBeEmptyBase.cs
@@ -62,10 +62,9 @@ public abstract class CommentsShouldNotBeEmptyBase<TSyntaxKind> : SonarDiagnosti
 
         foreach (var partition in partitions.Where(trivia => trivia.Any() && trivia.All(x => string.IsNullOrWhiteSpace(GetCommentText(x)))))
         {
-            var start = partition.First().GetLocation().SourceSpan.Start;
-            var end = partition.Last().GetLocation().SourceSpan.End;
-            var location = Location.Create(context.Tree, TextSpan.FromBounds(start, end));
-            context.ReportIssue(Diagnostic.Create(Rule, location));
+            var location = partition.First().GetLocation();
+            var secondary = partition.Skip(1).Select(x => x.GetLocation());
+            context.ReportIssue(Diagnostic.Create(Rule, location, secondary));
         }
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CommentsShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CommentsShouldNotBeEmpty.cs
@@ -10,7 +10,7 @@ public class SingleLine //
 
     // Noncompliant@-2 (a lot of whitespace before)
 
-    //            
+    //
 
     // Noncompliant@-2 (a lot of whitespace after)
 
@@ -75,6 +75,8 @@ public class SingleLine //
     //
     /// text
     // Noncompliant@-4
+    // Secondary@-4
+    // Secondary@-4
 
     //
     //
@@ -83,6 +85,8 @@ public class SingleLine //
      * text
      */
     // Noncompliant@-6
+    // Secondary@-6
+    // Secondary@-6
 
     //
     //
@@ -91,10 +95,14 @@ public class SingleLine //
      * text
      */
     // Noncompliant@-6
+    // Secondary@-6
+    // Secondary@-6
 
     void Method()
     {
-        // Noncompliant@+2
+        // Noncompliant@+4
+        // Secondary@+4
+        // Secondary@+4
 
         //
         //
@@ -106,6 +114,8 @@ public class SingleLine //
 
         // Noncompliant@-5
         // Noncompliant@-5
+        // Secondary@-5
+        // Secondary@-5
 
         //
         //
@@ -136,7 +146,7 @@ public class SingleLineDocumentation ///
             ///
     // Noncompliant@-1 (a lot of whitespace before)
 
-    ///					
+    ///
     // Noncompliant@-1 (a lot of whitespace after)
 
     ///
@@ -188,7 +198,7 @@ public class MultiLine /* */
     /*      */
     // Noncompliant@-1 (a lot of whitespace inside)
 
-    /**/					
+    /**/
     // Noncompliant@-1 (a lot of whitespace after)
 
     // Noncompliant@+1
@@ -286,7 +296,7 @@ public class MultiLineDocumentation /** */
     /**      */
     // Noncompliant@-1 (a lot of whitespace inside)
 
-    /***/						
+    /***/
     // Noncompliant@-1 (a lot of whitespace after)
 
     // Noncompliant@+1
@@ -381,7 +391,9 @@ public class MultiLineDocumentation /** */
 ///
 
 
-// Noncompliant@+2
+// Noncompliant@+4
+// Secondary@+4
+// Secondary@+4
 
 //
 //

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CommentsShouldNotBeEmpty.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/CommentsShouldNotBeEmpty.vb
@@ -14,7 +14,7 @@
         Dim b = 42 ''' Ipsem Lorum
         Dim c = 42 '''
 
-        '		
+        '
 
         ' Noncompliant@-2 (whitespace)
 
@@ -29,12 +29,16 @@
         '
         '
 
-        ' Noncompliant@+2
 
         '
         '
         '
         '
+
+        ' Noncompliant@-5
+        ' Secondary@-5
+        ' Secondary@-5
+        ' Secondary@-5
 
         ' Noncompliant@+2
 
@@ -45,6 +49,8 @@
         '
 
         ' Noncompliant@-4
+        ' Secondary@-4
+        ' Secondary@-4
 
         ' *
         ' Ipsem Lorum
@@ -80,10 +86,12 @@
         '
         ''' Ipsem Lorum
         ' Noncompliant@-4
+        ' Secondary@-4
+        ' Secondary@-4
     End Sub
 
     Public Sub DocumentationComment()
-        '''		
+        '''
         ' Noncompliant@-1 (whitespace)
 
         ''' *
@@ -133,11 +141,14 @@ End Class
 '''
 
 
-' Noncompliant@+2
 
 '
 '
 '
+
+' Noncompliant@-4
+' Secondary@-4
+' Secondary@-4
 
 ' Noncompliant@+1
 '''


### PR DESCRIPTION
This PR aims to fix squiggly lines under whitespace between `SingleLineCommentTrivia` entries.

## Before

![image](https://user-images.githubusercontent.com/115458417/216984529-696df67c-e956-40fb-8ac2-1f2f4f28bdeb.png)

## After

![image](https://user-images.githubusercontent.com/115458417/216984591-6ff23f06-cd2a-4227-ad61-01d0c4b0d37f.png)

