### PR TITLE
SE - Nullable: Propagate constraints via nullable constructor

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -41,7 +41,9 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             SerializeConstraints();
 
         public SymbolicValue WithConstraint(SymbolicConstraint constraint) =>
-            this with { Constraints = Constraints.SetItem(constraint.GetType(), constraint) };
+            HasConstraint(constraint)
+                ? this
+                : this with { Constraints = Constraints.SetItem(constraint.GetType(), constraint) };
 
         public SymbolicValue WithoutConstraint(SymbolicConstraint constraint) =>
             HasConstraint(constraint)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -123,8 +123,8 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var setter = new PreProcessTestCheck(OperationKind.Literal, x => x.Operation.Instance.ConstantValue.Value is false ? x.SetOperationConstraint(TestConstraint.First) : x.State);
         var validator = SETestContext.CreateCS(code, setter).Validator;
-        validator.ValidateTag("IsTrue", x => x.AllConstraints.Select(x => x.ToString()).OrderBy(x => x).JoinStr(", ").Should().Be("NotNull, True"));
-        validator.ValidateTag("IsFalse", x => x.AllConstraints.Select(x => x.ToString()).OrderBy(x => x).JoinStr(", ").Should().Be("False, First, NotNull"));
-        validator.ValidateTag("IsInt", x => x.AllConstraints.Select(x => x.ToString()).OrderBy(x => x).JoinStr(", ").Should().Be("NotNull"));
+        validator.ValidateTag("IsTrue", x => x.AllConstraints.Select(x => x.Kind).Should().BeEquivalentTo(new[] { ConstraintKind.ObjectNotNull, ConstraintKind.BoolTrue }));
+        validator.ValidateTag("IsFalse", x => x.AllConstraints.Select(x => x.Kind).Should().BeEquivalentTo(new[] { ConstraintKind.ObjectNotNull, ConstraintKind.BoolFalse, (ConstraintKind)ConstraintKindTest.First }));
+        validator.ValidateTag("IsInt", x => x.AllConstraints.Select(x => x.Kind).Should().BeEquivalentTo(new[] { ConstraintKind.ObjectNotNull }));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -107,7 +107,6 @@ public partial class RoslynSymbolicExecutionTest
         validator.ValidateTag("TargetTyped", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("new() of int produces value 0"));
         validator.ValidateTag("GenericValue", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("new() of T produces value T"));
         validator.ValidateTag("GenericNull", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-}
     }
 
     [TestMethod]


### PR DESCRIPTION
Part of #6812 

Set argument constraints for `new Nullable<int>(value)` or `new Nullable<int>(42)`

This is a draft, the 1st `Squash 03-NewArg` commit doesn't need a review as it is in #6853