### PR TITLE
S3655: Static properties and fields called Value

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyNullableValueAccessBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyNullableValueAccessBase.cs
@@ -32,10 +32,11 @@ public abstract class EmptyNullableValueAccessBase : SymbolicRuleCheck
         if (operationInstance.Kind == OperationKindEx.PropertyReference
             && operationInstance.ToPropertyReference() is var reference
             && reference.Property.Name == nameof(Nullable<int>.Value)
-            && reference.Instance.Type.IsNullableValueType()
-            && context.HasConstraint(reference.Instance, ObjectConstraint.Null))
+            && reference.Instance is { } referenceInstance
+            && referenceInstance.Type.IsNullableValueType()
+            && context.HasConstraint(referenceInstance, ObjectConstraint.Null))
         {
-            ReportIssue(reference.Instance, reference.Instance.Syntax.ToString());
+            ReportIssue(referenceInstance, referenceInstance.Syntax.ToString());
         }
         else if (operationInstance.Kind == OperationKindEx.Conversion
             && operationInstance.ToConversion() is var conversion

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyNullableValueAccessBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyNullableValueAccessBase.cs
@@ -32,11 +32,11 @@ public abstract class EmptyNullableValueAccessBase : SymbolicRuleCheck
         if (operationInstance.Kind == OperationKindEx.PropertyReference
             && operationInstance.ToPropertyReference() is var reference
             && reference.Property.Name == nameof(Nullable<int>.Value)
-            && reference.Instance is { } referenceInstance
-            && referenceInstance.Type.IsNullableValueType()
-            && context.HasConstraint(referenceInstance, ObjectConstraint.Null))
+            && reference.Instance is { } instance
+            && instance.Type.IsNullableValueType()
+            && context.HasConstraint(instance, ObjectConstraint.Null))
         {
-            ReportIssue(referenceInstance, referenceInstance.Syntax.ToString());
+            ReportIssue(instance, instance.Syntax.ToString());
         }
         else if (operationInstance.Kind == OperationKindEx.Conversion
             && operationInstance.ToConversion() is var conversion

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -1002,18 +1002,18 @@ namespace TypeWithStaticPropertyCalledValue
             _ = ClassWithStaticPropertyCalledValue.Value.Value;                          // Compliant
             _ = ClassWithStaticPropertyCalledValue.Value.Value.InstanceProperty;         // Compliant
             _ = ClassWithStaticPropertyCalledValue.Value.Value.InstanceProperty.Value;   // Compliant
-            _ = new AClassWithInstancePropertyCalledValue().Value;                       // Compliant
+            _ = new ClassWithInstancePropertyCalledValue().Value;                        // Compliant
         }
     }
 
     class ClassWithStaticPropertyCalledValue
     {
-        public AClassWithInstancePropertyCalledValue InstanceProperty => new AClassWithInstancePropertyCalledValue();
+        public ClassWithInstancePropertyCalledValue InstanceProperty => new ClassWithInstancePropertyCalledValue();
 
-        public static AClassWithInstancePropertyCalledValue Value => new AClassWithInstancePropertyCalledValue();
+        public static ClassWithInstancePropertyCalledValue Value => new ClassWithInstancePropertyCalledValue();
     }
 
-    class AClassWithInstancePropertyCalledValue
+    class ClassWithInstancePropertyCalledValue
     {
         public ClassWithStaticPropertyCalledValue Value => new ClassWithStaticPropertyCalledValue();
     }
@@ -1025,23 +1025,23 @@ namespace TypeWithStaticFieldCalledValue
     {
         void Basics()
         {
-            _ = AClassWithStaticFieldCalledValue.Value;                            // Compliant, not on nullable value type
-            _ = AClassWithStaticFieldCalledValue.Value.Value;                      // Compliant
-            _ = AClassWithStaticFieldCalledValue.Value.Value.InstanceField;        // Compliant
-            _ = AClassWithStaticFieldCalledValue.Value.Value.InstanceField.Value;  // Compliant
-            _ = new AClassWithInstanceFieldCalledValue().Value;                    // Compliant
+            _ = ClassWithStaticFieldCalledValue.Value;                            // Compliant, not on nullable value type
+            _ = ClassWithStaticFieldCalledValue.Value.Value;                      // Compliant
+            _ = ClassWithStaticFieldCalledValue.Value.Value.InstanceField;        // Compliant
+            _ = ClassWithStaticFieldCalledValue.Value.Value.InstanceField.Value;  // Compliant
+            _ = new ClassWithInstanceFieldCalledValue().Value;                    // Compliant
         }
     }
 
