### PR TITLE
SE - Add cache for SymbolicValues

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -81,7 +81,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             SetOperationConstraint(operation.Instance, constraint);
 
         public ProgramState SetOperationConstraint(IOperation operation, SymbolicConstraint constraint) =>
-            SetOperationValue(operation, (this[operation] ?? new()).WithConstraint(constraint));
+            SetOperationValue(operation, (this[operation] ?? SymbolicValue.Constraintless).WithConstraint(constraint));
 
         public ProgramState SetSymbolValue(ISymbol symbol, SymbolicValue value) =>
             value is null
@@ -89,7 +89,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 : this with { SymbolValue = SymbolValue.SetItem(symbol, value) };
 
         public ProgramState SetSymbolConstraint(ISymbol symbol, SymbolicConstraint constraint) =>
-            SetSymbolValue(symbol, (this[symbol] ?? new()).WithConstraint(constraint));
+            SetSymbolValue(symbol, (this[symbol] ?? SymbolicValue.Constraintless).WithConstraint(constraint));
 
         public ProgramState SetCapture(CaptureId capture, IOperation operation) =>
             this with { CaptureOperation = CaptureOperation.SetItem(capture, operation) };

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -81,7 +81,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             SetOperationConstraint(operation.Instance, constraint);
 
         public ProgramState SetOperationConstraint(IOperation operation, SymbolicConstraint constraint) =>
-            SetOperationValue(operation, (this[operation] ?? SymbolicValue.Constraintless).WithConstraint(constraint));
+            SetOperationValue(operation, (this[operation] ?? SymbolicValue.Empty).WithConstraint(constraint));
 
         public ProgramState SetSymbolValue(ISymbol symbol, SymbolicValue value) =>
             value is null
@@ -89,7 +89,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 : this with { SymbolValue = SymbolValue.SetItem(symbol, value) };
 
         public ProgramState SetSymbolConstraint(ISymbol symbol, SymbolicConstraint constraint) =>
-            SetSymbolValue(symbol, (this[symbol] ?? SymbolicValue.Constraintless).WithConstraint(constraint));
+            SetSymbolValue(symbol, (this[symbol] ?? SymbolicValue.Empty).WithConstraint(constraint));
 
         public ProgramState SetCapture(CaptureId capture, IOperation operation) =>
             this with { CaptureOperation = CaptureOperation.SetItem(capture, operation) };

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -108,10 +108,12 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             {
                 return SingleConstraint(constraint);
             }
+
             if (baseValue.HasConstraint(constraint))
             {
                 return baseValue;
             }
+
             var constraintType = constraint.GetType();
             var containsContraintType = baseValue.Constraints.ContainsKey(constraintType);
             if (constraintCount == 1)
@@ -120,6 +122,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                     ? SingleConstraint(constraint)
                     : PairConstraint(baseValue.Constraints.Values.First(), constraint);
             }
+
             if (constraintCount == 2 && containsContraintType)
             {
                 return PairConstraint(OtherConstraint(baseValue, constraintType), constraint);

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -102,10 +102,10 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         }
 
         public SymbolicValue WithoutConstraint(SymbolicConstraint constraint) =>
-            RemoveConstraint(this, constraint);
+            HasConstraint(constraint) ? RemoveConstraint(this, constraint.GetType()) : this;
 
         public SymbolicValue WithoutConstraint<T>() where T : SymbolicConstraint =>
-            RemoveConstraint<T>(this);
+            HasConstraint<T>() ? RemoveConstraint(this, typeof(T)) : this;
 
         public bool HasConstraint<T>() where T : SymbolicConstraint =>
             Constraints.ContainsKey(typeof(T));
@@ -126,12 +126,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             Constraints.Any()
                 ? Constraints.Values.Select(x => x.ToString()).OrderBy(x => x).JoinStr(", ")
                 : "No constraints";
-
-        private static SymbolicValue RemoveConstraint(SymbolicValue baseValue, SymbolicConstraint constraint) =>
-            baseValue.HasConstraint(constraint) ? RemoveConstraint(baseValue, constraint.GetType()) : baseValue;
-
-        private static SymbolicValue RemoveConstraint<T>(SymbolicValue baseValue) where T : SymbolicConstraint =>
-            baseValue.HasConstraint<T>() ? RemoveConstraint(baseValue, typeof(T)) : baseValue;
 
         private static SymbolicValue RemoveConstraint(SymbolicValue baseValue, Type type)
         {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -55,10 +55,10 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         private static ConcurrentDictionary<CacheKey, SymbolicValue> constraintCache = new();
 
         // Reuse instances to save memory. This "True" has the same semantic meaning and any other symbolic value with BoolConstraint.True constraint
-        public static readonly SymbolicValue Constraintless = new();
-        public static readonly SymbolicValue This = Constraintless.WithConstraint(ObjectConstraint.NotNull);
-        public static readonly SymbolicValue Null = Constraintless.WithConstraint(ObjectConstraint.Null);
-        public static readonly SymbolicValue NotNull = Constraintless.WithConstraint(ObjectConstraint.NotNull);
+        public static readonly SymbolicValue Empty = new();
+        public static readonly SymbolicValue This = Empty.WithConstraint(ObjectConstraint.NotNull);
+        public static readonly SymbolicValue Null = Empty.WithConstraint(ObjectConstraint.Null);
+        public static readonly SymbolicValue NotNull = Empty.WithConstraint(ObjectConstraint.NotNull);
         public static readonly SymbolicValue True = NotNull.WithConstraint(BoolConstraint.True);
         public static readonly SymbolicValue False = NotNull.WithConstraint(BoolConstraint.False);
 
@@ -139,7 +139,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             switch (constraintCount)
             {
                 case 1:
-                    return Constraintless;
+                    return Empty;
                 case 2:
                     var otherConstraint = OtherSingle(baseValue, type);
                     return SingleConstraint(otherConstraint);
@@ -196,7 +196,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             }
             else
             {
-                result = Constraintless with { Constraints = Constraintless.Constraints.SetItem(constraint.GetType(), constraint) };
+                result = Empty with { Constraints = Empty.Constraints.SetItem(constraint.GetType(), constraint) };
                 return constraintCache.GetOrAdd(cacheKey, result);
             }
         }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -83,7 +83,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             var constraintCount = baseValue.Constraints.Count;
             if (constraintCount == 0 || (constraintCount == 1 && baseValue.Constraints.ContainsKey(constraint.GetType())))
             {
-                return GetOrAddSingleConstraint(constraint);
+                return SingleConstraint(constraint);
             }
 
             return baseValue with { Constraints = baseValue.Constraints.SetItem(constraint.GetType(), constraint) };
