### PR TITLE
S3655: "In" method params

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyNullableValueAccessTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/EmptyNullableValueAccessTest.cs
@@ -63,7 +63,7 @@ public class EmptyNullableValueAccessTest
 
     [TestMethod]
     public void EmptyNullableValueAccess_Roslyn_NullableContext() =>
-        roslynCS.AddPaths("EmptyNullableValueAccess.NullableContext.cs").WithOptions(ParseOptionsHelper.FromCSharp8).WithConcurrentAnalysis(false).Verify();
+        roslynCS.AddPaths("EmptyNullableValueAccess.NullableContext.cs").WithOptions(ParseOptionsHelper.FromCSharp8).Verify();
 
     [DataTestMethod]
     [DataRow(ProjectType.Product)]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.NullableContext.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.NullableContext.cs
@@ -1,4 +1,5 @@
-﻿#nullable enable
+﻿
+#nullable enable
 
 using System;
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -767,6 +767,13 @@ class InParams
         _ = iParam.Value;       // Compliant, iParam is "in" and its value can't be modified
     }
 
+    void LocalAsInParamToAnotherMethod()
+    {
+        int? iLocal = null;
+        MethodWithReadInParam(in iLocal);
+        _ = iLocal.Value;       // Noncompliant, arg is "in" and its value must still be null here
+    }
+
     static void MethodWithReadInParam(in int? i) { }
 }
 
@@ -1028,24 +1035,27 @@ namespace TypeWithStaticPropertyCalledValue
     {
         void Basics()
         {
-            _ = ClassWithStaticPropertyCalledValue.Value;                                // Compliant, not on nullable value type
-            _ = ClassWithStaticPropertyCalledValue.Value.Value;                          // Compliant
-            _ = ClassWithStaticPropertyCalledValue.Value.Value.InstanceProperty;         // Compliant
-            _ = ClassWithStaticPropertyCalledValue.Value.Value.InstanceProperty.Value;   // Compliant
-            _ = new ClassWithInstancePropertyCalledValue().Value;                        // Compliant
+            // Ensures rule doesn't raise NRE on custom property called Value having no instance (static)
+            _ = StaticValue.Value;                                // Compliant, not on nullable value type
+
+            // Ensures rule doesn't raise NRE on nested Value property
+            _ = StaticValue.Value.Value;                          // Compliant
+            _ = StaticValue.Value.Value.InstanceProperty;         // Compliant
+            _ = StaticValue.Value.Value.InstanceProperty.Value;   // Compliant
+            _ = new InstanceValue().Value;                        // Compliant
         }
     }
 
-    class ClassWithStaticPropertyCalledValue
+    class StaticValue
     {
-        public ClassWithInstancePropertyCalledValue InstanceProperty => null;
+        public InstanceValue InstanceProperty => null;
 
-        public static ClassWithInstancePropertyCalledValue Value => null;
+        public static InstanceValue Value => null;
     }
 
-    class ClassWithInstancePropertyCalledValue
+    class InstanceValue
     {
-        public ClassWithStaticPropertyCalledValue Value => null;
+        public StaticValue Value => null;
     }
 }
 
@@ -1055,23 +1065,26 @@ namespace TypeWithStaticFieldCalledValue
     {
         void Basics()
         {
-            _ = ClassWithStaticFieldCalledValue.Value;                            // Compliant, not on nullable value type
-            _ = ClassWithStaticFieldCalledValue.Value.Value;                      // Compliant
-            _ = ClassWithStaticFieldCalledValue.Value.Value.InstanceField;        // Compliant
-            _ = ClassWithStaticFieldCalledValue.Value.Value.InstanceField.Value;  // Compliant
-            _ = new ClassWithInstanceFieldCalledValue().Value;                    // Compliant
+            // Ensures rule doesn't raise NRE on custom field called Value having no instance (static)
+            _ = StaticValue.Value;                            // Compliant, not on nullable value type
+
+            // Ensures rule doesn't raise NRE on nested Value field
+            _ = StaticValue.Value.Value;                      // Compliant
+            _ = StaticValue.Value.Value.InstanceField;        // Compliant
+            _ = StaticValue.Value.Value.InstanceField.Value;  // Compliant
+            _ = new InstanceValue().Value;                    // Compliant
         }
     }
 
