### PR TITLE
Fix SE: DictionaryContentHash is not stable to ordering

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/HashCode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/HashCode.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Helpers
         private const int RotateOffset = 17;
 
         public static int DictionaryContentHash<TKey, TValue>(IDictionary<TKey, TValue> dictionary) =>
-            dictionary.Aggregate(0, (seed, kvp) => Combine(seed, kvp.Key, kvp.Value));
+            dictionary.Aggregate(0, (seed, kvp) => seed ^ Combine(kvp.Key, kvp.Value));
 
         public static int EnumerableContentHash<TValue>(IEnumerable<TValue> enumerable) =>
             enumerable.Aggregate(0, (seed, x) => Combine(seed, x));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DictionaryExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/DictionaryExtensionsTest.cs
@@ -46,5 +46,16 @@ namespace SonarAnalyzer.UnitTest.Helpers
             dict1.DictionaryEquals(dict1).Should().BeTrue();
             dict1.DictionaryEquals(dict2).Should().BeTrue();
         }
+
+        [TestMethod]
+        public void DictionaryEquals_SameContent_DifferentOrdering()
+        {
+            var numbers = Enumerable.Range(1, 1000);
+            var dict1 = numbers.ToDictionary(x => x, x => x);
+            var dict2 = numbers.OrderByDescending(x => x).ToDictionary(x => x, x => x);
+            dict1.DictionaryEquals(dict1).Should().BeTrue();
+            dict1.DictionaryEquals(dict2).Should().BeTrue();
+            dict2.DictionaryEquals(dict1).Should().BeTrue();
+        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/HashCodeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/HashCodeTest.cs
@@ -54,8 +54,8 @@ namespace SonarAnalyzer.UnitTest.Helpers
         public void DictionaryContentHash_StableForImmutableDictionary()
         {
             var numbers = Enumerable.Range(1, 1000);
-            var dict1 = numbers.ToImmutableDictionary(x => x.ToString(), x => x);
-            var dict2 = numbers.OrderByDescending(x => x).ToImmutableDictionary(x => x.ToString(), x => x);
+            var dict1 = numbers.ToImmutableDictionary(x => x, x => x);
+            var dict2 = numbers.OrderByDescending(x => x).ToImmutableDictionary(x => x, x => x);
             var hashCode1 = SonarAnalyzer.Helpers.HashCode.DictionaryContentHash(dict1);
             var hashCode2 = SonarAnalyzer.Helpers.HashCode.DictionaryContentHash(dict2);
             hashCode1.Should().Be(hashCode2);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/HashCodeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/HashCodeTest.cs
@@ -49,5 +49,16 @@ namespace SonarAnalyzer.UnitTest.Helpers
             var hashCode2 = SonarAnalyzer.Helpers.HashCode.DictionaryContentHash(dict2);
             hashCode1.Should().Be(hashCode2);
         }
+
+        [TestMethod]
+        public void DictionaryContentHash_StableForImmutableDictionary()
+        {
+            var numbers = Enumerable.Range(1, 1000);
+            var dict1 = numbers.ToDictionary(x => x.ToString(), x => x).ToImmutableDictionary();
+            var dict2 = numbers.OrderByDescending(x => x).ToDictionary(x => x.ToString(), x => x).ToImmutableDictionary();
+            var hashCode1 = SonarAnalyzer.Helpers.HashCode.DictionaryContentHash(dict1);
+            var hashCode2 = SonarAnalyzer.Helpers.HashCode.DictionaryContentHash(dict2);
+            hashCode1.Should().Be(hashCode2);
+        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/HashCodeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/HashCodeTest.cs
@@ -54,8 +54,8 @@ namespace SonarAnalyzer.UnitTest.Helpers
         public void DictionaryContentHash_StableForImmutableDictionary()
         {
             var numbers = Enumerable.Range(1, 1000);
-            var dict1 = numbers.ToDictionary(x => x.ToString(), x => x).ToImmutableDictionary();
-            var dict2 = numbers.OrderByDescending(x => x).ToDictionary(x => x.ToString(), x => x).ToImmutableDictionary();
+            var dict1 = numbers.ToImmutableDictionary(x => x.ToString(), x => x);
+            var dict2 = numbers.OrderByDescending(x => x).ToImmutableDictionary(x => x.ToString(), x => x);
             var hashCode1 = SonarAnalyzer.Helpers.HashCode.DictionaryContentHash(dict1);
             var hashCode2 = SonarAnalyzer.Helpers.HashCode.DictionaryContentHash(dict2);
             hashCode1.Should().Be(hashCode2);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/HashCodeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/HashCodeTest.cs
@@ -38,5 +38,16 @@ namespace SonarAnalyzer.UnitTest.Helpers
             hash4.Should().NotBe(0).And.NotBe(hash2).And.NotBe(hash3);
             hash5.Should().NotBe(0).And.NotBe(hash2).And.NotBe(hash3).And.NotBe(hash4);
         }
+
+        [TestMethod]
+        public void DictionaryContentHash_StableForUnsortedDictionary()
+        {
+            var numbers = Enumerable.Range(1, 1000);
+            var dict1 = numbers.ToDictionary(x => x, x => x);
+            var dict2 = numbers.OrderByDescending(x => x).ToDictionary(x => x, x => x);
+            var hashCode1 = SonarAnalyzer.Helpers.HashCode.DictionaryContentHash(dict1);
+            var hashCode2 = SonarAnalyzer.Helpers.HashCode.DictionaryContentHash(dict2);
+            hashCode1.Should().Be(hashCode2);
+        }
     }
 }


### PR DESCRIPTION
Dictionaries don't maintain a order so these both dictionaries should be identical
* `["A" = 1, "B" = 2]`
* `["B" = 2, "A" = 1]`

`Hashcode.DictionaryContentHash` returns different hashcodes for both dictionaries.

See the failing test cases here https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=64968&view=ms.vss-test-web.build-test-results-tab