@@ -113,13 +113,13 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                         otherConstraint = kvp.Value;
                     }
                 }
-                return GetOrAddSingleConstraint(otherConstraint);
+                return SingleConstraint(otherConstraint);
             }
 
             return baseValue with { Constraints = baseValue.Constraints.Remove(type) };
         }
 
-        private static SymbolicValue GetOrAddSingleConstraint(SymbolicConstraint constraint)
+        private static SymbolicValue SingleConstraint(SymbolicConstraint constraint)
         {
             if (singleConstraintCache.TryGetValue(constraint.Kind, out var result))
             {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Concurrent;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 
 namespace SonarAnalyzer.SymbolicExecution.Roslyn

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -169,8 +169,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             private readonly ConstraintKind first;
             private readonly ConstraintKind? second;
 
-            public CacheKey(ConstraintKind first) : this(first, null) { }
-
             public CacheKey(ConstraintKind first, ConstraintKind? second)
             {
                 if (first == second)

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -75,12 +75,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 ? Constraints.Values.Select(x => x.ToString()).OrderBy(x => x).JoinStr(", ")
                 : "No constraints";
 
-        private static SymbolicValue RemoveConstraint(SymbolicValue baseValue, SymbolicConstraint constraint) =>
-            baseValue.HasConstraint(constraint) ? RemoveConstraint(baseValue, constraint.GetType()) : baseValue;
-
-        private static SymbolicValue RemoveConstraint<T>(SymbolicValue baseValue) where T : SymbolicConstraint =>
-            baseValue.HasConstraint<T>() ? RemoveConstraint(baseValue, typeof(T)) : baseValue;
-
         private static SymbolicValue AddOrReplaceConstraint(SymbolicValue baseValue, SymbolicConstraint constraint)
         {
             if (baseValue.HasConstraint(constraint))
@@ -102,6 +96,12 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             return baseValue with { Constraints = baseValue.Constraints.SetItem(constraint.GetType(), constraint) };
         }
 
+        private static SymbolicValue RemoveConstraint(SymbolicValue baseValue, SymbolicConstraint constraint) =>
+            baseValue.HasConstraint(constraint) ? RemoveConstraint(baseValue, constraint.GetType()) : baseValue;
+
+        private static SymbolicValue RemoveConstraint<T>(SymbolicValue baseValue) where T : SymbolicConstraint =>
+            baseValue.HasConstraint<T>() ? RemoveConstraint(baseValue, typeof(T)) : baseValue;
+
         private static SymbolicValue RemoveConstraint(SymbolicValue baseValue, Type type)
         {
             var constraintCount = baseValue.Constraints.Count;
@@ -112,8 +112,8 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
 
             if (constraintCount == 2)
             {
-                var otherConstraint = baseValue.Constraints.Keys.FirstOrDefault(x => x != type);
-                return GetOrAddSingleConstraint(Constraintless, baseValue.Constraints[otherConstraint]);
+                var otherConstraintType = baseValue.Constraints.Keys.FirstOrDefault(x => x != type);
+                return GetOrAddSingleConstraint(Constraintless, baseValue.Constraints[otherConstraintType]);
             }
 
             return baseValue with { Constraints = baseValue.Constraints.Remove(type) };

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -25,8 +25,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
 {
     public sealed record SymbolicValue
     {
-        private static ConcurrentDictionary<ConstraintKind, SymbolicValue> singleConstraintCache = new();
-
         // Reuse instances to save memory. This "True" has the same semantic meaning and any other symbolic value with BoolConstraint.True constraint
         public static readonly SymbolicValue Constraintless = new();
         public static readonly SymbolicValue This = Constraintless.WithConstraint(ObjectConstraint.NotNull);
@@ -119,17 +117,12 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             return baseValue with { Constraints = baseValue.Constraints.Remove(type) };
         }
 
-        private static SymbolicValue SingleConstraint(SymbolicConstraint constraint)
-        {
-            if (singleConstraintCache.TryGetValue(constraint.Kind, out var result))
+        private static SymbolicValue SingleConstraint(SymbolicConstraint constraint) =>
+            constraint.Kind switch
             {
-                return result;
-            }
-            else
-            {
-                result = Constraintless with { Constraints = Constraintless.Constraints.SetItem(constraint.GetType(), constraint) };
-                return singleConstraintCache.GetOrAdd(constraint.Kind, result);
-            }
-        }
+                ConstraintKind.ObjectNotNull => NotNull,
+                ConstraintKind.ObjectNull => Null,
+                _ => null,
+            } ?? Constraintless with { Constraints = Constraintless.Constraints.SetItem(constraint.GetType(), constraint) };
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             }
         }
 
-        private static ConcurrentDictionary<CacheKey, SymbolicValue> constraintCache = new();
+        private static ConcurrentDictionary<CacheKey, SymbolicValue> cache = new();
 
         // Reuse instances to save memory. This "True" has the same semantic meaning and any other symbolic value with BoolConstraint.True constraint
         public static readonly SymbolicValue Empty = new();
@@ -129,8 +129,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
 
         private static SymbolicValue RemoveConstraint(SymbolicValue baseValue, Type type)
         {
-            var constraintCount = baseValue.Constraints.Count;
-            switch (constraintCount)
+            switch (baseValue.Constraints.Count)
             {
                 case 1:
                     return Empty;
@@ -181,7 +180,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             }
         }
 
-        private static SymbolicValue SingleConstraint(SymbolicConstraint constraint)
+        private static SymbolicValue SingleConstraintValue(SymbolicConstraint constraint)
         {
             var cacheKey = new CacheKey(constraint.Kind);
             if (constraintCache.TryGetValue(cacheKey, out var result))
@@ -195,7 +194,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             }
         }
 
-        private static SymbolicValue PairConstraint(SymbolicConstraint first, SymbolicConstraint second)
+        private static SymbolicValue PairConstraintValue(SymbolicConstraint first, SymbolicConstraint second)
         {
             var cacheKey = new CacheKey(first.Kind, second.Kind);
             if (constraintCache.TryGetValue(cacheKey, out var result))

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicValue.cs
@@ -19,8 +19,6 @@
  */
 
 using System.Collections.Concurrent;
-using System.Data;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 
 namespace SonarAnalyzer.SymbolicExecution.Roslyn

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -195,7 +195,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
-        public void PairCache_OrderDosntMatter()
+        public void PairCache_OrderDoesNotMatter()
         {
             var one = SymbolicValue.Empty.WithConstraint(ObjectConstraint.Null).WithConstraint(DummyConstraint.Dummy);
             var two = SymbolicValue.Empty.WithConstraint(DummyConstraint.Dummy).WithConstraint(ObjectConstraint.Null);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -183,7 +183,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         public void SingleCache_AddSameConstraintKind_FromCustom()
         {
             var sut = SymbolicValue.Constraintless.WithConstraint(DummyConstraint.Dummy);
-            sut.Should().NotBeSameAs(SymbolicValue.Constraintless.WithConstraint(DummyConstraint.Dummy));
+            sut.Should().BeSameAs(SymbolicValue.Constraintless.WithConstraint(DummyConstraint.Dummy));
             sut.Should().BeSameAs(sut.WithConstraint(DummyConstraint.Dummy));
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -200,7 +200,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Null);
             var one = SymbolicValue.NotNull.WithConstraint(DummyConstraint.Dummy);
             var two = SymbolicValue.NotNull.WithConstraint(DummyConstraint.Dummy);
-            one.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy).And.NotBeSameAs(two); // Requires a cache for pairs
+            one.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy).And.BeSameAs(two); // Requires a cache for pairs
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -195,12 +195,21 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
-        public void SingleCache_AddOtherConstraintType()
+        public void PairCache_AddOtherConstraintType()
         {
             SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Null);
             var one = SymbolicValue.NotNull.WithConstraint(DummyConstraint.Dummy);
             var two = SymbolicValue.NotNull.WithConstraint(DummyConstraint.Dummy);
-            one.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy).And.BeSameAs(two); // Requires a cache for pairs
+            one.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy).And.BeSameAs(two);
+        }
+
+        [TestMethod]
+        public void PairCache_ReplaceExistingConstraintType()
+        {
+            var sut = SymbolicValue.Null.WithConstraint(TestConstraint.First);
+            var one = sut.WithConstraint(TestConstraint.Second).WithConstraint(TestConstraint.First);
+            var two = one.WithConstraint(TestConstraint.Second).WithConstraint(TestConstraint.First);
+            sut.Should().HaveOnlyConstraints(ObjectConstraint.Null, TestConstraint.First).And.BeSameAs(one).And.BeSameAs(two);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -277,10 +277,32 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         public void PairCache_RemoveThirdLastEntry_Type()
         {
             var sut = SymbolicValue.Null.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);
-            sut.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy, TestConstraint.First);
             var one = sut.WithoutConstraint<DummyConstraint>();
             var two = sut.WithoutConstraint<DummyConstraint>();
             one.Should().HaveOnlyConstraints(ObjectConstraint.Null, TestConstraint.First).And.BeSameAs(two);
