### PR TITLE
S1905: Use NullableAnnotation() to find differences in type annotations

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/ISymbolNullableExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/ISymbolNullableExtensions.cs
@@ -19,15 +19,55 @@ namespace StyleCop.Analyzers.Lightup
         private static readonly Func<IMethodSymbol, NullableAnnotation> MethodSymbolReturnAccessor =
             CreateSymbolNullableAnnotationAccessor<IMethodSymbol>("ReturnNullableAnnotation"); // TypeArgumentNullableAnnotations is not yet supported
 
+        /// <summary>
+        /// Nullable annotation associated with the type, or < see cref="NullableAnnotation.None" /> if there are none.
+        /// </summary>
         public static NullableAnnotation NullableAnnotation(this ITypeSymbol type) => TypeSymbolAccessor(type);
+
+        /// <summary>
+        /// Gets the top-level nullability of the parameter.
+        /// </summary>
         public static NullableAnnotation NullableAnnotation(this IParameterSymbol parameter) => ParameterSymbolAccessor(parameter);
+
+        /// <summary>
+        /// Gets the top-level nullability of this local variable.
+        /// </summary>
         public static NullableAnnotation NullableAnnotation(this ILocalSymbol local) => LocalSymbolAccessor(local);
+
+        /// <summary>
+        /// Gets the top-level nullability of this property.
+        /// </summary>
         public static NullableAnnotation NullableAnnotation(this IPropertySymbol property) => PropertySymbolAccessor(property);
+
+        /// <summary>
+        /// Gets the top-level nullability of this field.
+        /// </summary>
         public static NullableAnnotation NullableAnnotation(this IFieldSymbol field) => FieldSymbolAccessor(field);
+
+        /// <summary>
+        /// The top-level nullability of the event.
+        /// </summary>
         public static NullableAnnotation NullableAnnotation(this IEventSymbol eventSymbol) => EventSymbolAccessor(eventSymbol);
+
+        /// <summary>
+        /// Gets the top-level nullability of the elements stored in the array.
+        /// </summary>
         public static NullableAnnotation ElementNullableAnnotation(this IArrayTypeSymbol arrayType) => ArrayTypeSymbolElementAccessor(arrayType);
+
+        /// <summary>
+        /// If <see cref="ITypeParameterSymbol.HasReferenceTypeConstraint"/> is <see langword="true" />, returns the top-level nullability of the
+        /// class constraint that was specified for the type parameter. If there was no class constraint, this returns <see cref="NullableAnnotation.None"/>.
+        /// </summary>
         public static NullableAnnotation ReferenceTypeConstraintNullableAnnotation(this ITypeParameterSymbol eventSymbol) => TypeParameterSymbolReferenceTypeConstraintAccessor(eventSymbol);
+
+        /// <summary>
+        /// If this method can be applied to an object, returns the top-level nullability of the object it is applied to.
+        /// </summary>
         public static NullableAnnotation ReceiverNullableAnnotation(this IMethodSymbol method) => MethodSymbolReceiverAccessor(method);
