### PR TITLE
Make UtilityAnalyzerBase stateless by removing properties

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/AnalysisWarningAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/AnalysisWarningAnalyzerBase.cs
@@ -37,11 +37,11 @@ public abstract class AnalysisWarningAnalyzerBase : UtilityAnalyzerBase
     protected sealed override void Initialize(SonarAnalysisContext context) =>
         context.RegisterCompilationStartAction(c =>
             {
-                ReadParameters(c);
-                if (IsAnalyzerEnabled && !RoslynHelper.IsRoslynCfgSupported(MinimalSupportedRoslynVersion))     // MsBuild 15 is bound with Roslyn 2.x, where Roslyn CFG is not available.
+                var parameter = ReadParameters(c);
+                if (parameter.IsAnalyzerEnabled && !RoslynHelper.IsRoslynCfgSupported(MinimalSupportedRoslynVersion))     // MsBuild 15 is bound with Roslyn 2.x, where Roslyn CFG is not available.
                 {
                     // This can be removed after we bump Microsoft.CodeAnalysis references to 3.0 or higher.
-                    var path = Path.GetFullPath(Path.Combine(OutPath, "../../AnalysisWarnings.MsBuild.json"));
+                    var path = Path.GetFullPath(Path.Combine(parameter.OutPath, "../../AnalysisWarnings.MsBuild.json"));
                     lock (FileWriteLock)
                     {
                         if (!File.Exists(path))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/CopyPasteTokenAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/CopyPasteTokenAnalyzerBase.cs
@@ -31,13 +31,13 @@ namespace SonarAnalyzer.Rules
         protected abstract string GetCpdValue(SyntaxToken token);
         protected abstract bool IsUsingDirective(SyntaxNode node);
 
-        protected sealed override bool AnalyzeTestProjects => false;
+        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) => base.ReadParameters(context) with { AnalyzeTestProjects = false };
         protected sealed override bool AnalyzeUnchangedFiles => true;
         protected sealed override string FileName => "token-cpd.pb";
 
         protected CopyPasteTokenAnalyzerBase() : base(DiagnosticId, Title) { }
 
-        protected sealed override CopyPasteTokenInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override CopyPasteTokenInfo CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel)
         {
             var cpdTokenInfo = new CopyPasteTokenInfo { FilePath = syntaxTree.FilePath };
             foreach (var token in syntaxTree.GetRoot().DescendantTokens(n => !IsUsingDirective(n)))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/CopyPasteTokenAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/CopyPasteTokenAnalyzerBase.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules
         protected abstract string GetCpdValue(SyntaxToken token);
         protected abstract bool IsUsingDirective(SyntaxNode node);
 
-        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+        protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
             base.ReadParameters(context) with { AnalyzeTestProjects = false };
 
         protected sealed override bool AnalyzeUnchangedFiles => true;
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules
 
         protected CopyPasteTokenAnalyzerBase() : base(DiagnosticId, Title) { }
 
-        protected sealed override CopyPasteTokenInfo CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override CopyPasteTokenInfo CreateMessage(UtilityAnalyzerParameters parameters, SyntaxTree syntaxTree, SemanticModel semanticModel)
         {
             var cpdTokenInfo = new CopyPasteTokenInfo { FilePath = syntaxTree.FilePath };
             foreach (var token in syntaxTree.GetRoot().DescendantTokens(n => !IsUsingDirective(n)))

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/CopyPasteTokenAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/CopyPasteTokenAnalyzerBase.cs
@@ -31,7 +31,9 @@ namespace SonarAnalyzer.Rules
         protected abstract string GetCpdValue(SyntaxToken token);
         protected abstract bool IsUsingDirective(SyntaxNode node);
 
-        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) => base.ReadParameters(context) with { AnalyzeTestProjects = false };
+        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            base.ReadParameters(context) with { AnalyzeTestProjects = false };
+
         protected sealed override bool AnalyzeUnchangedFiles => true;
         protected sealed override string FileName => "token-cpd.pb";
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/FileMetadataAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/FileMetadataAnalyzerBase.cs
@@ -29,11 +29,12 @@ namespace SonarAnalyzer.Rules
         private const string Title = "File metadata generator";
 
         protected sealed override string FileName => "file-metadata.pb";
-        protected override bool AnalyzeGeneratedCode => true;
+        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            base.ReadParameters(context) with { AnalyzeGeneratedCode = true };
 
         protected FileMetadataAnalyzerBase() : base(DiagnosticId, Title) { }
 
-        protected sealed override FileMetadataInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel) =>
+        protected sealed override FileMetadataInfo CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel) =>
             new FileMetadataInfo
             {
                 FilePath = syntaxTree.FilePath,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/FileMetadataAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/FileMetadataAnalyzerBase.cs
@@ -29,13 +29,13 @@ namespace SonarAnalyzer.Rules
         private const string Title = "File metadata generator";
 
         protected sealed override string FileName => "file-metadata.pb";
-        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+        protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
             base.ReadParameters(context) with { AnalyzeGeneratedCode = true };
 
         protected FileMetadataAnalyzerBase() : base(DiagnosticId, Title) { }
 
-        protected sealed override FileMetadataInfo CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel) =>
-            new FileMetadataInfo
+        protected sealed override FileMetadataInfo CreateMessage(UtilityAnalyzerParameters parameters, SyntaxTree syntaxTree, SemanticModel semanticModel) =>
+            new()
             {
                 FilePath = syntaxTree.FilePath,
                 IsGenerated = Language.GeneratedCodeRecognizer.IsGenerated(syntaxTree),

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/LogAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/LogAnalyzerBase.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules
         protected abstract string LanguageVersion(Compilation compilation);
 
         protected sealed override string FileName => "log.pb";
-        protected override bool AnalyzeGeneratedCode => true;
+        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) => base.ReadParameters(context) with { AnalyzeGeneratedCode = true };
 
         protected LogAnalyzerBase() : base(DiagnosticId, Title) { }
 
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules
                 new LogInfo { Severity = LogSeverity.Info, Text = "Concurrent execution: " + (IsConcurrentExecutionEnabled() ? "enabled" : "disabled") }
             };
 