+        }
+
+        [TestMethod]
+        public void PairCache_RemoveFourthLastEntry_Kind()
+        {
+            var boolSymbolValue = SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.NotNull).WithConstraint(BoolConstraint.True);
+            var sut = boolSymbolValue.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);
+            sut.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True, DummyConstraint.Dummy, TestConstraint.First);
+            var one = sut.WithoutConstraint(DummyConstraint.Dummy);
+            var two = sut.WithoutConstraint(DummyConstraint.Dummy);
+            one.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True, TestConstraint.First).And.NotBeSameAs(two); // Requires cache for triplets
+            one.WithoutConstraint(TestConstraint.First).Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True).And.BeSameAs(boolSymbolValue);
+        }
+
+        [TestMethod]
+        public void PairCache_RemoveFourthLastEntry_Type()
+        {
+            var boolSymbolValue = SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.NotNull).WithConstraint(BoolConstraint.True);
+            var sut = boolSymbolValue.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);
+            var one = sut.WithoutConstraint<DummyConstraint>();
+            var two = sut.WithoutConstraint<DummyConstraint>();
+            one.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True, TestConstraint.First).And.NotBeSameAs(two); // Requires cache for triplets
+            one.WithoutConstraint<TestConstraint>().Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True).And.BeSameAs(boolSymbolValue);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -183,7 +183,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         public void SingleCache_AddSameConstraintKind_FromCustom()
         {
             var sut = SymbolicValue.Constraintless.WithConstraint(DummyConstraint.Dummy);
-            sut.Should().BeSameAs(SymbolicValue.Constraintless.WithConstraint(DummyConstraint.Dummy));
+            sut.Should().NotBeSameAs(SymbolicValue.Constraintless.WithConstraint(DummyConstraint.Dummy));
             sut.Should().BeSameAs(sut.WithConstraint(DummyConstraint.Dummy));
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -195,6 +195,15 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
+        public void PairCache_OrderDosntMatter()
+        {
+            var one = SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.Null).WithConstraint(DummyConstraint.Dummy);
+            var two = SymbolicValue.Constraintless.WithConstraint(DummyConstraint.Dummy).WithConstraint(ObjectConstraint.Null);
+            var three = SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.NotNull).WithConstraint(DummyConstraint.Dummy).WithConstraint(ObjectConstraint.Null);
+            one.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy).And.BeSameAs(two).And.BeSameAs(three);
+        }
+
+        [TestMethod]
         public void PairCache_AddOtherConstraintType()
         {
             SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Null);
