### PR TITLE
SonarLintXmlReader: Do not depend on exception logic

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/SonarLintXmlReader.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/SonarLintXmlReader.cs
@@ -42,7 +42,7 @@ public class SonarLintXmlReader
 
     public SonarLintXmlReader(SourceText sonarLintXmlText)
     {
-        var sonarLintXml = ParseContent(sonarLintXmlText);
+        var sonarLintXml = sonarLintXmlText is null ? SonarLintXml.Empty : ParseContent(sonarLintXmlText);
         var settings = sonarLintXml.Settings?.GroupBy(x => x.Key).ToDictionary(x => x.Key, x => x.First().Value) ?? new Dictionary<string, string>();
         Exclusions = ReadArray("sonar.exclusions");
         Inclusions = ReadArray("sonar.inclusions");


### PR DESCRIPTION
Line
```
public static readonly SonarLintXmlReader Empty = new(null);
```
sends `null` into constructor, that was propagated into `ParseContent` where it threw `NullReferenceException` due to `.ToString()`, that was caught by `catch` and `.Empty` was returned.
