### PR TITLE
SE - Nullable: Change `PropertyReference` to branching processor

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationDispatcher.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationDispatcher.cs
@@ -30,7 +30,8 @@ internal static class OperationDispatcher
         { OperationKindEx.Invocation, new Invocation() },
         { OperationKindEx.IsNull, new IsNull() },
         { OperationKindEx.IsPattern, new IsPattern() },
-        { OperationKindEx.IsType, new IsType() }
+        { OperationKindEx.IsType, new IsType() },
+        { OperationKindEx.PropertyReference, new PropertyReference() },
     };
 
     private static readonly Dictionary<OperationKind, ISimpleProcessor> Simple = new()
@@ -53,7 +54,6 @@ internal static class OperationDispatcher
         { OperationKindEx.LocalReference, new LocalReference() },
         { OperationKindEx.ObjectCreation, new ObjectCreation() },
         { OperationKindEx.ParameterReference, new ParameterReference() },
-        { OperationKindEx.PropertyReference, new PropertyReference() },
         { OperationKindEx.RecursivePattern, new RecursivePattern() },
         { OperationKindEx.ReDimClause, new ReDimClause() },
         { OperationKindEx.SimpleAssignment, new Assignment() },

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Assignment.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Assignment.cs
@@ -30,7 +30,7 @@ internal sealed class Assignment : SimpleProcessor<ISimpleAssignmentOperationWra
         var rightSide = context.State[assignment.Value];
         var newState = context.State
             .SetOperationValue(assignment.Target, rightSide)
-            .SetOperationValue(assignment.WrappedOperation, rightSide);
+            .SetOperationValue(assignment, rightSide);
         return newState.ResolveCapture(assignment.Target).TrackedSymbol() is { } symbol
             ? newState.SetSymbolValue(symbol, rightSide)
             : newState;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
@@ -27,8 +27,8 @@ internal sealed class Binary : BranchingProcessor<IBinaryOperationWrapper>
     protected override IBinaryOperationWrapper Convert(IOperation operation) =>
         IBinaryOperationWrapper.FromOperation(operation);
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(SymbolicContext context, IBinaryOperationWrapper operation) =>
-        BinaryConstraint(operation.OperatorKind, context.State[operation.LeftOperand], context.State[operation.RightOperand]);
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IBinaryOperationWrapper operation) =>
+        BinaryConstraint(operation.OperatorKind, state[operation.LeftOperand], state[operation.RightOperand]);
 
     protected override ProgramState LearnBranchingConstraint(ProgramState state, IBinaryOperationWrapper operation, bool falseBranch) =>
         operation.OperatorKind.IsAnyEquality()

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
@@ -41,7 +41,7 @@ internal abstract class BranchingProcessor<T> : MultiProcessor<T>
         var state = PreProcess(context.State, operation);
         if (BoolConstraintFromOperation(state, operation) is { } constraint)
         {
-            return context.SetOperationConstraint(constraint).ToArray();    // We already know the answer from existing constraints
+            return state.SetOperationConstraint(context.Operation, constraint).ToArray();    // We already know the answer from existing constraints
         }
         else
         {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
@@ -30,12 +30,12 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors;
 internal abstract class BranchingProcessor<T> : MultiProcessor<T>
     where T : IOperationWrapper
 {
-    protected abstract SymbolicConstraint BoolConstraintFromOperation(SymbolicContext context, T operation);
+    protected abstract SymbolicConstraint BoolConstraintFromOperation(ProgramState state, T operation);
     protected abstract ProgramState LearnBranchingConstraint(ProgramState state, T operation, bool falseBranch);
 
     protected override ProgramState[] Process(SymbolicContext context, T operation)
     {
-        if (BoolConstraintFromOperation(context, operation) is { } constraint)
+        if (BoolConstraintFromOperation(context.State, operation) is { } constraint)
         {
             return context.SetOperationConstraint(constraint).ToArray();    // We already know the answer from existing constraints
         }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsNull.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsNull.cs
@@ -27,8 +27,8 @@ internal sealed class IsNull : BranchingProcessor<IIsNullOperationWrapper>
     protected override IIsNullOperationWrapper Convert(IOperation operation) =>
         IIsNullOperationWrapper.FromOperation(operation);
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(SymbolicContext context, IIsNullOperationWrapper operation) =>
-        context.State[operation.Operand] is { } value && value.HasConstraint<ObjectConstraint>()
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsNullOperationWrapper operation) =>
+        state[operation.Operand] is { } value && value.HasConstraint<ObjectConstraint>()
             ? BoolConstraint.From(value.HasConstraint(ObjectConstraint.Null))
             : null;
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsPattern.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsPattern.cs
@@ -27,8 +27,8 @@ internal sealed class IsPattern : BranchingProcessor<IIsPatternOperationWrapper>
     protected override IIsPatternOperationWrapper Convert(IOperation operation) =>
         IIsPatternOperationWrapper.FromOperation(operation);
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(SymbolicContext context, IIsPatternOperationWrapper operation) =>
-        BoolContraintFromConstant(context.State, operation) ?? BoolConstraintFromPattern(context.State, operation);
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsPatternOperationWrapper operation) =>
+        BoolContraintFromConstant(state, operation) ?? BoolConstraintFromPattern(state, operation);
 
     protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsPatternOperationWrapper operation, bool falseBranch) =>
         state.ResolveCapture(operation.Value).TrackedSymbol() is { } testedSymbol

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsType.cs
@@ -27,7 +27,7 @@ internal sealed class IsType : BranchingProcessor<IIsTypeOperationWrapper>
     protected override IIsTypeOperationWrapper Convert(IOperation operation) =>
         IIsTypeOperationWrapper.FromOperation(operation);
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(SymbolicContext context, IIsTypeOperationWrapper operation) =>
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsTypeOperationWrapper operation) =>
         null;
 
     protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsTypeOperationWrapper operation, bool falseBranch) =>

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/References.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/References.cs
@@ -66,37 +66,37 @@ internal sealed class FieldReference : SimpleProcessor<IFieldReferenceOperationW
     }
 }
 
