### PR TITLE
SE: Serialize Captures with prefix

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/CfgSerializer/CfgSerializer.RoslynCfgWalker.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/CfgSerializer/CfgSerializer.RoslynCfgWalker.cs
@@ -126,7 +126,7 @@ namespace SonarAnalyzer.CFG
                 }
                 if (region.CaptureIds.Any())
                 {
-                    sb.Append(", Captures: ").Append(string.Join(", ", region.CaptureIds.Select(x => "#" + x.GetHashCode())));  // Same as IOperationExtension.SerializeSuffix
+                    sb.Append(", Captures: ").Append(string.Join(", ", region.CaptureIds.Select(x => x.Serialize())));  // Same as IOperationExtension.SerializeSuffix
                 }
                 return sb.ToString();
             }

--- a/analyzers/src/SonarAnalyzer.CFG/Extensions/IOperationExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Extensions/IOperationExtensions.cs
@@ -111,8 +111,8 @@ namespace SonarAnalyzer.Extensions
             op switch
             {
                 var _ when IInvocationOperationWrapper.IsInstance(op) => ": " + IInvocationOperationWrapper.FromOperation(op).TargetMethod.Name,
-                var _ when IFlowCaptureOperationWrapper.IsInstance(op) => ": #" + IFlowCaptureOperationWrapper.FromOperation(op).Id.GetHashCode(),
-                var _ when IFlowCaptureReferenceOperationWrapper.IsInstance(op) => ": #" + IFlowCaptureReferenceOperationWrapper.FromOperation(op).Id.GetHashCode(),
+                var _ when IFlowCaptureOperationWrapper.IsInstance(op) => ": " + IFlowCaptureOperationWrapper.FromOperation(op).Id.Serialize(),
+                var _ when IFlowCaptureReferenceOperationWrapper.IsInstance(op) => ": " + IFlowCaptureReferenceOperationWrapper.FromOperation(op).Id.Serialize(),
                 _ => null
             };
     }

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/CaptureId.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/CaptureId.cs
@@ -35,5 +35,8 @@ namespace StyleCop.Analyzers.Lightup
 
         public override int GetHashCode() =>
             instance.GetHashCode();
