### PR TITLE
Bump CSharp plugin size

### DIFF
--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -217,8 +217,8 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>5600000</maxsize>
-                  <minsize>5400000</minsize>
+                  <maxsize>5700000</maxsize>
+                  <minsize>5500000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>


### PR DESCRIPTION
Fix master: 

>C:\ProgramData\vsts-agent\1\s\sonar-csharp-plugin\target\sonar-csharp-plugin-8.54.0.62875.jar size (5601929) too large. Max. is 5600000C:\ProgramData\vsts-agent\1\s\sonar-csharp-plugin\target\sonar-csharp-plugin-8.54.0.62875.jar
