### PR TITLE
SE - Nullable: Add support for nullable.Equals(arg)

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
@@ -170,21 +170,13 @@ internal sealed partial class Invocation : MultiProcessor<IInvocationOperationWr
         }
     }
 
-    private static ProgramState[] ProcessEquals(SymbolicContext context, IInvocationOperationWrapper invocation)
-    {
-        if (invocation.Arguments.Length == 2 && invocation.TargetMethod.IsStatic)
+    private static ProgramState[] ProcessEquals(SymbolicContext context, IInvocationOperationWrapper invocation) =>
+        invocation switch
         {
-            return ProcessEquals(context, invocation.Arguments[0].ToArgument().Value, invocation.Arguments[1].ToArgument().Value);
-        }
-        else if (invocation.Arguments.Length == 1 && invocation.TargetMethod.ContainingType.IsNullableValueType())
-        {
-            return ProcessEquals(context, invocation.Instance, invocation.Arguments[0].ToArgument().Value);
-        }
-        else
-        {
-            return context.State.ToArray();
-        }
-    }
+            { Arguments.Length: 2, TargetMethod.IsStatic: true } => ProcessEquals(context, invocation.Arguments[0].ToArgument().Value, invocation.Arguments[1].ToArgument().Value),
+            { Arguments.Length: 1 } when invocation.TargetMethod.ContainingType.IsNullableValueType() => ProcessEquals(context, invocation.Instance, invocation.Arguments[0].ToArgument().Value),
+            _ => context.State.ToArray()
+        };
 
     private static ProgramState[] ProcessEquals(SymbolicContext context, IOperation leftOperation, IOperation rightOperation)
     {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Invocation.cs
@@ -172,10 +172,23 @@ internal sealed partial class Invocation : MultiProcessor<IInvocationOperationWr
 
     private static ProgramState[] ProcessEquals(SymbolicContext context, IInvocationOperationWrapper invocation)
     {
-        if (invocation.TargetMethod.IsStatic && invocation.Arguments.Length == 2
-            && invocation.Arguments[0].ToArgument().Value is var leftOperation
-            && invocation.Arguments[1].ToArgument().Value is var rightOperation
-            && context.State[leftOperation]?.Constraint<ObjectConstraint>() is var leftConstraint
+        if (invocation.Arguments.Length == 2 && invocation.TargetMethod.IsStatic)
+        {
+            return ProcessEquals(context, invocation.Arguments[0].ToArgument().Value, invocation.Arguments[1].ToArgument().Value);
+        }
+        else if (invocation.Arguments.Length == 1 && invocation.TargetMethod.ContainingType.IsNullableValueType())
+        {
+            return ProcessEquals(context, invocation.Instance, invocation.Arguments[0].ToArgument().Value);
+        }
+        else
+        {
+            return context.State.ToArray();
+        }
+    }
+
+    private static ProgramState[] ProcessEquals(SymbolicContext context, IOperation leftOperation, IOperation rightOperation)
+    {
+        if (context.State[leftOperation]?.Constraint<ObjectConstraint>() is var leftConstraint
             && context.State[rightOperation]?.Constraint<ObjectConstraint>() is var rightConstraint
             && (leftConstraint == ObjectConstraint.Null || rightConstraint == ObjectConstraint.Null))
         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -980,7 +980,7 @@ Tag(""End"");";
                 var result = left.Equals(right);
                 Tag("Result", result);
                 """;
-            SETestContext.CreateCS(code).Validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));    //FIXME: Should also have , BoolConstraint.From(expectedResult)
+            SETestContext.CreateCS(code).Validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(expectedResult)));
         }
 
         [DataTestMethod]
@@ -1014,19 +1014,14 @@ Tag(""End"");";
             validator.TagStates("End").Should().SatisfyRespectively(
                 x =>
                 {
-                    x[result].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
-                    x[arg].Should().HaveNoConstraints();
+                    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
+                    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.Null);
+                },
+                x =>
+                {
+                    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
+                    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
                 });
-                //x =>
-                //{
-                //    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
-                //    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.Null);
-                //},
-                //x =>
-                //{
-                //    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
-                //    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
-                //});
         }
 
         [TestMethod]
@@ -1045,21 +1040,21 @@ Tag(""End"");";
                      x[result].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
                      x[arg].Should().HaveNoConstraints();
                  });
-                //x =>
-                //{
-                //    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
-                //    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
-                //},
-                //x =>
-                //{
-                //    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
-                //    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
-                //},
-                //x =>
-                //{
-                //    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
-                //    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.Null);
-                //});
+            //x =>
+            //{
+            //    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
+            //    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+            //},
+            //x =>
+            //{
+            //    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
+            //    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+            //},
+            //x =>
+            //{
+            //    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
+            //    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.Null);
+            //});
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -1001,11 +1001,14 @@ Tag(""End"");";
             SETestContext.CreateCS(code).Validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
         }
 
-        [TestMethod]
-        public void Invocation_NullableEquals_Null_SplitsToBothResults()
+        [DataTestMethod]
+        [DataRow("isNull", "arg")]
+        [DataRow("arg", "null")]
+        public void Invocation_NullableEquals_Null_SplitsToBothResults(string left, string right)
         {
             var code = $"""
-                var result = arg.Equals(null);
+                int? isNull = null;
+                var result = {left}.Equals({right});
                 Tag("End");
                 """;
             var validator = SETestContext.CreateCS(code, ", int? arg").Validator;
@@ -1022,39 +1025,6 @@ Tag(""End"");";
                     x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
                     x[arg].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
                 });
-        }
-
-        [TestMethod]
-        public void Invocation_NullableEquals_Literal_SplitsToThreeResults()
-        {
-            var code = $"""
-                var result = arg.Equals(42);
-                Tag("End");
-                """;
-            var validator = SETestContext.CreateCS(code, ", int? arg").Validator;
-            var result = validator.Symbol("result");
-            var arg = validator.Symbol("arg");
-            validator.TagStates("End").Should().SatisfyRespectively(
-                 x =>
-                 {
-                     x[result].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
-                     x[arg].Should().HaveNoConstraints();
-                 });
-            //x =>
-            //{
-            //    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
-            //    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
-            //},
-            //x =>
-            //{
-            //    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
-            //    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
-            //},
-            //x =>
-            //{
-            //    x[result].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
-            //    x[arg].Should().HaveOnlyConstraint(ObjectConstraint.Null);
-            //});
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes #6812 

Support for `object.Equals(left, right)` has some (limited) capabilities. This PR introduces the same functionality for `nullable.Equals(arg)`