-internal sealed class PropertyReference : SimpleProcessor<IPropertyReferenceOperationWrapper>
+internal sealed class PropertyReference : BranchingProcessor<IPropertyReferenceOperationWrapper>
 {
     protected override IPropertyReferenceOperationWrapper Convert(IOperation operation) =>
         IPropertyReferenceOperationWrapper.FromOperation(operation);
 
-    protected override ProgramState Process(SymbolicContext context, IPropertyReferenceOperationWrapper propertyReference)
+    protected override ProgramState PreProcess(ProgramState state, IPropertyReferenceOperationWrapper operation)
     {
-        var state = context.State;
-        if (propertyReference.Instance.TrackedSymbol() is { } symbol)
+        if (operation.Instance.TrackedSymbol() is { } symbol)
         {
-            if (propertyReference.Instance.Type.IsNullableValueType())
+            if (!IsNullableHasValue(operation))
             {
-                if (propertyReference.Property.Name == "Value" && state[symbol] is { } value)
-                {
-                    state = state.SetOperationValue(context.Operation, value);
-                }
-                else if (propertyReference.Property.Name == "HasValue")
-                {
-                    // Return directly, do not set NotNull on the symbol itself
-                    return state[symbol]?.Constraint<ObjectConstraint>() is { } objectConstraint
-                        ? state.SetOperationConstraint(context.Operation, BoolConstraint.From(objectConstraint == ObjectConstraint.NotNull))
-                        : state;
-                }
+                state = state.SetSymbolConstraint(symbol, ObjectConstraint.NotNull);
             }
-            return state.SetSymbolConstraint(symbol, ObjectConstraint.NotNull);
+            if (operation.Property.Name == "Value" && state[symbol] is { } value)
+            {
+                state = state.SetOperationValue(operation, value);
+            }
         }
-        else
-        {
-            return state;
-        }
+        return state;
     }
+
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IPropertyReferenceOperationWrapper operation) =>
+        IsNullableHasValue(operation) && state[operation.Instance]?.Constraint<ObjectConstraint>() is { } objectConstraint
+            ? BoolConstraint.From(objectConstraint == ObjectConstraint.NotNull)
+            : null;
+
+    protected override ProgramState LearnBranchingConstraint(ProgramState state, IPropertyReferenceOperationWrapper operation, bool falseBranch) =>
+        state;  // ToDo: Implement later to support branching on .HasValue
+
+    private static bool IsNullableHasValue(IPropertyReferenceOperationWrapper operation) =>
+        operation.Instance.Type.IsNullableValueType() && operation.Property.Name == "HasValue";
 }
 
 internal sealed class ArrayElementReference : SimpleProcessor<IArrayElementReferenceOperationWrapper>

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/References.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/References.cs
@@ -75,11 +75,11 @@ internal sealed class PropertyReference : BranchingProcessor<IPropertyReferenceO
     {
         if (operation.Instance.TrackedSymbol() is { } symbol)
         {
-            if (!IsNullableHasValue(operation))
+            if (!IsNullableProperty(operation, "HasValue"))
             {
                 state = state.SetSymbolConstraint(symbol, ObjectConstraint.NotNull);
             }
-            if (operation.Property.Name == "Value" && state[symbol] is { } value)
+            if (IsNullableProperty(operation, "Value") && state[symbol] is { } value)
             {
                 state = state.SetOperationValue(operation, value);
             }
@@ -88,15 +88,15 @@ internal sealed class PropertyReference : BranchingProcessor<IPropertyReferenceO
     }
 
     protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IPropertyReferenceOperationWrapper operation) =>