-        protected sealed override LogInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel) =>
+        protected sealed override LogInfo CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel) =>
             syntaxTree.IsGenerated(Language.GeneratedCodeRecognizer, semanticModel.Compilation)
             ? new LogInfo { Severity = LogSeverity.Debug, Text = $"File '{syntaxTree.FilePath}' was recognized as generated" }
             : null;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/LogAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/LogAnalyzerBase.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules
         protected abstract string LanguageVersion(Compilation compilation);
 
         protected sealed override string FileName => "log.pb";
-        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+        protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
             base.ReadParameters(context) with { AnalyzeGeneratedCode = true };
 
         protected LogAnalyzerBase() : base(DiagnosticId, Title) { }
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules
                 new LogInfo { Severity = LogSeverity.Info, Text = "Concurrent execution: " + (IsConcurrentExecutionEnabled() ? "enabled" : "disabled") }
             };
 
-        protected sealed override LogInfo CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel) =>
+        protected sealed override LogInfo CreateMessage(UtilityAnalyzerParameters parameters, SyntaxTree syntaxTree, SemanticModel semanticModel) =>
             syntaxTree.IsGenerated(Language.GeneratedCodeRecognizer, semanticModel.Compilation)
             ? new LogInfo { Severity = LogSeverity.Debug, Text = $"File '{syntaxTree.FilePath}' was recognized as generated" }
             : null;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/LogAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/LogAnalyzerBase.cs
@@ -31,7 +31,8 @@ namespace SonarAnalyzer.Rules
         protected abstract string LanguageVersion(Compilation compilation);
 
         protected sealed override string FileName => "log.pb";
-        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) => base.ReadParameters(context) with { AnalyzeGeneratedCode = true };
+        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            base.ReadParameters(context) with { AnalyzeGeneratedCode = true };
 
         protected LogAnalyzerBase() : base(DiagnosticId, Title) { }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/MetricsAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/MetricsAnalyzerBase.cs
@@ -31,11 +31,11 @@ namespace SonarAnalyzer.Rules
         protected abstract MetricsBase GetMetrics(SyntaxTree syntaxTree, SemanticModel semanticModel);
 
         protected sealed override string FileName => "metrics.pb";
-        protected sealed override bool AnalyzeTestProjects => false;
+        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) => base.ReadParameters(context) with { AnalyzeTestProjects = false };
 
         protected MetricsAnalyzerBase() : base(DiagnosticId, Title) { }
 
-        protected sealed override MetricsInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override MetricsInfo CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel)
         {
             var metrics = GetMetrics(syntaxTree, semanticModel);
             var complexity = metrics.Complexity;
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules
                 CognitiveComplexity = metrics.CognitiveComplexity,
             };
 
-            var comments = metrics.GetComments(IgnoreHeaderComments);
+            var comments = metrics.GetComments(parameter.IgnoreHeaderComments);
             metricsInfo.NoSonarComment.AddRange(comments.NoSonar);
             metricsInfo.NonBlankComment.AddRange(comments.NonBlank);
             metricsInfo.CodeLine.AddRange(metrics.CodeLines);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/MetricsAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/MetricsAnalyzerBase.cs
@@ -31,7 +31,8 @@ namespace SonarAnalyzer.Rules
         protected abstract MetricsBase GetMetrics(SyntaxTree syntaxTree, SemanticModel semanticModel);
 
         protected sealed override string FileName => "metrics.pb";
-        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) => base.ReadParameters(context) with { AnalyzeTestProjects = false };
+        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            base.ReadParameters(context) with { AnalyzeTestProjects = false };
 
         protected MetricsAnalyzerBase() : base(DiagnosticId, Title) { }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/MetricsAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/MetricsAnalyzerBase.cs
@@ -31,12 +31,12 @@ namespace SonarAnalyzer.Rules
         protected abstract MetricsBase GetMetrics(SyntaxTree syntaxTree, SemanticModel semanticModel);
 
         protected sealed override string FileName => "metrics.pb";
-        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+        protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
             base.ReadParameters(context) with { AnalyzeTestProjects = false };
 
         protected MetricsAnalyzerBase() : base(DiagnosticId, Title) { }
 
-        protected sealed override MetricsInfo CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override MetricsInfo CreateMessage(UtilityAnalyzerParameters parameters, SyntaxTree syntaxTree, SemanticModel semanticModel)
         {
             var metrics = GetMetrics(syntaxTree, semanticModel);
             var complexity = metrics.Complexity;
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules
                 CognitiveComplexity = metrics.CognitiveComplexity,
             };
 
-            var comments = metrics.GetComments(parameter.IgnoreHeaderComments);
+            var comments = metrics.GetComments(parameters.IgnoreHeaderComments);
             metricsInfo.NoSonarComment.AddRange(comments.NoSonar);
             metricsInfo.NonBlankComment.AddRange(comments.NonBlank);
             metricsInfo.CodeLine.AddRange(metrics.CodeLines);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules
 
         protected SymbolReferenceAnalyzerBase() : base(DiagnosticId, Title) { }
 
