### PR TITLE
S3655: Null conditional operator, null coalescing assignment, value tuples

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -528,20 +528,20 @@ class NullCoaleascingAssignment
     {
         (int? first, int? second)? tuple = null;
         tuple ??= (42, 42);
-        _ = tuple.Value.first.Value;  // Noncompliant, FP: non-empty
-        _ = tuple.Value.second.Value; // Compliant, non-empty
+        _ = tuple.Value.first.Value;  // Noncompliant {{'tuple' is null on at least one execution path.}}, FP: tuple non-empty
+        _ = tuple.Value.second.Value; // Compliant, both tuple and tuple.Value.second non-empty
         tuple = null;
         tuple ??= (42, 42);
-        _ = tuple.Value.second.Value; // Noncompliant, FP: non-empty
-        _ = tuple.Value.first.Value;  // Compliant, non-empty
+        _ = tuple.Value.second.Value; // Noncompliant {{'tuple' is null on at least one execution path.}}, FP: tuple non-empty
+        _ = tuple.Value.first.Value;  // Compliant, both tuple and tuple.Value.first non-empty
         tuple = null;
         tuple ??= (null, 42);
-        _ = tuple.Value.first.Value;  // Noncompliant, empty
-        _ = tuple.Value.second.Value; // Compliant, non-empty
+        _ = tuple.Value.first.Value;  // Noncompliant {{'tuple' is null on at least one execution path.}}, FP: tuple non-empty, FN: should report about first instead
+        _ = tuple.Value.second.Value; // Compliant, both tuple and tuple.Value.second non-empty
         tuple = null;
         tuple ??= (null, 42);
-        _ = tuple.Value.second.Value; // Noncompliant, FP: non-empty
-        _ = tuple.Value.first.Value;  // FN: empty
+        _ = tuple.Value.second.Value; // Noncompliant {{'tuple' is null on at least one execution path.}}, FP: tuple non-empty
+        _ = tuple.Value.first.Value;  // FN: tuple non-empty but tuple.Value.first empty
     }
 }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -444,6 +444,50 @@ class TernaryOperator
         true || ((b = null) == null) ? b.Value : false;                     // FN
 }
 
