### PR TITLE
S3900: Basic rule implementation

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -38,11 +38,11 @@ public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
     {
         var operation = context.Operation.Instance;
         if (operation.Kind == OperationKindEx.ParameterReference
-            && operation.ToParameterReference() is { Parameter: var parameterSymbol }
-            && parameterSymbol.Type.IsValueType is false
+            && operation.ToParameterReference() is var parameter
+            && parameter.Parameter.Type.IsValueType is false
             && IsParameterDereferenced(context.Operation)
-            && NullableStateIsNotKnownForParameter(parameterSymbol)
-            && !IgnoreBecauseOfParameterAttribute(parameterSymbol))
+            && NullableStateIsNotKnownForParameter(parameter.Parameter)
+            && !IgnoreBecauseOfParameterAttribute(parameter.Parameter))
         {
             var message = SemanticModel.GetDeclaredSymbol(Node).IsConstructor()
                 ? "Refactor this constructor to avoid using members of parameter '{0}' because it could be null."

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -40,9 +40,10 @@ public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
             && !parameterSymbol.Type.IsValueType
             && IsParameterDereferenced(context.Operation)
             && !IgnoreBecauseOfParameterAttribute(parameterSymbol)
-            && NullableStateIsNotKnownForParameter(parameterSymbol))
+            && NullableStateIsNotKnownForParameter(parameterSymbol)
+            && SemanticModel.GetDeclaredSymbol(Node) is { } methodSymbol)
         {
-            var message = SemanticModel.GetDeclaredSymbol(Node).IsConstructor()
+            var message = methodSymbol.IsConstructor()
                 ? "Refactor this constructor to avoid using members of parameter '{0}' because it could be null."
                 : "Refactor this method to add validation of parameter '{0}' before using it.";
             ReportIssue(reference, string.Format(message, syntax.ToString()), context);

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -38,11 +38,11 @@ public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
     {
         var operation = context.Operation.Instance;
         if (operation.Kind == OperationKindEx.ParameterReference
-            && operation.ToParameterReference() is var parameter
-            && parameter.Parameter.Type.IsValueType is false
+            && operation.ToParameterReference().Parameter is var parameter
+            && parameter.Type.IsValueType is false
             && IsParameterDereferenced(context.Operation)
-            && NullableStateIsNotKnownForParameter(parameter.Parameter)
-            && !IgnoreBecauseOfParameterAttribute(parameter.Parameter))
+            && NullableStateIsNotKnownForParameter(parameter)
+            && !IgnoreBecauseOfParameterAttribute(parameter))
         {
             var message = SemanticModel.GetDeclaredSymbol(Node).IsConstructor()
                 ? "Refactor this constructor to avoid using members of parameter '{0}' because it could be null."

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -31,7 +31,8 @@ public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
 
     protected override DiagnosticDescriptor Rule => S3900;
 
-    public override bool ShouldExecute() => true;
+    public override bool ShouldExecute() =>
+        Node is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax;
 
     protected override ProgramState PreProcessSimple(SymbolicContext context)
     {
@@ -40,10 +41,9 @@ public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
             && parameterSymbol.Type.IsValueType is false
             && IsParameterDereferenced(context.Operation)
             && NullableStateIsNotKnownForParameter(parameterSymbol)
-            && !IgnoreBecauseOfParameterAttribute(parameterSymbol)
-            && SemanticModel.GetDeclaredSymbol(Node) is { } methodSymbol)
+            && !IgnoreBecauseOfParameterAttribute(parameterSymbol))
         {
-            var message = methodSymbol.IsConstructor()
+            var message = SemanticModel.GetDeclaredSymbol(Node).IsConstructor()
                 ? "Refactor this constructor to avoid using members of parameter '{0}' because it could be null."
                 : "Refactor this method to add validation of parameter '{0}' before using it.";
             ReportIssue(context.Operation.Instance, string.Format(message, context.Operation.Instance.Syntax), context);

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -25,7 +25,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.CSharp;
 public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
 {
     private const string DiagnosticId = "S3900";
-    private const string MessageFormat = "Refactor this method to add validation of parameter '{0}' before using it.";
+    private const string MessageFormat = "{0}";
 
     internal static readonly DiagnosticDescriptor S3900 = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -36,7 +36,7 @@ public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
     protected override ProgramState PreProcessSimple(SymbolicContext context)
     {
         if (context.Operation.Instance.Kind == OperationKindEx.ParameterReference
-            && context.Operation.Instance.ToParameterReference() is { WrappedOperation: var reference, Parameter: var parameterSymbol }
+            && context.Operation.Instance.ToParameterReference() is { Parameter: var parameterSymbol }
             && parameterSymbol.Type.IsValueType is false
             && IsParameterDereferenced(context.Operation)
             && NullableStateIsNotKnownForParameter(parameterSymbol)
@@ -46,7 +46,7 @@ public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
             var message = methodSymbol.IsConstructor()
                 ? "Refactor this constructor to avoid using members of parameter '{0}' because it could be null."
                 : "Refactor this method to add validation of parameter '{0}' before using it.";
-            ReportIssue(reference, string.Format(message, context.Operation.Instance.Syntax), context);
+            ReportIssue(context.Operation.Instance, string.Format(message, context.Operation.Instance.Syntax), context);
         }
 
         return context.State;

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -36,7 +36,7 @@ public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
     protected override ProgramState PreProcessSimple(SymbolicContext context)
     {
         if (context.Operation.Instance.Kind == OperationKindEx.ParameterReference
-            && context.Operation.Instance.ToParameterReference() is { WrappedOperation: var reference, WrappedOperation.Syntax: var syntax, Parameter: var parameterSymbol }
+            && context.Operation.Instance.ToParameterReference() is { WrappedOperation: var reference, Parameter: var parameterSymbol }
             && !parameterSymbol.Type.IsValueType
             && IsParameterDereferenced(context.Operation)
             && !IgnoreBecauseOfParameterAttribute(parameterSymbol)
@@ -46,7 +46,7 @@ public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
             var message = methodSymbol.IsConstructor()
                 ? "Refactor this constructor to avoid using members of parameter '{0}' because it could be null."
                 : "Refactor this method to add validation of parameter '{0}' before using it.";
-            ReportIssue(reference, string.Format(message, syntax.ToString()), context);
+            ReportIssue(reference, string.Format(message, context.Operation.Instance.Syntax), context);
         }
 
         return context.State;
@@ -61,7 +61,7 @@ public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
                 OperationKindEx.Await,
                 OperationKindEx.ArrayElementReference);
 
-        bool IgnoreBecauseOfParameterAttribute(IParameterSymbol symbol) =>
+        static bool IgnoreBecauseOfParameterAttribute(IParameterSymbol symbol) =>
             symbol.HasAttribute(KnownType.Microsoft_AspNetCore_Mvc_FromServicesAttribute);
 
         bool NullableStateIsNotKnownForParameter(IParameterSymbol symbol) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -36,8 +36,9 @@ public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
 
     protected override ProgramState PreProcessSimple(SymbolicContext context)
     {
-        if (context.Operation.Instance.Kind == OperationKindEx.ParameterReference
-            && context.Operation.Instance.ToParameterReference() is { Parameter: var parameterSymbol }
+        var operation = context.Operation.Instance;
+        if (operation.Kind == OperationKindEx.ParameterReference
+            && operation.ToParameterReference() is { Parameter: var parameterSymbol }
             && parameterSymbol.Type.IsValueType is false
             && IsParameterDereferenced(context.Operation)
             && NullableStateIsNotKnownForParameter(parameterSymbol)
@@ -46,7 +47,7 @@ public class PublicMethodArgumentsShouldBeCheckedForNull : SymbolicRuleCheck
             var message = SemanticModel.GetDeclaredSymbol(Node).IsConstructor()
                 ? "Refactor this constructor to avoid using members of parameter '{0}' because it could be null."
                 : "Refactor this method to add validation of parameter '{0}' before using it.";
-            ReportIssue(context.Operation.Instance, string.Format(message, context.Operation.Instance.Syntax), context);
+            ReportIssue(operation, string.Format(message, operation.Syntax), context);
         }
 
         return context.State;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
@@ -69,6 +69,9 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         internal static IPropertyReferenceOperationWrapper ToPropertyReference(this IOperation operation) =>
             IPropertyReferenceOperationWrapper.FromOperation(operation);
 
+        internal static IParameterReferenceOperationWrapper ToParameterReference(this IOperation operation) =>
+            IParameterReferenceOperationWrapper.FromOperation(operation);
+
         internal static IEventReferenceOperationWrapper ToEventReference(this IOperation operation) =>
             IEventReferenceOperationWrapper.FromOperation(operation);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.CSharp11.cs
@@ -8,12 +8,19 @@
         o[1].ToString(); // Noncompliant {{Refactor this method to add validation of parameter 'o' before using it.}}
     }
 
-    public void Compliant(object[] o)
+    public void ListPattern1(object[] o)
     {
         if (o is [not null, not null])
         {
             o.ToString();       // Noncompliant - FP
-            o[1].ToString();    // Compliant
+        }
+    }
+
+    public void ListPattern2(object[] o)
+    {
+        if (o is [not null, not null])
+        {
+            o[1].ToString();    // Noncompliant - FP
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.CSharp11.cs
@@ -5,14 +5,14 @@
 
     public void NotCompliantCases(object[] o)
     {
-        o[1].ToString(); // FIXME Non-compliant {{Refactor this method to add validation of parameter 'o' before using it.}}
+        o[1].ToString(); // Noncompliant {{Refactor this method to add validation of parameter 'o' before using it.}}
     }
 
     public void Compliant(object[] o)
     {
         if (o is [not null, not null])
         {
-            o.ToString();       // Compliant
+            o.ToString();       // Noncompliant - FP
             o[1].ToString();    // Compliant
         }
     }
@@ -22,6 +22,6 @@ public interface ISomeInterface
 {
     public static virtual void NotCompliantCases(object o)
     {
-        o.ToString(); // FIXME Non-compliant {{Refactor this method to add validation of parameter 'o' before using it.}}
+        o.ToString(); // Noncompliant {{Refactor this method to add validation of parameter 'o' before using it.}}
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.CSharp8.cs
@@ -20,7 +20,7 @@ public interface IWithDefaultMembers
 
     void Reset(string s)
     {
-        s.ToString(); // FIXME Non-compliant
+        s.ToString(); // Noncompliant
     }
 }
 
@@ -66,7 +66,7 @@ public class SwitchExpressions
     {
         var result = b switch
         {
-            _ => s.ToString() // FIXME Non-compliant
+            _ => s.ToString() // Noncompliant
         };
     }
 
@@ -75,7 +75,7 @@ public class SwitchExpressions
         var result = val switch
         {
             1 => "a",
-            2 => s.ToString(), // FIXME Non-compliant
+            2 => s.ToString(), // Noncompliant
             _ => "b"
         };
     }
@@ -87,7 +87,7 @@ public class SwitchExpressions
             1 => "a",
             2 => condition switch
             {
-                _ => s.ToString() // FIXME Non-compliant
+                _ => s.ToString() // Noncompliant
             },
             _ => "b"
         };
@@ -97,7 +97,7 @@ public class SwitchExpressions
     {
         var result = s switch
         {
-            null => s.ToString(),   // FIXME Non-compliant
+            null => s.ToString(),   // FN
             _ => s.ToString()       // Compliant as null was already handled
         };
     }
@@ -116,7 +116,7 @@ public class SwitchExpressions
     {
         return address switch
         {
-            { State: "WA" } addr => s.ToString(), // FIXME Non-compliant
+            { State: "WA" } addr => s.ToString(), // Noncompliant
             _ => string.Empty
         };
     }
@@ -125,7 +125,7 @@ public class SwitchExpressions
     {
         return s switch
         {
-            { Length: 5 } => s.ToString(), // FIXME Non-compliant - FP we know that the length is 5 so the string cannot be null
+            { Length: 5 } => s.ToString(), // Compliant - we know that the length is 5 so the string cannot be null
             _ => string.Empty
         };
     }
@@ -134,7 +134,7 @@ public class SwitchExpressions
     {
         return person switch
         {
-            { Address: { State: "WA" } } pers => s.ToString(), // FIXME Non-compliant
+            { Address: { State: "WA" } } pers => s.ToString(), // Noncompliant
             _ => string.Empty
         };
     }
@@ -143,7 +143,7 @@ public class SwitchExpressions
     {
         return address switch
         {
-            var (name, state) => s.ToString(), // FN
+            var (name, state) => s.ToString(), // Noncompliant
             _ => string.Empty
         };
     }
@@ -152,8 +152,8 @@ public class SwitchExpressions
     {
         return address switch
         {
-            Address addr when addr.Name.Length > 0 => s.ToString(),         // FIXME Non-compliant
-            Address addr when addr.Name.Length == s.Length => string.Empty, // FIXME Non-compliant
+            Address addr when addr.Name.Length > 0 => s.ToString(),         // Noncompliant
+            Address addr when addr.Name.Length == s.Length => string.Empty, // Noncompliant
             _ => string.Empty
         };
     }
@@ -162,7 +162,7 @@ public class SwitchExpressions
     {
         return address switch
         {
-            Address addr => s.ToString(), // FIXME Non-compliant
+            Address addr => s.ToString(), // Noncompliant
             _ => string.Empty
         };
     }
@@ -171,8 +171,8 @@ public class SwitchExpressions
     {
         return condition switch
         {
-            true => s.ToString(), // FIXME Non-compliant
-            false => s.ToString() // FIXME Non-compliant
+            true => s.ToString(), // Noncompliant
+            false => s.ToString() // Noncompliant
         };
     }
 }
@@ -187,7 +187,7 @@ public class SwitchStatement
                 break;
 
             default:
-                s.ToString(); // Compliant - the null is handled by the case null branch.
+                s.ToString(); // Noncompliant - FP
                 break;
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.CSharp8.cs
@@ -9,7 +9,7 @@
     public void NullCoalescenceAssignment_Null(string s1)
     {
         s1 ??= null;
-        s1.ToString(); // FN
+        s1.ToString(); // Covered by S2259
     }
 }
 
@@ -30,12 +30,12 @@ public class LocalStaticFunctions
     {
         string LocalFunction(object o)
         {
-            return o.ToString(); // FN: local functions are not supported by the CFG
+            return o.ToString(); // Compliant - local methods are not accessible from other assemblies
         }
 
         static string LocalStaticFunction(object o)
         {
-            return o.ToString(); // FN: local functions are not supported by the CFG
+            return o.ToString();
         }
     }
 }
@@ -97,8 +97,8 @@ public class SwitchExpressions
     {
         var result = s switch
         {
-            null => s.ToString(),   // FN
-            _ => s.ToString()       // Compliant as null was already handled
+            null => s.ToString(), // Covered by S2259
+            _ => s.ToString()
         };
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.CSharp9.cs
@@ -33,19 +33,19 @@ public class Sample
 
         if (arg is null)
         {
-            arg.ToString();     // FN
+            arg.ToString();     // Covered by S2259
         }
         if (arg is int or bool or null)
         {
-            arg.ToString();     // FN
+            arg.ToString();
         }
         else if (arg is not not null)
         {
-            arg.ToString();     // FN
+            arg.ToString();
         }
         else if (!(arg is not null))
         {
-            arg.ToString();     // FN
+            arg.ToString();
         }
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.CSharp9.cs
@@ -9,7 +9,7 @@ public class Sample
 
     public void TargetTypedNew(object arg)
     {
-        arg.ToString();         // FN, can't build CFG for this method
+        arg.ToString();         // Noncompliant
 
         StringBuilder sb = new();
     }
@@ -23,12 +23,12 @@ public class Sample
 
         if (arg is int and > 0 and > 1)
         {
-            arg.ToString();     // Compliant
+            arg.ToString();     // Noncompliant - FP
         }
 
         if (arg is int or bool or long)
         {
-            arg.ToString();     // Compliant
+            arg.ToString();     // Noncompliant - FP
         }
 
         if (arg is null)
@@ -63,7 +63,7 @@ public class Sample
         get => null;
         set
         {
-            field = value.ToString();   // FIXME Non-compliant
+            field = value.ToString();   // Noncompliant
         }
     }
 
@@ -72,7 +72,7 @@ public class Sample
         get => null;
         init
         {
-            field = value.ToString();   // FIXME Non-compliant
+            field = value.ToString();   // Noncompliant
         }
     }
 }
@@ -81,7 +81,7 @@ public record Record
 {
     public void Method(object arg)
     {
-        arg.ToString();                 // FIXME Non-compliant
+        arg.ToString();                 // Noncompliant
     }
 }
 
@@ -94,7 +94,7 @@ public partial class Partial
 {
     public partial void Method(object arg)
     {
-        arg.ToString();                 // FIXME Non-compliant
+        arg.ToString();                 // Noncompliant
     }
 }
 
@@ -107,7 +107,7 @@ public class UsingFromServicesAttribute
         service.GetValue();             // Compliant, it's attributed with FromServices attribute
 
     public int GetPrice(IService service) =>
-        service.GetValue();             // FIXME Non-compliant
+        service.GetValue();             // Noncompliant
 
     public interface IService
     {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -13,7 +13,7 @@ public class Program
 //      ^
         Bar(o);         // Compliant, we care about dereference only
 
-        throw e;        // FN
+        throw e;        // FN - the SE engine uses the throw statement as branch rather than an operation
     }
 
     public void Bar(object o) { }
@@ -76,20 +76,20 @@ public class Program
     {
         if (string.IsNullOrEmpty(s1))
         {
-            s1.ToString(); // FN
+            s1.ToString(); // Null check was performed, so this belongs to S2259
         }
         else
         {
-            s1.ToString(); // Compliant
+            s1.ToString();
         }
 
         if (string.IsNullOrWhiteSpace(s2))
         {
-            s2.ToString(); // FN
+            s2.ToString(); // Null check was performed, so this belongs to S2259
         }
         else
         {
-            s2.ToString(); // Compliant
+            s2.ToString();
         }
     }
 
@@ -119,7 +119,7 @@ public class Program
         var c = o?.ToString()?.IsNormalized();
         if (c == null)
         {
-            o.GetType().GetMethods();               // FN
+            o.GetType().GetMethods();               // Null check was performed, so this belongs to S2259
         }
     }
 