-        protected sealed override SymbolReferenceInfo CreateMessage(UtilityAnalyzerParameters parameter, SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override SymbolReferenceInfo CreateMessage(UtilityAnalyzerParameters parameters, SyntaxTree syntaxTree, SemanticModel semanticModel)
         {
             var symbolReferenceInfo = new SymbolReferenceInfo { FilePath = syntaxTree.FilePath };
             var references = GetReferences(syntaxTree.GetRoot(), semanticModel);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules
 
         protected SymbolReferenceAnalyzerBase() : base(DiagnosticId, Title) { }
 
-        protected sealed override SymbolReferenceInfo CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override SymbolReferenceInfo CreateMessage(UtilityAnalyzerParameters parameter, SyntaxTree syntaxTree, SemanticModel semanticModel)
         {
             var symbolReferenceInfo = new SymbolReferenceInfo { FilePath = syntaxTree.FilePath };
             var references = GetReferences(syntaxTree.GetRoot(), semanticModel);
@@ -56,8 +56,8 @@ namespace SonarAnalyzer.Rules
             return symbolReferenceInfo;
         }
 
-        protected override bool ShouldGenerateMetrics(UtilityAnalyzerParameter parameter, SyntaxTree tree) =>
-            base.ShouldGenerateMetrics(parameter, tree)
+        protected override bool ShouldGenerateMetrics(UtilityAnalyzerParameters parameters, SyntaxTree tree) =>
+            base.ShouldGenerateMetrics(parameters, tree)
             && !HasTooManyTokens(tree);
 
         private Dictionary<ISymbol, List<ReferenceInfo>> GetReferences(SyntaxNode root, SemanticModel model)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules
 
         protected SymbolReferenceAnalyzerBase() : base(DiagnosticId, Title) { }
 
-        protected sealed override SymbolReferenceInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override SymbolReferenceInfo CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel)
         {
             var symbolReferenceInfo = new SymbolReferenceInfo { FilePath = syntaxTree.FilePath };
             var references = GetReferences(syntaxTree.GetRoot(), semanticModel);
@@ -56,8 +56,8 @@ namespace SonarAnalyzer.Rules
             return symbolReferenceInfo;
         }
 
-        protected override bool ShouldGenerateMetrics(SyntaxTree tree) =>
-            base.ShouldGenerateMetrics(tree)
+        protected override bool ShouldGenerateMetrics(UtilityAnalyzerParameter parameter, SyntaxTree tree) =>
+            base.ShouldGenerateMetrics(parameter, tree)
             && !HasTooManyTokens(tree);
 
         private Dictionary<ISymbol, List<ReferenceInfo>> GetReferences(SyntaxNode root, SemanticModel model)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules
         protected abstract TokenClassifierBase GetTokenClassifier(SemanticModel semanticModel, bool skipIdentifierTokens);
         protected abstract TriviaClassifierBase GetTriviaClassifier();
 
-        protected sealed override TokenTypeInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override TokenTypeInfo CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel)
         {
             var tokens = syntaxTree.GetRoot().DescendantTokens();
             var identifierTokenKind = Language.SyntaxKind.IdentifierToken;  // Performance optimization

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules
         protected abstract TokenClassifierBase GetTokenClassifier(SemanticModel semanticModel, bool skipIdentifierTokens);
         protected abstract TriviaClassifierBase GetTriviaClassifier();
 
-        protected sealed override TokenTypeInfo CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override TokenTypeInfo CreateMessage(UtilityAnalyzerParameters parameters, SyntaxTree syntaxTree, SemanticModel semanticModel)
         {
             var tokens = syntaxTree.GetRoot().DescendantTokens();
             var identifierTokenKind = Language.SyntaxKind.IdentifierToken;  // Performance optimization

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -26,7 +26,8 @@ namespace SonarAnalyzer.Rules
 {
     public readonly record struct UtilityAnalyzerParameter(bool IsAnalyzerEnabled, bool IgnoreHeaderComments, bool AnalyzeGeneratedCode, bool AnalyzeTestProjects, string OutPath, bool IsTestProject)
     {
-        public static readonly UtilityAnalyzerParameter Default = new(IsAnalyzerEnabled: false, IgnoreHeaderComments: false, AnalyzeGeneratedCode: false, AnalyzeTestProjects: true, OutPath: null, IsTestProject: false);
+        public static readonly UtilityAnalyzerParameter Default =
+            new(IsAnalyzerEnabled: false, IgnoreHeaderComments: false, AnalyzeGeneratedCode: false, AnalyzeTestProjects: true, OutPath: null, IsTestProject: false);
     }
 
     public abstract class UtilityAnalyzerBase : SonarDiagnosticAnalyzer

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -24,18 +24,17 @@ using SonarAnalyzer.Protobuf;
 
 namespace SonarAnalyzer.Rules
 {
+    public readonly record struct UtilityAnalyzerParameter(bool IsAnalyzerEnabled, bool IgnoreHeaderComments, bool AnalyzeGeneratedCode, bool AnalyzeTestProjects, string OutPath, bool IsTestProject)
+    {
+        public static readonly UtilityAnalyzerParameter Default = new(IsAnalyzerEnabled: false, IgnoreHeaderComments: false, AnalyzeGeneratedCode: false, AnalyzeTestProjects: true, OutPath: null, IsTestProject: false);
+    }
+
     public abstract class UtilityAnalyzerBase : SonarDiagnosticAnalyzer
     {
         protected static readonly ISet<string> FileExtensionWhitelist = new HashSet<string> { ".cs", ".csx", ".vb" };
         private readonly DiagnosticDescriptor rule;
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
-        protected bool IsAnalyzerEnabled { get; set; }
-        protected bool IgnoreHeaderComments { get; set; }
-        protected virtual bool AnalyzeGeneratedCode { get; set; }
-        protected virtual bool AnalyzeTestProjects => true;
-        protected string OutPath { get; set; }
-        protected bool IsTestProject { get; set; }
         protected override bool EnableConcurrentExecution => false;
 
         protected UtilityAnalyzerBase(string diagnosticId, string title) =>
@@ -50,7 +49,7 @@ namespace SonarAnalyzer.Rules
                 EndOffset = lineSpan.EndLinePosition.Character
             };
 
-        protected void ReadParameters(SonarCompilationStartAnalysisContext context)
+        protected virtual UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context)
         {
             var outPath = context.ProjectConfiguration().OutPath;
             // For backward compatibility with S4MSB <= 5.0
@@ -60,13 +59,17 @@ namespace SonarAnalyzer.Rules
             }
             if (context.Options.SonarLintXml() != null && !string.IsNullOrEmpty(outPath))
             {
+                var language = context.Compilation.Language;
                 var sonarLintXml = context.SonarLintXml();
-                IgnoreHeaderComments = sonarLintXml.IgnoreHeaderComments(context.Compilation.Language);
-                AnalyzeGeneratedCode = sonarLintXml.AnalyzeGeneratedCode(context.Compilation.Language);
-                OutPath = Path.Combine(outPath, context.Compilation.Language == LanguageNames.CSharp ? "output-cs" : "output-vbnet");
-                IsAnalyzerEnabled = true;
-                IsTestProject = context.IsTestProject();
+                return new UtilityAnalyzerParameter(
+                    IsAnalyzerEnabled: true,
+                    IgnoreHeaderComments: sonarLintXml.IgnoreHeaderComments(language),
+                    AnalyzeGeneratedCode: sonarLintXml.AnalyzeGeneratedCode(language),
+                    AnalyzeTestProjects: true,
+                    OutPath: Path.Combine(outPath, language == LanguageNames.CSharp ? "output-cs" : "output-vbnet"),
+                    IsTestProject: context.IsTestProject());
             }
+            return UtilityAnalyzerParameter.Default;
         }
     }
 
@@ -78,7 +81,7 @@ namespace SonarAnalyzer.Rules
 
         protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract string FileName { get; }
-        protected abstract TMessage CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel);
+        protected abstract TMessage CreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel);
 
         protected virtual bool AnalyzeUnchangedFiles => false;
 
