### PR TITLE
SE: Learn NotNull on relational operator on nullable value types

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
@@ -48,9 +48,9 @@ internal sealed class Binary : BranchingProcessor<IBinaryOperationWrapper>
         where T : SymbolicConstraint
     {
         var useOpposite = falseBranch ^ binary.OperatorKind.IsNotEquals();
-        // We can take the 1st constraint and "testedSymbol" because they are exclusive. Symbols with T constraint will be recognized as the constraining side.
-        if (FirstBinaryOperandConstraint<T>(state, binary) is { } constraint
-            && FirstBinaryOperandSymbolWithoutConstraint<T>(state, binary) is { } testedSymbol
+        // We can take left or right constraint and "testedSymbol" because they are exclusive. Symbols with T constraint will be recognized as the constraining side.
+        if (BinaryOperandConstraint<T>(state, binary) is { } constraint
+            && BinaryOperandSymbolWithoutConstraint<T>(state, binary) is { } testedSymbol
             && !(useOpposite && constraint is BoolConstraint && testedSymbol.GetSymbolType().IsNullableBoolean()))  // Don't learn False for "nullableBool != true", because it could also be <null>.
         {
             constraint = constraint.ApplyOpposite(useOpposite);     // Beware that opposite of ObjectConstraint.NotNull doesn't exist and returns <null>
@@ -62,27 +62,27 @@ internal sealed class Binary : BranchingProcessor<IBinaryOperationWrapper>
         }
     }
 
-    // We can take the 1st constraint and "testedSymbol" because they are exclusive. Symbols with NotNull constraint will be recognized as the constraining side.
+    // We can take the left or right constraint and "testedSymbol" because they are exclusive. Symbols with NotNull constraint will be recognized as the constraining side.
     // We only learn in the true branch because not being >, >=, <, <= than a non-empty nullable means either being null or non-null with non-matching value.
     private static ProgramState LearnBranchingRelationalConstraint(ProgramState state, IBinaryOperationWrapper binary, bool falseBranch) =>
         !falseBranch
-        && FirstBinaryOperandConstraint<ObjectConstraint>(state, binary) == ObjectConstraint.NotNull
-        && FirstBinaryOperandSymbolWithoutConstraint<ObjectConstraint>(state, binary) is { } testedSymbol
+        && BinaryOperandConstraint<ObjectConstraint>(state, binary) == ObjectConstraint.NotNull
+        && BinaryOperandSymbolWithoutConstraint<ObjectConstraint>(state, binary) is { } testedSymbol
         && testedSymbol.GetSymbolType().IsNullableValueType()
             ? state.SetSymbolConstraint(testedSymbol, ObjectConstraint.NotNull)
             : null;
 
-    private static SymbolicConstraint FirstBinaryOperandConstraint<T>(ProgramState state, IBinaryOperationWrapper binary) where T : SymbolicConstraint =>
-        OperandConstraint<T>(state, binary.LeftOperand) ?? OperandConstraint<T>(state, binary.RightOperand);
+    private static SymbolicConstraint BinaryOperandConstraint<T>(ProgramState state, IBinaryOperationWrapper binary) where T : SymbolicConstraint =>
+        state[binary.LeftOperand]?.Constraint<T>() ?? state[binary.RightOperand]?.Constraint<T>();
 
-    private static ISymbol FirstBinaryOperandSymbolWithoutConstraint<T>(ProgramState state, IBinaryOperationWrapper binary) where T : SymbolicConstraint =>
+    private static ISymbol BinaryOperandSymbolWithoutConstraint<T>(ProgramState state, IBinaryOperationWrapper binary) where T : SymbolicConstraint =>
         OperandSymbolWithoutConstraint<T>(state, binary.LeftOperand) ?? OperandSymbolWithoutConstraint<T>(state, binary.RightOperand);
 
     private static ISymbol OperandSymbolWithoutConstraint<T>(ProgramState state, IOperation candidate) where T : SymbolicConstraint =>
-        candidate.TrackedSymbol() is { } symbol && (state[symbol] is null || !state[symbol].HasConstraint<T>()) ? symbol : null;
-
-    private static SymbolicConstraint OperandConstraint<T>(ProgramState state, IOperation candidate) where T : SymbolicConstraint =>
-        state[candidate] is { } value && value.HasConstraint<T>() ? value.Constraint<T>() : null;
+        candidate.TrackedSymbol() is { } symbol
+        && (state[symbol] is null || !state[symbol].HasConstraint<T>())
+            ? symbol
+            : null;
 
     private static SymbolicConstraint BinaryConstraint(BinaryOperatorKind kind, SymbolicValue left, SymbolicValue right)
     {


### PR DESCRIPTION
Related to https://github.com/SonarSource/sonar-dotnet/pull/7034: improve learning in branching on relational operators.

Extend the SE to learn `ObjectConstraint.NotNull`:
- on the true branch only
- when a relational operator (>=, >, <=, <) is used between an operand with a defined `ObjectConstraint` (which has to be `ObjectConstraint.NotNull`, otherwise the branching would have not happened at all, due to https://github.com/SonarSource/sonar-dotnet/pull/7054) and a symbol of a nullable value type.

~Draft because it targets https://github.com/SonarSource/sonar-dotnet/pull/7054, and has to be merged after that PR.~
