### PR TITLE
SyntaxFacade: fix the order of parameters in IsKnownAttributeType

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -50,7 +50,7 @@ internal sealed class CSharpSyntaxFacade : SyntaxFacade<SyntaxKind>
 
     public override bool IsNullLiteral(SyntaxNode node) => node.IsNullLiteral();
 
-    public override bool IsKnownAttributeType(SyntaxNode attribute, KnownType knownType, SemanticModel model) =>
+    public override bool IsKnownAttributeType(SemanticModel model, SyntaxNode attribute, KnownType knownType) =>
         AttributeSyntaxExtensions.IsKnownType(Cast<AttributeSyntax>(attribute), knownType, model);
 
     public override IEnumerable<SyntaxNode> ArgumentExpressions(SyntaxNode node) =>

--- a/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
@@ -32,7 +32,7 @@ public abstract class SyntaxFacade<TSyntaxKind>
     public abstract bool IsAnyKind(SyntaxNode node, ISet<TSyntaxKind> syntaxKinds);
     public abstract bool IsAnyKind(SyntaxNode node, params TSyntaxKind[] syntaxKinds);
     public abstract bool IsAnyKind(SyntaxTrivia trivia, params TSyntaxKind[] syntaxKinds);
-    public abstract bool IsKnownAttributeType(SyntaxNode attribute, KnownType knownType, SemanticModel model);
+    public abstract bool IsKnownAttributeType(SemanticModel model, SyntaxNode attribute, KnownType knownType);
     public abstract IEnumerable<SyntaxNode> ArgumentExpressions(SyntaxNode node);
     public abstract ImmutableArray<SyntaxNode> AssignmentTargets(SyntaxNode assignment);
     public abstract SyntaxNode AssignmentLeft(SyntaxNode assignment);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DebuggerDisplayUsesExistingMembersBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DebuggerDisplayUsesExistingMembersBase.cs
@@ -43,7 +43,7 @@ public abstract class DebuggerDisplayUsesExistingMembersBase<TAttributeSyntax, T
             c =>
             {
                 var attribute = (TAttributeSyntax)c.Node;
-                if (Language.Syntax.IsKnownAttributeType(attribute, KnownType.System_Diagnostics_DebuggerDisplayAttribute, c.SemanticModel)
+                if (Language.Syntax.IsKnownAttributeType(c.SemanticModel, attribute, KnownType.System_Diagnostics_DebuggerDisplayAttribute)
                     && AttributeFormatString(attribute) is { } formatString
                     && Language.Syntax.StringValue(formatString, c.SemanticModel) is { } formatStringText
                     && FirstInvalidMemberName(c, formatStringText, attribute) is { } firstInvalidMember)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
@@ -50,7 +50,7 @@ internal sealed class VisualBasicSyntaxFacade : SyntaxFacade<SyntaxKind>
 
     public override bool IsAnyKind(SyntaxTrivia trivia, params SyntaxKind[] syntaxKinds) => trivia.IsAnyKind(syntaxKinds);
 
-    public override bool IsKnownAttributeType(SyntaxNode attribute, KnownType knownType, SemanticModel model) =>
+    public override bool IsKnownAttributeType(SemanticModel model, SyntaxNode attribute, KnownType knownType) =>
         AttributeSyntaxExtensions.IsKnownType(Cast<AttributeSyntax>(attribute), knownType, model);
 
     public override IEnumerable<SyntaxNode> ArgumentExpressions(SyntaxNode node) =>


### PR DESCRIPTION
Relates to https://github.com/SonarSource/sonar-dotnet/pull/6760

https://github.com/SonarSource/sonar-dotnet/pull/6760 has introduced a new method `IsKnownAttribute` in `SyntaxFacade` for the needs of https://github.com/SonarSource/sonar-dotnet/issues/6703.

This PR does cleanup of https://github.com/SonarSource/sonar-dotnet/pull/6760, fixing the order of parameters of the new API, to conform to code conventions.

