### PR TITLE
S3655: RSPEC update and test fixes

### DIFF
--- a/analyzers/rspec/cs/S3655_c#.html
+++ b/analyzers/rspec/cs/S3655_c#.html
@@ -1,28 +1,32 @@
 <p>Nullable value types can hold either a value or <code>null</code>. The value held in the nullable type can be accessed with the <code>Value</code>
-property, but <code>.Value</code> throws an <code>InvalidOperationException</code> when the value is <code>null</code>. To avoid the exception, a
-nullable type should always be tested before <code>.Value</code> is accessed.</p>
+property or by casting it to the underlying type, but both operations throw an <code>InvalidOperationException</code> when the value is
+<code>null</code>. To avoid the exception, a nullable type should always be tested before the value is accessed.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
-int? nullable = null;
-...
-UseValue(nullable.Value); // Noncompliant
+public void Sample(bool condition)
+{
+    int? nullableValue = condition ? 42 : null;
+    Console.WriteLine(nullableValue.Value); // Noncompliant
+
+    int? nullableCast = condition ? 42 : null;
+    Console.WriteLine((int)nullableCast);   // Noncompliant
+}
 </pre>
 <h2>Compliant Solution</h2>
 <pre>
-int? nullable = null;
-...
-if (nullable.HasValue)
+public void Sample(bool condition)
 {
-  UseValue(nullable.Value);
-}
-</pre>
-<p>or</p>
-<pre>
-int? nullable = null;
-...
-if (nullable != null)
-{
-  UseValue(nullable.Value);
+    int? nullableValue = condition ? 42 : null;
+    if (nullableValue.HasValue)
+    {
+      Console.WriteLine(nullableValue.Value);
+    }
+
+    int? nullableCast = condition ? 42 : null;
+    if (nullableCast is not null)
+    {
+      Console.WriteLine((int)nullableCast);
+    }
 }
 </pre>
 <h2>See</h2>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -159,16 +159,20 @@ class AssignmentAndDeconstruction
 
     void SecondLevel()
     {
-        (_, (int? i1, int? i2)) = (42, (42, null));
+        (int? i1, (int? i2, int? i3)) = (42, (42, null));
         _ = i1.Value;       // Compliant
-        _ = i2.Value;       // FN
+        _ = i2.Value;       // Compliant
+        _ = i3.Value;       // FN
     }
 
     void ThirdLevel()
     {
-        (_, (_, (int? i1, int? i2), _)) = (42, (42, (42, null), 42));
+        (int? i1, (int? i2, (int? i3, int? i4), int? i5)) = (42, (42, (42, null), 42));
         _ = i1.Value;       // Compliant
-        _ = i2.Value;       // FN
+        _ = i2.Value;       // Compliant
+        _ = i3.Value;       // Compliant
+        _ = i4.Value;       // FN
+        _ = i5.Value;       // Compliant
     }
 
     void WithDiscard()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.vb
@@ -10,7 +10,7 @@ Class Basics
             Console.WriteLine(i.Value)
         End If
         Console.WriteLine(i.Value)  ' Noncompliant {{'i' is Nothing on at least one execution path.}}
-        '                 ~
+        '                 ^
     End Sub
 
     Sub DereferenceOnValueResult(i As Integer?)


### PR DESCRIPTION
Improves https://github.com/SonarSource/sonar-dotnet/issues/6794
- RSPEC update, incorporating changes in https://github.com/SonarSource/rspec/pull/1620
- Fix squiggle detection in VB tests
- Improvement mentioned in https://github.com/SonarSource/sonar-dotnet/pull/7006 but forgotten in its implementation: `comment received offline on https://github.com/SonarSource/sonar-dotnet/pull/6962#discussion_r1149128723: The idea was to assert all (again) is to be sure that the pairing (left vs. right) doesn't go out of sync. That would ensure that it works, and that it works for a good reason. In theory, the pairing could go out of sync somewhere and it could end up as a green test by coincidence.` 