+class NullConditionalOperator
+{
+    void Basics(int? i)
+    {
+        _ = (i?.GetHashCode()).Value;                  // Noncompliant, ?. branches the state of i
+        i = Unknown();
+        _ = ((i?.GetHashCode())?.GetHashCode()).Value; // Noncompliant
+        i = Unknown();
+        _ = (i?.GetHashCode().GetHashCode()).Value;    // Noncompliant
+
+        int? Unknown() => null;
+    }
+
+    void WithFuncOfNullable(Func<int?> f)
+    {
+        _ = f().Value;                // Compliant, f unknown
+        f = Unknown();
+        _ = f.Invoke().Value;         // Compliant, f unknown
+        f = Unknown();
+        _ = f?.Invoke().Value;        // Compliant, Value never called when f is null
+        f = Unknown();
+        _ = (f?.Invoke()).Value;      // Noncompliant, ?. branches the state of f, and Value called on a null path
+        f = Unknown();
+        _ = (f?.Invoke()).ToString(); // Compliant, ?. branches the state of f, but Value never called anyway
+        f = Unknown();
+        _ = f?.Invoke()?.ToString();  // Compliant, ?. branches the state of f, but Value never called anyway
+
+        Func<int?> Unknown() => null;
+    }
+
+    void WithFuncOfFuncOfNullable(Func<Func<int?>> f)
+    {
+        _ = f()().Value;               // Compliant, f unknown
+        f = Unknown();
+        _ = f?.Invoke()().Value;       // Compliant, Value never called when f is null
+        f = Unknown();
+        _ = (f?.Invoke()()).Value;     // Noncompliant, ?. branches the state of f
+        f = Unknown();
+        _ = (f?.Invoke())().Value;     // Noncompliant, ?. branches the state of f
+
+        Func<Func<int?>> Unknown() => null;
+    }
+}
+
 class Linq
 {
     private IEnumerable<TestClass> Numbers = new[]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -442,6 +442,7 @@ class NullConditionalOperator
 {
     void Basics(int? i)
     {
+        i = Unknown();
         _ = (i?.GetHashCode()).Value;                  // Noncompliant, ?. branches the state of i
         i = Unknown();
         _ = ((i?.GetHashCode())?.GetHashCode()).Value; // Noncompliant
@@ -453,6 +454,7 @@ class NullConditionalOperator
 
     void WithFuncOfNullable(Func<int?> f)
     {
+        f = Unknown();
         _ = f().Value;                // Compliant, f unknown
         f = Unknown();
         _ = f.Invoke().Value;         // Compliant, f unknown
@@ -470,6 +472,7 @@ class NullConditionalOperator
 
     void WithFuncOfFuncOfNullable(Func<Func<int?>> f)
     {
+        f = Unknown();
         _ = f()().Value;               // Compliant, f unknown
         f = Unknown();
         _ = f?.Invoke()().Value;       // Compliant, Value never called when f is null
@@ -486,6 +489,7 @@ class ValueTuple
 {
     void MembersAccess((int? first, int? second)? tuple, int? i)
     {
+        tuple = Unknown();
         _ = tuple.Value;              // Compliant, unknown
         tuple = Unknown();
         _ = tuple.Value.first.Value;  // Compliant, tuple unknown, then first unknown

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -141,12 +141,6 @@ class Basics
             return intOrNull.Value;                                       // FN - content of static local function is not inspected by SE
         }
     }
-
-    int NullCoalescingAssignment(int? param)
-    {
-        param ??= 42;
-        return param.Value;                                               // Compliant, value is always set
-    }
 }
 
 class AssignmentAndDeconstruction
@@ -454,7 +448,7 @@ class NullConditionalOperator
         i = Unknown();
         _ = (i?.GetHashCode().GetHashCode()).Value;    // Noncompliant
 
-        int? Unknown() => null;
+        static int? Unknown() => null;
     }
 
     void WithFuncOfNullable(Func<int?> f)
@@ -471,7 +465,7 @@ class NullConditionalOperator
         f = Unknown();
         _ = f?.Invoke()?.ToString();  // Compliant, ?. branches the state of f, but Value never called anyway
 
-        Func<int?> Unknown() => null;
+        static Func<int?> Unknown() => null;
     }
 
     void WithFuncOfFuncOfNullable(Func<Func<int?>> f)
@@ -482,9 +476,68 @@ class NullConditionalOperator
         f = Unknown();
         _ = (f?.Invoke()()).Value;     // Noncompliant, ?. branches the state of f
         f = Unknown();
-        _ = (f?.Invoke())().Value;     // Noncompliant, ?. branches the state of f
+        _ = (f?.Invoke())().Value;     // Compliant, ?. branches the state of f, but f.Invoke() is unknown
 
-        Func<Func<int?>> Unknown() => null;
+        static Func<Func<int?>> Unknown() => null;
+    }
+}
+
+class ValueTuple
+{
+    void MembersAccess((int? first, int? second)? tuple, int? i)
+    {
+        _ = tuple.Value;              // Compliant, unknown
+        tuple = Unknown();
+        _ = tuple.Value.first.Value;  // Compliant, tuple unknown, then first unknown
+        _ = tuple.Value.second.Value; // Compliant, tuple unknown, then second unknown
+        tuple = (null, i);
+        _ = tuple.Value;              // Compliant, non-empty
+        _ = tuple.Value.first.Value;  // FN, empty
+        _ = tuple.Value.second.Value; // Compliant, second still unknown
+        tuple = (i, null);
+        _ = tuple.Value;              // Compliant, non-empty
+        _ = tuple.Value.first.Value;  // Compliant, first still unknown
+        _ = tuple.Value.second.Value; // FN, empty
+
+        static (int? first, int? second)? Unknown() => null;
+    }
+}
+
+class NullCoaleascingAssignment
+{
+    void WithNullableOfInt(int? i1, int? i2, int? i3)
+    {
+        i1 ??= 42;
+        _ = i1.Value;  // Compliant, always non-empty
+        i1 = null;
+        i1 ??= null;
+        _ = i1.Value;  // Noncompliant, always empty
+        i1 = 42;
+        i1 ??= null;
+        _ = i1.Value;  // Compliant, always non-empty
+
+        i2 ??= i3;
+        _ = i2.Value;  // Compliant, both i2 and i3 are unknown
+    }
+
+    void WithNullableOfValueTuple()
+    {
+        (int? first, int? second)? tuple = null;
+        tuple ??= (42, 42);
+        _ = tuple.Value.first.Value;  // Noncompliant, FP: non-empty
+        _ = tuple.Value.second.Value; // Compliant, non-empty
+        tuple = null;
+        tuple ??= (42, 42);
+        _ = tuple.Value.second.Value; // Noncompliant, FP: non-empty
+        _ = tuple.Value.first.Value;  // Compliant, non-empty
+        tuple = null;
+        tuple ??= (null, 42);
+        _ = tuple.Value.first.Value;  // Noncompliant, empty
+        _ = tuple.Value.second.Value; // Compliant, non-empty
+        tuple = null;
+        tuple ??= (null, 42);
+        _ = tuple.Value.second.Value; // Noncompliant, FP: non-empty
+        _ = tuple.Value.first.Value;  // FN: empty
     }
 }
 


### PR DESCRIPTION
Improves https://github.com/SonarSource/sonar-dotnet/issues/6794

Documents scenarios found in peach validation for https://github.com/SonarSource/sonar-dotnet/issues/6794, such as
```cs
if ((Validation?.Invoke(options)).Value) 
if ((Validation?.Invoke(options, Dependency1, Dependency2)).Value)
...
```
source: `dotnet-runtime:src/libraries/Microsoft.Extensions.Options/src/ValidateOptions.cs`.

And also:
```cs
public async ValueTask HandleAsync(Server server, Player player)
{
    var block = await player.World.GetBlockAsync((int)player.Position.X, (int)player.HeadY, (int)player.Position.Z);
    switch (Action)
    {
        // ...
        case EAction.StartSprinting:
        if ((bool)(block?.IsFluid))
                player.Swimming = true;
        player.Sprinting = true;
        break;
        // ...
    }
    // ...
}
```
source: `obsidian:Obsidian/Net/Packets/Play/Serverbound/PlayerCommandPacket.cs`.

And also:
```cs
(DateTime from, DateTime to)? toLoad = null;
// ...
toLoad ??= (DateTime.MinValue, DateTime.MaxValue);
// ...
var reader = Database.DocumentsStorage.TimeSeriesStorage.GetReader(Context, item.DocumentId, timeSeriesName, toLoad.Value.from, toLoad.Value.to);
// ...
```
source: `ravendb:src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs`.
