### PR TITLE
S3655: Honor null forgiving operator

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyNullableValueAccessBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyNullableValueAccessBase.cs
@@ -35,7 +35,7 @@ public abstract class EmptyNullableValueAccessBase : SymbolicRuleCheck
             && reference.Instance is { } instance
             && instance.Type.IsNullableValueType()
             && context.HasConstraint(instance, ObjectConstraint.Null)
-            && NoNullForgiving(reference.Instance))
+            && NotNullFlowState(reference.Instance))
         {
             ReportIssue(instance, instance.Syntax.ToString());
         }
@@ -44,14 +44,14 @@ public abstract class EmptyNullableValueAccessBase : SymbolicRuleCheck
             && conversion.Operand.Type.IsNullableValueType()
             && conversion.Type.IsNonNullableValueType()
             && context.HasConstraint(conversion.Operand, ObjectConstraint.Null)
-            && NoNullForgiving(conversion.Operand))
+            && NotNullFlowState(conversion.Operand))
         {
             ReportIssue(conversion.Operand, conversion.Operand.Syntax.ToString());
         }
 
         return context.State;
 
-        bool NoNullForgiving(IOperation reference) =>
+        bool NotNullFlowState(IOperation reference) =>
             SemanticModel.GetTypeInfo(reference.Syntax).Nullability().FlowState != NullableFlowState.NotNull;
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyNullableValueAccessBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyNullableValueAccessBase.cs
@@ -35,7 +35,7 @@ public abstract class EmptyNullableValueAccessBase : SymbolicRuleCheck
             && reference.Instance is { } instance
             && instance.Type.IsNullableValueType()
             && context.HasConstraint(instance, ObjectConstraint.Null)
-            && NotNullFlowState(reference.Instance))
+            && FlowState(reference.Instance) != NullableFlowState.NotNull)
         {
             ReportIssue(instance, instance.Syntax.ToString());
         }
@@ -44,14 +44,14 @@ public abstract class EmptyNullableValueAccessBase : SymbolicRuleCheck
             && conversion.Operand.Type.IsNullableValueType()
             && conversion.Type.IsNonNullableValueType()
             && context.HasConstraint(conversion.Operand, ObjectConstraint.Null)
-            && NotNullFlowState(conversion.Operand))
+            && FlowState(conversion.Operand) != NullableFlowState.NotNull)
         {
             ReportIssue(conversion.Operand, conversion.Operand.Syntax.ToString());
         }
 
         return context.State;
 
-        bool NotNullFlowState(IOperation reference) =>
-            SemanticModel.GetTypeInfo(reference.Syntax).Nullability().FlowState != NullableFlowState.NotNull;
+        NullableFlowState FlowState(IOperation reference) =>
+            SemanticModel.GetTypeInfo(reference.Syntax).Nullability().FlowState;
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyNullableValueAccessBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyNullableValueAccessBase.cs
@@ -34,7 +34,8 @@ public abstract class EmptyNullableValueAccessBase : SymbolicRuleCheck
             && reference.Property.Name == nameof(Nullable<int>.Value)
             && reference.Instance is { } instance
             && instance.Type.IsNullableValueType()
-            && context.HasConstraint(instance, ObjectConstraint.Null))
+            && context.HasConstraint(instance, ObjectConstraint.Null)
+            && NoNullForgiving(reference.Instance))
         {
             ReportIssue(instance, instance.Syntax.ToString());
         }
@@ -42,11 +43,15 @@ public abstract class EmptyNullableValueAccessBase : SymbolicRuleCheck
             && operationInstance.ToConversion() is var conversion
             && conversion.Operand.Type.IsNullableValueType()
             && conversion.Type.IsNonNullableValueType()
-            && context.HasConstraint(conversion.Operand, ObjectConstraint.Null))
+            && context.HasConstraint(conversion.Operand, ObjectConstraint.Null)
+            && NoNullForgiving(conversion.Operand))
         {
             ReportIssue(conversion.Operand, conversion.Operand.Syntax.ToString());
         }
 
         return context.State;
+
+        bool NoNullForgiving(IOperation reference) =>
+            SemanticModel.GetTypeInfo(reference.Syntax).Nullability().FlowState != NullableFlowState.NotNull;
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.NullableContext.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.NullableContext.cs
@@ -7,42 +7,42 @@ class NullForgivingOperator
 {
     void Basics(int? i)
     {
-        _ = i!.Value;               // Compliant, unknown
+        _ = i!.Value;               // Compliant, user-asserted non-empty via bang
         i = SomeMethod();
-        _ = i!.Value;               // Compliant, unknown
+        _ = i!.Value;               // Compliant
 
         i = null;
-        _ = i!.Value;               // Noncompliant, empty
+        _ = i!.Value;               // Compliant
         i = new int?();
-        _ = i!.Value;               // Noncompliant, empty
+        _ = i!.Value;               // Compliant
         i = new Nullable<int>();
-        _ = i!.Value;               // Noncompliant, empty
+        _ = i!.Value;               // Compliant
 
         i = 42;
-        _ = i!.Value;               // Compliant, non-empty
+        _ = i!.Value;               // Compliant
     }
 
     void CastToValueType(int? i)
     {
-        _ = (int)i!;                // Compliant, unknown
+        _ = (int)i!;                // Compliant, user-asserted non-empty via bang
         i = SomeMethod();
-        _ = (int)i!;                // Compliant, unknown
+        _ = (int)i!;                // Compliant
 
         i = null;
-        _ = (int)i!;                // Noncompliant, empty
+        _ = (int)i!;                // Compliant
         i = new int?();
-        _ = (int)i!;                // Noncompliant, empty
+        _ = (int)i!;                // Compliant
         i = new Nullable<int>();
-        _ = (int)i!;                // Noncompliant, empty
+        _ = (int)i!;                // Compliant
     }
 
     void CastToNullableType(int? i)
     {
-        _ = ((int?)i)!.Value;       // Compliant, unknown
-        _ = (i as int?)!.Value;     // Compliant, unknown
+        _ = ((int?)i)!.Value;       // Compliant, user-asserted non-empty via bang
+        _ = (i as int?)!.Value;     // Compliant
 
-        _ = ((int?)null)!.Value;    // Noncompliant
-        _ = (null as int?)!.Value;  // Noncompliant
+        _ = ((int?)null)!.Value;    // Compliant
+        _ = (null as int?)!.Value;  // Compliant
     }
 
     static int? SomeMethod() => null;


### PR DESCRIPTION
Improves https://github.com/SonarSource/sonar-dotnet/issues/6794
Follows discussion had [here](https://github.com/SonarSource/sonar-dotnet/pull/6996#discussion_r1152789753).

When the user specifies the null forgiving operator on a value access of a `Nullable<T>` (e.g. `nullable!.Value`), no issue is raised by S3655, even when a path is found, in which `nullable` is `null`.

It also removes false positives encountered during peach validation for https://github.com/SonarSource/sonar-dotnet/issues/6794, such as
```cs
Label? after = null;
if (info.Is64BitSwitch)
{
    after = _ilg.DefineLabel();
    // ...
}
// ...
if (info.Is64BitSwitch)
{
    _ilg.MarkLabel(after!.Value); // <- This should be compliant
}
``` 
source: `dotnet-runtime:src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs`