### PR TITLE
S3655: Add non-compliance to ITs in intentional findings

### DIFF
--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/IntentionalFindings/S3655.cs
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/IntentionalFindings/S3655.cs
@@ -1,0 +1,19 @@
+﻿/*
+ * <Your-Product-Name>
+ * Copyright (c) <Year-From>-<Year-To> <Your-Company-Name>
+ *
+ * Please configure this header in your SonarCloud/SonarQube quality profile.
+ * You can also set it in SonarLint.xml additional file for SonarLint or standalone NuGet analyzer.
+ */
+
+namespace IntentionalFindings
+{
+    public class S3655
+    {
+        public void ValueAccessOnEmptyNullable()
+        {
+            int? i = null;
+            _ = i.Value; // Noncompliant (S3655) {{'i' is null on at least one execution path.}}
+        }
+    }
+}


### PR DESCRIPTION
Improves https://github.com/SonarSource/sonar-dotnet/issues/6794

S3655 is never triggered in any integration test.
This PR introduces a non-compliance into the `IntentionalFindings` project of `analyzers\its\sources\ManuallyAddedNoncompliantIssues.CS`, to ensure that the rule is triggered when executing integration tests.