@@ -89,8 +92,8 @@ namespace SonarAnalyzer.Rules
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterCompilationStartAction(startContext =>
             {
-                ReadParameters(startContext);
-                if (!IsAnalyzerEnabled)
+                var parameter = ReadParameters(startContext);
+                if (!parameter.IsAnalyzerEnabled)
                 {
                     return;
                 }
@@ -98,9 +101,9 @@ namespace SonarAnalyzer.Rules
                 var treeMessages = new List<TMessage>();
                 startContext.RegisterSemanticModelAction(modelContext =>
                 {
-                    if (ShouldGenerateMetrics(modelContext))
+                    if (ShouldGenerateMetrics(parameter, modelContext))
                     {
-                        treeMessages.Add(CreateMessage(modelContext.Tree, modelContext.SemanticModel));
+                        treeMessages.Add(CreateMessage(parameter, modelContext.Tree, modelContext.SemanticModel));
                     }
                 });
 
@@ -112,8 +115,8 @@ namespace SonarAnalyzer.Rules
                         .ToArray();
                     lock (FileWriteLock)
                     {
-                        Directory.CreateDirectory(OutPath);
-                        using var stream = File.Create(Path.Combine(OutPath, FileName));
+                        Directory.CreateDirectory(parameter.OutPath);
+                        using var stream = File.Create(Path.Combine(parameter.OutPath, FileName));
                         foreach (var message in allMessages)
                         {
                             message.WriteDelimitedTo(stream);
@@ -122,14 +125,14 @@ namespace SonarAnalyzer.Rules
                 });
             });
 
-        protected virtual bool ShouldGenerateMetrics(SyntaxTree tree) =>
+        protected virtual bool ShouldGenerateMetrics(UtilityAnalyzerParameter parameter, SyntaxTree tree) =>
             // The results of Metrics and CopyPasteToken analyzers are not needed for Test projects yet the plugin side expects the protobuf files, so we create empty ones.
-            (AnalyzeTestProjects || !IsTestProject)
+            (parameter.AnalyzeTestProjects || !parameter.IsTestProject)
             && FileExtensionWhitelist.Contains(Path.GetExtension(tree.FilePath))
-            && (AnalyzeGeneratedCode || !Language.GeneratedCodeRecognizer.IsGenerated(tree));
+            && (parameter.AnalyzeGeneratedCode || !Language.GeneratedCodeRecognizer.IsGenerated(tree));
 
-        private bool ShouldGenerateMetrics(SonarSematicModelReportingContext context) =>
+        private bool ShouldGenerateMetrics(UtilityAnalyzerParameter parameter, SonarSematicModelReportingContext context) =>
             (AnalyzeUnchangedFiles || !context.IsUnchanged(context.Tree))
-            && ShouldGenerateMetrics(context.Tree);
+            && ShouldGenerateMetrics(parameter, context.Tree);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/AnalysisWarningAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/AnalysisWarningAnalyzerTest.cs
@@ -19,6 +19,7 @@
  */
 
 using System.IO;
+using SonarAnalyzer.AnalysisContext;
 using SonarAnalyzer.CFG.Helpers;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Rules;