-    class AClassWithStaticFieldCalledValue
+    class ClassWithStaticFieldCalledValue
     {
-        public AClassWithInstanceFieldCalledValue InstanceField = new AClassWithInstanceFieldCalledValue();
+        public ClassWithInstanceFieldCalledValue InstanceField = new ClassWithInstanceFieldCalledValue();
 
-        public static AClassWithInstanceFieldCalledValue Value = new AClassWithInstanceFieldCalledValue();
+        public static ClassWithInstanceFieldCalledValue Value = new ClassWithInstanceFieldCalledValue();
     }
 
-    class AClassWithInstanceFieldCalledValue
+    class ClassWithInstanceFieldCalledValue
     {
-        public AClassWithStaticFieldCalledValue Value = new AClassWithStaticFieldCalledValue();
+        public ClassWithStaticFieldCalledValue Value = new ClassWithStaticFieldCalledValue();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -949,99 +949,99 @@ namespace WithAliases
     }
 }
 
-namespace TypeWithValueInstanceProperty
+namespace TypeWithInstancePropertyCalledValue
 {
     class Test
     {
         void Basics1()
         {
-            ClassWithValueProperty i = null;
-            _ = i.Value;                                                       // Compliant, ClassWithValueProperty not a nullable type
+            ClassWithPropertyCalledValue i = null;
+            _ = i.Value;                                                     // Compliant, not a nullable type
         }
 
         void Basics2()
         {
-            ClassWithValueProperty i = null;
-            _ = i.APropertyNotCalledValue;                                     // Compliant, ClassWithValuePropertyAndImplicitCast not a nullable type
+            ClassWithPropertyCalledValue i = null;
+            _ = i.APropertyNotCalledValue;                                   // Compliant, not a nullable type
         }
 
         void ImplicitCast()
         {
-            StructWithValuePropertyAndCastOperators i = null as int?;          // Noncompliant, FP
-            _ = i.Value;                                                       // Compliant, ClassWithValuePropertyAndImplicitCast not a nullable type
+            StructWithPropertyCalledValueAndCastOperators i = null as int?;  // Noncompliant, FP
+            _ = i.Value;                                                     // Compliant, not a nullable type
         }
 
-        int ExplicitCast1 => ((StructWithValuePropertyAndCastOperators)(null as long?)).Value;                              // Noncompliant, FP, just gives 42
-        StructWithValuePropertyAndCastOperators ExplicitCast2 => (null as StructWithValuePropertyAndCastOperators?).Value;  // Noncompliant, FP, just gives a struct
-        int ExplicitCast3 => (null as StructWithValuePropertyAndCastOperators?).Value.Value;                                // Noncompliant, FP, just gives 42
+        int ExplicitCast1 => ((StructWithPropertyCalledValueAndCastOperators)(null as long?)).Value;                                    // Noncompliant, FP, just gives 42
+        StructWithPropertyCalledValueAndCastOperators ExplicitCast2 => (null as StructWithPropertyCalledValueAndCastOperators?).Value;  // Noncompliant, FP, just gives a struct
+        int ExplicitCast3 => (null as StructWithPropertyCalledValueAndCastOperators?).Value.Value;                                      // Noncompliant, FP, just gives 42
     }
 
-    class ClassWithValueProperty
+    class ClassWithPropertyCalledValue
     {
         public int Value => 42;
         public int APropertyNotCalledValue => 42;
     }
 
-    struct StructWithValuePropertyAndCastOperators
+    struct StructWithPropertyCalledValueAndCastOperators
     {
         public int Value => 42;
         public int APropertyNotCalledValue => 42;
 
-        public static implicit operator StructWithValuePropertyAndCastOperators(int? value) => new StructWithValuePropertyAndCastOperators();
-        public static explicit operator StructWithValuePropertyAndCastOperators(long? value) => new StructWithValuePropertyAndCastOperators();
+        public static implicit operator StructWithPropertyCalledValueAndCastOperators(int? value) => new StructWithPropertyCalledValueAndCastOperators();
+        public static explicit operator StructWithPropertyCalledValueAndCastOperators(long? value) => new StructWithPropertyCalledValueAndCastOperators();
     }
 }
 
