### PR TITLE
Remove inexistent mvn profile from build script

### DIFF
--- a/docs/contributing-plugin.md
+++ b/docs/contributing-plugin.md
@@ -20,7 +20,7 @@
 
         * or run the following commands:
             1. `msbuild /t:rebuild .\analyzers\SonarAnalyzer.sln`
-            1. `mvn clean install -P local-analyzer -D analyzer.configuration=Debug`
+            1. `mvn clean install -D analyzer.configuration=Debug`
 
 ## Developing with Eclipse or IntelliJ
 

--- a/scripts/build/dev-build.ps1
+++ b/scripts/build/dev-build.ps1
@@ -102,7 +102,7 @@ try {
             $skipTests = ""
         }
         Invoke-InLocation ".." {
-            Exec { & mvn clean install -P local-analyzer -D analyzer.configuration=$buildConfiguration $skipTests }
+            Exec { & mvn clean install -D analyzer.configuration=$buildConfiguration $skipTests }
         }
     }
 


### PR DESCRIPTION
the `local-analyzer` maven profile had been deleted in  #5839
