### PR TITLE
SE - Nullable: Learn object constraint from equals

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
                 // Update DefaultValue when adding new types
                 true => SymbolicValue.True,
                 false => SymbolicValue.False,
-                null when (operation.Instance.Type ?? ConvertedType(operation.Parent)).CanBeNull() => SymbolicValue.Null,  // ToDo: MMF-2401, this will need to be reviewed
+                null when CanBeNull(operation) => SymbolicValue.Null,
                 string => SymbolicValue.NotNull,
                 _ => null
             };
@@ -60,5 +60,11 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
         private static ITypeSymbol ConvertedType(IOperation operation) =>
             // Some version of Roslyn can send null here with "return default;". It's not reproducible by UTs, as we have "Type" set in that case.
             operation?.Kind == OperationKindEx.Conversion ? operation.ToConversion().Type : null;
+
+        private static bool CanBeNull(IOperationWrapperSonar operation)
+        {
+            var type = operation.Instance.Type ?? ConvertedType(operation.Parent);
+            return type is null || type.CanBeNull();
+        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -357,12 +357,15 @@ if (value = boolParameter)
         }
 
         [DataTestMethod]
-        [DataRow("arg is null")]
-        [DataRow("!!(arg is null)")]
-        [DataRow("arg is not not null")]
-        public void Branching_LearnsObjectConstraint_ConstantPattern_Null(string expression)
+        [DataRow("arg is null", "object")]
+        [DataRow("arg is null", "int?")]
+        [DataRow("!!(arg is null)", "object")]
+        [DataRow("!!(arg is null)", "int?")]
+        [DataRow("arg is not not null", "object")]
+        [DataRow("arg is not not null", "int?")]
+        public void Branching_LearnsObjectConstraint_ConstantPattern_Null(string expression, string argType)
         {
-            var validator = CreateIfElseEndValidatorCS(expression, OperationKind.ConstantPattern);
+            var validator = CreateIfElseEndValidatorCS(expression, OperationKind.ConstantPattern, argType);
             validator.ValidateTag("If", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
             validator.ValidateTag("Else", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
             validator.TagValues("End").Should().HaveCount(2)
@@ -371,12 +374,15 @@ if (value = boolParameter)
         }
 
         [DataTestMethod]
-        [DataRow("!(arg is null)")]
-        [DataRow("!!!(arg is null)")]
-        [DataRow("arg is not null")]
-        public void Branching_LearnsObjectConstraint_ConstantPattern_Null_Negated(string expression)
+        [DataRow("!(arg is null)", "object")]
+        [DataRow("!(arg is null)", "int?")]
+        [DataRow("!!!(arg is null)", "object")]
+        [DataRow("!!!(arg is null)", "int?")]
+        [DataRow("arg is not null", "object")]
+        [DataRow("arg is not null", "int?")]
+        public void Branching_LearnsObjectConstraint_ConstantPattern_Null_Negated(string expression, string argType)
         {
-            var validator = CreateIfElseEndValidatorCS(expression, OperationKind.ConstantPattern);
+            var validator = CreateIfElseEndValidatorCS(expression, OperationKind.ConstantPattern, argType);
             validator.ValidateTag("If", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
             validator.ValidateTag("Else", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
             validator.TagValues("End").Should().HaveCount(2)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -167,6 +167,27 @@ if (value = boolParameter)
         }
 
         [DataTestMethod]
+        [DataRow("arg == null")]
+        [DataRow("null == arg")]
+        [DataRow("(object)(object)arg == (object)(object)null")]
+        [DataRow("(object)(object)arg == (object)(object)isNull")]
+        [DataRow("!!!(arg != null)")]
+        [DataRow("!!!(null != arg)")]
+        [DataRow("!(bool)(object)!!(arg != null)")]
+        [DataRow("!(bool)(object)!!(null != arg)")]
+        [DataRow("!!!((object)arg != (object)null)")]
+        [DataRow("!!!((object)null != (object)arg)")]
+        public void Branching_LearnsObjectConstraint_Nullable_CS(string expression)
+        {
+            var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "int?");
+            validator.ValidateTag("If", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
+            validator.ValidateTag("Else", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+            validator.TagValues("End").Should().HaveCount(2)
+                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
+                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
+        }
+
+        [DataTestMethod]
         [DataRow("arg != null")]
         [DataRow("arg != isNull")]
         [DataRow("null != arg")]
@@ -180,6 +201,25 @@ if (value = boolParameter)
         public void Branching_LearnsObjectConstraint_Binary_Negated_CS(string expression)
         {
             var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary);
+            validator.ValidateTag("If", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+            validator.ValidateTag("Else", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
+            validator.TagValues("End").Should().HaveCount(2)
+                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
+                .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
+        }
+
+        [DataTestMethod]
+        [DataRow("arg != null")]
+        [DataRow("null != arg")]
+        [DataRow("(object)(object)arg != (object)(object)null")]
+        [DataRow("(object)(object)arg != (object)(object)isNull")]
+        [DataRow("!!!(arg == null)")]
+        [DataRow("!!!(null == arg)")]
+        [DataRow("!(bool)(object)!!(arg == null)")]
+        [DataRow("!(bool)(object)!!(null == arg)")]
+        public void Branching_LearnsObjectConstraint_Binary_Negated_Nullable_CS(string expression)
+        {
+            var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "int?");
             validator.ValidateTag("If", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
             validator.ValidateTag("Else", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
             validator.TagValues("End").Should().HaveCount(2)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -1712,11 +1712,11 @@ public class Repro_6241<T>
         HashSet<T> value = null;
         if (value is null)
         {
-            value.ToString();   // FN
+            value.ToString();   // Noncompliant
         }
         else
         {
-            value.ToString();   // Noncompliant FP
+            value.ToString();   // Compliant
         }
     }
 


### PR DESCRIPTION
Part of #8612
Fixes #6241

Same functionality as we had for reference types, but for nullable types.
```
if(arg == null)
  // We know arg is Null
else
  // We know arg is NotNull
```

The problem here was, that `if(arg == null)`, the `null` literal doesn't have any `Type` in the CFG. So we were missing the `Null` constraint on it.