### PR TITLE
ITs Fix: Point to staging VM with downgraded VS2022

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ trigger:
 pool: 
   name: '.Net Bubble staging'
   demands:
-    - PR_NUMBER -equal 182
+    - PR_NUMBER -equals 182
 
 variables:
   - group: sonar-dotnet-variables

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,10 @@ schedules:
 trigger:
 - master
 
-pool: '.Net Bubble - GCP'
+pool: 
+  name: '.Net Bubble staging'
+  demands:
+    - PR_NUMBER -equal 182
 
 variables:
   - group: sonar-dotnet-variables


### PR DESCRIPTION
Fixes failing ITs by trying to sidestep [this roslyn bug](https://github.com/dotnet/roslyn/issues/67211)