@@ -88,25 +89,35 @@ public class AnalysisWarningAnalyzerTest
 
     private sealed class TestAnalysisWarningAnalyzer_CS : CS.AnalysisWarningAnalyzer
     {
+        private readonly bool isAnalyzerEnabled;
+        private readonly string outPath;
         protected override int MinimalSupportedRoslynVersion { get; }
 
         public TestAnalysisWarningAnalyzer_CS(bool isAnalyzerEnabled, int minimalSupportedRoslynVersion, string outPath)
         {
-            IsAnalyzerEnabled = isAnalyzerEnabled;
+            this.isAnalyzerEnabled = isAnalyzerEnabled;
             MinimalSupportedRoslynVersion = minimalSupportedRoslynVersion;
-            OutPath = outPath;
+            this.outPath = outPath;
         }
+
+        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            base.ReadParameters(context) with { IsAnalyzerEnabled = isAnalyzerEnabled, OutPath = outPath };
     }
 
     private sealed class TestAnalysisWarningAnalyzer_VB : VB.AnalysisWarningAnalyzer
     {
+        private readonly bool isAnalyzerEnabled;
+        private readonly string outPath;
         protected override int MinimalSupportedRoslynVersion { get; }
 
         public TestAnalysisWarningAnalyzer_VB(bool isAnalyzerEnabled, int minimalSupportedRoslynVersion, string outPath)
         {
-            IsAnalyzerEnabled = isAnalyzerEnabled;
+            this.isAnalyzerEnabled = isAnalyzerEnabled;
             MinimalSupportedRoslynVersion = minimalSupportedRoslynVersion;
-            OutPath = outPath;
+            this.outPath = outPath;
         }
+
+        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            base.ReadParameters(context) with { IsAnalyzerEnabled = isAnalyzerEnabled, OutPath = outPath };
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/AnalysisWarningAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/AnalysisWarningAnalyzerTest.cs
@@ -100,7 +100,7 @@ public class AnalysisWarningAnalyzerTest
             this.outPath = outPath;
         }
 
-        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+        protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
             base.ReadParameters(context) with { IsAnalyzerEnabled = isAnalyzerEnabled, OutPath = outPath };
     }
 
@@ -117,7 +117,7 @@ public class AnalysisWarningAnalyzerTest
             this.outPath = outPath;
         }
 
-        protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+        protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
             base.ReadParameters(context) with { IsAnalyzerEnabled = isAnalyzerEnabled, OutPath = outPath };
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/CopyPasteTokenAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/CopyPasteTokenAnalyzerTest.cs
@@ -151,7 +151,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 this.isTestProject = isTestProject;
             }
 
-            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
                 base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
 
@@ -166,7 +166,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 this.isTestProject = isTestProject;
             }
 
-            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
                 base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/CopyPasteTokenAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/CopyPasteTokenAnalyzerTest.cs
@@ -19,6 +19,7 @@
  */
 
 using System.IO;
+using SonarAnalyzer.AnalysisContext;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Protobuf;
 using SonarAnalyzer.Rules;
@@ -141,22 +142,32 @@ namespace SonarAnalyzer.UnitTest.Rules
         // We need to set protected properties and this class exists just to enable the analyzer without bothering with additional files with parameters
         private sealed class TestCopyPasteTokenAnalyzer_CS : CS.CopyPasteTokenAnalyzer
         {
+            private readonly string outPath;
+            private readonly bool isTestProject;
+
             public TestCopyPasteTokenAnalyzer_CS(string outPath, bool isTestProject)
             {
-                IsAnalyzerEnabled = true;
-                OutPath = outPath;
-                IsTestProject = isTestProject;
+                this.outPath = outPath;
+                this.isTestProject = isTestProject;
             }
+
+            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+                base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
 
         private sealed class TestCopyPasteTokenAnalyzer_VB : VB.CopyPasteTokenAnalyzer
         {
+            private readonly string outPath;
+            private readonly bool isTestProject;
+
             public TestCopyPasteTokenAnalyzer_VB(string outPath, bool isTestProject)
             {
-                IsAnalyzerEnabled = true;
-                OutPath = outPath;
-                IsTestProject = isTestProject;
+                this.outPath = outPath;
+                this.isTestProject = isTestProject;
             }
+
+            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+                base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/FileMetadataAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/FileMetadataAnalyzerTest.cs
@@ -99,7 +99,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             tree.SetupGet(x => x.Encoding).Returns(() => null);
             var sut = new TestFileMetadataAnalyzer(null, isTestProject);
 
-            sut.TestCreateMessage(UtilityAnalyzerParameter.Default, tree.Object, null).Encoding.Should().BeEmpty();
+            sut.TestCreateMessage(UtilityAnalyzerParameters.Default, tree.Object, null).Encoding.Should().BeEmpty();
         }
 
         [DataTestMethod]
@@ -142,11 +142,11 @@ namespace SonarAnalyzer.UnitTest.Rules
                 this.isTestProject = isTestProject;
             }
 
-            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
                 base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
 
-            public FileMetadataInfo TestCreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel) =>
-                CreateMessage(parameter, syntaxTree, semanticModel);
+            public FileMetadataInfo TestCreateMessage(UtilityAnalyzerParameters parameters, SyntaxTree syntaxTree, SemanticModel semanticModel) =>
+                CreateMessage(parameters, syntaxTree, semanticModel);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/FileMetadataAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/FileMetadataAnalyzerTest.cs
@@ -19,7 +19,9 @@
  */
 
 using Moq;
+using SonarAnalyzer.AnalysisContext;
 using SonarAnalyzer.Protobuf;
