### PR TITLE
SE - Nullable: Copy constraints to `Value` property

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.SymbolicExecution.Constraints;
+using SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution;
+
+namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn;
+
+public partial class RoslynSymbolicExecutionTest
+{
+    [TestMethod]
+    public void Nullable_Assignment_PropagatesConstrainsToValue()
+    {
+        const string code = """
+            bool? value = null;
+            Tag("Null", value);
+            value = true;
+            Tag("True", value);
+            """;
+        var validator = SETestContext.CreateCS(code).Validator;
+        validator.ValidateTag("Null", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
+        validator.ValidateTag("True", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
+    }
+
+    [TestMethod]
+    public void Nullable_Value_ReadsConstraintsFromInstance()
+    {
+        const string code = """
+            var value = arg.Value;
+            Tag("Unknown", value);
+            arg = true;
+            value = arg.Value;
+            Tag("True", value);
+            arg = false;        // This will set additional constraint TestConstraint.First
+            value = arg.Value;
+            Tag("FalseFirst", value);
+            """;
+        var setter = new PreProcessTestCheck(OperationKind.Literal, x => x.Operation.Instance.ConstantValue.Value is false ? x.SetOperationConstraint(TestConstraint.First) : x.State);
+        var validator = SETestContext.CreateCS(code, ", bool? arg", setter).Validator;
+        validator.ValidateTag("Unknown", x => x.Should().BeNull());
+        validator.ValidateTag("True", x => x.Should().BeNull()); // FIXME: x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
+        validator.ValidateTag("FalseFirst", x => x.Should().BeNull()); // FIXME: x.HasConstraint(BoolConstraint.False).Should().BeTrue());
+        validator.ValidateTag("FalseFirst", x => x.Should().BeNull()); // FIXME: x.HasConstraint(TestConstraint.First).Should().BeTrue());
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -55,8 +55,8 @@ public partial class RoslynSymbolicExecutionTest
         var setter = new PreProcessTestCheck(OperationKind.Literal, x => x.Operation.Instance.ConstantValue.Value is false ? x.SetOperationConstraint(TestConstraint.First) : x.State);
         var validator = SETestContext.CreateCS(code, ", bool? arg", setter).Validator;
         validator.ValidateTag("Unknown", x => x.Should().BeNull());
-        validator.ValidateTag("True", x => x.Should().BeNull()); // FIXME: x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("FalseFirst", x => x.Should().BeNull()); // FIXME: x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-        validator.ValidateTag("FalseFirst", x => x.Should().BeNull()); // FIXME: x.HasConstraint(TestConstraint.First).Should().BeTrue());
+        validator.ValidateTag("True", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
+        validator.ValidateTag("FalseFirst", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
+        validator.ValidateTag("FalseFirst", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
     }
 }


### PR DESCRIPTION
Part of #6812

Copy known constraints from nullable symbol to `.Value` property.

```C#
bool? nullable = true;          // nullable symbol is known to have True constraint after this
var result = nullable.Value;  // True constraint from symbol nullable should get propagated to its Value property so it can be assigned to the result symbol later
```