### PR TITLE
Update parent POM to 66.0.234

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>65.0.218</version>
+    <version>66.0.234</version>
   </parent>
 
   <groupId>org.sonarsource.dotnet</groupId>


### PR DESCRIPTION
Burgr releasability check mandates the change: https://burgr.sonarsource.com/projects/SonarSource/sonar-dotnet/main