### PR TITLE
SE: Use Nullable<int> instead of Lazy<int> for HashCode caching in old SE

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ExplodedGraphNode.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ExplodedGraphNode.cs
@@ -25,20 +25,12 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar
         public ProgramState ProgramState { get; }
         public ProgramPoint ProgramPoint { get; }
 
-        private readonly Lazy<int> hash;
+        private int? hash;
 
         public ExplodedGraphNode(ProgramPoint programPoint, ProgramState programState)
         {
             ProgramState = programState;
             ProgramPoint = programPoint;
-
-            this.hash = new Lazy<int>(() =>
-            {
-                var h = 19;
-                h = h * 31 + ProgramState.GetHashCode();
-                h = h * 31 + ProgramPoint.GetHashCode();
-                return h;
-            });
         }
 
         public override bool Equals(object obj)
@@ -62,6 +54,15 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar
             return ProgramState.Equals(other.ProgramState) && ProgramPoint.Equals(other.ProgramPoint);
         }
 
-        public override int GetHashCode() => this.hash.Value;
+        public override int GetHashCode() =>
+            hash ??= ComputeHash();
+
+        private int ComputeHash()
+        {
+            var h = 19;
+            h = h * 31 + ProgramState.GetHashCode();
+            h = h * 31 + ProgramPoint.GetHashCode();
+            return h;
+        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ProgramPoint.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ProgramPoint.cs
@@ -27,20 +27,12 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar
         public Block Block { get; }
         public int Offset { get; }
 
-        private readonly Lazy<int> hash;
+        private int? hash;
 
         internal ProgramPoint(Block block, int offset)
         {
             Block = block;
             Offset = offset;
-
-            this.hash = new Lazy<int>(() =>
-            {
-                var h = 19;
-                h = h * 31 + Block.GetHashCode();
-                h = h * 31 + Offset.GetHashCode();
-                return h;
-            });
         }
 
         internal ProgramPoint(Block block)
@@ -71,6 +63,15 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar
             return Block == other.Block && Offset == other.Offset;
         }
 
-        public override int GetHashCode() => this.hash.Value;
+        public override int GetHashCode() =>
+            hash ??= ComputeHash();
+
+        private int ComputeHash()
+        {
+            var h = 19;
+            h = h * 31 + Block.GetHashCode();
+            h = h * 31 + Offset.GetHashCode();
+            return h;
+        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ProgramState.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar
             SymbolicValue.Base
         };
 
-        private readonly Lazy<int> hash;
+        private int? hash;
 
         private int ComputeHash()
         {
@@ -256,7 +256,6 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar
             ProgramPointVisitCounts = programPointVisitCounts;
             ExpressionStack = expressionStack;
             Relationships = relationships;
-            this.hash = new Lazy<int>(ComputeHash);
         }
 
         public ProgramState PushValue(SymbolicValue symbolicValue)
@@ -431,7 +430,8 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar
                 Relationships.SetEquals(other.Relationships);
         }
 
-        public override int GetHashCode() => this.hash.Value;
+        public override int GetHashCode() =>
+            hash ??= ComputeHash();
 
         public ProgramState SetConstraint(SymbolicValue symbolicValue, SymbolicConstraint constraint)
         {


### PR DESCRIPTION
This PR touches the old SE engine in a low-effort, low-risk manner. It saves a lot of small object allocations:

![image](https://user-images.githubusercontent.com/103252490/229882696-23935b9b-fab5-4077-90f3-ec214a4bbd21.png)

`Lazy<int>`, `LazyHelper`, and `Func<int>` allocations are eliminated. This results in a total reduction of the allocated objects by 55.000 (total 700.000 ~8%).

The total bytes allocated are down to 37.537.986 from 39.939.178 (~6%).