### PR TITLE
SE: Precision: Fix missing NotNull constraint in RoslynSymbolicExecution.SetBranchingConstraints

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
@@ -46,8 +46,11 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             programPointHash = ProgramPoint.Hash(block, index);
         }
 
-        public ExplodedNode CreateNext(ProgramState state) =>
-            new(Block, operations, index + 1, state, FinallyPoint);
+        public ExplodedNode CreateNext(ProgramState state)
+        {
+            state?.CheckStateConsistency();
+            return new(Block, operations, index + 1, state, FinallyPoint);
+        }
 
         public int AddVisit()
         {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
@@ -44,13 +44,11 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             this.operations = operations;
             this.index = index;
             programPointHash = ProgramPoint.Hash(block, index);
+            state.CheckConsistency();
         }
 
         public ExplodedNode CreateNext(ProgramState state)
-        {
-            state?.CheckConsistency();
-            return new(Block, operations, index + 1, state, FinallyPoint);
-        }
+            => new(Block, operations, index + 1, state, FinallyPoint);
 
         public int AddVisit()
         {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
 
         public ExplodedNode CreateNext(ProgramState state)
         {
-            state?.CheckStateConsistency();
+            state?.CheckConsistency();
             return new(Block, operations, index + 1, state, FinallyPoint);
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
 
         public ExplodedNode CreateNext(ProgramState state)
         {
-            state?.CheckStateConsistency();
+            //state?.CheckStateConsistency();
             return new(Block, operations, index + 1, state, FinallyPoint);
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
 
         public ExplodedNode CreateNext(ProgramState state)
         {
-            //state?.CheckStateConsistency();
+            state?.CheckStateConsistency();
             return new(Block, operations, index + 1, state, FinallyPoint);
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
@@ -47,8 +47,8 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             state.CheckConsistency();
         }
 
-        public ExplodedNode CreateNext(ProgramState state)
-            => new(Block, operations, index + 1, state, FinallyPoint);
+        public ExplodedNode CreateNext(ProgramState state) =>
+            new(Block, operations, index + 1, state, FinallyPoint);
 
         public int AddVisit()
         {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -217,15 +217,21 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         [ExcludeFromCodeCoverage]
         public void CheckConsistency()
         {
-            Debug.Assert(SymbolValue.Values.All(CheckConstraintAlsoHasNotNull<BoolConstraint>), "If a BoolConstraint is set for a symbol, NotNull should also be set.");
-            Debug.Assert(SymbolValue.Values.All(CheckConstraintAlsoHasNotNull<LockConstraint>), "If a LockConstraint is set for a symbol, NotNull should also be set.");
-            Debug.Assert(SymbolValue.Values.All(x => CheckOnlyConstraint(x, ObjectConstraint.Null)), "If Null is set for a symbol, no other constraint should be set.");
-            Debug.Assert(OperationValue.Values.All(CheckConstraintAlsoHasNotNull<BoolConstraint>), "If a BoolConstraint is set for a operation, NotNull should also be set.");
-            Debug.Assert(OperationValue.Values.All(CheckConstraintAlsoHasNotNull<LockConstraint>), "If a LockConstraint is set for a operation, NotNull should also be set.");
-            Debug.Assert(OperationValue.Values.All(x => CheckOnlyConstraint(x, ObjectConstraint.Null)), "If Null is set for a operation, no other constraint should be set.");
+            AssertCommonConditions(SymbolValue.Values);
+            AssertCommonConditions(OperationValue.Values);
 
-            static bool CheckConstraintAlsoHasNotNull<T>(SymbolicValue value) where T : SymbolicConstraint =>
-                !value.HasConstraint<T>() || value.HasConstraint(ObjectConstraint.NotNull);
+            static void AssertCommonConditions(IEnumerable<SymbolicValue> values)
+            {
+                foreach (var value in values)
+                {
+                    Debug.Assert(CheckConstraintAlsoHasNotNull<BoolConstraint>(value), "If a BoolConstraint is set, NotNull should also be set.");
+                    Debug.Assert(CheckConstraintAlsoHasNotNull<LockConstraint>(value), "If a LockConstraint is set, NotNull should also be set.");
+                    Debug.Assert(CheckOnlyConstraint(value, ObjectConstraint.Null), "If Null is set, no other constraint should be set.");
+                }
+            }
+
+            static bool CheckConstraintAlsoHasNotNull<T>(SymbolicValue value) where T : SymbolicConstraint
+                => !value.HasConstraint<T>() || value.HasConstraint(ObjectConstraint.NotNull);
 
             static bool CheckOnlyConstraint(SymbolicValue value, SymbolicConstraint single)
                 => !value.HasConstraint(single) || value.AllConstraints.Count() == 1;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 
@@ -213,7 +214,8 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         }
 
         [Conditional("DEBUG")]
-        public void CheckStateConsistency()
+        [ExcludeFromCodeCoverage]
+        public void CheckConsistency()
         {
             Debug.Assert(SymbolValue.Values.All(CheckConstraintAlsoHasNotNull<BoolConstraint>), "If a BoolConstraint is set for a symbol, NotNull should also be set.");
             Debug.Assert(SymbolValue.Values.All(CheckConstraintAlsoHasNotNull<LockConstraint>), "If a LockConstraint is set for a symbol, NotNull should also be set.");

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -126,11 +126,11 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
         public ProgramState RemoveSymbols(Func<ISymbol, bool> remove) =>
             this with { SymbolValue = SymbolValue.Where(kv => PreservedSymbols.Contains(kv.Key) || !remove(kv.Key)).ToImmutableDictionary() };
 
-        public ProgramState ResetFieldConstraints()
-            => ResetFieldConstraints(field => true);
+        public ProgramState ResetFieldConstraints() =>
+            ResetFieldConstraints(field => true);
 
-        public ProgramState ResetStaticFieldConstraints(INamedTypeSymbol containingType)
-            => ResetFieldConstraints(field => field.IsStatic && containingType.DerivesFrom(field.ContainingType));
+        public ProgramState ResetStaticFieldConstraints(INamedTypeSymbol containingType) =>
+            ResetFieldConstraints(field => field.IsStatic && containingType.DerivesFrom(field.ContainingType));
 
         public ProgramState AddVisit(int programPointHash) =>
             this with { VisitCount = VisitCount.SetItem(programPointHash, GetVisitCount(programPointHash) + 1) };
@@ -230,11 +230,11 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 }
             }
 
-            static bool CheckConstraintAlsoHasNotNull<T>(SymbolicValue value) where T : SymbolicConstraint
-                => !value.HasConstraint<T>() || value.HasConstraint(ObjectConstraint.NotNull);
+            static bool CheckConstraintAlsoHasNotNull<T>(SymbolicValue value) where T : SymbolicConstraint =>
+                !value.HasConstraint<T>() || value.HasConstraint(ObjectConstraint.NotNull);
 
-            static bool CheckOnlyConstraint(SymbolicValue value, SymbolicConstraint single)
-                => !value.HasConstraint(single) || value.AllConstraints.Count() == 1;
+            static bool CheckOnlyConstraint(SymbolicValue value, SymbolicConstraint single) =>
+                !value.HasConstraint(single) || value.AllConstraints.Count() == 1;
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -244,8 +244,8 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             var constraint = BoolConstraint.From((branch.Source.ConditionKind == ControlFlowConditionKind.WhenTrue) == branch.IsConditionalSuccessor);
             state = state.SetOperationConstraint(branchValue, ObjectConstraint.NotNull).SetOperationConstraint(branchValue, constraint);
             return branchValue.TrackedSymbol() is { } symbol
-                && symbol.GetSymbolType() is { } symbolType
-                && (symbolType.SpecialType is SpecialType.System_Boolean || symbolType.IsNullableBoolean())
+                && symbol.GetSymbolType() is { } type
+                && (type.SpecialType is SpecialType.System_Boolean || type.IsNullableBoolean())
                 ? state.SetSymbolConstraint(symbol, ObjectConstraint.NotNull).SetSymbolConstraint(symbol, constraint)
                 : state;
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -284,16 +284,18 @@ if (value = boolParameter)
             var validator = CreateIfElseEndValidatorVB("arg", OperationKind.Binary, "Integer");
             validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
             validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
-            validator.TagValues("End").Should().SatisfyRespectively(x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
+            validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
         }
 
-        [TestMethod]
-        public void Branching_LearnsObjectConstraint_NullableInteger_VB()
+        [DataTestMethod]
+        [DataRow("Integer?")]
+        [DataRow("Boolean?")]
+        public void Branching_LearnsObjectConstraint_Nullable_VB(string parameterType)
         {
-            var validator = CreateIfElseEndValidatorVB("arg", OperationKind.Binary, "Integer?");
+            var validator = CreateIfElseEndValidatorVB("arg", OperationKind.Binary, parameterType);
             validator.ValidateTag("If", x => x.Should().HaveNoConstraints("arg.GetValueOrDefault() is called in 'if arg' and arg is not found in RoslynSymbolicExecution.SetBranchingConstraints"));
             validator.ValidateTag("Else", x => x.Should().HaveNoConstraints());
-            validator.TagValues("End").Should().SatisfyRespectively(x => x.Should().HaveNoConstraints());
+            validator.ValidateTag("End", x => x.Should().HaveNoConstraints());
         }
 
         [DataTestMethod]
@@ -313,24 +315,6 @@ if (value = boolParameter)
             validator.ValidateTagOrder(branchValue, "End");
             validator.ValidateTag(branchValue, x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(expectedPath)));
             validator.TagValues("End").Should().SatisfyRespectively(x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(expectedPath)));
-        }
-
-        [TestMethod]
-        public void Branching_LearnsObjectConstraint_NullableBool_UnknownVB()
-        {
-            var validator = SETestContext.CreateVB($$"""
-                Dim b As Boolean? = Unknown(Of Boolean?)
-                if b Then
-                    Tag("True", b)
-                else
-                    Tag("False", b)
-                End if
-                Tag("End", b)
-                """).Validator;
-            validator.ValidateTagOrder("True", "False", "End");
-            validator.ValidateTag("True", x => x.Should().HaveNoConstraints("b.GetValueOrDefault() is called in 'if b' and b is not found in RoslynSymbolicExecution.SetBranchingConstraints"));
-            validator.ValidateTag("False", x => x.Should().HaveNoConstraints());
-            validator.TagValues("End").Should().SatisfyRespectively(x => x.Should().HaveNoConstraints());
         }
 
         [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/SETestContext.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/SETestContext.cs
@@ -89,7 +89,6 @@ Public Class Sample
     End Sub
 
     Private Shared Function Unknown(Of T)() As T
-        Return Nothing
     End Function
 
 End Class";

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/SETestContext.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/SETestContext.cs
@@ -88,6 +88,10 @@ Public Class Sample
     Private Shared Sub Tag(Name As String, Optional Arg As Object = Nothing)
     End Sub
 
+    Private Shared Function Unknown(Of T)() As T
+        Return Nothing
+    End Function
+
 End Class";
             return new(code, AnalyzerLanguage.VisualBasic, additionalChecks);
         }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,7 +173,7 @@ stages:
 
       - powershell: |
           cd analyzers
-          & dotnet test -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverReport=coverage/coverage.xml
+          & dotnet test -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=coverage/coverage.xml
         displayName: '.Net UTs'
 
       - task: PublishPipelineArtifact@1


### PR DESCRIPTION
Part of #6105

Based on #7019

Fixes missing "NotNull" caused by  RoslynSymbolicExecution.SetBranchingConstraints