### PR TITLE
Removing unused security plugin from Java ITs

### DIFF
--- a/its/src/test/java/com/sonar/it/csharp/Tests.java
+++ b/its/src/test/java/com/sonar/it/csharp/Tests.java
@@ -86,7 +86,6 @@ public class Tests {
     .restoreProfileAtStartup(FileLocation.of("profiles/template_rule.xml"))
     .restoreProfileAtStartup(FileLocation.of("profiles/custom_parameters.xml"))
     .restoreProfileAtStartup(FileLocation.of("profiles/custom_complexity.xml"))
-    .addPlugin(MavenLocation.of("com.sonarsource.security", "sonar-security-plugin", "7.3.0.1282"))
     .activateLicense()
     .build();
 


### PR DESCRIPTION
The security plugin version 7.3.0.1282 was added to Java ITs with #1930 for the UCFGDeserializationTest class. 
We don't have this test anymore since the security-frontend was moved outside of this repo.