### PR TITLE
SE - Nullable: Add support for `nullable.GetValueOrDefault()`

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
@@ -204,8 +204,8 @@ internal sealed partial class Invocation : MultiProcessor<IInvocationOperationWr
         var instanceValue = context.State[invocation.Instance];
         if (instanceValue?.HasConstraint(ObjectConstraint.Null) is true)
         {
-            return ((INamedTypeSymbol)invocation.Instance.Type).TypeArguments.Single().Is(KnownType.System_Boolean)
-                ? context.State.SetOperationValue(invocation, SymbolicValue.False).ToArray()
+            return ConstantCheck.ConstraintFromType(((INamedTypeSymbol)invocation.Instance.Type).TypeArguments.Single()) is { } orDefaultConstraint
+                ? context.SetOperationConstraint(orDefaultConstraint).ToArray()
                 : context.State.ToArray();
         }
         else if (instanceValue is not null)

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
@@ -51,6 +51,7 @@ internal sealed partial class Invocation : MultiProcessor<IInvocationOperationWr
         }
         return invocation switch
         {
+            _ when IsNullableGetValueOrDefault(invocation) => ProcessNullableGetValueOrDefault(context, invocation),
             _ when invocation.TargetMethod.Is(KnownType.Microsoft_VisualBasic_Information, "IsNothing") => ProcessInformationIsNothing(context, invocation),
             _ when invocation.TargetMethod.Is(KnownType.System_Diagnostics_Debug, nameof(Debug.Assert)) => ProcessDebugAssert(context, invocation),
             _ when invocation.TargetMethod.ContainingType.IsAny(KnownType.System_Linq_Enumerable, KnownType.System_Linq_Queryable) => ProcessLinqEnumerableAndQueryable(context, invocation),
@@ -196,6 +197,9 @@ internal sealed partial class Invocation : MultiProcessor<IInvocationOperationWr
         }
         return context.State.ToArray();
     }
+
+    private static ProgramState[] ProcessNullableGetValueOrDefault(SymbolicContext context, IInvocationOperationWrapper invocation) =>
+        context.State.SetOperationValue(invocation, context.State[invocation.Instance]).ToArray();
 
     private static bool IsThrowHelper(IMethodSymbol method) =>
         method.Is(KnownType.System_Diagnostics_Debug, nameof(Debug.Fail))

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
@@ -36,7 +36,8 @@ internal sealed partial class Invocation : MultiProcessor<IInvocationOperationWr
         var state = context.State;
         if (!invocation.TargetMethod.IsStatic             // Also applies to C# extensions
             && !invocation.TargetMethod.IsExtensionMethod // VB extensions in modules are not marked as static
-            && invocation.Instance.TrackedSymbol() is { } symbol)
+            && invocation.Instance.TrackedSymbol() is { } symbol
+            && !IsNullableGetValueOrDefault(invocation))
         {
             state = state.SetSymbolConstraint(symbol, ObjectConstraint.NotNull);
         }
@@ -216,4 +217,7 @@ internal sealed partial class Invocation : MultiProcessor<IInvocationOperationWr
             },
             _ => context.State.ToArray()
         };
+
+    private static bool IsNullableGetValueOrDefault(IInvocationOperationWrapper invocation) =>
+        invocation.TargetMethod.Is(KnownType.System_Nullable_T, nameof(Nullable<int>.GetValueOrDefault));
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
@@ -204,7 +204,8 @@ internal sealed partial class Invocation : MultiProcessor<IInvocationOperationWr
         var instanceValue = context.State[invocation.Instance];
         if (instanceValue?.HasConstraint(ObjectConstraint.Null) is true)
         {
-            return ConstantCheck.ConstraintFromType(((INamedTypeSymbol)invocation.Instance.Type).TypeArguments.Single()) is { } orDefaultConstraint
+            var valueType = ((INamedTypeSymbol)invocation.Instance.Type).TypeArguments.Single();
+            return ConstantCheck.ConstraintFromType(valueType) is { } orDefaultConstraint
                 ? context.SetOperationConstraint(orDefaultConstraint).ToArray()
                 : context.State.ToArray();
         }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -77,6 +77,9 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 ? this with { OperationValue = OperationValue.Remove(ResolveCapture(operation)) }
                 : this with { OperationValue = OperationValue.SetItem(ResolveCapture(operation), value) };
 
+        public ProgramState SetOperationConstraint(IOperationWrapper operation, SymbolicConstraint constraint) =>
+            SetOperationConstraint(operation.WrappedOperation, constraint);
+
         public ProgramState SetOperationConstraint(IOperationWrapperSonar operation, SymbolicConstraint constraint) =>
             SetOperationConstraint(operation.Instance, constraint);
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -77,9 +77,6 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 ? this with { OperationValue = OperationValue.Remove(ResolveCapture(operation)) }
                 : this with { OperationValue = OperationValue.SetItem(ResolveCapture(operation), value) };
 