-    class ClassWithStaticFieldCalledValue
+    class StaticValue
     {
-        public ClassWithInstanceFieldCalledValue InstanceField = null;
+        public InstanceValue InstanceField = null;
 
-        public static ClassWithInstanceFieldCalledValue Value = null;
+        public static InstanceValue Value = null;
     }
 
-    class ClassWithInstanceFieldCalledValue
+    class InstanceValue
     {
-        public ClassWithStaticFieldCalledValue Value = null;
+        public StaticValue Value = null;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -739,19 +739,6 @@ class OutAndRefParams
 
 class InParams
 {
-    void InParamOfALocalFunction(int? iParam)
-    {
-        iParam = null;
-        LocalFunctionWithReadInParam(iParam);
-        _ = iParam.Value;       // Noncompliant, empty
-
-        iParam = 42;
-        LocalFunctionWithReadInParam(iParam);
-        _ = iParam.Value;       // Compliant, non-empty
-
-        static void LocalFunctionWithReadInParam(in int? i) { }
-    }
-
     void InParamOfTheMethodItself(in int? iParam)
     {
         _ = iParam.Value;       // Compliant, unknown
@@ -762,19 +749,26 @@ class InParams
     void InParamOfAnotherMethod(in int? iParam)
     {
         _ = iParam.Value;       // Compliant, unknown
-
-        MethodWithReadInParam(iParam);
+        InParam(in iParam);
         _ = iParam.Value;       // Compliant, iParam is "in" and its value can't be modified
     }
 
-    void LocalAsInParamToAnotherMethod()
+    void InParamToAnotherMethod(int? iParam)
     {
         int? iLocal = null;
-        MethodWithReadInParam(in iLocal);
+        InParam(in iLocal);
         _ = iLocal.Value;       // Noncompliant, arg is "in" and its value must still be null here
+
+        iParam = null;
+        InParam(in iParam);
+        _ = iParam.Value;       // Noncompliant, empty
+
+        iParam = 42;
+        InParam(in iParam);
+        _ = iParam.Value;       // Compliant, non-empty
     }
 
-    static void MethodWithReadInParam(in int? i) { }
+    static void InParam(in int? i) { }
 }
 
 class MutableField

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -737,6 +737,39 @@ class OutAndRefParams
     }
 }
 
+class InParams
+{
+    void InParamOfALocalFunction(int? iParam)
+    {
+        iParam = null;
+        LocalFunctionWithReadInParam(iParam);
+        _ = iParam.Value;       // Noncompliant, empty
+
+        iParam = 42;
+        LocalFunctionWithReadInParam(iParam);
+        _ = iParam.Value;       // Compliant, non-empty
+
+        static void LocalFunctionWithReadInParam(in int? i) { }
+    }
+
+    void InParamOfTheMethodItself(in int? iParam)
+    {
+        _ = iParam.Value;       // Compliant, unknown
+        iParam = null;          // Error, CS8331
+        _ = iParam.Value;       // Compliant, iParam is "in" and its value can't be modified
+    }
+
+    void InParamOfAnotherMethod(in int? iParam)
+    {
+        _ = iParam.Value;       // Compliant, unknown
+
+        MethodWithReadInParam(iParam);
+        _ = iParam.Value;       // Compliant, iParam is "in" and its value can't be modified
+    }
+
+    static void MethodWithReadInParam(in int? i) { }
+}
+
 class MutableField
 {
     int? theField;
@@ -781,9 +814,6 @@ class MutableField
         theField = 42;
         MethodNotChangingTheField();
         _ = theField.Value;          // Compliant, unknown
-
-        void LocalFunctionChangingTheField() => theField = null;
-        void LocalFunctionNotChangingTheField() { }
     }
 
     void MethodChangingTheField() => theField = null;


### PR DESCRIPTION
Part 7 of task 6 of https://github.com/SonarSource/sonar-dotnet/issues/6794

Previous task: https://github.com/SonarSource/sonar-dotnet/pull/7000

Addresses:
- comments received on https://github.com/SonarSource/sonar-dotnet/pull/6996 on commits already merged into `feature/SE`, reviewed twice due to a change of base branch as explained [here](https://github.com/SonarSource/sonar-dotnet/pull/6996#discussion_r1151472642);
- comment received offline on https://github.com/SonarSource/sonar-dotnet/pull/6962#discussion_r1149128723: `The idea was to assert all (again) is to be sure that the pairing (left vs. right) doesn't go out of sync. That would ensure that it works, and that it works for a good reason. In theory, the pairing could go out of sync somewhere and it could end up as a green test by coincidence.`