### PR TITLE
Fix S2198 FP: Exclude Infinity checks 

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SillyMathematicalComparison.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SillyMathematicalComparison.cs
@@ -72,7 +72,8 @@ namespace SonarAnalyzer.Rules.CSharp
 
         // 'char' needs to roundtrip {{char -> int -> double}}, can't go {{char -> double}}
         private static bool TryConvertToDouble(object constant, out double typedConstant) =>
-            ConversionHelper.TryConvertWith(constant is char ? Convert.ToInt32(constant) : constant, Convert.ToDouble, out typedConstant);
+            ConversionHelper.TryConvertWith(constant is char ? Convert.ToInt32(constant) : constant, Convert.ToDouble, out typedConstant)
+            && !double.IsInfinity(typedConstant);
 
         private static ValuesRange? TryGetRange(ITypeSymbol typeSymbol) =>
             typeSymbol switch

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SillyMathematicalComparison.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SillyMathematicalComparison.cs
@@ -453,5 +453,44 @@ namespace SonarAnalyzer.UnitTest.TestCases
             _ = 42f != double.MaxValue; // Compliant
             _ = 42f <= double.MaxValue; // Compliant
         }
+
+        public void Edgecases()
+        {
+            const float fPositiveInfinity = float.PositiveInfinity;
+            const float fNegativeInfinity = float.NegativeInfinity;
+            const double dPositiveInfinity = double.PositiveInfinity;
+            const double dNegativeInfinity = double.NegativeInfinity;
+
+            const float fNan = float.NaN;
+            const double dNan = double.NaN;
+
+            float f = 42;
+
+            _ = f <= fPositiveInfinity; // Compliant
+            _ = fNegativeInfinity < f; // Compliant
+
+            _ = fNegativeInfinity != f; // Compliant
+            _ = dNegativeInfinity == f; // Compliant
+
+            _ = f >= dPositiveInfinity; // Compliant
+            _ = dNegativeInfinity > f; // Compliant
+            _ = f != fPositiveInfinity; // Compliant
+            _ = f == dPositiveInfinity; // Compliant
+
+
+            _ = f == fNan; // Compliant
+            _ = f != fNan; // Compliant
+            _ = f <= fNan; // Compliant
+            _ = f >= fNan; // Compliant
+            _ = f > fNan; // Compliant
+            _ = f < fNan; // Compliant
+
+            _ = dNan == f; // Compliant
+            _ = dNan != f; // Compliant
+            _ = dNan <= f; // Compliant
+            _ = dNan >= f; // Compliant
+            _ = dNan > f; // Compliant
+            _ = dNan < f; // Compliant
+        }
     }
 }


### PR DESCRIPTION
[Example FP](https://peach.sonarsource.com/project/issues?languages=cs&resolved=false&rules=csharpsquid%3AS2198&id=_NET_Team&open=AYY-IcRInuGymX21wEA8)

Generally looks like:

```csharp
const float i = float.PositiveInfinity;
float x = 42;
_ = 42 >= i; // Should NOT raise
```