+
+        /// <summary>
+        /// Gets the top-level nullability of the return type of the method.
+        /// </summary>
         public static NullableAnnotation ReturnNullableAnnotation(this IMethodSymbol method) => MethodSymbolReturnAccessor(method);
 
         private static Func<T, NullableAnnotation> CreateSymbolNullableAnnotationAccessor<T>(string propertyName = nameof(NullableAnnotation)) where T : ISymbol

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/ISymbolNullableExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/ISymbolNullableExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    public static class ISymbolNullableExtensions
+    {
+        private static readonly Func<ITypeSymbol, NullableAnnotation> TypeSymbolAccessor = CreateSymbolNullableAnnotationAccessor<ITypeSymbol>();
+        private static readonly Func<IArrayTypeSymbol, NullableAnnotation> ArrayTypeSymbolElementAccessor = CreateSymbolNullableAnnotationAccessor<IArrayTypeSymbol>("ElementNullableAnnotation");
+        private static readonly Func<IParameterSymbol, NullableAnnotation> ParameterSymbolAccessor = CreateSymbolNullableAnnotationAccessor<IParameterSymbol>();
+        private static readonly Func<ILocalSymbol, NullableAnnotation> LocalSymbolAccessor = CreateSymbolNullableAnnotationAccessor<ILocalSymbol>();
+        private static readonly Func<IPropertySymbol, NullableAnnotation> PropertySymbolAccessor = CreateSymbolNullableAnnotationAccessor<IPropertySymbol>();
+        private static readonly Func<IFieldSymbol, NullableAnnotation> FieldSymbolAccessor = CreateSymbolNullableAnnotationAccessor<IFieldSymbol>();
+        private static readonly Func<IEventSymbol, NullableAnnotation> EventSymbolAccessor = CreateSymbolNullableAnnotationAccessor<IEventSymbol>();
+        private static readonly Func<ITypeParameterSymbol, NullableAnnotation> TypeParameterSymbolReferenceTypeConstraintAccessor =
+            CreateSymbolNullableAnnotationAccessor<ITypeParameterSymbol>("ReferenceTypeConstraintNullableAnnotation"); // ConstraintNullableAnnotations is not yet supported
+        private static readonly Func<IMethodSymbol, NullableAnnotation> MethodSymbolReceiverAccessor =
+            CreateSymbolNullableAnnotationAccessor<IMethodSymbol>("ReceiverNullableAnnotation");
+        private static readonly Func<IMethodSymbol, NullableAnnotation> MethodSymbolReturnAccessor =
+            CreateSymbolNullableAnnotationAccessor<IMethodSymbol>("ReturnNullableAnnotation"); // TypeArgumentNullableAnnotations is not yet supported
+
+        public static NullableAnnotation NullableAnnotation(this ITypeSymbol type) => TypeSymbolAccessor(type);
+        public static NullableAnnotation NullableAnnotation(this IParameterSymbol parameter) => ParameterSymbolAccessor(parameter);
+        public static NullableAnnotation NullableAnnotation(this ILocalSymbol local) => LocalSymbolAccessor(local);
+        public static NullableAnnotation NullableAnnotation(this IPropertySymbol property) => PropertySymbolAccessor(property);
+        public static NullableAnnotation NullableAnnotation(this IFieldSymbol field) => FieldSymbolAccessor(field);
+        public static NullableAnnotation NullableAnnotation(this IEventSymbol eventSymbol) => EventSymbolAccessor(eventSymbol);
+        public static NullableAnnotation ElementNullableAnnotation(this IArrayTypeSymbol arrayType) => ArrayTypeSymbolElementAccessor(arrayType);
+        public static NullableAnnotation ReferenceTypeConstraintNullableAnnotation(this ITypeParameterSymbol eventSymbol) => TypeParameterSymbolReferenceTypeConstraintAccessor(eventSymbol);
+        public static NullableAnnotation ReceiverNullableAnnotation(this IMethodSymbol method) => MethodSymbolReceiverAccessor(method);
+        public static NullableAnnotation ReturnNullableAnnotation(this IMethodSymbol method) => MethodSymbolReturnAccessor(method);
+
+        private static Func<T, NullableAnnotation> CreateSymbolNullableAnnotationAccessor<T>(string propertyName = nameof(NullableAnnotation)) where T : ISymbol
+            => LightupHelpers.CreateSyntaxPropertyAccessor<T, NullableAnnotation>(typeof(T), propertyName);
+    }
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantCast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantCast.cs
@@ -96,9 +96,7 @@ public sealed class RedundantCast : SonarDiagnosticAnalyzer
                 }
 
                 var elementType = GetElementType(invocation, methodSymbol, context.SemanticModel);
