### PR TITLE
SE: Disable SymbolicValue cache for NumberConstraint

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/NumberConstraint.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/NumberConstraint.cs
@@ -30,6 +30,7 @@ public sealed class NumberConstraint : SymbolicConstraint
 
     public BigInteger? Min { get; }
     public BigInteger? Max { get; }
+    public override bool CacheEnabled => false;
 
     public override SymbolicConstraint Opposite =>
         null;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/SymbolicConstraint.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/SymbolicConstraint.cs
@@ -27,6 +27,7 @@ namespace SonarAnalyzer.SymbolicExecution
         public ConstraintKind Kind { get; }
         public abstract SymbolicConstraint Opposite { get; }
         public virtual bool PreserveOnFieldReset => false;
+        public virtual bool CacheEnabled => true;
 
         protected SymbolicConstraint(ConstraintKind kind) =>
             Kind = kind;


### PR DESCRIPTION
Prerequisite for #7140

Without this, all `SymbolicValues` caches only the 1st instance that is ever created. Whatever values it has.