@@ -255,7 +264,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
-        public void SingleCache_RemoveThirdLastEntry_Kind()
+        public void PairCache_RemoveThirdLastEntry_Kind()
         {
             var sut = SymbolicValue.Null.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);
             sut.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy, TestConstraint.First);
@@ -265,7 +274,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
-        public void SingleCache_RemoveThirdLastEntry_Type()
+        public void PairCache_RemoveThirdLastEntry_Type()
         {
             var sut = SymbolicValue.Null.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);
             sut.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy, TestConstraint.First);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -268,15 +268,15 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void RemoveEntry_Miss_Returns_Instance_Kind()
         {
-            var sut = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First).WithConstraint(TestConstraint.Second);
+            var sut = SymbolicValue.Null.WithConstraint(TestConstraint.First);
             sut.WithoutConstraint(DummyConstraint.Dummy).Should().BeSameAs(sut);
         }
 
         [TestMethod]
         public void RemoveEntry_Miss_Returns_Instance_Type()
         {
-            var sut = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First).WithConstraint(TestConstraint.Second);
-            sut.WithoutConstraint<DummyConstraint>().Should().BeSameAs(sut);
+            var sut = SymbolicValue.Null.WithConstraint(TestConstraint.First);
+            sut.WithoutConstraint<DummyConstraint>().Should().BeSameAs(sut).And.HaveOnlyConstraints(ObjectConstraint.Null, TestConstraint.First);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.SymbolicExecution;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 using SonarAnalyzer.SymbolicExecution.Roslyn;
@@ -30,12 +31,12 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
     {
         [TestMethod]
         public void ToString_NoConstraints() =>
-            new SymbolicValue().ToString().Should().Be("No constraints");
+            SymbolicValue.Constraintless.ToString().Should().Be("No constraints");
 
         [TestMethod]
         public void ToString_WithConstraints()
         {
-            var sut = new SymbolicValue();
+            var sut = SymbolicValue.Constraintless;
 
             sut = sut.WithConstraint(LockConstraint.Held);
             sut.ToString().Should().Be("LockHeld");
@@ -53,7 +54,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void WithConstraint_Contains()
         {
-            var sut = new SymbolicValue().WithConstraint(TestConstraint.First);
+            var sut = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First);
             sut.HasConstraint(TestConstraint.First).Should().BeTrue();
             sut.HasConstraint(TestConstraint.Second).Should().BeFalse();
             sut.HasConstraint(LockConstraint.Held).Should().BeFalse();
@@ -62,7 +63,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void WithConstraint_Overwrites_IsImmutable()
         {
-            var one = new SymbolicValue().WithConstraint(TestConstraint.First);
+            var one = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First);
             var two = one.WithConstraint(TestConstraint.Second);
             one.HasConstraint(TestConstraint.First).Should().BeTrue();
             two.HasConstraint(TestConstraint.First).Should().BeFalse();
@@ -72,7 +73,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void WithoutConstraint_RemovesOnlyTheSame()
         {
-            var sut = new SymbolicValue()
+            var sut = SymbolicValue.Constraintless
                 .WithoutConstraint(TestConstraint.First)    // Do nothing
                 .WithConstraint(TestConstraint.First)
                 .WithoutConstraint(TestConstraint.Second);  // Do nothing
@@ -84,7 +85,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void WithoutConstraint_RemovesType()
         {
-            var sut = new SymbolicValue()
+            var sut = SymbolicValue.Constraintless
                 .WithConstraint(TestConstraint.First)
                 .WithConstraint(DummyConstraint.Dummy)
                 .WithoutConstraint<TestConstraint>();   // Act
@@ -95,7 +96,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void HasConstraint_ByType()
         {
-            var sut = new SymbolicValue();
+            var sut = SymbolicValue.Constraintless;
             sut.HasConstraint<TestConstraint>().Should().BeFalse();
             sut = sut.WithConstraint(TestConstraint.First);
             sut.HasConstraint<TestConstraint>().Should().BeTrue();
@@ -105,7 +106,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void HasConstraint_ByValue()
         {
-            var sut = new SymbolicValue();
+            var sut = SymbolicValue.Constraintless;
             sut.HasConstraint(TestConstraint.First).Should().BeFalse();
             sut = sut.WithConstraint(TestConstraint.First);
             sut.HasConstraint(TestConstraint.First).Should().BeTrue();
@@ -115,22 +116,22 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void Constraint_Existing_ReturnsInstance()
         {
-            var sut = new SymbolicValue().WithConstraint(TestConstraint.First).WithConstraint(DummyConstraint.Dummy);
+            var sut = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First).WithConstraint(DummyConstraint.Dummy);
             sut.Constraint<TestConstraint>().Should().Be(TestConstraint.First);
         }
 
         [TestMethod]
         public void Constraint_Missing_ReturnsNull() =>
-            new SymbolicValue().Constraint<BoolConstraint>().Should().BeNull();
+            SymbolicValue.Constraintless.Constraint<BoolConstraint>().Should().BeNull();
 
         [TestMethod]
         public void GetHashCode_ComputedFromConstraints()
         {
-            var empty1 = new SymbolicValue();
-            var empty2 = new SymbolicValue();
-            var basic = new SymbolicValue().WithConstraint(TestConstraint.First);
-            var same = new SymbolicValue().WithConstraint(TestConstraint.First);
-            var different = new SymbolicValue().WithConstraint(BoolConstraint.True);
+            var empty1 = SymbolicValue.Constraintless;
+            var empty2 = SymbolicValue.Constraintless;
+            var basic = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First);
+            var same = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First);
+            var different = SymbolicValue.Constraintless.WithConstraint(BoolConstraint.True);
             empty1.GetHashCode().Should().Be(empty2.GetHashCode()).And.Be(0);   // Hash seed for empty dictionary is zero
             basic.GetHashCode().Should().Be(basic.GetHashCode()).And.NotBe(0);
             basic.GetHashCode().Should().Be(same.GetHashCode());
@@ -140,12 +141,12 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void Equals_ReturnsTrueForSameConstraints()
         {
-            var basicSingle = new SymbolicValue().WithConstraint(TestConstraint.First);
-            var sameSingle = new SymbolicValue().WithConstraint(TestConstraint.First);
-            var basicMore = new SymbolicValue().WithConstraint(TestConstraint.First).WithConstraint(BoolConstraint.True);
-            var sameMore = new SymbolicValue().WithConstraint(TestConstraint.First).WithConstraint(BoolConstraint.True);
-            var differentConstraintValue = new SymbolicValue().WithConstraint(TestConstraint.Second);
-            var differentConstraintType = new SymbolicValue().WithConstraint(BoolConstraint.True);
+            var basicSingle = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First);
+            var sameSingle = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First);
+            var basicMore = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First).WithConstraint(BoolConstraint.True);
+            var sameMore = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First).WithConstraint(BoolConstraint.True);
+            var differentConstraintValue = SymbolicValue.Constraintless.WithConstraint(TestConstraint.Second);
+            var differentConstraintType = SymbolicValue.Constraintless.WithConstraint(BoolConstraint.True);
 
             basicSingle.Equals(basicSingle).Should().BeTrue();
             basicSingle.Equals(sameSingle).Should().BeTrue();
@@ -162,13 +163,121 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
 
         [TestMethod]
         public void AllConstraints_Empty() =>
-            new SymbolicValue().AllConstraints.Should().BeEmpty();
+            SymbolicValue.Constraintless.AllConstraints.Should().BeEmpty();
 
         [TestMethod]
         public void AllConstraints_ResturnsConstraints()
         {
-            var sut = new SymbolicValue().WithConstraint(TestConstraint.First).WithConstraint(DummyConstraint.Dummy);
+            var sut = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First).WithConstraint(DummyConstraint.Dummy);
             sut.AllConstraints.Should().HaveCount(2).And.Contain(new SymbolicConstraint[] { TestConstraint.First, DummyConstraint.Dummy });
+        }
+
+        [TestMethod]
+        public void SingleCache_AddSameConstraintKind_FromPredefined()
+        {
+            var sut = SymbolicValue.Null;
+            sut.Should().BeSameAs(SymbolicValue.Null);
+            sut.Should().BeSameAs(sut.WithConstraint(ObjectConstraint.Null));
+        }
+
+        [TestMethod]
+        public void SingleCache_AddSameConstraintKind_FromCustom()
+        {
+            var sut = SymbolicValue.Constraintless.WithConstraint(DummyConstraint.Dummy);
+            sut.Should().BeSameAs(SymbolicValue.Constraintless.WithConstraint(DummyConstraint.Dummy));
+            sut.Should().BeSameAs(sut.WithConstraint(DummyConstraint.Dummy));
+        }
+
+        [TestMethod]
+        public void SingleCache_AddSameConstraintType()
+        {
+            SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Null);
+            SymbolicValue.NotNull.WithConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Null);
+        }
+
+        [TestMethod]
+        public void SingleCache_AddOtherConstraintType()
+        {
+            SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Null);
+            var one = SymbolicValue.NotNull.WithConstraint(DummyConstraint.Dummy);
+            var two = SymbolicValue.NotNull.WithConstraint(DummyConstraint.Dummy);
+            one.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy).And.NotBeSameAs(two); // Requires a cache for pairs
+        }
+
+        [TestMethod]
+        public void SingleCache_RemoveLastEntry_Kind()
+        {
+            var sut = SymbolicValue.Null;
+            sut.WithoutConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Constraintless);
+        }
+
+        [TestMethod]
+        public void SingleCache_RemoveLastEntry_Type()
+        {
+            var sut = SymbolicValue.Null;
+            sut.WithoutConstraint<ObjectConstraint>().Should().BeSameAs(SymbolicValue.Constraintless);
+        }
+
+        [TestMethod]
+        public void SingleCache_RemoveLastEntry_Miss_Kind()
+        {
+            var sut = SymbolicValue.Null;
+            sut.WithoutConstraint(ObjectConstraint.NotNull).Should().BeSameAs(SymbolicValue.Null);
+        }
+
+        [TestMethod]
+        public void SingleCache_RemoveLastEntry_Miss_Type()
+        {
+            var sut = SymbolicValue.Null;
+            sut.WithoutConstraint<DummyConstraint>().Should().BeSameAs(SymbolicValue.Null);
+        }
+
+        [TestMethod]
+        public void SingleCache_RemoveSecondLastEntry_Kind()
+        {
+            var sut = SymbolicValue.Null.WithConstraint(DummyConstraint.Dummy);
+            sut.WithoutConstraint(DummyConstraint.Dummy).Should().BeSameAs(SymbolicValue.Null);
+        }
+
+        [TestMethod]
+        public void SingleCache_RemoveSecondLastEntry_Type()
+        {
+            var sut = SymbolicValue.Null.WithConstraint(DummyConstraint.Dummy);
+            sut.WithoutConstraint<DummyConstraint>().Should().BeSameAs(SymbolicValue.Null);
+        }
+
+        [TestMethod]
+        public void SingleCache_RemoveThirdLastEntry_Kind()
+        {
+            var sut = SymbolicValue.Null.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);
+            sut.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy, TestConstraint.First);
+            var one = sut.WithoutConstraint(DummyConstraint.Dummy);
+            var two = sut.WithoutConstraint(DummyConstraint.Dummy);
+            one.Should().HaveOnlyConstraints(ObjectConstraint.Null, TestConstraint.First).And.NotBeSameAs(two); // Requires a cache for pairs
+        }
+
+        [TestMethod]
+        public void SingleCache_RemoveThirdLastEntry_Type()
+        {
+            var sut = SymbolicValue.Null.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);
+            sut.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy, TestConstraint.First);
+            var one = sut.WithoutConstraint<DummyConstraint>();
+            var two = sut.WithoutConstraint<DummyConstraint>();
+            one.Should().HaveOnlyConstraints(ObjectConstraint.Null, TestConstraint.First).And.NotBeSameAs(two); // Requires a cache for pairs
+        }
+
+        [TestMethod]
+        public void RemoveEntry_Miss_Returns_Instance_Kind()
+        {
+            var sut = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First).WithConstraint(TestConstraint.Second);
+            sut.WithoutConstraint(DummyConstraint.Dummy).Should().BeSameAs(sut);
+        }
+
+        [TestMethod]
+        public void RemoveEntry_Miss_Returns_Instance_Type()
+        {
+            var sut = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First).WithConstraint(TestConstraint.Second);
+            sut.WithoutConstraint<DummyConstraint>().Should().BeSameAs(sut);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -261,7 +261,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             sut.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy, TestConstraint.First);
             var one = sut.WithoutConstraint(DummyConstraint.Dummy);
             var two = sut.WithoutConstraint(DummyConstraint.Dummy);
