### PR TITLE
SE: Fix test case IsNull_CoalesceAssignment_UnknownToNotNull

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.IsNull.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.IsNull.cs
@@ -224,11 +224,9 @@ Tag(""Arg"", arg);";
             validator.ValidateContainsOperation(OperationKind.IsNull);
             var arg = validator.Symbol("arg");
             var notNullValue = validator.Symbol("notNullValue");
-            validator.TagStates("End").Should().SatisfyRespectively(x =>
-            {
-                x[arg].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
-                x[notNullValue].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
-            });
+            var state = validator.TagStates("End").Should().ContainSingle().Which;
+            state[arg].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+            state[notNullValue].Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes misleading test case found here https://github.com/SonarSource/sonar-dotnet/pull/7023#discussion_r1158442446

The root cause was that `notNullValue` was not kept because `PreserveTestCheck` was missing.