+using SonarAnalyzer.Rules;
 using SonarAnalyzer.Rules.CSharp;
 
 namespace SonarAnalyzer.UnitTest.Rules
@@ -97,7 +99,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             tree.SetupGet(x => x.Encoding).Returns(() => null);
             var sut = new TestFileMetadataAnalyzer(null, isTestProject);
 
-            sut.TestCreateMessage(tree.Object, null).Encoding.Should().BeEmpty();
+            sut.TestCreateMessage(default(UtilityAnalyzerParameter), tree.Object, null).Encoding.Should().BeEmpty();
         }
 
         [DataTestMethod]
@@ -131,15 +133,20 @@ namespace SonarAnalyzer.UnitTest.Rules
         // We need to set protected properties and this class exists just to enable the analyzer without bothering with additional files with parameters
         private sealed class TestFileMetadataAnalyzer : FileMetadataAnalyzer
         {
+            private readonly string outPath;
+            private readonly bool isTestProject;
+
             public TestFileMetadataAnalyzer(string outPath, bool isTestProject)
             {
-                IsAnalyzerEnabled = true;
-                OutPath = outPath;
-                IsTestProject = isTestProject;
+                this.outPath = outPath;
+                this.isTestProject = isTestProject;
             }
 
-            public FileMetadataInfo TestCreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel) =>
-                CreateMessage(syntaxTree, semanticModel);
+            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+                base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
+
+            public FileMetadataInfo TestCreateMessage(UtilityAnalyzerParameter parameter, SyntaxTree syntaxTree, SemanticModel semanticModel) =>
+                CreateMessage(parameter, syntaxTree, semanticModel);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/FileMetadataAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/FileMetadataAnalyzerTest.cs
@@ -99,7 +99,7 @@ namespace SonarAnalyzer.UnitTest.Rules
             tree.SetupGet(x => x.Encoding).Returns(() => null);
             var sut = new TestFileMetadataAnalyzer(null, isTestProject);
 
-            sut.TestCreateMessage(default(UtilityAnalyzerParameter), tree.Object, null).Encoding.Should().BeEmpty();
+            sut.TestCreateMessage(UtilityAnalyzerParameter.Default, tree.Object, null).Encoding.Should().BeEmpty();
         }
 
         [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/LogAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/LogAnalyzerTest.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using SonarAnalyzer.AnalysisContext;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Protobuf;
 using SonarAnalyzer.Rules;
@@ -148,22 +149,28 @@ namespace SonarAnalyzer.UnitTest.Rules
         // We need to set protected properties and this class exists just to enable the analyzer without bothering with additional files with parameters
         private sealed class TestLogAnalyzer_CS : CS.LogAnalyzer
         {
+            private readonly string outPath;
+
             public TestLogAnalyzer_CS(string outPath)
             {
-                IsAnalyzerEnabled = true;
-                OutPath = outPath;
-                IsTestProject = false;
+                this.outPath = outPath;
             }
+
+            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+                base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = false };
         }
 
         private sealed class TestLogAnalyzer_VB : VB.LogAnalyzer
         {
+            private readonly string outPath;
+
             public TestLogAnalyzer_VB(string outPath)
             {
-                IsAnalyzerEnabled = true;
-                OutPath = outPath;
-                IsTestProject = false;
+                this.outPath = outPath;
             }
+
+            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+                base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = false };
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/LogAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/LogAnalyzerTest.cs
@@ -156,7 +156,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 this.outPath = outPath;
             }
 
-            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
                 base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = false };
         }
 
@@ -169,7 +169,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 this.outPath = outPath;
             }
 
-            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
                 base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = false };
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/MetricsAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/MetricsAnalyzerTest.cs
@@ -19,7 +19,9 @@
  */
 
 using System.IO;
+using SonarAnalyzer.AnalysisContext;
 using SonarAnalyzer.Protobuf;
+using SonarAnalyzer.Rules;
 using SonarAnalyzer.Rules.CSharp;
 
 namespace SonarAnalyzer.UnitTest.Rules
@@ -85,12 +87,17 @@ namespace SonarAnalyzer.UnitTest.Rules
         // We need to set protected properties and this class exists just to enable the analyzer without bothering with additional files with parameters
         private sealed class TestMetricsAnalyzer : MetricsAnalyzer
         {
+            private readonly string outPath;
+            private readonly bool isTestProject;
+
             public TestMetricsAnalyzer(string outPath, bool isTestProject)
             {
-                IsAnalyzerEnabled = true;
-                OutPath = outPath;
-                IsTestProject = isTestProject;
+                this.outPath = outPath;
+                this.isTestProject = isTestProject;
             }
+
+            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+                base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/MetricsAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/MetricsAnalyzerTest.cs
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 this.isTestProject = isTestProject;
             }
 
-            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
                 base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
@@ -245,7 +245,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 this.isTestProject = isTestProject;
             }
 
-            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
                 base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
 
@@ -260,7 +260,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 this.isTestProject = isTestProject;
             }
 
-            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
                 base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
@@ -19,6 +19,7 @@
  */
 
 using System.IO;
+using SonarAnalyzer.AnalysisContext;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Protobuf;
 using SonarAnalyzer.Rules;