-                // Generic types {T} and {T?} are equal and there is no way to access NullableAnnotation field right now
-                // See https://github.com/SonarSource/sonar-dotnet/issues/3273
-                if (elementType != null && elementType.Equals(castType) && string.Equals(elementType.ToString(), castType.ToString(), StringComparison.Ordinal))
+                if (elementType != null && elementType.Equals(castType) && elementType.NullableAnnotation() == castType.NullableAnnotation())
                 {
                     var methodCalledAsStatic = methodSymbol.MethodKind == MethodKind.Ordinary;
                     ReportIssue(context, invocation, returnType, GetReportLocation(invocation, methodCalledAsStatic));

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/TypeHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/TypeHelper.cs
@@ -22,9 +22,6 @@ namespace SonarAnalyzer.Helpers;
 
 internal static class TypeHelper
 {
-    private static readonly Func<ITypeSymbol, NullableAnnotation> NullableAnnotationAccessor =
-        LightupHelpers.CreateSyntaxPropertyAccessor<ITypeSymbol, NullableAnnotation>(typeof(ITypeSymbol), nameof(NullableAnnotation));
-
     #region TypeKind
 
     public static bool IsInterface(this ITypeSymbol self) =>
@@ -208,6 +205,4 @@ internal static class TypeHelper
             ITypeSymbol x => x,
             _ => null,
         };
-
-    public static NullableAnnotation NullableAnnotation(this ITypeSymbol type) => NullableAnnotationAccessor(type);
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/ISymbolNullableExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/ISymbolNullableExtensionsTest.cs
@@ -1,0 +1,117 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using StyleCop.Analyzers.Lightup;
+using NullableAnnotation = StyleCop.Analyzers.Lightup.NullableAnnotation;
+
+namespace SonarAnalyzer.UnitTest.Wrappers;
+
+[TestClass]
+public class ISymbolNullableExtensionsTest
+{
+    [DataTestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void NullableAnnotation_SimpleAnnitations(bool nullable)
+    {
+        var nullableAnnotation = nullable ? "?" : string.Empty;
+        var (tree, model) = TestHelper.CompileCS($$"""
+            #nullable enable
+            using System;
+            class C
+            {
+                object{{nullableAnnotation}} ObjectField;
+                object{{nullableAnnotation}}[] ArrayField;
+                object{{nullableAnnotation}} Property { get; set; }
+                event EventHandler{{nullableAnnotation}} MyEvent;
+
+                object{{nullableAnnotation}} Method(object{{nullableAnnotation}} parameter)
+                {
+                    object{{nullableAnnotation}} local;
+                    return null;
+                }
+            }
+            """);
+        var expected = nullable ? NullableAnnotation.Annotated : NullableAnnotation.NotAnnotated;
+
+        GetSymbol<IFieldSymbol>("ObjectField").NullableAnnotation().Should().Be(expected);
+        GetSymbol<IPropertySymbol>("Property").NullableAnnotation().Should().Be(expected);
+        GetSymbol<IEventSymbol>("MyEvent").NullableAnnotation().Should().Be(expected);
+        GetSymbol<IParameterSymbol>("parameter").NullableAnnotation().Should().Be(expected);
+        GetSymbol<ILocalSymbol>("local").NullableAnnotation().Should().Be(expected);
+        GetSymbol<IFieldSymbol>("ArrayField").Type.Should().BeAssignableTo<IArrayTypeSymbol>().Which.ElementNullableAnnotation().Should().Be(expected);
+        GetSymbol<IMethodSymbol>("Method").ReturnNullableAnnotation().Should().Be(expected);
+
+        T GetSymbol<T>(string name) where T : ISymbol
+        {
+            var node = tree.GetRoot().DescendantTokens().Single(x => x.ValueText == name).Parent;
+            node.Should().NotBeNull();
+            return model.GetDeclaredSymbol(node).Should().BeAssignableTo<T>().Which;
+        }
+    }
+
+    [DataTestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void NullableAnnotation_Receiver(bool nullable)
+    {
+        var nullableAnnotation = nullable ? "?" : string.Empty;
+        var (tree, model) = TestHelper.CompileCS($$"""
+        #nullable enable
+        using System;
+        static class C
+        {
+            static object ExtensionMethod(this object{{nullableAnnotation}} receiver)
+            {
+                return receiver.ExtensionMethod();
+            }
+        }
+        """);
+        var invocation = tree.GetRoot().DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>().First();
+        var symbol = model.GetSymbolInfo(invocation).Symbol.Should().BeAssignableTo<IMethodSymbol>().Which;
+
+        var expected = nullable ? NullableAnnotation.Annotated : NullableAnnotation.NotAnnotated;
+        symbol.ReceiverNullableAnnotation().Should().Be(expected);
+    }
+
+    [DataTestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void NullableAnnotation_ReferenceTypeConstrain(bool nullable)
+    {
+        var nullableAnnotation = nullable ? "?" : string.Empty;
+        var (tree, model) = TestHelper.CompileCS($$"""
+        #nullable enable
+        using System;
+        class C<T> where T: class
+        {
+            T{{nullableAnnotation}} field;
+        }
+        """);
+        var fieldDeclaration = tree.GetRoot().DescendantNodesAndSelf().OfType<FieldDeclarationSyntax>().First();
+        var symbol = model.GetDeclaredSymbol(fieldDeclaration.Declaration.Variables[0]).Should().BeAssignableTo<IFieldSymbol>().Which.Type.Should().BeAssignableTo<ITypeParameterSymbol>().Which;
+
+        var expected = nullable ? NullableAnnotation.Annotated : NullableAnnotation.NotAnnotated;
+        symbol.NullableAnnotation().Should().Be(expected);
+        symbol.ReferenceTypeConstraintNullableAnnotation().Should().Be(NullableAnnotation.NotAnnotated);
+
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/ISymbolNullableExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Wrappers/ISymbolNullableExtensionsTest.cs
@@ -112,6 +112,5 @@ public class ISymbolNullableExtensionsTest
         var expected = nullable ? NullableAnnotation.Annotated : NullableAnnotation.NotAnnotated;
         symbol.NullableAnnotation().Should().Be(expected);
         symbol.ReferenceTypeConstraintNullableAnnotation().Should().Be(NullableAnnotation.NotAnnotated);
-
     }
 }


### PR DESCRIPTION
Part of #6825

This PR lights up NullableAnnotation() for all symbols that support this property. It also adds the missing usage in RedundantCast that motivated #6825.

The PR was started by working on #5217 which was postponed until later.