### PR TITLE
SE: Turn off State.CheckConsistency

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -213,7 +213,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             return state;
         }
 
-        [Conditional("DEBUG - TurnedOff")]
+        [Conditional("DEBUG_TurnedOff")]
         [ExcludeFromCodeCoverage]
         public void CheckConsistency()
         {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -213,7 +213,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             return state;
         }
 
-        [Conditional("DEBUG")]
+        [Conditional("DEBUG - TurnedOff")]
         [ExcludeFromCodeCoverage]
         public void CheckConsistency()
         {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -213,7 +213,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn
             return state;
         }
 
-        [Conditional("DEBUG_TurnedOff")]
+        [Conditional("DEBUG_TurnedOff")] // Turned off until all consistency check violations are fixed.
         [ExcludeFromCodeCoverage]
         public void CheckConsistency()
         {


### PR DESCRIPTION
As the print is going to be closed, we need to turn off the consistency check for the time being. Once we start working on #7025 again, we can re-enable it.