@@ -235,22 +236,32 @@ namespace SonarAnalyzer.UnitTest.Rules
         // We need to set protected properties and this class exists just to enable the analyzer without bothering with additional files with parameters
         private sealed class TestSymbolReferenceAnalyzer_CS : CS.SymbolReferenceAnalyzer
         {
+            private readonly string outPath;
+            private readonly bool isTestProject;
+
             public TestSymbolReferenceAnalyzer_CS(string outPath, bool isTestProject)
             {
-                IsAnalyzerEnabled = true;
-                OutPath = outPath;
-                IsTestProject = isTestProject;
+                this.outPath = outPath;
+                this.isTestProject = isTestProject;
             }
+
+            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+                base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
 
         private sealed class TestSymbolReferenceAnalyzer_VB : VB.SymbolReferenceAnalyzer
         {
+            private readonly string outPath;
+            private readonly bool isTestProject;
+
             public TestSymbolReferenceAnalyzer_VB(string outPath, bool isTestProject)
             {
-                IsAnalyzerEnabled = true;
-                OutPath = outPath;
-                IsTestProject = isTestProject;
+                this.outPath = outPath;
+                this.isTestProject = isTestProject;
             }
+
+            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+                base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/TokenTypeAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/TokenTypeAnalyzerTest.cs
@@ -190,7 +190,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 this.isTestProject = isTestProject;
             }
 
-            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
                 base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
 
@@ -205,7 +205,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 this.isTestProject = isTestProject;
             }
 
-            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+            protected override UtilityAnalyzerParameters ReadParameters(SonarCompilationStartAnalysisContext context) =>
                 base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/TokenTypeAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/TokenTypeAnalyzerTest.cs
@@ -19,6 +19,7 @@
  */
 
 using System.IO;
+using SonarAnalyzer.AnalysisContext;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Protobuf;
 using SonarAnalyzer.Rules;
@@ -180,22 +181,32 @@ namespace SonarAnalyzer.UnitTest.Rules
         // We need to set protected properties and this class exists just to enable the analyzer without bothering with additional files with parameters
         private sealed class TestTokenTypeAnalyzer_CS : CS.TokenTypeAnalyzer
         {
+            private readonly string outPath;
+            private readonly bool isTestProject;
+
             public TestTokenTypeAnalyzer_CS(string outPath, bool isTestProject)
             {
-                IsAnalyzerEnabled = true;
-                OutPath = outPath;
-                IsTestProject = isTestProject;
+                this.outPath = outPath;
+                this.isTestProject = isTestProject;
             }
+
+            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+                base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
 
         private sealed class TestTokenTypeAnalyzer_VB : VB.TokenTypeAnalyzer
         {
+            private readonly string outPath;
+            private readonly bool isTestProject;
+
             public TestTokenTypeAnalyzer_VB(string outPath, bool isTestProject)
             {
-                IsAnalyzerEnabled = true;
-                OutPath = outPath;
-                IsTestProject = isTestProject;
+                this.outPath = outPath;
+                this.isTestProject = isTestProject;
             }
+
+            protected override UtilityAnalyzerParameter ReadParameters(SonarCompilationStartAnalysisContext context) =>
+                base.ReadParameters(context) with { IsAnalyzerEnabled = true, OutPath = outPath, IsTestProject = isTestProject };
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/UtilityAnalyzerBaseTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/UtilityAnalyzerBaseTest.cs
@@ -125,10 +125,12 @@ namespace SonarAnalyzer.UnitTest.Rules.Utilities
         private class TestUtilityAnalyzer : UtilityAnalyzerBase
         {
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => throw new NotImplementedException();
-            public bool TestIsAnalyzerEnabled => IsAnalyzerEnabled;
-            public bool TestAnalyzeGeneratedCode => AnalyzeGeneratedCode;
-            public bool TestIgnoreHeaderComments => IgnoreHeaderComments;
-            public string TestOutPath => OutPath;
+            public UtilityAnalyzerParameter Parameters { get; }
+            public bool TestIsAnalyzerEnabled => Parameters.IsAnalyzerEnabled;
+            public bool TestAnalyzeGeneratedCode => Parameters.AnalyzeGeneratedCode;
+            public bool TestIgnoreHeaderComments => Parameters.IgnoreHeaderComments;
+            public string TestOutPath => Parameters.OutPath;
+
 
             public TestUtilityAnalyzer(string language, params string[] additionalPaths) : base("S9999-test", "Title")
             {
@@ -140,7 +142,7 @@ namespace SonarAnalyzer.UnitTest.Rules.Utilities
                     _ => throw new InvalidOperationException($"Unexpected {nameof(language)}: {language}")
                 };
                 var context = new Mock<CompilationStartAnalysisContext>(compilation, new AnalyzerOptions(additionalFiles), default).Object;
-                ReadParameters(new SonarCompilationStartAnalysisContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context));
+                Parameters = ReadParameters(new SonarCompilationStartAnalysisContext(AnalysisScaffolding.CreateSonarAnalysisContext(), context));
             }
 
             protected override void Initialize(SonarAnalysisContext context) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/UtilityAnalyzerBaseTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/UtilityAnalyzerBaseTest.cs
@@ -46,8 +46,8 @@ namespace SonarAnalyzer.UnitTest.Rules.Utilities
             // We do not test what is read from the SonarLint file, but we need it
             var utilityAnalyzer = new TestUtilityAnalyzer(language, @"TestResources\SonarLintXml\All_properties_cs\SonarLint.xml", additionalPath);
 
-            utilityAnalyzer.TestOutPath.Should().Be(expectedOutPath);
-            utilityAnalyzer.TestIsAnalyzerEnabled.Should().BeTrue();
+            utilityAnalyzer.Parameters.OutPath.Should().Be(expectedOutPath);
+            utilityAnalyzer.Parameters.IsAnalyzerEnabled.Should().BeTrue();
         }
 
         [DataTestMethod]