-        IsNullableHasValue(operation) && state[operation.Instance]?.Constraint<ObjectConstraint>() is { } objectConstraint
+        IsNullableProperty(operation, "HasValue") && state[operation.Instance]?.Constraint<ObjectConstraint>() is { } objectConstraint
             ? BoolConstraint.From(objectConstraint == ObjectConstraint.NotNull)
             : null;
 
     protected override ProgramState LearnBranchingConstraint(ProgramState state, IPropertyReferenceOperationWrapper operation, bool falseBranch) =>
         state;  // ToDo: Implement later to support branching on .HasValue
 
-    private static bool IsNullableHasValue(IPropertyReferenceOperationWrapper operation) =>
-        operation.Instance is not null && operation.Instance.Type.IsNullableValueType() && operation.Property.Name == "HasValue";
+    private static bool IsNullableProperty(IPropertyReferenceOperationWrapper operation, string name) =>
+        operation.Instance is not null && operation.Instance.Type.IsNullableValueType() && operation.Property.Name == name;
 }
 
 internal sealed class ArrayElementReference : SimpleProcessor<IArrayElementReferenceOperationWrapper>

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/References.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/References.cs
@@ -96,7 +96,7 @@ internal sealed class PropertyReference : BranchingProcessor<IPropertyReferenceO
         state;  // ToDo: Implement later to support branching on .HasValue
 
     private static bool IsNullableHasValue(IPropertyReferenceOperationWrapper operation) =>
-        operation.Instance.Type.IsNullableValueType() && operation.Property.Name == "HasValue";
+        operation.Instance is not null && operation.Instance.Type.IsNullableValueType() && operation.Property.Name == "HasValue";
 }
 
 internal sealed class ArrayElementReference : SimpleProcessor<IArrayElementReferenceOperationWrapper>

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -36,6 +36,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
 
         public ExceptionState Exception => Exceptions.IsEmpty ? null : Exceptions.Peek();
         public SymbolicValue this[IOperationWrapperSonar operation] => this[operation.Instance];
+        public SymbolicValue this[IOperationWrapper operation] => this[operation.WrappedOperation];
         public SymbolicValue this[IOperation operation] => OperationValue.TryGetValue(ResolveCapture(operation), out var value) ? value : null;
         public SymbolicValue this[ISymbol symbol] => SymbolValue.TryGetValue(symbol, out var value) ? value : null;
         public IOperation this[CaptureId capture] => CaptureOperation.TryGetValue(capture, out var value) ? value : null;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -60,14 +60,19 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             Exceptions = original.Exceptions;
         }
 
+        public ProgramState SetOperationValue(IOperationWrapper operation, SymbolicValue value) =>
+            operation is null
+                ? throw new ArgumentNullException(nameof(operation))
+                : SetOperationValue(operation.WrappedOperation, value);
+
         public ProgramState SetOperationValue(IOperationWrapperSonar operation, SymbolicValue value) =>
-            operation == null
+            operation is null
                 ? throw new ArgumentNullException(nameof(operation))
                 : SetOperationValue(operation.Instance, value);
 
         public ProgramState SetOperationValue(IOperation operation, SymbolicValue value) =>
             (operation ?? throw new ArgumentNullException(nameof(operation))) is var _
-            && value == null
+            && value is null
                 ? this with { OperationValue = OperationValue.Remove(ResolveCapture(operation)) }
                 : this with { OperationValue = OperationValue.SetItem(ResolveCapture(operation), value) };
 
@@ -78,7 +83,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             SetOperationValue(operation, (this[operation] ?? new()).WithConstraint(constraint));
 
         public ProgramState SetSymbolValue(ISymbol symbol, SymbolicValue value) =>
