### PR TITLE
New Rule S5842: Regular expressions should not match an empty string

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
@@ -1,0 +1,28 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Rules.CSharp;
+
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RegexShouldNotRepresentEmptyString : RegexShouldNotRepresentEmptyStringBase<SyntaxKind>
+{
+    protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
+}

--- a/analyzers/src/SonarAnalyzer.Common/Rules/RegularExpressions/RegexShouldNotRepresentEmptyStringBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/RegularExpressions/RegexShouldNotRepresentEmptyStringBase.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.RegularExpressions;
+
+namespace SonarAnalyzer.Rules;
+
+public abstract class RegexShouldNotRepresentEmptyStringBase<TSyntaxKind> : SonarDiagnosticAnalyzer<TSyntaxKind>
+    where TSyntaxKind : struct
+{
+    private const string DiagnosticId = "S101"; //"S5842";
+
+    protected sealed override string MessageFormat => "The regular expression should not match an empty string.";
+
+    protected RegexShouldNotRepresentEmptyStringBase() : base(DiagnosticId) { }
+
+    protected override void Initialize(SonarAnalysisContext context)
+    {
+        context.RegisterNodeAction(
+            Language.GeneratedCodeRecognizer,
+            c => Analyze(c, RegexContext.FromCtor(Language, c.SemanticModel, c.Node)),
+            Language.SyntaxKind.ObjectCreationExpressions);
+
+        context.RegisterNodeAction(
+            Language.GeneratedCodeRecognizer,
+            c => Analyze(c, RegexContext.FromMethod(Language, c.SemanticModel, c.Node)),
+            Language.SyntaxKind.InvocationExpression);
+
+        context.RegisterNodeAction(
+            Language.GeneratedCodeRecognizer,
+            c => Analyze(c, RegexContext.FromAttribute(Language, c.SemanticModel, c.Node)),
+            Language.SyntaxKind.Attribute);
+    }
+
+    private void Analyze(SonarSyntaxNodeReportingContext c, RegexContext context)
+    {
+        if (context is { }
+            && context.Regex is { } regex
+            && regex.IsMatch(string.Empty))
+        {
+            c.ReportIssue(Diagnostic.Create(Rule, context.PatternNode.GetLocation()));
+        }
+    }
+}

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
@@ -1,0 +1,28 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Rules.VisualBasic;
+
+
+[DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+public sealed class RegexShouldNotRepresentEmptyString : RegexShouldNotRepresentEmptyStringBase<SyntaxKind>
+{
+    protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RegularExpressions/RegexShouldNotRepresentEmptyStringTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/RegularExpressions/RegexShouldNotRepresentEmptyStringTest.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using CS = SonarAnalyzer.Rules.CSharp;
+using VB = SonarAnalyzer.Rules.VisualBasic;
+
+namespace SonarAnalyzer.UnitTest.Rules;
+
+[TestClass]
+public class RegexShouldNotRepresentEmptyStringTest
+{
+    private readonly VerifierBuilder builderCS = new VerifierBuilder<CS.RegexShouldNotRepresentEmptyString>()
+        .WithBasePath("RegularExpressions")
+        .AddReferences(MetadataReferenceFacade.RegularExpressions)
+        .AddReferences(NuGetMetadataReference.SystemComponentModelAnnotations());
+
+    private readonly VerifierBuilder builderVB = new VerifierBuilder<VB.RegexShouldNotRepresentEmptyString>()
+        .WithBasePath("RegularExpressions")
+        .AddReferences(MetadataReferenceFacade.RegularExpressions)
+        .AddReferences(NuGetMetadataReference.SystemComponentModelAnnotations());
+
+    [TestMethod]
+    public void RegexShouldNotRepresentEmptyString_CS() =>
+        builderCS.AddPaths("RegexShouldNotRepresentEmptyString.cs").Verify();
+
+    [TestMethod]
+    public void RegexShouldNotRepresentEmptyString_CSharp9() =>
+        builderCS.AddPaths("RegexShouldNotRepresentEmptyString.CSharp9.cs")
+        .WithOptions(ParseOptionsHelper.FromCSharp9)
+        .Verify();
+
+    [TestMethod]
+    public void RegexShouldNotRepresentEmptyString_VB() =>
+        builderVB.AddPaths("RegexShouldNotRepresentEmptyString.vb").Verify();
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.CSharp9.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.RegularExpressions;
+
+class Compliant
+{
+    void ImplicitObject()
+    {
+        Regex defaultOrder = new("some pattern"); // Compliant
+    }
+}
+
+class Noncompliant
+{
+    void ImplicitObject()
+    {
+        Regex patternOnly = new("A*"); // Noncompliant {{The regular expression should not match an empty string.}}
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+
+class Compliant
+{
+    void Ctor()
+    {
+        var defaultOrder = new Regex("some pattern", RegexOptions.None); // Compliant
+
+        var namedArgs = new Regex(
+            options: RegexOptions.None,
+            pattern: "some pattern");
+    }
+
+    void Static()
+    {
+        var isMatch = Regex.IsMatch("some input", "some pattern", RegexOptions.None); // Compliant
+    }
+
+    [RegularExpression("[0-9]+")] // Compliant
+    public string Attribute { get; set; }
+}
+
+class Noncompliant
+{
+    void Ctor()
+    {
+        var patternOnly = new Regex("A*"); // Noncompliant {{The regular expression should not match an empty string.}}
+        //                          ^^^^
+    }
+
+    void Static()
+    {
+        var isMatch = Regex.IsMatch("some input", "A*"); // Noncompliant
+        //                                        ^^^^
+        var match = Regex.Match("some input", "A*"); // Noncompliant
+        var matches = Regex.Matches("some input", "A*"); // Noncompliant
+        var replace = Regex.Replace("some input", "A*", "some replacement"); // Noncompliant
+        var split = Regex.Split("some input", "A*"); // Noncompliant
+    }
+
+    [RegularExpression("A*")] // Noncompliant
+    public string Attribute { get; set; }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.cs
@@ -6,16 +6,16 @@ class Compliant
 {
     void Ctor()
     {
-        var defaultOrder = new Regex("some pattern", RegexOptions.None); // Compliant
+        var defaultOrder = new Regex("valid pattern", RegexOptions.None); // Compliant
 
         var namedArgs = new Regex(
             options: RegexOptions.None,
-            pattern: "some pattern");
+            pattern: "valid pattern");
     }
 
     void Static()
     {
-        var isMatch = Regex.IsMatch("some input", "some pattern", RegexOptions.None); // Compliant
+        var isMatch = Regex.IsMatch("some input", "valid pattern", RegexOptions.None); // Compliant
     }
 
     [RegularExpression("[0-9]+")] // Compliant
@@ -32,12 +32,12 @@ class Noncompliant
 
     void Static()
     {
-        var isMatch = Regex.IsMatch("some input", "A*"); // Noncompliant
+        var isMatch = Regex.IsMatch("some input", "A*");                     // Noncompliant
         //                                        ^^^^
-        var match = Regex.Match("some input", "A*"); // Noncompliant
-        var matches = Regex.Matches("some input", "A*"); // Noncompliant
+        var match = Regex.Match("some input", "A*");                         // Noncompliant
+        var matches = Regex.Matches("some input", "A*");                     // Noncompliant
         var replace = Regex.Replace("some input", "A*", "some replacement"); // Noncompliant
-        var split = Regex.Split("some input", "A*"); // Noncompliant
+        var split = Regex.Split("some input", "A*");                         // Noncompliant
     }
 
     [RegularExpression("A*")] // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.vb
@@ -1,0 +1,34 @@
+﻿Imports System.ComponentModel.DataAnnotations
+Imports System.Text.RegularExpressions
+
+Class Compliant
+    Private Sub Ctor()
+        Dim defaultOrder = New Regex("some pattern", RegexOptions.None)
+        Dim namedArgs = New Regex(options:=RegexOptions.None, pattern:="some pattern")
+    End Sub
+
+    Private Sub [Static]()
+        Dim isMatch = Regex.IsMatch("some input", "some pattern", RegexOptions.None)
+    End Sub
+
+    <RegularExpression("[0-9]+")>
+    Public Property Attribute As String
+End Class
+
+Class Noncompliant
+    Private Sub Ctor()
+        Dim patternOnly = New Regex("A*") ' Noncompliant {{The regular expression should not match an empty string.}}
+        '                           ^^^^
+    End Sub
+
+    Private Sub [Static]()
+        Dim isMatch = Regex.IsMatch("some input", "A*") ' Noncompliant
+        Dim match = Regex.Match("some input", "A*") ' Noncompliant
+        Dim matches = Regex.Matches("some input", "A*") ' Noncompliant
+        Dim replace = Regex.Replace("some input", "A*", "some replacement") ' Noncompliant
+        Dim split = Regex.Split("some input", "A*") ' Noncompliant
+    End Sub
+
+    <RegularExpression("A*")> ' Noncompliant
+    Public Property Attribute As String
+End Class

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/RegularExpressions/RegexShouldNotRepresentEmptyString.vb
@@ -3,12 +3,12 @@ Imports System.Text.RegularExpressions
 
 Class Compliant
     Private Sub Ctor()
-        Dim defaultOrder = New Regex("some pattern", RegexOptions.None)
-        Dim namedArgs = New Regex(options:=RegexOptions.None, pattern:="some pattern")
+        Dim defaultOrder = New Regex("valid pattern", RegexOptions.None)
+        Dim namedArgs = New Regex(options:=RegexOptions.None, pattern:="valid pattern")
     End Sub
 
     Private Sub [Static]()
-        Dim isMatch = Regex.IsMatch("some input", "some pattern", RegexOptions.None)
+        Dim isMatch = Regex.IsMatch("some input", "valid pattern", RegexOptions.None)
     End Sub
 
     <RegularExpression("[0-9]+")>
@@ -22,11 +22,11 @@ Class Noncompliant
     End Sub
 
     Private Sub [Static]()
-        Dim isMatch = Regex.IsMatch("some input", "A*") ' Noncompliant
-        Dim match = Regex.Match("some input", "A*") ' Noncompliant
-        Dim matches = Regex.Matches("some input", "A*") ' Noncompliant
+        Dim isMatch = Regex.IsMatch("some input", "A*")                     ' Noncompliant
+        Dim match = Regex.Match("some input", "A*")                         ' Noncompliant
+        Dim matches = Regex.Matches("some input", "A*")                     ' Noncompliant
         Dim replace = Regex.Replace("some input", "A*", "some replacement") ' Noncompliant
-        Dim split = Regex.Split("some input", "A*") ' Noncompliant
+        Dim split = Regex.Split("some input", "A*")                         ' Noncompliant
     End Sub
 
     <RegularExpression("A*")> ' Noncompliant


### PR DESCRIPTION
Implementing [RSPEC-5842](https://rules.sonarsource.com/java/RSPEC-5842).

[RSPEC-5842]: https://sonarsource.atlassian.net/browse/RSPEC-5842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