-        public ProgramState SetOperationConstraint(IOperationWrapper operation, SymbolicConstraint constraint) =>
-            SetOperationConstraint(operation.WrappedOperation, constraint);
-
         public ProgramState SetOperationConstraint(IOperationWrapperSonar operation, SymbolicConstraint constraint) =>
             SetOperationConstraint(operation.Instance, constraint);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -213,9 +213,9 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var validator = SETestContext.CreateCS(code, ", int? arg").Validator;
         validator.ValidateTag("UnknownArg", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("UnknownValue", x => x.Should().HaveNoConstraints());
+        validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
         validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
         validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
         validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
     }
@@ -240,9 +240,9 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var validator = SETestContext.CreateCS(code, ", bool? arg").Validator;
         validator.ValidateTag("UnknownArg", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("UnknownValue", x => x.Should().HaveNoConstraints());                             // FIXME: Should be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
+        validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
         validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));          // FIXME: Should be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
+        validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
         validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
         validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -213,9 +213,9 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var validator = SETestContext.CreateCS(code, ", int? arg").Validator;
         validator.ValidateTag("UnknownArg", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));    // FIXME: Should be HaveNoConstraints());
+        validator.ValidateTag("UnknownValue", x => x.Should().HaveNoConstraints());
         validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));       // FIXME: Should be HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
         validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
         validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
     }
@@ -240,10 +240,10 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var validator = SETestContext.CreateCS(code, ", bool? arg").Validator;
         validator.ValidateTag("UnknownArg", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));    // FIXME: Should be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
+        validator.ValidateTag("UnknownValue", x => x.Should().HaveNoConstraints());                             // FIXME: Should be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
         validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));       // FIXME: Should be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
+        validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));          // FIXME: Should be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
         validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
-        validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));    // FIXME: SHould be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
+        validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -264,7 +264,7 @@ public partial class RoslynSymbolicExecutionTest
     {
         const string code = """
             bool? nullable;
-            if(boolParameter)
+            if (boolParameter)
                 nullable = true;
             else
                 nullable = null;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -246,4 +246,16 @@ public partial class RoslynSymbolicExecutionTest
         validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
         validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
     }
+
+    [TestMethod]
+    public void Nullable_GetValueOrDefault_SubExpression()
+    {
+        const string code = """
+            var value = (Condition ? null : (bool?)true).GetValueOrDefault();
+            Tag("Value", value);
+            """;
+        SETestContext.CreateCS(code).Validator.TagValues("Value").Should().SatisfyRespectively(
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False),
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -192,4 +192,58 @@ public partial class RoslynSymbolicExecutionTest
         validator.ValidateTag("ToNullableAs", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
         validator.ValidateTag("ToBoolExplicit", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
     }
+
+    [TestMethod]
+    public void Nullable_GetValueOrDefault_Int()
+    {
+        const string code = """
+            var value = arg.GetValueOrDefault();
+            Tag("UnknownArg", arg);
+            Tag("UnknownValue", value);
+
+            arg = null;
+            value = arg.GetValueOrDefault();
+            Tag("NullArg", arg);
+            Tag("NullValue", value);
+
+            arg = 42;
+            value = arg.GetValueOrDefault();
+            Tag("NotNullArg", arg);
+            Tag("NotNullValue", value);
+            """;
+        var validator = SETestContext.CreateCS(code, ", int? arg").Validator;
+        validator.ValidateTag("UnknownArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));      // FIXME: Should be HaveNoConstraints());
+        validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));    // FIXME: Should be HaveNoConstraints());
+        validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));         // FIXME: Should be HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));       // FIXME: Should be HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+    }
+
+    [TestMethod]
+    public void Nullable_GetValueOrDefault_Bool()
+    {
+        const string code = """
+            var value = arg.GetValueOrDefault();
+            Tag("UnknownArg", arg);
+            Tag("UnknownValue", value);
+
+            arg = null;
+            value = arg.GetValueOrDefault();
+            Tag("NullArg", arg);
+            Tag("NullValue", value);
+
+            arg = true;
+            value = arg.GetValueOrDefault();
+            Tag("NotNullArg", arg);
+            Tag("NotNullValue", value);
+            """;
+        var validator = SETestContext.CreateCS(code, ", bool? arg").Validator;
+        validator.ValidateTag("UnknownArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));      // FIXME: Should be HaveNoConstraints());
+        validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));    // FIXME: Should be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
+        validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));         // FIXME: Should be HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));       // FIXME: Should be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
+        validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
+        validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));    // FIXME: SHould be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -201,23 +201,23 @@ public partial class RoslynSymbolicExecutionTest
             Tag("UnknownArg", arg);
             Tag("UnknownValue", value);
 
-            arg = null;
+            arg = null;     // Adds DummyConstraint
             value = arg.GetValueOrDefault();
             Tag("NullArg", arg);
             Tag("NullValue", value);
 
-            arg = 42;
+            arg = 42;       // Adds DummyConstraint
             value = arg.GetValueOrDefault();
             Tag("NotNullArg", arg);
             Tag("NotNullValue", value);
             """;
-        var validator = SETestContext.CreateCS(code, ", int? arg").Validator;
+        var validator = SETestContext.CreateCS(code, ", int? arg", new LiteralDummyTestCheck()).Validator;
         validator.ValidateTag("UnknownArg", x => x.Should().HaveNoConstraints());
         validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy));
         validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy));
