### PR TITLE
Fix S2094 FP: type specifications, attributes and conditional compilation

### DIFF
--- a/analyzers/its/expected/Ember-MM/Ember.Plugins-{9496C697-5AFD-4813-AEDC-AF33FACEADF0}-S2094.json
+++ b/analyzers/its/expected/Ember-MM/Ember.Plugins-{9496C697-5AFD-4813-AEDC-AF33FACEADF0}-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\Ember-MM\Ember.Plugins\PluginActionContext.cs",
 "region":  {

--- a/analyzers/its/expected/Net5/Net5--net5.0-S2094.json
+++ b/analyzers/its/expected/Net5/Net5--net5.0-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\Net5\Net5\ModuleInitializers.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\Net5\Net5\ParameterValidation.cs",
 "region":  {
@@ -28,7 +28,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\Net5\Net5\S2330.cs",
 "region":  {
@@ -41,7 +41,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\Net5\Net5\S3240.cs",
 "region":  {
@@ -54,7 +54,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\Net5\Net5\S3247.cs",
 "region":  {
@@ -67,7 +67,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\Net5\Net5\S3453.cs",
 "region":  {
@@ -80,7 +80,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\Net5\Net5\StaticLambdas.cs",
 "region":  {

--- a/analyzers/its/expected/Net7/Net7--net7.0-S2094.json
+++ b/analyzers/its/expected/Net7/Net7--net7.0-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\Net7\Net7\features\WarningWave7.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka--netstandard2.0-S2094.json
+++ b/analyzers/its/expected/akka.net/Akka--netstandard2.0-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Actor\ActorSelection.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Actor\FSM.cs",
 "region":  {
@@ -28,7 +28,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Event\LoggerInitialized.cs",
 "region":  {
@@ -41,7 +41,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Event\Logging.cs",
 "region":  {
@@ -54,7 +54,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\IO\Dns.cs",
 "region":  {
@@ -67,7 +67,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\IO\Inet.cs",
 "region":  {
@@ -80,7 +80,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\IO\Tcp.cs",
 "region":  {
@@ -93,7 +93,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\IO\Tcp.cs",
 "region":  {
@@ -106,7 +106,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\IO\Tcp.cs",
 "region":  {
@@ -119,7 +119,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\IO\Udp.cs",
 "region":  {
@@ -132,7 +132,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\IO\Udp.cs",
 "region":  {
@@ -145,7 +145,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\IO\UdpConnected.cs",
 "region":  {
@@ -158,7 +158,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Pattern\BackoffOptions.cs",
 "region":  {
@@ -171,7 +171,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Routing\Listeners.cs",
 "region":  {
@@ -184,7 +184,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka\Routing\RouterMsg.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.Benchmarks--netcoreapp3.1-S2094.json
+++ b/analyzers/its/expected/akka.net/Akka.Benchmarks--netcoreapp3.1-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\benchmark\Akka.Benchmarks\IO\TcpOperationsBenchmarks.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\benchmark\Akka.Benchmarks\IO\TcpOperationsBenchmarks.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.Cluster--netstandard2.0-S2094.json
+++ b/analyzers/its/expected/akka.net/Akka.Cluster--netstandard2.0-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Cluster\ClusterDaemon.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Cluster\ClusterHeartbeat.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.DI.TestKit--netstandard2.0-S2094.json
+++ b/analyzers/its/expected/akka.net/Akka.DI.TestKit--netstandard2.0-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\contrib\dependencyinjection\Akka.DI.TestKit\DiResolverSpec.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\contrib\dependencyinjection\Akka.DI.TestKit\DiResolverSpec.cs",
 "region":  {
@@ -28,7 +28,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\contrib\dependencyinjection\Akka.DI.TestKit\DiResolverSpec.cs",
 "region":  {
@@ -41,7 +41,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\contrib\dependencyinjection\Akka.DI.TestKit\DiResolverSpec.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner--net471-S2094.json
+++ b/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner--net471-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner\Program.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner\Program.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner--net5.0-S2094.json
+++ b/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner--net5.0-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner\Program.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner\Program.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner--netcoreapp3.1-S2094.json
+++ b/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner--netcoreapp3.1-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner\Program.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner\Program.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner.Shared--netstandard2.0-S2094.json
+++ b/analyzers/its/expected/akka.net/Akka.MultiNodeTestRunner.Shared--netstandard2.0-S2094.json
@@ -2,20 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
-"location":  {
-"uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\CompilerErrorCollection.cs",
-"region":  {
-"startLine":  14,
-"startColumn":  18,
-"endLine":  14,
-"endColumn":  41
-}
-}
-},
-{
-"id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Reporting\TestRunCoordinator.cs",
 "region":  {
@@ -28,7 +15,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\Messages.cs",
 "region":  {
@@ -41,7 +28,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\MessageSinkActor.cs",
 "region":  {
@@ -54,7 +41,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\SinkCoordinator.cs",
 "region":  {
@@ -67,7 +54,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\SinkCoordinator.cs",
 "region":  {
@@ -80,7 +67,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\SinkCoordinator.cs",
 "region":  {
@@ -93,7 +80,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\TimelineLogCollectorActor.cs",
 "region":  {
@@ -106,7 +93,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.MultiNodeTestRunner.Shared\Sinks\TimelineLogCollectorActor.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.Remote--netstandard2.0-S2094.json
+++ b/analyzers/its/expected/akka.net/Akka.Remote--netstandard2.0-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote\Endpoint.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote\Endpoint.cs",
 "region":  {
@@ -28,7 +28,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote\EndpointManager.cs",
 "region":  {
@@ -41,7 +41,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote\EndpointManager.cs",
 "region":  {
@@ -54,7 +54,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote\Transport\AkkaPduCodec.cs",
 "region":  {
@@ -67,7 +67,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote\Transport\AkkaProtocolTransport.cs",
 "region":  {
@@ -80,7 +80,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote\Transport\AkkaProtocolTransport.cs",
 "region":  {
@@ -93,7 +93,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote\Transport\AkkaProtocolTransport.cs",
 "region":  {
@@ -106,7 +106,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote\Transport\AkkaProtocolTransport.cs",
 "region":  {
@@ -119,7 +119,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote\Transport\TestTransport.cs",
 "region":  {
@@ -132,7 +132,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote\Transport\ThrottleTransportAdapter.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.Remote.Tests.Performance--netcoreapp3.1-S2094.json
+++ b/analyzers/its/expected/akka.net/Akka.Remote.Tests.Performance--netcoreapp3.1-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Remote.Tests.Performance\Transports\RemoteMessagingThroughputSpecBase.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/Akka.Streams--netstandard2.0-S2094.json
+++ b/analyzers/its/expected/akka.net/Akka.Streams--netstandard2.0-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Streams\Attributes.cs",
 "region":  {
@@ -15,7 +15,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Streams\Attributes.cs",
 "region":  {
@@ -28,7 +28,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Streams\Attributes.cs",
 "region":  {
@@ -41,7 +41,7 @@
 },
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\core\Akka.Streams\Stage\Context.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/RemotePingPong--net471-S2094.json
+++ b/analyzers/its/expected/akka.net/RemotePingPong--net471-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\benchmark\RemotePingPong\Program.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/RemotePingPong--net5.0-S2094.json
+++ b/analyzers/its/expected/akka.net/RemotePingPong--net5.0-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\benchmark\RemotePingPong\Program.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/RemotePingPong--netcoreapp3.1-S2094.json
+++ b/analyzers/its/expected/akka.net/RemotePingPong--netcoreapp3.1-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\benchmark\RemotePingPong\Program.cs",
 "region":  {

--- a/analyzers/its/expected/akka.net/TcpEchoService.Server--netcoreapp3.1-S2094.json
+++ b/analyzers/its/expected/akka.net/TcpEchoService.Server--netcoreapp3.1-S2094.json
@@ -2,7 +2,7 @@
 "issues":  [
 {
 "id":  "S2094",
-"message":  "Remove this empty class, or add members to it.",
+"message":  "Remove this empty class, write its code or make it an "interface".",
 "location":  {
 "uri":  "sources\akka.net\src\examples\TcpEchoService.Server\Actors.cs",
 "region":  {

--- a/analyzers/rspec/cs/S2094_c#.html
+++ b/analyzers/rspec/cs/S2094_c#.html
@@ -14,9 +14,10 @@ public interface IEmpty
 }
 </pre>
 <h2>Exceptions</h2>
-<p>Partial classes are ignored entirely, as they are often used with Source Generators. Subclasses of System.Exception are be ignored, as even an
-empty Exception class can provide useful information by its type name alone. Subclasses of certain framework types - like the PageModel class used in
-ASP.NET Core Razor Pages - are also be ignored.</p>
+<p>Partial classes are ignored entirely, as they are often used with Source Generators. Subclasses of System.Exception are ignored, as even an empty
+Exception class can provide useful information by its type name alone. Subclasses of System.Attribute are ignored, as well as classes which are
+annotated with attributes. Subclasses of generic classes are ignored, as even when empty they can be used for type specialization. Subclasses of
+certain framework types - like the PageModel class used in ASP.NET Core Razor Pages - are also be ignored.</p>
 <pre>
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/analyzers/rspec/cs/S2094_c#.html
+++ b/analyzers/rspec/cs/S2094_c#.html
@@ -17,7 +17,7 @@ public interface IEmpty
 <p>Partial classes are ignored entirely, as they are often used with Source Generators. Subclasses of System.Exception are ignored, as even an empty
 Exception class can provide useful information by its type name alone. Subclasses of System.Attribute are ignored, as well as classes which are
 annotated with attributes. Subclasses of generic classes are ignored, as even when empty they can be used for type specialization. Subclasses of
-certain framework types - like the PageModel class used in ASP.NET Core Razor Pages - are also be ignored.</p>
+certain framework types - like the PageModel class used in ASP.NET Core Razor Pages - are also ignored.</p>
 <pre>
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/analyzers/rspec/vbnet/S2094_vb.net.html
+++ b/analyzers/rspec/vbnet/S2094_vb.net.html
@@ -14,9 +14,10 @@ Public Interface IEmpty
 End Interface
 </pre>
 <h2>Exceptions</h2>
-<p>Partial classes are ignored entirely, as they are often used with Source Generators. Subclasses of System.Exception will be ignored, as even an
-empty Exception class can provide useful information by its type name alone. Subclasses of certain framework types - like the PageModel class used in
-ASP.NET Core Razor Pages - will also be ignored.</p>
+<p>Partial classes are ignored entirely, as they are often used with Source Generators. Subclasses of System.Exception are ignored, as even an empty
+Exception class can provide useful information by its type name alone. Subclasses of System.Attribute are ignored, as well as classes which are
+annotated with attributes. Subclasses of generic classes are ignored, as even when empty they can be used for type specialization. Subclasses of
+certain framework types - like the PageModel class used in ASP.NET Core Razor Pages - are also be ignored.</p>
 <pre>
 Imports Microsoft.AspNetCore.Mvc.RazorPages
 

--- a/analyzers/rspec/vbnet/S2094_vb.net.html
+++ b/analyzers/rspec/vbnet/S2094_vb.net.html
@@ -17,7 +17,7 @@ End Interface
 <p>Partial classes are ignored entirely, as they are often used with Source Generators. Subclasses of System.Exception are ignored, as even an empty
 Exception class can provide useful information by its type name alone. Subclasses of System.Attribute are ignored, as well as classes which are
 annotated with attributes. Subclasses of generic classes are ignored, as even when empty they can be used for type specialization. Subclasses of
-certain framework types - like the PageModel class used in ASP.NET Core Razor Pages - are also be ignored.</p>
+certain framework types - like the PageModel class used in ASP.NET Core Razor Pages - are also ignored.</p>
 <pre>
 Imports Microsoft.AspNetCore.Mvc.RazorPages
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeEmpty.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.CSharp;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class ClassShouldNotBeEmpty : ClassShouldNotBeEmptyBase<SyntaxKind>
+public sealed class ClassShouldNotBeEmpty : ClassShouldNotBeEmptyBase<SyntaxKind, BaseTypeDeclarationSyntax>
 {
     protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
@@ -30,12 +30,13 @@ public sealed class ClassShouldNotBeEmpty : ClassShouldNotBeEmptyBase<SyntaxKind
         && !typeDeclaration.Modifiers.Any(x => x.IsKind(SyntaxKind.PartialKeyword))
         && (node is ClassDeclarationSyntax || IsParameterlessRecord(node));
 
-    protected override bool IsClassWithDeclaredBaseClass(SyntaxNode node) =>
-        node is ClassDeclarationSyntax { BaseList: not null };
-
-    protected override bool HasGenericBaseClassOrInterface(SyntaxNode node) =>
+    protected override BaseTypeDeclarationSyntax GetIfHasDeclaredBaseClass(SyntaxNode node) =>
         node is ClassDeclarationSyntax { BaseList: not null } declaration
-        && declaration.BaseList.Types.Any(x => x.Type is GenericNameSyntax);
+            ? declaration
+            : null;
+
+    protected override bool HasGenericBaseClassOrInterface(BaseTypeDeclarationSyntax declaration) =>
+        declaration.BaseList.Types.Any(x => x.Type is GenericNameSyntax);
 
     protected override bool HasAnyAttribute(SyntaxNode node) =>
         node is TypeDeclarationSyntax { AttributeLists.Count: > 0  };

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeEmpty.cs
@@ -30,9 +30,25 @@ public sealed class ClassShouldNotBeEmpty : ClassShouldNotBeEmptyBase<SyntaxKind
         && !typeDeclaration.Modifiers.Any(x => x.IsKind(SyntaxKind.PartialKeyword))
         && (node is ClassDeclarationSyntax || IsParameterlessRecord(node));
 
-    protected override bool IsClassWithDeclaredBaseClass(SyntaxNode node) => node is ClassDeclarationSyntax { BaseList: not null };
+    protected override bool IsClassWithDeclaredBaseClass(SyntaxNode node) =>
+        node is ClassDeclarationSyntax { BaseList: not null };
 
-    protected override string DeclarationTypeKeyword(SyntaxNode node) => ((TypeDeclarationSyntax)node).Keyword.ValueText;
+    protected override bool HasGenericBaseClassOrInterface(SyntaxNode node) =>
+        node is ClassDeclarationSyntax { BaseList: not null } declaration
+        && declaration.BaseList.Types.Any(x => x.Type is GenericNameSyntax);
+
+    protected override bool HasAnyAttribute(SyntaxNode node) =>
+        node is TypeDeclarationSyntax { AttributeLists.Count: > 0  };
+
+    protected override string DeclarationTypeKeyword(SyntaxNode node) =>
+        ((TypeDeclarationSyntax)node).Keyword.ValueText;
+
+    protected override bool HasConditionalCompilationDirectives(SyntaxNode node) =>
+        node.DescendantNodes(descendIntoTrivia: true).Any(x => x.IsAnyKind(
+            SyntaxKind.IfDirectiveTrivia,
+            SyntaxKind.ElifDirectiveTrivia,
+            SyntaxKind.ElseDirectiveTrivia,
+            SyntaxKind.EndIfDirectiveTrivia));
 
     private bool IsParameterlessRecord(SyntaxNode node) =>
         RecordDeclarationSyntaxWrapper.IsInstance(node)

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -60,6 +60,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType Microsoft_AspNetCore_Mvc_ControllerAttribute = new("Microsoft.AspNetCore.Mvc.ControllerAttribute");
         public static readonly KnownType Microsoft_AspNetCore_Mvc_DisableRequestSizeLimitAttribute = new("Microsoft.AspNetCore.Mvc.DisableRequestSizeLimitAttribute");
         public static readonly KnownType Microsoft_AspNetCore_Mvc_FromServicesAttribute = new("Microsoft.AspNetCore.Mvc.FromServicesAttribute");
+        public static readonly KnownType Microsoft_AspNetCore_Mvc_IActionResult = new("Microsoft.AspNetCore.Mvc.IActionResult");
         public static readonly KnownType Microsoft_AspNetCore_Mvc_IgnoreAntiforgeryTokenAttribute = new("Microsoft.AspNetCore.Mvc.IgnoreAntiforgeryTokenAttribute");
         public static readonly KnownType Microsoft_AspNetCore_Mvc_NonActionAttribute = new("Microsoft.AspNetCore.Mvc.NonActionAttribute");
         public static readonly KnownType Microsoft_AspNetCore_Mvc_NonControllerAttribute = new("Microsoft.AspNetCore.Mvc.NonControllerAttribute");

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ClassShouldNotBeEmptyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ClassShouldNotBeEmptyBase.cs
@@ -62,9 +62,11 @@ public abstract class ClassShouldNotBeEmptyBase<TSyntaxKind> : SonarDiagnosticAn
 
     private bool ShouldIgnoreBecauseOfBaseClassOrInterface(SyntaxNode node, SemanticModel model) =>
         IsClassWithDeclaredBaseClass(node)
-        && (HasGenericBaseClassOrInterface(node)
-            || (model.GetDeclaredSymbol(node) is INamedTypeSymbol classSymbol
-                && (classSymbol.BaseType is { IsAbstract: true }
-                || classSymbol.DerivesFromAny(BaseClassesToIgnore)
-                || classSymbol.ImplementsAny(InterfacesToIgnore))));
+        && (HasGenericBaseClassOrInterface(node) || ShouldIgnoreType(node, model));
+
+    private static bool ShouldIgnoreType(SyntaxNode node, SemanticModel model) =>
+        model.GetDeclaredSymbol(node) is INamedTypeSymbol classSymbol
+            && (classSymbol.BaseType is { IsAbstract: true }
+            || classSymbol.DerivesFromAny(BaseClassesToIgnore)
+            || classSymbol.ImplementsAny(InterfacesToIgnore));
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ClassShouldNotBeEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ClassShouldNotBeEmpty.cs
@@ -29,7 +29,23 @@ public sealed class ClassShouldNotBeEmpty : ClassShouldNotBeEmptyBase<SyntaxKind
         node is ClassBlockSyntax { Members.Count: 0 } classSyntax
         && !classSyntax.ClassStatement.Modifiers.Any(x => x.IsKind(SyntaxKind.PartialKeyword));
 
-    protected override bool IsClassWithDeclaredBaseClass(SyntaxNode node) => node is ClassBlockSyntax { Inherits.Count: > 0 };
+    protected override bool IsClassWithDeclaredBaseClass(SyntaxNode node) =>
+        node is ClassBlockSyntax { Inherits.Count: > 0 };
 
-    protected override string DeclarationTypeKeyword(SyntaxNode node) => ((TypeBlockSyntax)node).BlockStatement.DeclarationKeyword.ValueText.ToLower();
+    protected override bool HasGenericBaseClassOrInterface(SyntaxNode node) =>
+        node is ClassBlockSyntax { Inherits.Count: > 0 } classBlock
+        && classBlock.Inherits.Any(x => x.Types.Any(t => t is GenericNameSyntax));
+
+    protected override bool HasAnyAttribute(SyntaxNode node) =>
+        node is ClassBlockSyntax { ClassStatement.AttributeLists.Count: > 0 };
+
+    protected override bool HasConditionalCompilationDirectives(SyntaxNode node) =>
+        node.DescendantNodes(descendIntoTrivia: true).Any(x => x.IsAnyKind(
+            SyntaxKind.IfDirectiveTrivia,
+            SyntaxKind.ElseIfDirectiveTrivia,
+            SyntaxKind.ElseDirectiveTrivia,
+            SyntaxKind.EndIfDirectiveTrivia));
+
+    protected override string DeclarationTypeKeyword(SyntaxNode node) =>
+        ((TypeBlockSyntax)node).BlockStatement.DeclarationKeyword.ValueText.ToLower();
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ClassShouldNotBeEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ClassShouldNotBeEmpty.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.Rules.VisualBasic;
 
 [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-public sealed class ClassShouldNotBeEmpty : ClassShouldNotBeEmptyBase<SyntaxKind>
+public sealed class ClassShouldNotBeEmpty : ClassShouldNotBeEmptyBase<SyntaxKind, TypeBlockSyntax>
 {
     protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
@@ -29,12 +29,13 @@ public sealed class ClassShouldNotBeEmpty : ClassShouldNotBeEmptyBase<SyntaxKind
         node is ClassBlockSyntax { Members.Count: 0 } classSyntax
         && !classSyntax.ClassStatement.Modifiers.Any(x => x.IsKind(SyntaxKind.PartialKeyword));
 
-    protected override bool IsClassWithDeclaredBaseClass(SyntaxNode node) =>
-        node is ClassBlockSyntax { Inherits.Count: > 0 };
-
-    protected override bool HasGenericBaseClassOrInterface(SyntaxNode node) =>
+    protected override TypeBlockSyntax GetIfHasDeclaredBaseClass(SyntaxNode node) =>
         node is ClassBlockSyntax { Inherits.Count: > 0 } classBlock
-        && classBlock.Inherits.Any(x => x.Types.Any(t => t is GenericNameSyntax));
+            ? classBlock
+            : null;
+
+    protected override bool HasGenericBaseClassOrInterface(TypeBlockSyntax declaration) =>
+        declaration.Inherits.Any(x => x.Types.Any(t => t is GenericNameSyntax));
 
     protected override bool HasAnyAttribute(SyntaxNode node) =>
         node is ClassBlockSyntax { ClassStatement.AttributeLists.Count: > 0 };

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ClassShouldNotBeEmptyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ClassShouldNotBeEmptyTest.cs
@@ -45,7 +45,9 @@ public class ClassShouldNotBeEmptyTest
 
     private static readonly MetadataReference[] AdditionalReferences = new[]
     {
-        AspNetCoreMetadataReference.MicrosoftAspNetCoreRazorPages
+        AspNetCoreMetadataReference.MicrosoftAspNetCoreMvcAbstractions,
+        AspNetCoreMetadataReference.MicrosoftAspNetCoreMvcCore,
+        AspNetCoreMetadataReference.MicrosoftAspNetCoreRazorPages,
     };
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.CSharp10.cs
@@ -1,5 +1,5 @@
 ﻿
-record class EmptyRecordClass1();        // Noncompliant {{Remove this empty record, or add members to it.}}
+record class EmptyRecordClass1();        // Noncompliant {{Remove this empty record, write its code or make it an "interface".}}
 //           ^^^^^^^^^^^^^^^^^
 record class EmptyRecordClass2() { };    // Noncompliant
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.CSharp9.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-record EmptyRecord1();                                      // Noncompliant {{Remove this empty record, or add members to it.}}
+record EmptyRecord1();                                      // Noncompliant {{Remove this empty record, write its code or make it an "interface".}}
 //     ^^^^^^^^^^^^
 record EmptyRecord2() { };                                  // Noncompliant
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.Inheritance.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.Inheritance.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using System;
 
 class BaseClass
@@ -18,6 +19,9 @@ abstract class AbstractBaseWithoutAbstractMethods
 class NoImplementation: AbstractBaseWithAbstractMethods { }          // Error - abstract methods should be implemented
 class DefaultImplementation: AbstractBaseWithoutAbstractMethods { }  // Compliant - the class will use the default implementation of DefaultMethod
 
-class EmptyPageModel: PageModel { }                                  // Compliant - an empty PageModel can be fully functional, the C# code can be in the cshtml file
 class CustomException: Exception { }                                 // Compliant - empty exception classes are allowed, the name of the class already provides information
+class CustomAttribute: Attribute { }                                 // Compliant - empty attribute classes are allowed, the name of the class already provides information
+
+class EmptyPageModel: PageModel { }                                  // Compliant - an empty PageModel can be fully functional, the C# code can be in the cshtml file
+class CustomActionResult: ActionResult { }                           // Compliant - an empty action result can still provide information by its name
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.Inheritance.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.Inheritance.vb
@@ -1,4 +1,5 @@
-﻿Imports Microsoft.AspNetCore.Mvc.RazorPages
+﻿Imports Microsoft.AspNetCore.Mvc
+Imports Microsoft.AspNetCore.Mvc.RazorPages
 Imports System
 
 Public Class BaseClass
@@ -9,7 +10,7 @@ Public Class BaseClass
     End Property
 End Class
 
-Public Class SubClass       ' Noncompliant - not derived from any special base class
+Public Class SubClass               ' Noncompliant - not derived from any special base class
     Inherits BaseClass
 End Class
 
@@ -22,18 +23,26 @@ MustInherit Class AbstractBaseWithoutAbstractMethods
     End Sub
 End Class
 
-Class NoImplementation       ' Error - abstract methods should be implemented
+Class NoImplementation              ' Error - abstract methods should be implemented
     Inherits AbstractBaseWithAbstractMethods
 End Class
 
-Class DefaultImplementation  ' Compliant - the class will use the default implementation of DefaultMethod
+Class DefaultImplementation         ' Compliant - the class will use the default implementation of DefaultMethod
     Inherits AbstractBaseWithoutAbstractMethods
 End Class
 
-Public Class EmptyPageModel ' Compliant - an empty PageModel can be fully functional, the VB code can be in the vbhtml file
+Public Class CustomException        ' Compliant - empty exception classes are allowed, the name of the class already provides information
+    Inherits Exception
+End Class
+
+Public Class CustomAttribute        ' Compliant - empty attribute classes are allowed, the name of the class already provides information
+    Inherits Exception
+End Class
+
+Public Class EmptyPageModel         ' Compliant - an empty PageModel can be fully functional, the VB code can be in the vbhtml file
     Inherits PageModel
 End Class
 
-Public Class CustomException ' Compliant - empty exception classes are allowed, the name of the class already provides information
-    Inherits Exception
+Public Class CustomActionResult     ' Compliant - an empty action result can still provide information by its name
+    Inherits ActionResult
 End Class

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
-class Empty { }                              // Noncompliant {{Remove this empty class, or add members to it.}}
+class Empty { }                              // Noncompliant {{Remove this empty class, write its code or make it an "interface".}}
 //    ^^^^^
 
 public class PublicEmpty { }                 // Noncompliant
@@ -73,6 +75,13 @@ class GenericNotEmptyWithConstraints<T>
     void Method(T arg) { }
 }
 
+class IntegerList: List<int> { }             // Compliant - creates a more specific type without adding new members to it (similar to using the typedef keyword in C/C++)
+class StringLookup<T>: Dictionary<string, T> { }
+interface IIntegerSet<T>: ISet<int> { }
+
+[ComVisible(true)]
+class ClassWithAttribute { }                 // Compliant - types with attributes are ignored
+
 static class StaticEmpty { }                 // Noncompliant
 
 abstract class AbstractEmpty { }             // Noncompliant
@@ -89,6 +98,16 @@ interface IMarker { }                        // Compliant - this rule only deals
 struct EmptyStruct { }                       // Compliant - this rule only deals with classes
 
 enum EmptyEnum { }                           // Compliant - this rule only deals with classes
+
+class Conditional                            // Compliant - it's not empty when the given symbol is defined
+{
+#if NOTDEFINED
+    public override string ToString()
+    {
+        return "Debug Text";
+    }
+#endif
+}
 
 class { }                                    // Error
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.cs
@@ -82,6 +82,12 @@ interface IIntegerSet<T>: ISet<int> { }
 [ComVisible(true)]
 class ClassWithAttribute { }                 // Compliant - types with attributes are ignored
 
+[ComVisible(true), Obsolete]
+class ClassWithMultipleAttributes { }
+
+[]                                           // Error
+class AttributeError { }
+
 static class StaticEmpty { }                 // Noncompliant
 
 abstract class AbstractEmpty { }             // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.vb
@@ -1,6 +1,8 @@
 ﻿Imports System
+Imports System.Collections.Generic
+Imports System.Runtime.InteropServices
 
-Class Empty                                         ' Noncompliant {{Remove this empty class, or add members to it.}}
+Class Empty                                         ' Noncompliant {{Remove this empty class, write its code or make it an "interface".}}
     ' ^^^^^
 End Class
 
@@ -97,6 +99,22 @@ Class GenericNotEmptyWithConstraints(Of T As Class)
     End Sub
 End Class
 
+Class IntegerList                                   ' Compliant - creates a more specific type without adding new members to it (similar to using the typedef keyword in C/C++)
+    Inherits List(Of Integer)
+End Class
+
+Class StringLookup(Of T)
+    Inherits Dictionary(Of String, T)
+End Class
+
+Interface IIntegerSet(Of T)
+    Inherits ISet(Of Integer)
+End Interface
+
+<ComVisible(True)>
+Class ClassWithAttribute                            ' Compliant - types with attributes are ignored
+End Class
+
 MustInherit Class AbstractEmpty                     ' Noncompliant
 End Class
 
@@ -117,5 +135,13 @@ End Interface
 Structure EmptyStruct                               ' Compliant - this rule only deals with classes
 End Structure
 
+Class Conditional                                   ' Compliant - it's not empty when the given symbol is defined
+#If NOTDEFINED Then
+    Public Overrides Function ToString() As String
+        Return "Debug Text"
+    End Function
+#End If
+End Class
+
 Class                                               ' Error
-End Class                                    
+End Class

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ClassShouldNotBeEmpty.vb
@@ -115,6 +115,14 @@ End Interface
 Class ClassWithAttribute                            ' Compliant - types with attributes are ignored
 End Class
 
+<ComVisible(True), Obsolete>
+Class ClassWithMultipleAttributes
+End Class
+
+<>                                                  ' Error
+Class AttributeError                                ' Noncompliant
+End Class
+
 MustInherit Class AbstractEmpty                     ' Noncompliant
 End Class
 


### PR DESCRIPTION
Fixes #6704

Exceptions were added for the following test cases:
- class has attributes
- class is derived from a generic class/interface
- class contains conditional compiler directive
- class is derived from `System.Attribute` or implements the `IActionResult` interface in ASP.NET

The rule message was changed to be similar to Java and other languages covering S2094.