-            one.Should().HaveOnlyConstraints(ObjectConstraint.Null, TestConstraint.First).And.NotBeSameAs(two); // Requires a cache for pairs
+            one.Should().HaveOnlyConstraints(ObjectConstraint.Null, TestConstraint.First).And.BeSameAs(two);
         }
 
         [TestMethod]
@@ -271,7 +271,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
             sut.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy, TestConstraint.First);
             var one = sut.WithoutConstraint<DummyConstraint>();
             var two = sut.WithoutConstraint<DummyConstraint>();
-            one.Should().HaveOnlyConstraints(ObjectConstraint.Null, TestConstraint.First).And.NotBeSameAs(two); // Requires a cache for pairs
+            one.Should().HaveOnlyConstraints(ObjectConstraint.Null, TestConstraint.First).And.BeSameAs(two);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -222,6 +222,23 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
+        public void TripletCache_AddOtherConstraintType()
+        {
+            var one = SymbolicValue.NotNull.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);
+            var two = SymbolicValue.NotNull.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);
+            one.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy, TestConstraint.First).And.NotBeSameAs(two); // Requires cache for triplets
+        }
+
+        [TestMethod]
+        public void TripletCache_ReplaceExistingConstraintType()
+        {
+            var sut = SymbolicValue.Null.WithConstraint(TestConstraint.First).WithConstraint(DummyConstraint.Dummy);
+            var one = sut.WithConstraint(TestConstraint.Second).WithConstraint(TestConstraint.First);
+            var two = one.WithConstraint(TestConstraint.Second).WithConstraint(TestConstraint.First);
+            sut.Should().HaveOnlyConstraints(ObjectConstraint.Null, TestConstraint.First, DummyConstraint.Dummy).And.NotBeSameAs(one).And.NotBeSameAs(two); // Requires cache for triplets
+        }
+
+        [TestMethod]
         public void SingleCache_RemoveLastEntry_Kind()
         {
             var sut = SymbolicValue.Null;
@@ -283,7 +300,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
-        public void PairCache_RemoveFourthLastEntry_Kind()
+        public void TripletCache_RemoveFourthLastEntry_Kind()
         {
             var boolSymbolValue = SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.NotNull).WithConstraint(BoolConstraint.True);
             var sut = boolSymbolValue.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);