@@ -253,7 +253,7 @@ public class ReproIssue2476
             contentType = "";
         }
 
-        var parts = contentType.Split('/', ';');
+        var parts = contentType.Split('/', ';'); // Covered by S2259
     }
 
     public void Method6(string contentType)
@@ -268,7 +268,7 @@ public class ReproIssue2476
             contentType = null;
         }
 
-        var parts = contentType.Split('/', ';'); // Compliant
+        var parts = contentType.Split('/', ';'); // Covered by S2259
     }
 }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -30,7 +30,7 @@ public class Program
 
     protected internal void NotCompliantCases_ProtectedInternal(object o)
     {
-        o.ToString(); // Noncompliant - FP (method visibility)
+        o.ToString(); // Noncompliant
     }
 
     internal void CompliantCases_Internal(object o)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -282,7 +282,7 @@ public class ReproIssue2591
             name = Guid.NewGuid().ToString("N");
         }
 
-        return name.Trim(); // Noncompliant FP
+        return name.Trim(); // Noncompliant - FP
     }
 
     public string FooWithStringJoin(string name)
@@ -292,7 +292,7 @@ public class ReproIssue2591
             name = Guid.NewGuid().ToString("N");
         }
 
-        return string.Join("_", name.Split(System.IO.Path.GetInvalidFileNameChars())); // Noncompliant FP
+        return string.Join("_", name.Split(System.IO.Path.GetInvalidFileNameChars())); // Noncompliant - FP
     }
 
     public string FooWithObject(object name)
