### PR TITLE
S3655: Document comparisons

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -337,21 +337,7 @@ class Comparisons
 
         i = null;
         if (i < 0) _ = i.Value;        // Noncompliant, FP: negative, therefore non-empty
-
-        i = Unknown();
-        if (i >= 0 || i < 0)
-            _ = i.Value;               // Compliant, non-empty
-        else
-            _ = i.Value;               // FN, empty
-
-        i = Unknown();
-        if (i < 0 || i == 0 || i > 0)
-            _ = i.Value;               // Compliant, non-empty
-        else
-            _ = i.Value;               // FN, empty
     }
-
-    static int? Unknown() => null;
 }
 
 class ComplexConditionsSingleNullable

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -341,12 +341,6 @@ class Comparisons
             _ = i.Value;                  // FN, empty
 
         i = Unknown();
-        if (i <= 0 || i > 0)
-            _ = i.Value;                  // Compliant, non-empty
-        else
-            _ = i.Value;                  // FN, empty
-
-        i = Unknown();
         if (i < 0 || i == 0 || i > 0)
             _ = i.Value;                  // Compliant, non-empty
         else

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -323,28 +323,32 @@ class Arithmetic
 
 class Comparisons
 {
+    void NullIsDifferentThanANumber(int? i)
+    {
+        i = null;
+        if (i == 42) _ = i.Value;           // Compliant, 42, therefore non-empty
+        if (i == 0 || i == 1) _ = i.Value;  // Compliant, 0 or 1, therefore non-empty
+    }
+
     void NullIsNeitherSmallerNorBiggerThanANumber(int? i)
     {
         i = null;
-        if (i > 0) _ = i.Value;           // Noncompliant, FP: positive, therefore non-empty
+        if (i > 0) _ = i.Value;        // Noncompliant, FP: positive, therefore non-empty
 
         i = null;
-        if (i < 0) _ = i.Value;           // Noncompliant, FP: negative, therefore non-empty
-
-        i = null;
-        if (i == 42) _ = i.Value;         // Compliant, 42, therefore non-empty
+        if (i < 0) _ = i.Value;        // Noncompliant, FP: negative, therefore non-empty
 
         i = Unknown();
         if (i >= 0 || i < 0)
-            _ = i.Value;                  // Compliant, non-empty
+            _ = i.Value;               // Compliant, non-empty
         else
-            _ = i.Value;                  // FN, empty
+            _ = i.Value;               // FN, empty
 
         i = Unknown();
         if (i < 0 || i == 0 || i > 0)
-            _ = i.Value;                  // Compliant, non-empty
+            _ = i.Value;               // Compliant, non-empty
         else
-            _ = i.Value;                  // FN, empty
+            _ = i.Value;               // FN, empty
     }
 
     static int? Unknown() => null;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -321,6 +321,41 @@ class Arithmetic
     int? MultiplicationAndAssignments2(int? i) => (i = null) * (i = 42) * i.Value; // Compliant
 }
 
+class Comparisons
+{
+    void NullIsNeitherSmallerNorBiggerThanANumber(int? i)
+    {
+        i = null;
+        if (i > 0) _ = i.Value;           // Noncompliant, FP: positive, therefore non-empty
+
+        i = null;
+        if (i < 0) _ = i.Value;           // Noncompliant, FP: negative, therefore non-empty
+
+        i = null;
+        if (i == 42) _ = i.Value;         // Compliant, 42, therefore non-empty
+
+        i = Unknown();
+        if (i >= 0 || i < 0)
+            _ = i.Value;                  // Compliant, non-empty
+        else
+            _ = i.Value;                  // FN, empty
+
+        i = Unknown();
+        if (i <= 0 || i > 0)
+            _ = i.Value;                  // Compliant, non-empty
+        else
+            _ = i.Value;                  // FN, empty
+
+        i = Unknown();
+        if (i < 0 || i == 0 || i > 0)
+            _ = i.Value;                  // Compliant, non-empty
+        else
+            _ = i.Value;                  // FN, empty
+    }
+
+    static int? Unknown() => null;
+}
+
 class ComplexConditionsSingleNullable
 {
     bool LogicalAndLearningNonNull1(bool? b) => b.HasValue && b.Value;


### PR DESCRIPTION
Improves https://github.com/SonarSource/sonar-dotnet/issues/6794

Documents scenarios found in peach validation for https://github.com/SonarSource/sonar-dotnet/issues/6794, such as
```cs
if (discountTypeId > 0)
{
    return result[discountTypeId.Value];
}
```
source: `smartstore:Libraries/SmartStore.Services/Discounts/DiscountService.cs`.

Actual support for lifted comparison operators on nullable will come with https://github.com/SonarSource/sonar-dotnet/pull/7034.