@@ -295,7 +312,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         }
 
         [TestMethod]
-        public void PairCache_RemoveFourthLastEntry_Type()
+        public void TripletCache_RemoveFourthLastEntry_Type()
         {
             var boolSymbolValue = SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.NotNull).WithConstraint(BoolConstraint.True);
             var sut = boolSymbolValue.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -30,12 +30,12 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
     {
         [TestMethod]
         public void ToString_NoConstraints() =>
-            SymbolicValue.Constraintless.ToString().Should().Be("No constraints");
+            SymbolicValue.Empty.ToString().Should().Be("No constraints");
 
         [TestMethod]
         public void ToString_WithConstraints()
         {
-            var sut = SymbolicValue.Constraintless;
+            var sut = SymbolicValue.Empty;
 
             sut = sut.WithConstraint(LockConstraint.Held);
             sut.ToString().Should().Be("LockHeld");
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void WithConstraint_Contains()
         {
-            var sut = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First);
+            var sut = SymbolicValue.Empty.WithConstraint(TestConstraint.First);
             sut.HasConstraint(TestConstraint.First).Should().BeTrue();
             sut.HasConstraint(TestConstraint.Second).Should().BeFalse();
             sut.HasConstraint(LockConstraint.Held).Should().BeFalse();
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void WithConstraint_Overwrites_IsImmutable()
         {
-            var one = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First);
+            var one = SymbolicValue.Empty.WithConstraint(TestConstraint.First);
             var two = one.WithConstraint(TestConstraint.Second);
             one.HasConstraint(TestConstraint.First).Should().BeTrue();
             two.HasConstraint(TestConstraint.First).Should().BeFalse();
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void WithoutConstraint_RemovesOnlyTheSame()
         {
-            var sut = SymbolicValue.Constraintless
+            var sut = SymbolicValue.Empty
                 .WithoutConstraint(TestConstraint.First)    // Do nothing
                 .WithConstraint(TestConstraint.First)
                 .WithoutConstraint(TestConstraint.Second);  // Do nothing
@@ -84,7 +84,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void WithoutConstraint_RemovesType()
         {
-            var sut = SymbolicValue.Constraintless
+            var sut = SymbolicValue.Empty
                 .WithConstraint(TestConstraint.First)
                 .WithConstraint(DummyConstraint.Dummy)
                 .WithoutConstraint<TestConstraint>();   // Act
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void HasConstraint_ByType()
         {
-            var sut = SymbolicValue.Constraintless;
+            var sut = SymbolicValue.Empty;
             sut.HasConstraint<TestConstraint>().Should().BeFalse();
             sut = sut.WithConstraint(TestConstraint.First);
             sut.HasConstraint<TestConstraint>().Should().BeTrue();
@@ -105,7 +105,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void HasConstraint_ByValue()
         {
-            var sut = SymbolicValue.Constraintless;
+            var sut = SymbolicValue.Empty;
             sut.HasConstraint(TestConstraint.First).Should().BeFalse();
             sut = sut.WithConstraint(TestConstraint.First);
             sut.HasConstraint(TestConstraint.First).Should().BeTrue();
@@ -115,22 +115,22 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void Constraint_Existing_ReturnsInstance()
         {
-            var sut = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First).WithConstraint(DummyConstraint.Dummy);
+            var sut = SymbolicValue.Empty.WithConstraint(TestConstraint.First).WithConstraint(DummyConstraint.Dummy);
             sut.Constraint<TestConstraint>().Should().Be(TestConstraint.First);
         }
 
         [TestMethod]
         public void Constraint_Missing_ReturnsNull() =>
-            SymbolicValue.Constraintless.Constraint<BoolConstraint>().Should().BeNull();
+            SymbolicValue.Empty.Constraint<BoolConstraint>().Should().BeNull();
 
         [TestMethod]
         public void GetHashCode_ComputedFromConstraints()
         {
-            var empty1 = SymbolicValue.Constraintless;
-            var empty2 = SymbolicValue.Constraintless;
-            var basic = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First);
-            var same = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First);
-            var different = SymbolicValue.Constraintless.WithConstraint(BoolConstraint.True);
+            var empty1 = SymbolicValue.Empty;
+            var empty2 = SymbolicValue.Empty;
+            var basic = SymbolicValue.Empty.WithConstraint(TestConstraint.First);
+            var same = SymbolicValue.Empty.WithConstraint(TestConstraint.First);
+            var different = SymbolicValue.Empty.WithConstraint(BoolConstraint.True);
             empty1.GetHashCode().Should().Be(empty2.GetHashCode()).And.Be(0);   // Hash seed for empty dictionary is zero
             basic.GetHashCode().Should().Be(basic.GetHashCode()).And.NotBe(0);
             basic.GetHashCode().Should().Be(same.GetHashCode());
@@ -140,12 +140,12 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void Equals_ReturnsTrueForSameConstraints()
         {
-            var basicSingle = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First);
-            var sameSingle = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First);
-            var basicMore = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First).WithConstraint(BoolConstraint.True);
-            var sameMore = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First).WithConstraint(BoolConstraint.True);
-            var differentConstraintValue = SymbolicValue.Constraintless.WithConstraint(TestConstraint.Second);
-            var differentConstraintType = SymbolicValue.Constraintless.WithConstraint(BoolConstraint.True);
+            var basicSingle = SymbolicValue.Empty.WithConstraint(TestConstraint.First);
+            var sameSingle = SymbolicValue.Empty.WithConstraint(TestConstraint.First);
+            var basicMore = SymbolicValue.Empty.WithConstraint(TestConstraint.First).WithConstraint(BoolConstraint.True);
+            var sameMore = SymbolicValue.Empty.WithConstraint(TestConstraint.First).WithConstraint(BoolConstraint.True);
+            var differentConstraintValue = SymbolicValue.Empty.WithConstraint(TestConstraint.Second);
+            var differentConstraintType = SymbolicValue.Empty.WithConstraint(BoolConstraint.True);
 
             basicSingle.Equals(basicSingle).Should().BeTrue();
             basicSingle.Equals(sameSingle).Should().BeTrue();
@@ -162,12 +162,12 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
 
         [TestMethod]
         public void AllConstraints_Empty() =>
-            SymbolicValue.Constraintless.AllConstraints.Should().BeEmpty();
+            SymbolicValue.Empty.AllConstraints.Should().BeEmpty();
 
         [TestMethod]
         public void AllConstraints_ResturnsConstraints()
         {
-            var sut = SymbolicValue.Constraintless.WithConstraint(TestConstraint.First).WithConstraint(DummyConstraint.Dummy);
+            var sut = SymbolicValue.Empty.WithConstraint(TestConstraint.First).WithConstraint(DummyConstraint.Dummy);
             sut.AllConstraints.Should().HaveCount(2).And.Contain(new SymbolicConstraint[] { TestConstraint.First, DummyConstraint.Dummy });
         }
 
@@ -182,31 +182,31 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void SingleCache_AddSameConstraintKind_FromCustom()
         {
-            var sut = SymbolicValue.Constraintless.WithConstraint(DummyConstraint.Dummy);
-            sut.Should().BeSameAs(SymbolicValue.Constraintless.WithConstraint(DummyConstraint.Dummy));
+            var sut = SymbolicValue.Empty.WithConstraint(DummyConstraint.Dummy);
+            sut.Should().BeSameAs(SymbolicValue.Empty.WithConstraint(DummyConstraint.Dummy));
             sut.Should().BeSameAs(sut.WithConstraint(DummyConstraint.Dummy));
         }
 
         [TestMethod]
         public void SingleCache_AddSameConstraintType()
         {
-            SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Null);
+            SymbolicValue.Empty.WithConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Null);
             SymbolicValue.NotNull.WithConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Null);
         }
 
         [TestMethod]
         public void PairCache_OrderDosntMatter()
         {
-            var one = SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.Null).WithConstraint(DummyConstraint.Dummy);
-            var two = SymbolicValue.Constraintless.WithConstraint(DummyConstraint.Dummy).WithConstraint(ObjectConstraint.Null);
-            var three = SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.NotNull).WithConstraint(DummyConstraint.Dummy).WithConstraint(ObjectConstraint.Null);
+            var one = SymbolicValue.Empty.WithConstraint(ObjectConstraint.Null).WithConstraint(DummyConstraint.Dummy);
+            var two = SymbolicValue.Empty.WithConstraint(DummyConstraint.Dummy).WithConstraint(ObjectConstraint.Null);
+            var three = SymbolicValue.Empty.WithConstraint(ObjectConstraint.NotNull).WithConstraint(DummyConstraint.Dummy).WithConstraint(ObjectConstraint.Null);
             one.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy).And.BeSameAs(two).And.BeSameAs(three);
         }
 
         [TestMethod]
         public void PairCache_AddOtherConstraintType()
         {
-            SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Null);
+            SymbolicValue.Empty.WithConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Null);
             var one = SymbolicValue.NotNull.WithConstraint(DummyConstraint.Dummy);
             var two = SymbolicValue.NotNull.WithConstraint(DummyConstraint.Dummy);
             one.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy).And.BeSameAs(two);
