### PR TITLE
SE: Optimize SymbolicCheckList.InvokeChecks

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicCheckList.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicCheckList.cs
@@ -59,17 +59,18 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             }
         }
 
-        public SymbolicContext[] PreProcess(SymbolicContext context) =>
+        public IReadOnlyCollection<SymbolicContext> PreProcess(SymbolicContext context) =>
             InvokeChecks(context, preProcess: true);
 
-        public SymbolicContext[] PostProcess(SymbolicContext context) =>
+        public IReadOnlyCollection<SymbolicContext> PostProcess(SymbolicContext context) =>
             InvokeChecks(context, preProcess: false);
 
-        private SymbolicContext[] InvokeChecks(SymbolicContext context, bool preProcess)
+        private IReadOnlyCollection<SymbolicContext> InvokeChecks(SymbolicContext context, bool preProcess)
         {
             // Performance: Hotpath. Don't do changes here without profiling allocation impact.
-            var before = new List<SymbolicContext> { context };
-            var after = new List<SymbolicContext>();
+            const int listcapacity = 2;
+            var before = new List<SymbolicContext>(listcapacity) { context };
+            var after = new List<SymbolicContext>(listcapacity);
             foreach (var check in checks)
             {
                 foreach (var beforeContext in before)
@@ -83,7 +84,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
                 after = Interlocked.Exchange(ref before, after);
                 after.Clear();
             }
-            return before.ToArray();
+            return before;
         }
     }
 }


### PR DESCRIPTION
Part of #6964 

This is a more simple but also less efficient optimization than #7059. #7059 should be preferred as it allows to simplify the engine as well.

Simple refactoring which results in some modest reduction in allocations for `SonarAnalyzer.SymbolicExecution.Roslyn.SymbolicContext[]`. There were some unnecessary array copies taking place because of the `ToArray` call. The capacity is optimized for the common cases now.

The changes for `SonarAnalyzer.SymbolicExecution.Roslyn.SymbolicContext[]` are:

Measure | Before | After
--- |---| ---
No of objects | 17.842 | 12.514
Allocated bytes | 822.584  | 484.528

The change does not have a measurable impact in total (~1% improvement).