### PR TITLE
SE - Non-nullable value types: Add support for constrained generics

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/TypeHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/TypeHelper.cs
@@ -36,7 +36,6 @@ namespace SonarAnalyzer.Helpers
                 { TypeKind: TypeKind.Struct } => true,
                 ITypeParameterSymbol { IsValueType: true } => true,
                 ITypeParameterSymbol { HasReferenceTypeConstraint: false, ConstraintTypes: { IsEmpty: false } constraintTypes } => constraintTypes.Any(x => x.SpecialType == SpecialType.System_Enum),
-                ITypeParameterSymbol typeParameter when typeParameter != self => typeParameter.OriginalDefinition.IsStruct(),
                 _ => false,
             };
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/TypeHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/TypeHelperTest.cs
@@ -147,10 +147,8 @@ namespace SonarAnalyzer.UnitTest.Helpers
                     T field;
                 }
                 """);
-            var field = tree.GetRoot().DescendantNodes().OfType<FieldDeclarationSyntax>().First();
-            var fieldSymbol = (IFieldSymbol)model.GetDeclaredSymbol(field.Declaration.Variables[0]);
-            var fieldType = fieldSymbol.Type;
-            fieldType.IsStruct().Should().BeTrue();
+            var fieldSymbol = FirstFieldSymbol(tree, model);
+            fieldSymbol.Type.IsStruct().Should().BeTrue();
         }
 
         [DataTestMethod]
@@ -166,10 +164,8 @@ namespace SonarAnalyzer.UnitTest.Helpers
                     {{type}} field;
                 }
                 """);
-            var field = tree.GetRoot().DescendantNodes().OfType<FieldDeclarationSyntax>().First();
-            var fieldSymbol = (IFieldSymbol)model.GetDeclaredSymbol(field.Declaration.Variables[0]);
-            var fieldType = fieldSymbol.Type;
-            fieldType.IsStruct().Should().BeTrue();
+            var fieldSymbol = FirstFieldSymbol(tree, model);
+            fieldSymbol.Type.IsStruct().Should().BeTrue();
         }
 
         [DataTestMethod]
@@ -188,10 +184,8 @@ namespace SonarAnalyzer.UnitTest.Helpers
                     T field;
                 }
                 """);
-            var field = tree.GetRoot().DescendantNodes().OfType<FieldDeclarationSyntax>().First();
-            var fieldSymbol = (IFieldSymbol)model.GetDeclaredSymbol(field.Declaration.Variables[0]);
-            var fieldType = fieldSymbol.Type;
-            fieldType.IsStruct().Should().BeFalse();
+            var fieldSymbol = FirstFieldSymbol(tree, model);
+            fieldSymbol.Type.IsStruct().Should().BeFalse();
         }
 
         [DataTestMethod]
@@ -217,10 +211,8 @@ namespace SonarAnalyzer.UnitTest.Helpers
                     T? field;
                 }
                 """);
-            var field = tree.GetRoot().DescendantNodes().OfType<FieldDeclarationSyntax>().First();
-            var fieldSymbol = (IFieldSymbol)model.GetDeclaredSymbol(field.Declaration.Variables[0]);
-            var fieldType = fieldSymbol.Type;
-            fieldType.IsStruct().Should().BeFalse();
+            var fieldSymbol = FirstFieldSymbol(tree, model);
+            fieldSymbol.Type.IsStruct().Should().BeFalse();
         }
 
         [TestMethod]