@@ -58,8 +58,8 @@ namespace SonarAnalyzer.UnitTest.Rules.Utilities
             // We do not test what is read from the SonarLint file, but we need it
             var utilityAnalyzer = new TestUtilityAnalyzer(LanguageNames.CSharp, @"TestResources\SonarLintXml\All_properties_cs\SonarLint.xml", firstFile, secondFile);
 
-            utilityAnalyzer.TestOutPath.Should().Be(@"C:\foo\bar\.sonarqube\out\0\output-cs");
-            utilityAnalyzer.TestIsAnalyzerEnabled.Should().BeTrue();
+            utilityAnalyzer.Parameters.OutPath.Should().Be(@"C:\foo\bar\.sonarqube\out\0\output-cs");
+            utilityAnalyzer.Parameters.IsAnalyzerEnabled.Should().BeTrue();
         }
 
         [DataTestMethod]
@@ -72,8 +72,8 @@ namespace SonarAnalyzer.UnitTest.Rules.Utilities
             var sonarLintXmlPath = AnalysisScaffolding.CreateSonarLintXml(TestContext, language: language, analyzeGeneratedCode: analyzeGenerated);
             var utilityAnalyzer = new TestUtilityAnalyzer(language, sonarLintXmlPath, DefaultSonarProjectConfig);
 
-            utilityAnalyzer.TestAnalyzeGeneratedCode.Should().Be(analyzeGenerated);
-            utilityAnalyzer.TestIsAnalyzerEnabled.Should().BeTrue();
+            utilityAnalyzer.Parameters.AnalyzeGeneratedCode.Should().Be(analyzeGenerated);
+            utilityAnalyzer.Parameters.IsAnalyzerEnabled.Should().BeTrue();
         }
 
         [DataTestMethod]
@@ -86,20 +86,20 @@ namespace SonarAnalyzer.UnitTest.Rules.Utilities
             var sonarLintXmlPath = AnalysisScaffolding.CreateSonarLintXml(TestContext, language: language, ignoreHeaderComments: ignoreHeaderComments);
             var utilityAnalyzer = new TestUtilityAnalyzer(language, sonarLintXmlPath, DefaultSonarProjectConfig);
 
-            utilityAnalyzer.TestIgnoreHeaderComments.Should().Be(ignoreHeaderComments);
-            utilityAnalyzer.TestIsAnalyzerEnabled.Should().BeTrue();
+            utilityAnalyzer.Parameters.IgnoreHeaderComments.Should().Be(ignoreHeaderComments);
+            utilityAnalyzer.Parameters.IsAnalyzerEnabled.Should().BeTrue();
         }
 
         [TestMethod]
         public void NoSonarLintXml_AnalyzerNotEnabled()
         {
-            new TestUtilityAnalyzer(LanguageNames.CSharp, DefaultProjectOutFolderPath).TestIsAnalyzerEnabled.Should().BeFalse();
-            new TestUtilityAnalyzer(LanguageNames.CSharp, DefaultSonarProjectConfig).TestIsAnalyzerEnabled.Should().BeFalse();
+            new TestUtilityAnalyzer(LanguageNames.CSharp, DefaultProjectOutFolderPath).Parameters.IsAnalyzerEnabled.Should().BeFalse();
+            new TestUtilityAnalyzer(LanguageNames.CSharp, DefaultSonarProjectConfig).Parameters.IsAnalyzerEnabled.Should().BeFalse();
         }
 
         [TestMethod]
         public void NoOutputPath_AnalyzerNotEnabled() =>
-            new TestUtilityAnalyzer(LanguageNames.CSharp, AnalysisScaffolding.CreateSonarLintXml(TestContext, analyzeGeneratedCode: true)).TestIsAnalyzerEnabled.Should().BeFalse();
+            new TestUtilityAnalyzer(LanguageNames.CSharp, AnalysisScaffolding.CreateSonarLintXml(TestContext, analyzeGeneratedCode: true)).Parameters.IsAnalyzerEnabled.Should().BeFalse();
 
         [TestMethod]
         public void GetTextRange()
@@ -126,11 +126,6 @@ namespace SonarAnalyzer.UnitTest.Rules.Utilities
         {
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => throw new NotImplementedException();
             public UtilityAnalyzerParameter Parameters { get; }
-            public bool TestIsAnalyzerEnabled => Parameters.IsAnalyzerEnabled;
-            public bool TestAnalyzeGeneratedCode => Parameters.AnalyzeGeneratedCode;
-            public bool TestIgnoreHeaderComments => Parameters.IgnoreHeaderComments;
-            public string TestOutPath => Parameters.OutPath;
-
 
             public TestUtilityAnalyzer(string language, params string[] additionalPaths) : base("S9999-test", "Title")
             {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/UtilityAnalyzerBaseTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/UtilityAnalyzerBaseTest.cs
@@ -125,7 +125,7 @@ namespace SonarAnalyzer.UnitTest.Rules.Utilities
         private class TestUtilityAnalyzer : UtilityAnalyzerBase
         {
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => throw new NotImplementedException();
-            public UtilityAnalyzerParameter Parameters { get; }
+            public UtilityAnalyzerParameters Parameters { get; }
 
             public TestUtilityAnalyzer(string language, params string[] additionalPaths) : base("S9999-test", "Title")
             {


### PR DESCRIPTION
Pre-condition for https://github.com/SonarSource/sonar-dotnet/issues/6674

Analyzer should be stateless. This PR removes the properties from UtilityAnalyzerBase and captures them in `RegisterCompilationStartAction` per compilation.

After this change, `EnableConcurrentExecution` can be set to true (and also `var treeMessages = new List<TMessage>();` needs to be changed to `var treeMessages = new ConcurrentStack<TMessage>();` of course).