-namespace TypeWithValueStaticProperty
+namespace TypeWithStaticPropertyCalledValue
 {
     class Test
     {
         void Basics()
         {
-            _ = AClassWithStaticValueProperty.Value;                                // Compliant, not on nullable value type
-            _ = AClassWithStaticValueProperty.Value.Value;                          // Compliant
-            _ = AClassWithStaticValueProperty.Value.Value.InstanceProperty;         // Compliant
-            _ = AClassWithStaticValueProperty.Value.Value.InstanceProperty.Value;   // Compliant
-            _ = new AClassWithInstanceValueProperty().Value;                        // Compliant
+            _ = ClassWithStaticPropertyCalledValue.Value;                                // Compliant, not on nullable value type
+            _ = ClassWithStaticPropertyCalledValue.Value.Value;                          // Compliant
+            _ = ClassWithStaticPropertyCalledValue.Value.Value.InstanceProperty;         // Compliant
+            _ = ClassWithStaticPropertyCalledValue.Value.Value.InstanceProperty.Value;   // Compliant
+            _ = new AClassWithInstancePropertyCalledValue().Value;                       // Compliant
         }
     }
 
-    class AClassWithStaticValueProperty
+    class ClassWithStaticPropertyCalledValue
     {
-        public AClassWithInstanceValueProperty InstanceProperty => new AClassWithInstanceValueProperty();
+        public AClassWithInstancePropertyCalledValue InstanceProperty => new AClassWithInstancePropertyCalledValue();
 
-        public static AClassWithInstanceValueProperty Value => new AClassWithInstanceValueProperty();
+        public static AClassWithInstancePropertyCalledValue Value => new AClassWithInstancePropertyCalledValue();
     }
 
-    class AClassWithInstanceValueProperty
+    class AClassWithInstancePropertyCalledValue
     {
-        public AClassWithStaticValueProperty Value => new AClassWithStaticValueProperty();
+        public ClassWithStaticPropertyCalledValue Value => new ClassWithStaticPropertyCalledValue();
     }
 }
 
-namespace TypeWithValueStaticField
+namespace TypeWithStaticFieldCalledValue
 {
     class Test
     {
         void Basics()
         {
-            _ = AClassWithStaticValueField.Value;                                // Compliant, not on nullable value type
-            _ = AClassWithStaticValueField.Value.Value;                          // Compliant
-            _ = AClassWithStaticValueField.Value.Value.InstanceField;            // Compliant
-            _ = AClassWithStaticValueField.Value.Value.InstanceField.Value;      // Compliant
-            _ = new AClassWithInstanceValueField().Value;                        // Compliant
+            _ = AClassWithStaticFieldCalledValue.Value;                            // Compliant, not on nullable value type
+            _ = AClassWithStaticFieldCalledValue.Value.Value;                      // Compliant
+            _ = AClassWithStaticFieldCalledValue.Value.Value.InstanceField;        // Compliant
+            _ = AClassWithStaticFieldCalledValue.Value.Value.InstanceField.Value;  // Compliant
+            _ = new AClassWithInstanceFieldCalledValue().Value;                    // Compliant
         }
     }
 
-    class AClassWithStaticValueField
+    class AClassWithStaticFieldCalledValue
     {
-        public AClassWithInstanceValueField InstanceField = new AClassWithInstanceValueField();
+        public AClassWithInstanceFieldCalledValue InstanceField = new AClassWithInstanceFieldCalledValue();
 
-        public static AClassWithInstanceValueField Value = new AClassWithInstanceValueField();
+        public static AClassWithInstanceFieldCalledValue Value = new AClassWithInstanceFieldCalledValue();
     }
 
-    class AClassWithInstanceValueField
+    class AClassWithInstanceFieldCalledValue
     {
-        public AClassWithStaticValueField Value = new AClassWithStaticValueField();
+        public AClassWithStaticFieldCalledValue Value = new AClassWithStaticFieldCalledValue();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -1008,14 +1008,14 @@ namespace TypeWithStaticPropertyCalledValue
 
     class ClassWithStaticPropertyCalledValue
     {
-        public ClassWithInstancePropertyCalledValue InstanceProperty => new ClassWithInstancePropertyCalledValue();
+        public ClassWithInstancePropertyCalledValue InstanceProperty => null;
 
-        public static ClassWithInstancePropertyCalledValue Value => new ClassWithInstancePropertyCalledValue();
+        public static ClassWithInstancePropertyCalledValue Value => null;
     }
 
     class ClassWithInstancePropertyCalledValue
     {
-        public ClassWithStaticPropertyCalledValue Value => new ClassWithStaticPropertyCalledValue();
+        public ClassWithStaticPropertyCalledValue Value => null;
     }
 }
 
@@ -1035,13 +1035,13 @@ namespace TypeWithStaticFieldCalledValue
 
     class ClassWithStaticFieldCalledValue
     {
-        public ClassWithInstanceFieldCalledValue InstanceField = new ClassWithInstanceFieldCalledValue();
+        public ClassWithInstanceFieldCalledValue InstanceField = null;
 
-        public static ClassWithInstanceFieldCalledValue Value = new ClassWithInstanceFieldCalledValue();
+        public static ClassWithInstanceFieldCalledValue Value = null;
     }
 
     class ClassWithInstanceFieldCalledValue
     {
-        public ClassWithStaticFieldCalledValue Value = new ClassWithStaticFieldCalledValue();
+        public ClassWithStaticFieldCalledValue Value = null;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -949,7 +949,7 @@ namespace WithAliases
     }
 }
 