+
+        public string Serialize() =>
+            "#Capture-" + GetHashCode();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/RoslynCfgSerializerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Roslyn/RoslynCfgSerializerTest.cs
@@ -122,10 +122,10 @@ class Sample
             dot.Should().BeIgnoringLineEndings(
 @"digraph ""RoslynCfg"" {
 subgraph ""cluster_1"" {
-label = ""LocalLifetime region, Captures: #0""
-cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation: #0 / IdentifierNameSyntax: a|1# ParameterReferenceOperation / IdentifierNameSyntax: a|##########|## BranchValue ##|0# BinaryOperation / LiteralExpressionSyntax: 1|1# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: a|1# LiteralOperation / LiteralExpressionSyntax: 1|##########}""]
+label = ""LocalLifetime region, Captures: #Capture-0""
+cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation: #Capture-0 / IdentifierNameSyntax: a|1# ParameterReferenceOperation / IdentifierNameSyntax: a|##########|## BranchValue ##|0# BinaryOperation / LiteralExpressionSyntax: 1|1# FlowCaptureReferenceOperation: #Capture-0 / IdentifierNameSyntax: a|1# LiteralOperation / LiteralExpressionSyntax: 1|##########}""]
 cfg0_block2 [shape=record label=""{BLOCK #2|0# ExpressionStatementOperation / ExpressionStatementSyntax: c1();|1# InvocationOperation: c1 / InvocationExpressionSyntax: c1()|2# InstanceReferenceOperation / IdentifierNameSyntax: c1|##########}""]
-cfg0_block3 [shape=record label=""{BLOCK #3|## BranchValue ##|0# BinaryOperation / LiteralExpressionSyntax: 2|1# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: a|1# LiteralOperation / LiteralExpressionSyntax: 2|##########}""]
+cfg0_block3 [shape=record label=""{BLOCK #3|## BranchValue ##|0# BinaryOperation / LiteralExpressionSyntax: 2|1# FlowCaptureReferenceOperation: #Capture-0 / IdentifierNameSyntax: a|1# LiteralOperation / LiteralExpressionSyntax: 2|##########}""]
 cfg0_block4 [shape=record label=""{BLOCK #4|0# ExpressionStatementOperation / ExpressionStatementSyntax: c2();|1# InvocationOperation: c2 / InvocationExpressionSyntax: c2()|2# InstanceReferenceOperation / IdentifierNameSyntax: c2|##########}""]
 }
 cfg0_block0 [shape=record label=""{ENTRY #0}""]
@@ -192,25 +192,25 @@ class Sample
             dot.Should().BeIgnoringLineEndings(
 @"digraph ""RoslynCfg"" {
 subgraph ""cluster_1"" {
-label = ""LocalLifetime region, Captures: #0""
+label = ""LocalLifetime region, Captures: #Capture-0""
 subgraph ""cluster_2"" {
 label = ""TryAndFinally region""
 subgraph ""cluster_3"" {
 label = ""Try region""
 subgraph ""cluster_4"" {
 label = ""LocalLifetime region, Locals: i""
-cfg0_block3 [shape=record label=""{BLOCK #3|0# SimpleAssignmentOperation / IdentifierNameSyntax: var|1# LocalReferenceOperation / IdentifierNameSyntax: var|1# ConversionOperation / IdentifierNameSyntax: var|2# PropertyReferenceOperation / IdentifierNameSyntax: var|3# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: items|##########|0# ExpressionStatementOperation / ExpressionStatementSyntax: Bar(i);|1# InvocationOperation: Bar / InvocationExpressionSyntax: Bar(i)|2# InstanceReferenceOperation / IdentifierNameSyntax: Bar|2# ArgumentOperation / ArgumentSyntax: i|3# LocalReferenceOperation / IdentifierNameSyntax: i|##########}""]
+cfg0_block3 [shape=record label=""{BLOCK #3|0# SimpleAssignmentOperation / IdentifierNameSyntax: var|1# LocalReferenceOperation / IdentifierNameSyntax: var|1# ConversionOperation / IdentifierNameSyntax: var|2# PropertyReferenceOperation / IdentifierNameSyntax: var|3# FlowCaptureReferenceOperation: #Capture-0 / IdentifierNameSyntax: items|##########|0# ExpressionStatementOperation / ExpressionStatementSyntax: Bar(i);|1# InvocationOperation: Bar / InvocationExpressionSyntax: Bar(i)|2# InstanceReferenceOperation / IdentifierNameSyntax: Bar|2# ArgumentOperation / ArgumentSyntax: i|3# LocalReferenceOperation / IdentifierNameSyntax: i|##########}""]
 }
-cfg0_block2 [shape=record label=""{BLOCK #2|## BranchValue ##|0# InvocationOperation: MoveNext / IdentifierNameSyntax: items|1# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: items|##########}""]
+cfg0_block2 [shape=record label=""{BLOCK #2|## BranchValue ##|0# InvocationOperation: MoveNext / IdentifierNameSyntax: items|1# FlowCaptureReferenceOperation: #Capture-0 / IdentifierNameSyntax: items|##########}""]
 }
 subgraph ""cluster_5"" {
-label = ""Finally region, Captures: #1""
-cfg0_block4 [shape=record label=""{BLOCK #4|0# FlowCaptureOperation: #1 / IdentifierNameSyntax: items|1# ConversionOperation / IdentifierNameSyntax: items|2# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: items|##########|## BranchValue ##|0# IsNullOperation / IdentifierNameSyntax: items|1# FlowCaptureReferenceOperation: #1 / IdentifierNameSyntax: items|##########}""]
-cfg0_block5 [shape=record label=""{BLOCK #5|0# InvocationOperation: Dispose / IdentifierNameSyntax: items|1# FlowCaptureReferenceOperation: #1 / IdentifierNameSyntax: items|##########}""]
+label = ""Finally region, Captures: #Capture-1""
+cfg0_block4 [shape=record label=""{BLOCK #4|0# FlowCaptureOperation: #Capture-1 / IdentifierNameSyntax: items|1# ConversionOperation / IdentifierNameSyntax: items|2# FlowCaptureReferenceOperation: #Capture-0 / IdentifierNameSyntax: items|##########|## BranchValue ##|0# IsNullOperation / IdentifierNameSyntax: items|1# FlowCaptureReferenceOperation: #Capture-1 / IdentifierNameSyntax: items|##########}""]
+cfg0_block5 [shape=record label=""{BLOCK #5|0# InvocationOperation: Dispose / IdentifierNameSyntax: items|1# FlowCaptureReferenceOperation: #Capture-1 / IdentifierNameSyntax: items|##########}""]
 cfg0_block6 [shape=record label=""{BLOCK #6}""]
 }
 }
-cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation: #0 / IdentifierNameSyntax: items|1# InvocationOperation: GetEnumerator / IdentifierNameSyntax: items|2# ConversionOperation / IdentifierNameSyntax: items|3# ParameterReferenceOperation / IdentifierNameSyntax: items|##########}""]
+cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation: #Capture-0 / IdentifierNameSyntax: items|1# InvocationOperation: GetEnumerator / IdentifierNameSyntax: items|2# ConversionOperation / IdentifierNameSyntax: items|3# ParameterReferenceOperation / IdentifierNameSyntax: items|##########}""]
 }
 cfg0_block0 [shape=record label=""{ENTRY #0}""]
 cfg0_block7 [shape=record label=""{EXIT #7}""]
@@ -246,7 +246,7 @@ public class Sample
             dot.Should().BeIgnoringLineEndings(
 @"digraph ""RoslynCfg"" {
 subgraph ""cluster_1"" {
-label = ""LocalLifetime region, Captures: #0""
+label = ""LocalLifetime region, Captures: #Capture-0""
 subgraph ""cluster_2"" {
 label = ""TryAndFinally region""
 subgraph ""cluster_3"" {
@@ -257,18 +257,18 @@ subgraph ""cluster_5"" {
 label = ""LocalLifetime region, Locals: i, j""
 cfg0_block4 [shape=record label=""{BLOCK #4|0# SimpleAssignmentOperation / VariableDeclaratorSyntax: i = key|1# LocalReferenceOperation / VariableDeclaratorSyntax: i = key|1# LocalReferenceOperation / IdentifierNameSyntax: key|##########|0# SimpleAssignmentOperation / VariableDeclaratorSyntax: j = value|1# LocalReferenceOperation / VariableDeclaratorSyntax: j = value|1# LocalReferenceOperation / IdentifierNameSyntax: value|##########}""]
 }
-cfg0_block3 [shape=record label=""{BLOCK #3|0# DeconstructionAssignmentOperation / DeclarationExpressionSyntax: var (key, value)|1# DeclarationExpressionOperation / DeclarationExpressionSyntax: var (key, value)|2# TupleOperation / ParenthesizedVariableDesignationSyntax: (key, value)|3# LocalReferenceOperation / SingleVariableDesignationSyntax: key|3# LocalReferenceOperation / SingleVariableDesignationSyntax: value|1# ConversionOperation / DeclarationExpressionSyntax: var (key, value)|2# PropertyReferenceOperation / DeclarationExpressionSyntax: var (key, value)|3# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: values|##########}""]
+cfg0_block3 [shape=record label=""{BLOCK #3|0# DeconstructionAssignmentOperation / DeclarationExpressionSyntax: var (key, value)|1# DeclarationExpressionOperation / DeclarationExpressionSyntax: var (key, value)|2# TupleOperation / ParenthesizedVariableDesignationSyntax: (key, value)|3# LocalReferenceOperation / SingleVariableDesignationSyntax: key|3# LocalReferenceOperation / SingleVariableDesignationSyntax: value|1# ConversionOperation / DeclarationExpressionSyntax: var (key, value)|2# PropertyReferenceOperation / DeclarationExpressionSyntax: var (key, value)|3# FlowCaptureReferenceOperation: #Capture-0 / IdentifierNameSyntax: values|##########}""]
 }
-cfg0_block2 [shape=record label=""{BLOCK #2|## BranchValue ##|0# InvocationOperation: MoveNext / IdentifierNameSyntax: values|1# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: values|##########}""]
+cfg0_block2 [shape=record label=""{BLOCK #2|## BranchValue ##|0# InvocationOperation: MoveNext / IdentifierNameSyntax: values|1# FlowCaptureReferenceOperation: #Capture-0 / IdentifierNameSyntax: values|##########}""]
 }
 subgraph ""cluster_6"" {
-label = ""Finally region, Captures: #1""
-cfg0_block5 [shape=record label=""{BLOCK #5|0# FlowCaptureOperation: #1 / IdentifierNameSyntax: values|1# ConversionOperation / IdentifierNameSyntax: values|2# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: values|##########|## BranchValue ##|0# IsNullOperation / IdentifierNameSyntax: values|1# FlowCaptureReferenceOperation: #1 / IdentifierNameSyntax: values|##########}""]
-cfg0_block6 [shape=record label=""{BLOCK #6|0# InvocationOperation: Dispose / IdentifierNameSyntax: values|1# FlowCaptureReferenceOperation: #1 / IdentifierNameSyntax: values|##########}""]
+label = ""Finally region, Captures: #Capture-1""
+cfg0_block5 [shape=record label=""{BLOCK #5|0# FlowCaptureOperation: #Capture-1 / IdentifierNameSyntax: values|1# ConversionOperation / IdentifierNameSyntax: values|2# FlowCaptureReferenceOperation: #Capture-0 / IdentifierNameSyntax: values|##########|## BranchValue ##|0# IsNullOperation / IdentifierNameSyntax: values|1# FlowCaptureReferenceOperation: #Capture-1 / IdentifierNameSyntax: values|##########}""]
+cfg0_block6 [shape=record label=""{BLOCK #6|0# InvocationOperation: Dispose / IdentifierNameSyntax: values|1# FlowCaptureReferenceOperation: #Capture-1 / IdentifierNameSyntax: values|##########}""]
 cfg0_block7 [shape=record label=""{BLOCK #7}""]
 }
 }
-cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation: #0 / IdentifierNameSyntax: values|1# InvocationOperation: GetEnumerator / IdentifierNameSyntax: values|2# ConversionOperation / IdentifierNameSyntax: values|3# ParameterReferenceOperation / IdentifierNameSyntax: values|##########}""]
+cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation: #Capture-0 / IdentifierNameSyntax: values|1# InvocationOperation: GetEnumerator / IdentifierNameSyntax: values|2# ConversionOperation / IdentifierNameSyntax: values|3# ParameterReferenceOperation / IdentifierNameSyntax: values|##########}""]
 }
 cfg0_block0 [shape=record label=""{ENTRY #0}""]
 cfg0_block8 [shape=record label=""{EXIT #8}""]
@@ -391,21 +391,21 @@ class Sample
             dot.Should().BeIgnoringLineEndings(
 @"digraph ""RoslynCfg"" {
 subgraph ""cluster_1"" {
-label = ""LocalLifetime region, Locals: N/A, Captures: #0""
+label = ""LocalLifetime region, Locals: N/A, Captures: #Capture-0""
 subgraph ""cluster_2"" {
 label = ""TryAndFinally region""
 subgraph ""cluster_3"" {
 label = ""Try region""
-cfg0_block2 [shape=record label=""{BLOCK #2|0# InvocationOperation: Enter / IdentifierNameSyntax: x|1# ArgumentOperation / IdentifierNameSyntax: x|2# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: x|1# ArgumentOperation / IdentifierNameSyntax: x|2# LocalReferenceOperation / IdentifierNameSyntax: x|##########|0# ExpressionStatementOperation / ExpressionStatementSyntax: Bar();|1# InvocationOperation: Bar / InvocationExpressionSyntax: Bar()|2# InstanceReferenceOperation / IdentifierNameSyntax: Bar|##########}""]
+cfg0_block2 [shape=record label=""{BLOCK #2|0# InvocationOperation: Enter / IdentifierNameSyntax: x|1# ArgumentOperation / IdentifierNameSyntax: x|2# FlowCaptureReferenceOperation: #Capture-0 / IdentifierNameSyntax: x|1# ArgumentOperation / IdentifierNameSyntax: x|2# LocalReferenceOperation / IdentifierNameSyntax: x|##########|0# ExpressionStatementOperation / ExpressionStatementSyntax: Bar();|1# InvocationOperation: Bar / InvocationExpressionSyntax: Bar()|2# InstanceReferenceOperation / IdentifierNameSyntax: Bar|##########}""]
 }
 subgraph ""cluster_4"" {
 label = ""Finally region""
 cfg0_block3 [shape=record label=""{BLOCK #3|## BranchValue ##|0# LocalReferenceOperation / IdentifierNameSyntax: x|##########}""]
-cfg0_block4 [shape=record label=""{BLOCK #4|0# InvocationOperation: Exit / IdentifierNameSyntax: x|1# ArgumentOperation / IdentifierNameSyntax: x|2# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: x|##########}""]
+cfg0_block4 [shape=record label=""{BLOCK #4|0# InvocationOperation: Exit / IdentifierNameSyntax: x|1# ArgumentOperation / IdentifierNameSyntax: x|2# FlowCaptureReferenceOperation: #Capture-0 / IdentifierNameSyntax: x|##########}""]
 cfg0_block5 [shape=record label=""{BLOCK #5}""]
 }
 }
-cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation: #0 / IdentifierNameSyntax: x|1# FieldReferenceOperation / IdentifierNameSyntax: x|2# InstanceReferenceOperation / IdentifierNameSyntax: x|##########}""]
+cfg0_block1 [shape=record label=""{BLOCK #1|0# FlowCaptureOperation: #Capture-0 / IdentifierNameSyntax: x|1# FieldReferenceOperation / IdentifierNameSyntax: x|2# InstanceReferenceOperation / IdentifierNameSyntax: x|##########}""]
 }
 cfg0_block0 [shape=record label=""{ENTRY #0}""]
 cfg0_block6 [shape=record label=""{EXIT #6}""]
@@ -621,18 +621,18 @@ class Sample
 subgraph ""cluster_1"" {
 label = ""LocalLifetime region, Locals: b""
 subgraph ""cluster_2"" {
-label = ""LocalLifetime region, Captures: #0""
+label = ""LocalLifetime region, Captures: #Capture-0""
 cfg0_block1 [shape=record label=""{BLOCK #1|## BranchValue ##|0# ParameterReferenceOperation / IdentifierNameSyntax: arg|##########}""]
-cfg0_block2 [shape=record label=""{BLOCK #2|0# FlowCaptureOperation: #0 / LiteralExpressionSyntax: false|1# LiteralOperation / LiteralExpressionSyntax: false|##########}""]
-cfg0_block3 [shape=record label=""{BLOCK #3|0# FlowCaptureOperation: #0 / IdentifierNameSyntax: arg|1# LiteralOperation / IdentifierNameSyntax: arg|##########}""]
-cfg0_block4 [shape=record label=""{BLOCK #4|0# SimpleAssignmentOperation / VariableDeclaratorSyntax: b = arg && false|1# LocalReferenceOperation / VariableDeclaratorSyntax: b = arg && false|1# FlowCaptureReferenceOperation: #0 / BinaryExpressionSyntax: arg && false|##########}""]
+cfg0_block2 [shape=record label=""{BLOCK #2|0# FlowCaptureOperation: #Capture-0 / LiteralExpressionSyntax: false|1# LiteralOperation / LiteralExpressionSyntax: false|##########}""]
+cfg0_block3 [shape=record label=""{BLOCK #3|0# FlowCaptureOperation: #Capture-0 / IdentifierNameSyntax: arg|1# LiteralOperation / IdentifierNameSyntax: arg|##########}""]
+cfg0_block4 [shape=record label=""{BLOCK #4|0# SimpleAssignmentOperation / VariableDeclaratorSyntax: b = arg && false|1# LocalReferenceOperation / VariableDeclaratorSyntax: b = arg && false|1# FlowCaptureReferenceOperation: #Capture-0 / BinaryExpressionSyntax: arg && false|##########}""]
 }
 subgraph ""cluster_3"" {
-label = ""LocalLifetime region, Captures: #1, #2""
-cfg0_block5 [shape=record label=""{BLOCK #5|0# FlowCaptureOperation: #1 / IdentifierNameSyntax: b|1# LocalReferenceOperation / IdentifierNameSyntax: b|##########|## BranchValue ##|0# ParameterReferenceOperation / IdentifierNameSyntax: arg|##########}""]
-cfg0_block6 [shape=record label=""{BLOCK #6|0# FlowCaptureOperation: #2 / LiteralExpressionSyntax: true|1# LiteralOperation / LiteralExpressionSyntax: true|##########}""]
-cfg0_block7 [shape=record label=""{BLOCK #7|0# FlowCaptureOperation: #2 / IdentifierNameSyntax: arg|1# LiteralOperation / IdentifierNameSyntax: arg|##########}""]
-cfg0_block8 [shape=record label=""{BLOCK #8|0# ExpressionStatementOperation / ExpressionStatementSyntax: b = arg \|\| true;|1# SimpleAssignmentOperation / AssignmentExpressionSyntax: b = arg \|\| true|2# FlowCaptureReferenceOperation: #1 / IdentifierNameSyntax: b|2# FlowCaptureReferenceOperation: #2 / BinaryExpressionSyntax: arg \|\| true|##########}""]
+label = ""LocalLifetime region, Captures: #Capture-1, #Capture-2""
+cfg0_block5 [shape=record label=""{BLOCK #5|0# FlowCaptureOperation: #Capture-1 / IdentifierNameSyntax: b|1# LocalReferenceOperation / IdentifierNameSyntax: b|##########|## BranchValue ##|0# ParameterReferenceOperation / IdentifierNameSyntax: arg|##########}""]
+cfg0_block6 [shape=record label=""{BLOCK #6|0# FlowCaptureOperation: #Capture-2 / LiteralExpressionSyntax: true|1# LiteralOperation / LiteralExpressionSyntax: true|##########}""]
+cfg0_block7 [shape=record label=""{BLOCK #7|0# FlowCaptureOperation: #Capture-2 / IdentifierNameSyntax: arg|1# LiteralOperation / IdentifierNameSyntax: arg|##########}""]
+cfg0_block8 [shape=record label=""{BLOCK #8|0# ExpressionStatementOperation / ExpressionStatementSyntax: b = arg \|\| true;|1# SimpleAssignmentOperation / AssignmentExpressionSyntax: b = arg \|\| true|2# FlowCaptureReferenceOperation: #Capture-1 / IdentifierNameSyntax: b|2# FlowCaptureReferenceOperation: #Capture-2 / BinaryExpressionSyntax: arg \|\| true|##########}""]
 }
 }
 cfg0_block0 [shape=record label=""{ENTRY #0}""]


### PR DESCRIPTION
There are a lot of #numbers in the CFG serialization that make it unclear that #0, #1, #2 and so on sometimes mean a capture reference. This change will make it clear.

Old serialization:
```
1# FlowCaptureReferenceOperation: #0 / IdentifierNameSyntax: arg
```
New serialization:
```
1# FlowCaptureReferenceOperation: #Capture-0 / IdentifierNameSyntax: arg
```