### PR TITLE
Fix S1123 FN: The explanation should not be null or whitespace

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ObsoleteAttributes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ObsoleteAttributes.cs
@@ -24,4 +24,10 @@ namespace SonarAnalyzer.Rules.CSharp;
 public sealed class ObsoleteAttributes : ObsoleteAttributesBase<SyntaxKind>
 {
     protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
+
+    protected override SyntaxNode GetExplanationExpression(SyntaxNode node) =>
+        node is AttributeSyntax { ArgumentList.Arguments: { Count: >= 1 } arguments }
+            && arguments[0] is { Expression: { } expression }
+                ? expression
+                : null;
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ObsoleteAttributes.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ObsoleteAttributes.cs
@@ -24,4 +24,10 @@ namespace SonarAnalyzer.Rules.VisualBasic;
 public sealed class ObsoleteAttributes : ObsoleteAttributesBase<SyntaxKind>
 {
     protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
+
+    protected override SyntaxNode GetExplanationExpression(SyntaxNode node) =>
+       node is AttributeSyntax { ArgumentList.Arguments: { Count: >= 1 } arguments }
+           && arguments[0] is SimpleArgumentSyntax { Expression: { } } argument
+               ? argument.Expression
+               : null;
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ObsoleteAttributesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ObsoleteAttributesTest.cs
@@ -60,6 +60,7 @@ public class ObsoleteAttributesTest
     [TestMethod]
     public void ObsoleteAttributesNeedExplanation_VB14() =>
         explanationNeededVB.AddPaths("ObsoleteAttributesNeedExplanation.VB14.vb").WithOptions(ParseOptionsHelper.FromVisualBasic14).Verify();
+
 #endif
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ObsoleteAttributesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ObsoleteAttributesTest.cs
@@ -56,6 +56,10 @@ public class ObsoleteAttributesTest
     [TestMethod]
     public void ObsoleteAttributesNeedExplanation_CSharp10() =>
         explanationNeededCS.AddPaths("ObsoleteAttributesNeedExplanation.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+
+    [TestMethod]
+    public void ObsoleteAttributesNeedExplanation_VB14() =>
+        explanationNeededVB.AddPaths("ObsoleteAttributesNeedExplanation.VB14.vb").WithOptions(ParseOptionsHelper.FromVisualBasic14).Verify();
 #endif
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.CSharp9.cs
@@ -18,3 +18,28 @@ public record Record
         { }
     }
 }
+
+class Noncompliant
+{
+
+    [Obsolete("", true, DiagnosticId = "42")] // Noncompliant
+    void WithDiagnostics() { }
+
+    [Obsolete("", true, DiagnosticId = "42", UrlFormat = "https://sonarsource.com")] // Noncompliant
+    void WithDiagnosticsAndUrlFormat() { }
+}
+
+class Compliant
+{
+    [Obsolete("explanation", true, DiagnosticId = "42")]
+    void WithDiagnostics() { }
+
+    [Obsolete("explanation", true, DiagnosticId = "42", UrlFormat = "https://sonarsource.com")]
+    void WithDiagnosticsAndUrlFormat() { }
+}
+
+class Ignore
+{
+    [Obsolete(UrlFormat = "https://sonarsource.com")]
+    void NamedParametersOnly() { } // FN
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.VB14.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.VB14.vb
@@ -1,0 +1,27 @@
+﻿' Commented line for concurrent namespace
+
+Class Noncompliant
+    <Obsolete("", True, DiagnosticId:="42")> ' Noncompliant
+    Sub WithDiagnostics()
+    End Sub
+
+    <Obsolete("", True, DiagnosticId:="42", UrlFormat:="https://sonarsource.com")> ' Noncompliant
+    Sub WithDiagnosticsAndUrlFormat()
+    End Sub
+End Class
+
+Class Compliant
+    <Obsolete("explanation", True, DiagnosticId:="42")>
+    Sub WithDiagnostics()
+    End Sub
+
+    <Obsolete("explanation", True, DiagnosticId:="42", UrlFormat:="https://sonarsource.com")>
+    Sub WithDiagnosticsAndUrlFormat()
+    End Sub
+End Class
+
+Class Ignore
+    <Obsolete(UrlFormat:="https://sonarsource.com")>
+    Private Sub NamedParametersOnly() ' FP
+    End Sub
+End Class

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.cs
@@ -21,6 +21,15 @@ class Noncompliant
     [Obsolete("  ")] // Noncompliant
     void WithWhiteSpace() { }
 
+    [Obsolete("", true)] // Noncompliant
+    void WithTwoArguments() { }
+
+    [Obsolete("", true, DiagnosticId = "42")] // Noncompliant
+    void WithDiagnostics() { }
+
+    [Obsolete("", true, DiagnosticId = "42", UrlFormat = "https://sonarsource.com")] // Noncompliant
+    void WithDiagnosticsAndUrlFormat() { }
+
     [Obsolete] // Noncompliant
     [CLSCompliant(false)]
     uint Multiple() { return 0; }
@@ -78,6 +87,15 @@ class Compliant
     [Obsolete("explanation")]
     void Method() { }
 
+    [Obsolete("explanation", true)]
+    void WithTwoArguments() { }
+
+    [Obsolete("explanation", true, DiagnosticId = "42")]
+    void WithDiagnostics() { }
+
+    [Obsolete("explanation", true, DiagnosticId = "42", UrlFormat = "https://sonarsource.com")]
+    void WithDiagnosticsAndUrlFormat() { }
+
     [Obsolete("explanation")]
     string Property { get; set; }
 
@@ -103,6 +121,19 @@ struct ComplaintStruct
 {
     [Obsolete("explanation")]
     void Method() { }
+}
+
+class Ignore
+{
+    // FN the value of error is taken.
+    [Obsolete(error: true, message: "explanation")] // Noncompliant
+    public void NamedParmetersDifferentOrderFP() { }
+
+    [Obsolete(error: true, message: "")] // Noncompliant for wrong reason 
+    public void NamedParmetersDifferentOrder() { }
+
+    [Obsolete(UrlFormat = "https://sonarsource.com")]
+    void NamedParametersOnly() { } // FP
 }
 
 class NotApplicable

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.cs
@@ -24,12 +24,6 @@ class Noncompliant
     [Obsolete("", true)] // Noncompliant
     void WithTwoArguments() { }
 
-    [Obsolete("", true, DiagnosticId = "42")] // Noncompliant
-    void WithDiagnostics() { }
-
-    [Obsolete("", true, DiagnosticId = "42", UrlFormat = "https://sonarsource.com")] // Noncompliant
-    void WithDiagnosticsAndUrlFormat() { }
-
     [Obsolete] // Noncompliant
     [CLSCompliant(false)]
     uint Multiple() { return 0; }
@@ -90,12 +84,6 @@ class Compliant
     [Obsolete("explanation", true)]
     void WithTwoArguments() { }
 
-    [Obsolete("explanation", true, DiagnosticId = "42")]
-    void WithDiagnostics() { }
-
-    [Obsolete("explanation", true, DiagnosticId = "42", UrlFormat = "https://sonarsource.com")]
-    void WithDiagnosticsAndUrlFormat() { }
-
     [Obsolete("explanation")]
     string Property { get; set; }
 
@@ -125,15 +113,12 @@ struct ComplaintStruct
 
 class Ignore
 {
-    // FN the value of error is taken.
+    // FP the value of error is taken.
     [Obsolete(error: true, message: "explanation")] // Noncompliant
     public void NamedParmetersDifferentOrderFP() { }
 
     [Obsolete(error: true, message: "")] // Noncompliant for wrong reason 
     public void NamedParmetersDifferentOrder() { }
-
-    [Obsolete(UrlFormat = "https://sonarsource.com")]
-    void NamedParametersOnly() { } // FP
 }
 
 class NotApplicable

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.cs
@@ -12,6 +12,15 @@ class Noncompliant
     [global::System.Obsolete] // Noncompliant
     void GloballyDeclaredNamespace() { }
 
+    [Obsolete(null)] // Noncompliant
+    void WithNull() { }
+
+    [Obsolete("")] // Noncompliant
+    void WithEmptyString() { }
+
+    [Obsolete("  ")] // Noncompliant
+    void WithWhiteSpace() { }
+
     [Obsolete] // Noncompliant
     [CLSCompliant(false)]
     uint Multiple() { return 0; }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.vb
@@ -30,14 +30,6 @@ Class Noncompliant
     Sub WithTwoArguments()
     End Sub
 
-    <Obsolete("", True, DiagnosticId:="42")> ' Noncompliant
-    Sub WithDiagnostics()
-    End Sub
-
-    <Obsolete("", True, DiagnosticId:="42", UrlFormat:="https://sonarsource.com")> ' Noncompliant
-    Sub WithDiagnosticsAndUrlFormat()
-    End Sub
-
     <Obsolete> ' Noncompliant
     <CLSCompliant(False)>
     Function Multiple() As UInteger
@@ -108,14 +100,6 @@ Class Compliant
     Sub WithTwoArguments()
     End Sub
 
-    <Obsolete("explanation", True, DiagnosticId:="42")>
-    Sub WithDiagnostics()
-    End Sub
-
-    <Obsolete("explanation", True, DiagnosticId:="42", UrlFormat:="https://sonarsource.com")>
-    Sub WithDiagnosticsAndUrlFormat()
-    End Sub
-
     <Obsolete("explanation")>
     Property [Property] As String
 
@@ -141,12 +125,6 @@ Structure ComplaintStruct
     Sub Method()
     End Sub
 End Structure
-
-Class Ignore
-    <Obsolete(UrlFormat:="https://sonarsource.com")>
-    Private Sub NamedParametersOnly() ' FP
-    End Sub
-End Class
 
 Class NotApplicable
     <CLSCompliant(False)>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.vb
@@ -14,6 +14,18 @@ Class Noncompliant
     Private Sub GloballyDeclaredNamespace()
     End Sub
 
+    <Obsolete(Nothing)> ' Noncompliant
+    Sub WithNothing() { }
+    End Sub
+
+    <Obsolete("")> ' Noncompliant
+    Sub WithEmptyString() { }
+    End Sub
+
+    <Obsolete("  ")> ' Noncompliant
+    Sub WithWhiteSpace() { }
+    End Sub
+
     <Obsolete> ' Noncompliant
     <CLSCompliant(False)>
     Private Function Multiple() As UInteger

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ObsoleteAttributesNeedExplanation.vb
@@ -2,16 +2,16 @@
 
 <Obsolete>  ' Noncompliant^2#8 {{Add an explanation.}}
 Class Noncompliant
-    <Obsolete()> Private Sub WithBrackets() ' Noncompliant {{Add an explanation.}}
+    <Obsolete()> Sub WithBrackets() ' Noncompliant {{Add an explanation.}}
 '    ^^^^^^^^^^
     End Sub
 
     <System.Obsolete> ' Noncompliant
-    Private Sub FullyDeclaredNamespace()
+    Sub FullyDeclaredNamespace()
     End Sub
 
     <Global.System.Obsolete> ' Noncompliant
-    Private Sub GloballyDeclaredNamespace()
+    Sub GloballyDeclaredNamespace()
     End Sub
 
     <Obsolete(Nothing)> ' Noncompliant
@@ -26,13 +26,25 @@ Class Noncompliant
     Sub WithWhiteSpace() { }
     End Sub
 
+    <Obsolete("", True)> ' Noncompliant
+    Sub WithTwoArguments()
+    End Sub
+
+    <Obsolete("", True, DiagnosticId:="42")> ' Noncompliant
+    Sub WithDiagnostics()
+    End Sub
+
+    <Obsolete("", True, DiagnosticId:="42", UrlFormat:="https://sonarsource.com")> ' Noncompliant
+    Sub WithDiagnosticsAndUrlFormat()
+    End Sub
+
     <Obsolete> ' Noncompliant
     <CLSCompliant(False)>
-    Private Function Multiple() As UInteger
+    Function Multiple() As UInteger
         Return 0
     End Function
 
-    <Obsolete, CLSCompliant(False)> Private Function Combined() As UInteger ' Noncompliant
+    <Obsolete, CLSCompliant(False)> Function Combined() As UInteger ' Noncompliant
         Return 0
     End Function
 
@@ -43,19 +55,22 @@ Class Noncompliant
     End Enum
 
     <Obsolete> ' Noncompliant
-    Private Sub New()
+    Sub New()
     End Sub
 
     <Obsolete> ' Noncompliant
-    Private Sub Method()
+    Sub Method()
     End Sub
 
     <Obsolete> ' Noncompliant
-    Private Property [Property] As Integer
+    Property [Property] As Integer
+
     <Obsolete> ' Noncompliant
     Private Field As Integer
+
     <Obsolete> ' Noncompliant
-    Private Event [Event] As EventHandler
+    Event [Event] As EventHandler
+
     <Obsolete> ' Noncompliant
     Delegate Sub [Delegate]()
 End Class
@@ -69,7 +84,7 @@ End Interface
 <Obsolete> ' Noncompliant
 Structure ProgramStruct
     <Obsolete> ' Noncompliant
-    Private Sub Method()
+    Sub Method()
     End Sub
 End Structure
 
@@ -82,19 +97,34 @@ Class Compliant
     End Enum
 
     <Obsolete("explanation")>
-    Private Sub New()
+    Sub New()
     End Sub
 
     <Obsolete("explanation")>
-    Private Sub Method()
+    Sub Method()
+    End Sub
+
+    <Obsolete("explanation", True)>
+    Sub WithTwoArguments()
+    End Sub
+
+    <Obsolete("explanation", True, DiagnosticId:="42")>
+    Sub WithDiagnostics()
+    End Sub
+
+    <Obsolete("explanation", True, DiagnosticId:="42", UrlFormat:="https://sonarsource.com")>
+    Sub WithDiagnosticsAndUrlFormat()
     End Sub
 
     <Obsolete("explanation")>
-    Private Property [Property] As String
+    Property [Property] As String
+
     <Obsolete("explanation", True)>
     Private Field As Integer
+
     <Obsolete("explanation", False)>
-    Private Event [Event] As EventHandler
+    Event [Event] As EventHandler
+
     <Obsolete("explanation")>
     Delegate Sub [Delegate]()
 End Class
@@ -108,9 +138,15 @@ End Interface
 <Obsolete("explanation")>
 Structure ComplaintStruct
     <Obsolete("explanation")>
-    Private Sub Method()
+    Sub Method()
     End Sub
 End Structure
+
+Class Ignore
+    <Obsolete(UrlFormat:="https://sonarsource.com")>
+    Private Sub NamedParametersOnly() ' FP
+    End Sub
+End Class
 
 Class NotApplicable
     <CLSCompliant(False)>
@@ -119,24 +155,27 @@ Class NotApplicable
         bar
     End Enum
 
-    Private Sub New()
+    Sub New()
     End Sub
 
-    Private Sub Method()
+    Sub Method()
     End Sub
 
-    Private Property [Property] As Integer
+    Property [Property] As Integer
+
     Private Field As Integer
-    Private Event [Event] As EventHandler
+
+    Event [Event] As EventHandler
+
     Delegate Sub [Delegate]()
 
     <NotSystem.ObsoleteAttribute>
-    Private Sub SameName()
+    Sub SameName()
     End Sub
 End Class
 
 Namespace NotSystem
-    Public Class ObsoleteAttribute
+    Class ObsoleteAttribute
         Inherits Attribute
     End Class
 End Namespace


### PR DESCRIPTION
As mentioned by @martin-strecker-sonarsource reading the arguments should be improved. Result of a remark in #6593 .