@@ -242,14 +242,14 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         public void SingleCache_RemoveLastEntry_Kind()
         {
             var sut = SymbolicValue.Null;
-            sut.WithoutConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Constraintless);
+            sut.WithoutConstraint(ObjectConstraint.Null).Should().BeSameAs(SymbolicValue.Empty);
         }
 
         [TestMethod]
         public void SingleCache_RemoveLastEntry_Type()
         {
             var sut = SymbolicValue.Null;
-            sut.WithoutConstraint<ObjectConstraint>().Should().BeSameAs(SymbolicValue.Constraintless);
+            sut.WithoutConstraint<ObjectConstraint>().Should().BeSameAs(SymbolicValue.Empty);
         }
 
         [TestMethod]
@@ -302,7 +302,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void TripletCache_RemoveFourthLastEntry_Kind()
         {
-            var boolSymbolValue = SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.NotNull).WithConstraint(BoolConstraint.True);
+            var boolSymbolValue = SymbolicValue.Empty.WithConstraint(ObjectConstraint.NotNull).WithConstraint(BoolConstraint.True);
             var sut = boolSymbolValue.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);
             sut.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True, DummyConstraint.Dummy, TestConstraint.First);
             var one = sut.WithoutConstraint(DummyConstraint.Dummy);
@@ -314,7 +314,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn
         [TestMethod]
         public void TripletCache_RemoveFourthLastEntry_Type()
         {
-            var boolSymbolValue = SymbolicValue.Constraintless.WithConstraint(ObjectConstraint.NotNull).WithConstraint(BoolConstraint.True);
+            var boolSymbolValue = SymbolicValue.Empty.WithConstraint(ObjectConstraint.NotNull).WithConstraint(BoolConstraint.True);
             var sut = boolSymbolValue.WithConstraint(DummyConstraint.Dummy).WithConstraint(TestConstraint.First);
             var one = sut.WithoutConstraint<DummyConstraint>();
             var two = sut.WithoutConstraint<DummyConstraint>();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicValueTest.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.SymbolicExecution;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 using SonarAnalyzer.SymbolicExecution.Roslyn;


### PR DESCRIPTION
Part of #6964
See also #6105

Implementation of sub-task:
* [ ] Avoid allocations in ProgramState.SetOperationConstraint see https://github.com/SonarSource/sonar-dotnet/pull/6864#discussion_r1129202811

The idea is to have a fast cache for SymbolValues that can be accessed allocation free. If a SymbolValue is manipulated via `WithConstraint` or `WithoutConstraint` the result of the newly constructed SymbolValue is taken from the cache (or added during first use). The current implementation is using a single constraint cache, meaning: Only SymbolValues with a single constraint are cached. The current cache implementation supports the following SymbolValue operations:
* A new constraint added to SymbolValue.Empty (here still SymbolValue.Constraintless)
* Exchange of a constraint of the same type for a SymbolValue with only a single Constraint
* Constraint removed from a single constraint SymbolValue (produced  SymbolValue.Empty)
* Constraint removed from SymbolValue with two constraints (The remaining single constraint SymbolValue is taken from the cache or added on first use).

The current implementation can (and should) be extended to Constraint pairs:
```cs
private readonly record struct ConstraintKindPair(ContraintKind left, ContraintKind right)
{
    override Equals() // (NotNull, True) == (True, NotNull)
}

private static ConcurrentDictionary<ConstraintKindPair, SymbolicValue> pairConstraintCache = new();
```
I don't see any need for more than pairs. Anything that goes beyond that can be handled as is by creating new SymbolicValues.