-namespace TypeWithValueProperty
+namespace TypeWithValueInstanceProperty
 {
     class Test
     {
@@ -992,3 +992,56 @@ namespace TypeWithValueProperty
     }
 }
 
+namespace TypeWithValueStaticProperty
+{
+    class Test
+    {
+        void Basics()
+        {
+            _ = AClassWithStaticValueProperty.Value;                                // Compliant, not on nullable value type
+            _ = AClassWithStaticValueProperty.Value.Value;                          // Compliant
+            _ = AClassWithStaticValueProperty.Value.Value.InstanceProperty;         // Compliant
+            _ = AClassWithStaticValueProperty.Value.Value.InstanceProperty.Value;   // Compliant
+            _ = new AClassWithInstanceValueProperty().Value;                        // Compliant
+        }
+    }
+
+    class AClassWithStaticValueProperty
+    {
+        public AClassWithInstanceValueProperty InstanceProperty => new AClassWithInstanceValueProperty();
+
+        public static AClassWithInstanceValueProperty Value => new AClassWithInstanceValueProperty();
+    }
+
+    class AClassWithInstanceValueProperty
+    {
+        public AClassWithStaticValueProperty Value => new AClassWithStaticValueProperty();
+    }
+}
+
+namespace TypeWithValueStaticField
+{
+    class Test
+    {
+        void Basics()
+        {
+            _ = AClassWithStaticValueField.Value;                                // Compliant, not on nullable value type
+            _ = AClassWithStaticValueField.Value.Value;                          // Compliant
+            _ = AClassWithStaticValueField.Value.Value.InstanceField;            // Compliant
+            _ = AClassWithStaticValueField.Value.Value.InstanceField.Value;      // Compliant
+            _ = new AClassWithInstanceValueField().Value;                        // Compliant
+        }
+    }
+
+    class AClassWithStaticValueField
+    {
+        public AClassWithInstanceValueField InstanceField = new AClassWithInstanceValueField();
+
+        public static AClassWithInstanceValueField Value = new AClassWithInstanceValueField();
+    }
+
+    class AClassWithInstanceValueField
+    {
+        public AClassWithStaticValueField Value = new AClassWithStaticValueField();
+    }
+}


### PR DESCRIPTION
Part 6 of task 6 of https://github.com/SonarSource/sonar-dotnet/issues/6794

Previous task: https://github.com/SonarSource/sonar-dotnet/pull/6996

Fixes https://github.com/SonarSource/sonar-dotnet/issues/6794

Fixes  `NullReferenceException` issues encountered on peach, such as:
```
CSC : error AD0001: Analyzer 'SonarAnalyzer.Rules.CSharp.SymbolicExecutionRunner' threw an exception of type 'SonarAnalyzer.SymbolicExecution.SymbolicExecutionException' with message '
Error processing method: .ctor ## Method file: C:\Project\src\System.Private.ServiceModel\src\Internals\System\Runtime\IOThreadTimer.cs ## 
Method line: 55,8 ## Inner exception: System.NullReferenceException: Object reference not set to an instance of an object. ##    
at SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.EmptyNullableValueAccessBase.PreProcessSimple(SymbolicContext context) ##    
at SonarAnalyzer.SymbolicExecution.Roslyn.SymbolicCheck.PreProcess(SymbolicContext context) ##    
at SonarAnalyzer.SymbolicExecution.Roslyn.SymbolicCheckList.InvokeChecks(SymbolicContext context, Boolean preProcess) ##    
at SonarAnalyzer.SymbolicExecution.Roslyn.RoslynSymbolicExecution.ProcessOperation(ExplodedNode node)+MoveNext() ##    
at SonarAnalyzer.SymbolicExecution.Roslyn.RoslynSymbolicExecution.Execute() ##    
at SonarAnalyzer.Rules.SymbolicExecutionRunnerBase.AnalyzeRoslyn(SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext nodeContext, SyntaxNode body, ISymbol symbol)'. [C:\Project\src\System.Private.ServiceModel\src\System.Private.ServiceModel.csproj]
```