@@ -233,10 +225,8 @@ namespace SonarAnalyzer.UnitTest.Helpers
                     U field;
                 }
                 """);
-            var field = tree.GetRoot().DescendantNodes().OfType<FieldDeclarationSyntax>().First();
-            var fieldSymbol = (IFieldSymbol)model.GetDeclaredSymbol(field.Declaration.Variables[0]);
-            var fieldType = fieldSymbol.Type;
-            fieldType.IsStruct().Should().BeFalse();
+            var fieldSymbol = FirstFieldSymbol(tree, model);
+            fieldSymbol.Type.IsStruct().Should().BeFalse();
         }
 
         [TestMethod]
@@ -256,6 +246,13 @@ namespace SonarAnalyzer.UnitTest.Helpers
             var parameter = tree.GetRoot().DescendantNodes().OfType<ParameterSyntax>().First();
             var parameterSymbol = (IParameterSymbol)model.GetDeclaredSymbol(parameter);
             parameterSymbol.Type.IsStruct().Should().BeFalse(); // parameter must be a struct, but even the compiler doesn't recognizes this
+        }
+
+        private static IFieldSymbol FirstFieldSymbol(SyntaxTree tree, SemanticModel model)
+        {
+            var field = tree.GetRoot().DescendantNodes().OfType<FieldDeclarationSyntax>().First();
+            var fieldSymbol = (IFieldSymbol)model.GetDeclaredSymbol(field.Declaration.Variables[0]);
+            return fieldSymbol;
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/TypeHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/TypeHelperTest.cs
@@ -195,7 +195,7 @@ namespace SonarAnalyzer.UnitTest.Helpers
         }
 
         [DataTestMethod]
-        [DataRow("")]                      // Unbounded (can be nullable reference type or nullable value type)
+        [DataRow("")]                      // Unbounded (can be reference type or value type)
         [DataRow("where T: new()")]        // Unbounded
         [DataRow("where T: notnull")]      // Unbounded
         [DataRow("where T: class")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -548,7 +548,7 @@ if (value = boolParameter)
         public void Branching_LearnsObjectConstraint_RecursivePattern_ValueTypeConstraint(string expression, string argType)
         {
             var validator = CreateIfElseEndValidatorCS(expression, OperationKind.RecursivePattern, argType);
-            validator.ValidateTagOrder("If", "End");
+            validator.ValidateTagOrder("If", "End"); // Always true, else branch is not visited
             validator.ValidateTag("If", x => x.Should().HaveNoConstraints());
             validator.ValidateTag("End", x => x.Should().HaveNoConstraints());
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -532,15 +532,24 @@ if (value = boolParameter)
 
         [DataTestMethod]
         [DataRow("arg is { }", "T")]
-        [DataRow("arg is { }", "TStruct")]
         [DataRow("arg is string { }", "T")]     // Could have NotNull instead. T is not known to be reference type.
         [DataRow("(arg, Unknown<object>()) is ({ }, { })", "object")]   // We don't support learning for tuples (yet). Should behave same as "arg is { }". Gets tricky when nesting (a, (b, c))
         public void Branching_LearnsObjectConstraint_RecursivePattern_NoConstraint(string expression, string argType)
         {
             var validator = CreateIfElseEndValidatorCS(expression, OperationKind.RecursivePattern, argType);
-            validator.ValidateTag("If", x => x.Should().BeNull());
-            validator.ValidateTag("Else", x => x.Should().BeNull());
-            validator.ValidateTag("End", x => x.Should().BeNull());
+            validator.ValidateTag("If", x => x.Should().HaveNoConstraints());
+            validator.ValidateTag("Else", x => x.Should().HaveNoConstraints());
+            validator.ValidateTag("End", x => x.Should().HaveNoConstraints());
+        }
+
+        [DataTestMethod]
+        [DataRow("arg is { }", "TStruct")]
+        public void Branching_LearnsObjectConstraint_RecursivePattern_ValueTypeConstraint(string expression, string argType)
+        {
+            var validator = CreateIfElseEndValidatorCS(expression, OperationKind.RecursivePattern, argType);
+            validator.ValidateTagOrder("If", "End");
+            validator.ValidateTag("If", x => x.Should().HaveNoConstraints());
+            validator.ValidateTag("End", x => x.Should().HaveNoConstraints());
         }
 
         [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -544,6 +544,7 @@ if (value = boolParameter)
 
         [DataTestMethod]
         [DataRow("arg is { }", "TStruct")]
+        [DataRow("arg is TStruct { }", "TStruct")]
         public void Branching_LearnsObjectConstraint_RecursivePattern_ValueTypeConstraint(string expression, string argType)
         {
             var validator = CreateIfElseEndValidatorCS(expression, OperationKind.RecursivePattern, argType);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -556,14 +556,14 @@ public void Main<TClass, TStruct, TUnknown, TType, TInterface, TUnmanaged, TEnum
 }";
             var validator = SETestContext.CreateCSMethod(code).Validator;
             validator.ValidateContainsOperation(OperationKind.Literal);
-            validator.ValidateTag("Class", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-            validator.ValidateTag("Struct", x => x.Should().BeNull("struct cannot be null."));
-            validator.ValidateTag("Unknown", x => x.Should().BeNull("it can be struct."));
-            validator.ValidateTag("Type", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-            validator.ValidateTag("Interface", x => x.Should().BeNull("interfaces can be implemented by a struct."));
-            validator.ValidateTag("Unmanaged", x => x.Should().BeNull("unmanaged implies struct and cannot be null."));
-            validator.ValidateTag("Enum", x => x.Should().BeNull("Enum cannot be null."));
-            validator.ValidateTag("Delegate", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
+            validator.ValidateTag("Class", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+            validator.ValidateTag("Struct", x => x.Should().HaveNoConstraints("struct cannot be null."));
+            validator.ValidateTag("Unknown", x => x.Should().HaveNoConstraints("it can be struct."));
+            validator.ValidateTag("Type", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+            validator.ValidateTag("Interface", x => x.Should().HaveNoConstraints("interfaces can be implemented by a struct."));
+            validator.ValidateTag("Unmanaged", x => x.Should().HaveNoConstraints("unmanaged implies struct and cannot be null."));
+            validator.ValidateTag("Enum", x => x.Should().HaveNoConstraints("Enum cannot be null."));
+            validator.ValidateTag("Delegate", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -557,12 +557,12 @@ public void Main<TClass, TStruct, TUnknown, TType, TInterface, TUnmanaged, TEnum
             var validator = SETestContext.CreateCSMethod(code).Validator;
             validator.ValidateContainsOperation(OperationKind.Literal);
             validator.ValidateTag("Class", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-            validator.ValidateTag("Struct", x => x.Should().HaveNoConstraints("struct cannot be null."));
+            validator.ValidateTag("Struct", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "struct cannot be null."));
             validator.ValidateTag("Unknown", x => x.Should().HaveNoConstraints("it can be struct."));
             validator.ValidateTag("Type", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
             validator.ValidateTag("Interface", x => x.Should().HaveNoConstraints("interfaces can be implemented by a struct."));
-            validator.ValidateTag("Unmanaged", x => x.Should().HaveNoConstraints("unmanaged implies struct and cannot be null."));
-            validator.ValidateTag("Enum", x => x.Should().HaveNoConstraints("Enum cannot be null."));
+            validator.ValidateTag("Unmanaged", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "unmanaged implies struct and cannot be null."));
+            validator.ValidateTag("Enum", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "Enum cannot be null."));
             validator.ValidateTag("Delegate", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
         }
 


### PR DESCRIPTION
Part of #6105

This PR adds support for T in `<T> where T: struct` being recognized as non-nullable value type. 

Next PR: Tests for such constraints when used e.g. so `M(T? t)` will ensure that this is recognized as a nullable value type.