### PR TITLE
Performance: Token Type Utility Analyzer: Avoid allocations

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -27,6 +27,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override TokenClassifierBase GetTokenClassifier(SemanticModel semanticModel, bool skipIdentifierTokens) =>
             new TokenClassifier(semanticModel, skipIdentifierTokens);
+
         protected override TriviaClassifierBase GetTriviaClassifier() =>
             new TriviaClassifier();
 
@@ -64,7 +65,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     SyntaxKindEx.InterpolatedRawStringEndToken);
         }
 
-        private sealed class TriviaClassifier: TriviaClassifierBase
+        private sealed class TriviaClassifier : TriviaClassifierBase
         {
             protected override bool IsRegularComment(SyntaxTrivia trivia) =>
                 trivia.IsAnyKind(SyntaxKind.SingleLineCommentTrivia, SyntaxKind.MultiLineCommentTrivia);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -25,12 +25,14 @@ namespace SonarAnalyzer.Rules.CSharp
     {
         protected override ILanguageFacade<SyntaxKind> Language { get; } = CSharpFacade.Instance;
 
-        protected override TokenClassifierBase GetTokenClassifier(SyntaxToken token, SemanticModel semanticModel, bool skipIdentifierTokens) =>
-            new TokenClassifier(token, semanticModel, skipIdentifierTokens);
+        protected override TokenClassifierBase GetTokenClassifier(SemanticModel semanticModel, bool skipIdentifierTokens) =>
+            new TokenClassifier(semanticModel, skipIdentifierTokens);
+        protected override TriviaClassifierBase GetTriviaClassifier() =>
+            new TriviaClassifier();
 
         private sealed class TokenClassifier : TokenClassifierBase
         {
-            public TokenClassifier(SyntaxToken token, SemanticModel semanticModel, bool skipIdentifiers) : base(token, semanticModel, skipIdentifiers) { }
+            public TokenClassifier(SemanticModel semanticModel, bool skipIdentifiers) : base(semanticModel, skipIdentifiers) { }
 
             protected override SyntaxNode GetBindableParent(SyntaxToken token) =>
                 token.GetBindableParent();
@@ -40,9 +42,6 @@ namespace SonarAnalyzer.Rules.CSharp
 
             protected override bool IsKeyword(SyntaxToken token) =>
                 SyntaxFacts.IsKeywordKind(token.Kind());
-
-            protected override bool IsRegularComment(SyntaxTrivia trivia) =>
-                trivia.IsAnyKind(SyntaxKind.SingleLineCommentTrivia, SyntaxKind.MultiLineCommentTrivia);
 
             protected override bool IsNumericLiteral(SyntaxToken token) =>
                 token.IsKind(SyntaxKind.NumericLiteralToken);
@@ -63,6 +62,12 @@ namespace SonarAnalyzer.Rules.CSharp
                     SyntaxKind.InterpolatedStringTextToken,
                     SyntaxKind.InterpolatedStringEndToken,
                     SyntaxKindEx.InterpolatedRawStringEndToken);
+        }
+
+        private sealed class TriviaClassifier: TriviaClassifierBase
+        {
+            protected override bool IsRegularComment(SyntaxTrivia trivia) =>
+                trivia.IsAnyKind(SyntaxKind.SingleLineCommentTrivia, SyntaxKind.MultiLineCommentTrivia);
 
             protected override bool IsDocComment(SyntaxTrivia trivia) =>
                 trivia.IsAnyKind(SyntaxKind.SingleLineDocumentationCommentTrivia, SyntaxKind.MultiLineDocumentationCommentTrivia);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
@@ -43,8 +43,8 @@ namespace SonarAnalyzer.Rules
             var identifierTokenKind = Language.SyntaxKind.IdentifierToken;  // Performance optimization
             var skipIdentifierTokens = tokens
                 .Where(token => Language.Syntax.IsKind(token, identifierTokenKind))
-                .Take(IdentifierTokenCountThreshold + 1)
-                .Count() > IdentifierTokenCountThreshold;
+                .Skip(IdentifierTokenCountThreshold)
+                .Any()
 
             var tokenClassifier = GetTokenClassifier(semanticModel, skipIdentifierTokens);
             var triviaClassifier = GetTriviaClassifier();

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules
             var skipIdentifierTokens = tokens
                 .Where(token => Language.Syntax.IsKind(token, identifierTokenKind))
                 .Skip(IdentifierTokenCountThreshold)
-                .Any()
+                .Any();
 
             var tokenClassifier = GetTokenClassifier(semanticModel, skipIdentifierTokens);
             var triviaClassifier = GetTriviaClassifier();

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules
         {
             var tokens = syntaxTree.GetRoot().DescendantTokens();
             var identifierTokenKind = Language.SyntaxKind.IdentifierToken;  // Performance optimization
-            var skipIdentifierTokens = tokens.Count(token => Language.Syntax.IsKind(token, identifierTokenKind)) > IdentifierTokenCountThreshold;
+            var skipIdentifierTokens = tokens.Take(IdentifierTokenCountThreshold + 1).Count(token => Language.Syntax.IsKind(token, identifierTokenKind)) > IdentifierTokenCountThreshold;
 
             var tokenClassifier = GetTokenClassifier(semanticModel, skipIdentifierTokens);
             var triviaClassifier = GetTriviaClassifier();
@@ -170,13 +170,13 @@ namespace SonarAnalyzer.Rules
             public TokenTypeInfo.Types.TokenInfo ClassifyTrivia(SyntaxTrivia trivia) =>
                 trivia switch
                 {
-                    _ when IsRegularComment(trivia) => CollectClassified(trivia.SyntaxTree, TokenType.Comment, trivia.Span),
+                    _ when IsRegularComment(trivia) => TokenInfo(trivia.SyntaxTree, TokenType.Comment, trivia.Span),
                     _ when IsDocComment(trivia) => ClassifyDocComment(trivia),
                     // Handle preprocessor directives here
                     _ => null,
                 };
 
-            private TokenTypeInfo.Types.TokenInfo CollectClassified(SyntaxTree tree, TokenType tokenType, TextSpan span) =>
+            private TokenTypeInfo.Types.TokenInfo TokenInfo(SyntaxTree tree, TokenType tokenType, TextSpan span) =>
                 new()
                 {
                     TokenType = tokenType,
@@ -184,7 +184,7 @@ namespace SonarAnalyzer.Rules
                 };
 
             private TokenTypeInfo.Types.TokenInfo ClassifyDocComment(SyntaxTrivia trivia) =>
-                CollectClassified(trivia.SyntaxTree, TokenType.Comment, trivia.FullSpan);
+                TokenInfo(trivia.SyntaxTree, TokenType.Comment, trivia.FullSpan);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules
         {
             var tokens = syntaxTree.GetRoot().DescendantTokens();
             var identifierTokenKind = Language.SyntaxKind.IdentifierToken;  // Performance optimization
-            var skipIdentifierTokens = tokens.Take(IdentifierTokenCountThreshold + 1).Count(token => Language.Syntax.IsKind(token, identifierTokenKind)) > IdentifierTokenCountThreshold;
+            var skipIdentifierTokens = tokens.Where(token => Language.Syntax.IsKind(token, identifierTokenKind)).Take(IdentifierTokenCountThreshold + 1).Count() > IdentifierTokenCountThreshold;
 
             var tokenClassifier = GetTokenClassifier(semanticModel, skipIdentifierTokens);
             var triviaClassifier = GetTriviaClassifier();

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules
             {
                 if (token.HasLeadingTrivia)
                 {
-                    IterateTrivia(token.LeadingTrivia);
+                    IterateTrivia(triviaClassifier, spans, token.LeadingTrivia);
                 }
                 if (tokenClassifier.ClassifyToken(token) is { } tokenClassification)
                 {
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules
                 }
                 if (token.HasTrailingTrivia)
                 {
-                    IterateTrivia(token.TrailingTrivia);
+                    IterateTrivia(triviaClassifier, spans, token.TrailingTrivia);
                 }
             }
 
@@ -74,7 +74,7 @@ namespace SonarAnalyzer.Rules
             tokenTypeInfo.TokenInfo.AddRange(spans);
             return tokenTypeInfo;
 
-            void IterateTrivia(SyntaxTriviaList triviaList)
+            static void IterateTrivia(TriviaClassifierBase triviaClassifier, List<TokenTypeInfo.Types.TokenInfo> spans, SyntaxTriviaList triviaList)
             {
                 foreach (var trivia in triviaList)
                 {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
@@ -41,7 +41,10 @@ namespace SonarAnalyzer.Rules
         {
             var tokens = syntaxTree.GetRoot().DescendantTokens();
             var identifierTokenKind = Language.SyntaxKind.IdentifierToken;  // Performance optimization
-            var skipIdentifierTokens = tokens.Where(token => Language.Syntax.IsKind(token, identifierTokenKind)).Take(IdentifierTokenCountThreshold + 1).Count() > IdentifierTokenCountThreshold;
+            var skipIdentifierTokens = tokens
+                .Where(token => Language.Syntax.IsKind(token, identifierTokenKind))
+                .Take(IdentifierTokenCountThreshold + 1)
+                .Count() > IdentifierTokenCountThreshold;
 
             var tokenClassifier = GetTokenClassifier(semanticModel, skipIdentifierTokens);
             var triviaClassifier = GetTriviaClassifier();

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
@@ -119,12 +119,12 @@ namespace SonarAnalyzer.Rules
 
             private TokenTypeInfo.Types.TokenInfo TokenInfo(SyntaxToken token, TokenType tokenType) =>
                 string.IsNullOrWhiteSpace(token.ValueText)
-                ? null
-                : new()
-                {
-                    TokenType = tokenType,
-                    TextRange = GetTextRange(token.GetLocation().GetLineSpan()),
-                };
+                    ? null
+                    : new()
+                    {
+                        TokenType = tokenType,
+                        TextRange = GetTextRange(token.GetLocation().GetLineSpan()),
+                    };
 
             public TokenTypeInfo.Types.TokenInfo ClassifyToken(SyntaxToken token) =>
                 token switch

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
@@ -118,15 +118,6 @@ namespace SonarAnalyzer.Rules
                 this.skipIdentifiers = skipIdentifiers;
             }
 
-            private TokenInfo TokenInfo(SyntaxToken token, TokenType tokenType) =>
-                string.IsNullOrWhiteSpace(token.ValueText)
-                    ? null
-                    : new()
-                    {
-                        TokenType = tokenType,
-                        TextRange = GetTextRange(token.GetLocation().GetLineSpan()),
-                    };
-
             public TokenInfo ClassifyToken(SyntaxToken token) =>
                 token switch
                 {
@@ -136,6 +127,15 @@ namespace SonarAnalyzer.Rules
                     _ when IsIdentifier(token) && !skipIdentifiers => ClassifyIdentifier(token),
                     _ => null,
                 };
+
+            private static TokenInfo TokenInfo(SyntaxToken token, TokenType tokenType) =>
+                string.IsNullOrWhiteSpace(token.ValueText)
+                    ? null
+                    : new()
+                    {
+                        TokenType = tokenType,
+                        TextRange = GetTextRange(token.GetLocation().GetLineSpan()),
+                    };
 
             private TokenInfo ClassifyIdentifier(SyntaxToken token)
             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules
         protected virtual bool AnalyzeTestProjects => true;
         protected string OutPath { get; set; }
         protected bool IsTestProject { get; set; }
-        protected override bool EnableConcurrentExecution => false;
+        protected override bool EnableConcurrentExecution => true;
 
         protected UtilityAnalyzerBase(string diagnosticId, string title) =>
             rule = DiagnosticDescriptorFactory.CreateUtility(diagnosticId, title);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules
         protected virtual bool AnalyzeTestProjects => true;
         protected string OutPath { get; set; }
         protected bool IsTestProject { get; set; }
-        protected override bool EnableConcurrentExecution => true;
+        protected override bool EnableConcurrentExecution => false;
 
         protected UtilityAnalyzerBase(string diagnosticId, string title) =>
             rule = DiagnosticDescriptorFactory.CreateUtility(diagnosticId, title);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -25,12 +25,14 @@ namespace SonarAnalyzer.Rules.VisualBasic
     {
         protected override ILanguageFacade<SyntaxKind> Language { get; } = VisualBasicFacade.Instance;
 
-        protected override TokenClassifierBase GetTokenClassifier(SyntaxToken token, SemanticModel semanticModel, bool skipIdentifierTokens) =>
-            new TokenClassifier(token, semanticModel, skipIdentifierTokens);
+        protected override TokenClassifierBase GetTokenClassifier(SemanticModel semanticModel, bool skipIdentifierTokens) =>
+            new TokenClassifier(semanticModel, skipIdentifierTokens);
+        protected override TriviaClassifierBase GetTriviaClassifier() =>
+            new TriviaClassifier();
 
         private sealed class TokenClassifier : TokenClassifierBase
         {
-            public TokenClassifier(SyntaxToken token, SemanticModel semanticModel, bool skipIdentifiers) : base(token, semanticModel, skipIdentifiers) { }
+            public TokenClassifier(SemanticModel semanticModel, bool skipIdentifiers) : base(semanticModel, skipIdentifiers) { }
 
             protected override SyntaxNode GetBindableParent(SyntaxToken token) =>
                 token.GetBindableParent();
@@ -41,9 +43,6 @@ namespace SonarAnalyzer.Rules.VisualBasic
             protected override bool IsKeyword(SyntaxToken token) =>
                 SyntaxFacts.IsKeywordKind(token.Kind());
 
-            protected override bool IsRegularComment(SyntaxTrivia trivia) =>
-                trivia.IsKind(SyntaxKind.CommentTrivia);
-
             protected override bool IsNumericLiteral(SyntaxToken token) =>
                 token.IsAnyKind(SyntaxKind.DecimalLiteralToken, SyntaxKind.FloatingLiteralToken, SyntaxKind.IntegerLiteralToken);
 
@@ -53,6 +52,12 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     SyntaxKind.CharacterLiteralToken,
                     SyntaxKind.InterpolatedStringTextToken,
                     SyntaxKind.EndOfInterpolatedStringToken);
+        }
+
+        private sealed class TriviaClassifier : TriviaClassifierBase
+        {
+            protected override bool IsRegularComment(SyntaxTrivia trivia) =>
+                trivia.IsKind(SyntaxKind.CommentTrivia);
 
             protected override bool IsDocComment(SyntaxTrivia trivia) =>
                 trivia.IsKind(SyntaxKind.DocumentationCommentTrivia);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -27,6 +27,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
         protected override TokenClassifierBase GetTokenClassifier(SemanticModel semanticModel, bool skipIdentifierTokens) =>
             new TokenClassifier(semanticModel, skipIdentifierTokens);
+
         protected override TriviaClassifierBase GetTriviaClassifier() =>
             new TriviaClassifier();
 


### PR DESCRIPTION
The current implementation of the `TokenTypeAnalyzerBase` has the following problems:

* It allocates a new TokenClassifierBase per Token
* It does an "OrderBy" after all classification is collected
* It does a span-based text lookup in the tree for each classification

This PR changes how the TokenClassifierBase operates.

Instead of one new TokenClassifierBase per Token, the TokenClassifierBase is now created once per document. The token is passed to `ClassifyToken`.  `ClassifyToken` was changed

* from adding `TokenInfo` into the collecting list
* to returning the `TokenInfo` to the caller

The trivia handling was extracted into `TriviaClassifierBase` to allow `TokenClassifierBase.ClassifyToken()` to return a single `TokenInfo` instead of a list. The trivia is now processed before (LeadingTrivia) and after (TrailingTrivia) the token and so the ordering is guaranteed.

The calculation of the `TokenInfo.TextRange` was simplified, and the `GetSubText` call in `string.IsNullOrWhiteSpace(token.SyntaxTree.GetText().GetSubText(span).ToString())` check could be removed.

This PR is the groundwork needed to tackle `ClassifyIdentifier` next, which can be improved by avoiding querying the semantic model in many cases (e.g., an identifier in a parameter syntax is known to be an IParameterSymbol and there is no need to look up the symbol).