@@ -302,7 +302,7 @@ public class ReproIssue2591
             name = Guid.NewGuid().ToString("N");
         }
 
-        return name.ToString(); // Noncompliant FP
+        return name.ToString(); // Noncompliant - FP
     }
 }
 
@@ -383,7 +383,7 @@ public class Repro_3400
     public void ReassignedFromMethod(StringBuilder parameter)
     {
         parameter = Create();
-        parameter.Capacity = 1; // Noncompliant FP
+        parameter.Capacity = 1; // Noncompliant - FP
     }
 
     public void ReassignedFromConstructor(StringBuilder parameter)
@@ -395,7 +395,7 @@ public class Repro_3400
     public void ReassignedFromMethodOut(out StringBuilder parameter)
     {
         parameter = Create();
-        parameter.Capacity = 1; // Noncompliant FP
+        parameter.Capacity = 1; // Noncompliant - FP
     }
 
     public void ReassignedFromConstructorOut(out StringBuilder parameter)


### PR DESCRIPTION
Part of https://github.com/SonarSource/sonar-dotnet/issues/6793
Task 4

This PR works without [the implementation of ShouldExecute()](https://github.com/SonarSource/sonar-dotnet/pull/6942), so some of test cases have FPs, due to the visibility of the method not being checked.
[Re-assignment of the method parameters](https://github.com/SonarSource/sonar-dotnet/issues/6972) will be taken care of in a separate PR, as well as the re-organization/cleanup of the test cases.