-            value == null
+            value is null
                 ? this with { SymbolValue = SymbolValue.Remove(symbol) }
                 : this with { SymbolValue = SymbolValue.SetItem(symbol, value) };
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.OperationValue.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.OperationValue.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
     public partial class ProgramStateTest
     {
         [TestMethod]
-        public void SetOperationValue_WithWrapper_ReturnsValues()
+        public void SetOperationValue_WithWrapperSonar_ReturnsValues()
         {
             var value1 = new SymbolicValue();
             var value2 = new SymbolicValue();
@@ -35,6 +35,29 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             var op1 = new IOperationWrapperSonar(operations[0]);
             var op2 = new IOperationWrapperSonar(operations[1]);
             var op3 = new IOperationWrapperSonar(operations[2]);
+            var sut = ProgramState.Empty;
+
+            sut[op1].Should().BeNull();
+            sut[op2].Should().BeNull();
+            sut[op3].Should().BeNull();
+
+            sut = sut.SetOperationValue(op1, value1);
+            sut = sut.SetOperationValue(op2, value2);
+
+            sut[op1].Should().Be(value1);
+            sut[op2].Should().Be(value2);
+            sut[op3].Should().BeNull();     // Value was not set
+        }
+
+        [TestMethod]
+        public void SetOperationValue_WithWrapper_ReturnsValues()
+        {
+            var value1 = new SymbolicValue();
+            var value2 = new SymbolicValue();
+            var operations = TestHelper.CompileCfgBodyCS("var x = 0; x = 1; x = 42;").Blocks[1].Operations;
+            var op1 = ISimpleAssignmentOperationWrapper.FromOperation(operations[0]);
+            var op2 = IExpressionStatementOperationWrapper.FromOperation(operations[1]);
+            var op3 = IExpressionStatementOperationWrapper.FromOperation(operations[2]);
             var sut = ProgramState.Empty;
 
             sut[op1].Should().BeNull();
@@ -163,6 +186,10 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
 
         [TestMethod]
         public void SetOperationValue_WithWrapper_NullOperation_Throws() =>
+            ProgramState.Empty.Invoking(x => x.SetOperationValue((IOperationWrapper)null, new())).Should().Throw<ArgumentNullException>();
+
+        [TestMethod]
+        public void SetOperationValue_WithWrapperSonar_NullOperation_Throws() =>
             ProgramState.Empty.Invoking(x => x.SetOperationValue((IOperationWrapperSonar)null, new())).Should().Throw<ArgumentNullException>();
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -54,7 +54,7 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var setter = new PreProcessTestCheck(OperationKind.Literal, x => x.Operation.Instance.ConstantValue.Value is false ? x.SetOperationConstraint(TestConstraint.First) : x.State);
         var validator = SETestContext.CreateCS(code, ", bool? arg", setter).Validator;
-        validator.ValidateTag("Unknown", x => x.Should().BeNull());
+        validator.ValidateTag("Unknown", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("Accessing .Value would already throw, so it is NotNull by now"));
         validator.ValidateTag("True", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
         validator.ValidateTag("FalseFirst", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
         validator.ValidateTag("FalseFirst", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -44,7 +44,7 @@ public partial class RoslynSymbolicExecutionTest
     {
         const string code = """
             var value = arg.Value;
-            Tag("Unknown", value);
+            Tag("Unknown", arg);
             arg = true;
             value = arg.Value;
             Tag("True", value);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -883,5 +883,24 @@ Tag(""Value"", value);";
             validator.ValidateContainsOperation(OperationKind.Unary);
             validator.ValidateTag("Value", x => x.AllConstraints.Select(x => x.Kind).Should().ContainSingle().Which.Should().Be(expectedConstraint));
         }
+
+        [TestMethod]
+        public void ParameterReference_NonNullableValue_DoesNotPropagateState()
+        {
+            const string code = """
+                public class WithValue
+                {
+                    public object Value {get;}
+                };
+
+                public void Main()
+                {
+                    var instance = new WithValue();
+                    var value = instance.Value;     // Same name as Nullable.Value
+                    Tag("Value", value);
+                }
+                """;
+            SETestContext.CreateCSMethod(code).Validator.ValidateTag("Value", x => x.Should().BeNull());
+        }
     }
 }


### PR DESCRIPTION
Part of #6812

`PropertyReference` will need to be a branching processor. This changes its base class. The actual branching implementation will be done later.

There's one slight change in the conditions. From `nullable.Value`, we now learn that `nullable` cannot be null. Because it would throw otherwise.

This is a draft, rebase will be needed. Commits `Squash 04-NewArg` and `Squash 05-Conversions` do not need a review.