+        validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy));
     }
 
     [TestMethod]
@@ -228,23 +228,23 @@ public partial class RoslynSymbolicExecutionTest
             Tag("UnknownArg", arg);
             Tag("UnknownValue", value);
 
-            arg = null;
+            arg = null;       // Adds DummyConstraint
             value = arg.GetValueOrDefault();
             Tag("NullArg", arg);
             Tag("NullValue", value);
 
-            arg = true;
+            arg = true;       // Adds DummyConstraint
             value = arg.GetValueOrDefault();
             Tag("NotNullArg", arg);
             Tag("NotNullValue", value);
             """;
-        var validator = SETestContext.CreateCS(code, ", bool? arg").Validator;
+        var validator = SETestContext.CreateCS(code, ", bool? arg", new LiteralDummyTestCheck()).Validator;
         validator.ValidateTag("UnknownArg", x => x.Should().HaveNoConstraints());
         validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
-        validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy));
         validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
-        validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
-        validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
+        validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True, DummyConstraint.Dummy));
+        validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True, DummyConstraint.Dummy));
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -212,9 +212,9 @@ public partial class RoslynSymbolicExecutionTest
             Tag("NotNullValue", value);
             """;
         var validator = SETestContext.CreateCS(code, ", int? arg").Validator;
-        validator.ValidateTag("UnknownArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));      // FIXME: Should be HaveNoConstraints());
+        validator.ValidateTag("UnknownArg", x => x.Should().HaveNoConstraints());
         validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));    // FIXME: Should be HaveNoConstraints());
-        validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));         // FIXME: Should be HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
         validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));       // FIXME: Should be HaveOnlyConstraint(ObjectConstraint.Null));
         validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
         validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
@@ -239,9 +239,9 @@ public partial class RoslynSymbolicExecutionTest
             Tag("NotNullValue", value);
             """;
         var validator = SETestContext.CreateCS(code, ", bool? arg").Validator;
-        validator.ValidateTag("UnknownArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));      // FIXME: Should be HaveNoConstraints());
+        validator.ValidateTag("UnknownArg", x => x.Should().HaveNoConstraints());
         validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));    // FIXME: Should be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
-        validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));         // FIXME: Should be HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
         validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));       // FIXME: Should be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
         validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
         validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));    // FIXME: SHould be HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/PreserveTestCheck.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/PreserveTestCheck.cs
@@ -24,13 +24,19 @@ namespace SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution
 {
     public class PreserveTestCheck : SymbolicCheck
     {
-        private readonly string symbolName;
+        private readonly HashSet<string> symbolNames;
 
-        public PreserveTestCheck(string symbolName) =>
-            this.symbolName = symbolName;
+        public PreserveTestCheck(params string[] symbolNames)
+        {
+            if (symbolNames.Length == 0)
+            {
+                throw new ArgumentException("Value cannot be empty", nameof(symbolNames));
+            }
+            this.symbolNames = new(symbolNames);
+        }
 
         protected override ProgramState PreProcessSimple(SymbolicContext context) =>
-            context.Operation.Instance.TrackedSymbol() is { } symbol && symbol.Name == symbolName
+            context.Operation.Instance.TrackedSymbol() is { } symbol && symbolNames.Contains(symbol.Name)
                 ? context.State.Preserve(symbol)
                 : context.State;
     }


### PR DESCRIPTION
Part of #6812

```
value = nullable.GetValueOrDefault();
```
Depending on the `nullable`, we can learn
* `Null` => `NotNull`, and in case of `bool` also `False`.
* `NotNull` => propagate constraints like with `nullable.Value`
* no symbolic value => do nothing, `NonNullableValueTypeCheck` will give us `NotNull` for the value type