### PR TITLE
UTs: Automatic parameter comma in SETestContext

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -182,7 +182,7 @@ End If";
                 else
                     Tag("False && True");
                 """;
-        SETestContext.CreateCS(code, ", bool arg").Validator.ValidateTagOrder(
+        SETestContext.CreateCS(code, "bool arg").Validator.ValidateTagOrder(
             "True & True",
             "False & True",
             "False & False",
@@ -248,7 +248,7 @@ End If";
                 else
                     Tag("False || True Unreachable");
                 """;
-        SETestContext.CreateCS(code, ", bool arg").Validator.ValidateTagOrder(
+        SETestContext.CreateCS(code, "bool arg").Validator.ValidateTagOrder(
             "True | True",
             "False | True",
             "False | False",
@@ -350,7 +350,7 @@ else
 }}
 Tag(""End"");";
         var check = new PostProcessTestCheck(OperationKind.ParameterReference, x => x.SetOperationConstraint(BoolConstraint.True));
-        SETestContext.CreateCS(code, ", int a, int b", check).Validator.ValidateTagOrder(
+        SETestContext.CreateCS(code, "int a, int b", check).Validator.ValidateTagOrder(
             "If",
             "Else",
             "End");
@@ -396,7 +396,7 @@ Tag(""ForSymbolSymbolNone"", forSymbolSymbolNone);";
 object nullValue = null;
 var value = {expression};
 Tag(""End"");";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
         validator.TagStates("End").Should().HaveCount(2)
             .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.True).Any(x => x.Name == "value") && state.SymbolsWith(ObjectConstraint.Null).Any(x => x.Name == "arg"))
@@ -410,7 +410,7 @@ Tag(""End"");";
 object notNullValue = new object();
 var value = arg == notNullValue;
 Tag(""End"");";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
         validator.TagStates("End").Should().HaveCount(2)    // When False, we can't tell what constraints "args" have
             .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.True).Any(x => x.Name == "value") && state.SymbolsWith(ObjectConstraint.NotNull).Any(x => x.Name == "arg"))
@@ -447,7 +447,7 @@ Tag(""EqualsFalse"", EqualsFalse)";
         var code = @$"
 Dim Value = {expression}
 Tag(""End"")";
-        var validator = SETestContext.CreateVB(code, ", Arg As Object").Validator;
+        var validator = SETestContext.CreateVB(code, "Arg As Object").Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
         validator.TagStates("End").Should().HaveCount(2)
             .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.True).Any(x => x.Name == "Value") && state.SymbolsWith(ObjectConstraint.Null).Any(x => x.Name == "Arg"))
@@ -495,7 +495,7 @@ Tag(""ForSymbolSymbolNone"", forSymbolSymbolNone);";
 object nullValue = null;
 var value = {expression};
 Tag(""End"");";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
         validator.TagStates("End").Should().HaveCount(2)
             .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.True).Any(x => x.Name == "value") && state.SymbolsWith(ObjectConstraint.NotNull).Any(x => x.Name == "arg"))
@@ -509,7 +509,7 @@ Tag(""End"");";
 object notNullValue = new object();
 var value = arg != notNullValue;
 Tag(""End"");";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
         validator.TagStates("End").Should().HaveCount(2)    // When True, we can't tell what constraints "args" have
             .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.True).Any(x => x.Name == "value") && state.SymbolsWith(ObjectConstraint.NotNull).All(x => x.Name != "arg"))
@@ -546,7 +546,7 @@ Tag(""EqualsFalse"", EqualsFalse)";
         var code = @$"
 Dim Value = {expression}
 Tag(""End"")";
-        var validator = SETestContext.CreateVB(code, ", Arg As Object").Validator;
+        var validator = SETestContext.CreateVB(code, "Arg As Object").Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
         validator.TagStates("End").Should().HaveCount(2)
             .And.ContainSingle(state => state.SymbolsWith(BoolConstraint.True).Any(x => x.Name == "Value") && state.SymbolsWith(ObjectConstraint.NotNull).Any(x => x.Name == "Arg"))
@@ -588,7 +588,7 @@ Tag(""End"")";
             Tag("End");
             """;
 
-        var validator = SETestContext.CreateCS(code, ", int? arg").Validator;
+        var validator = SETestContext.CreateCS(code, "int? arg").Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
         validator.ValidateTagOrder("Value", "Else", "End");
     }
@@ -620,7 +620,7 @@ Tag(""End"")";
             }
             """;
 
-        var validator = SETestContext.CreateCS(code, ", int? arg").Validator;
+        var validator = SETestContext.CreateCS(code, "int? arg").Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
         validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "arg comparison true, hence non-null"));
         validator.ValidateTag("Else", x => x.Should().HaveNoConstraints("arg either null or comparison false"));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -98,7 +98,7 @@ if ((bool)(object)({unary}arg))
 {{
     Tag(""Arg"", arg);
 }}";
-        var validator = SETestContext.CreateCS(code, ", int arg").Validator;
+        var validator = SETestContext.CreateCS(code, "int arg").Validator;
         validator.ValidateContainsOperation(OperationKind.Unary);
         validator.ValidateTag("Arg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
     }
@@ -115,7 +115,7 @@ Tag(""End"", collection);";
         var check = new ConditionEvaluatedTestCheck(x => x.State[x.Operation].HasConstraint(BoolConstraint.True)
                                                              ? x.SetSymbolConstraint(x.Operation.Instance.AsPropertyReference().Value.Instance.TrackedSymbol(), DummyConstraint.Dummy)
                                                              : x.State);
-        var validator = SETestContext.CreateCS(code, ", ICollection<object> collection", check).Validator;
+        var validator = SETestContext.CreateCS(code, "ICollection<object> collection", check).Validator;
         validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull));
         validator.TagStates("End").Should().HaveCount(2);
     }
@@ -854,7 +854,7 @@ switch (arg)
         break;
 }
 Tag(""End"", arg);";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.FlowCaptureReference);
         validator.ValidateTag("Null", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
         validator.ValidateTag("Default", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
@@ -869,7 +869,7 @@ Tag(""End"", arg);";
         var code = @"
 arg?.ToString();
 Tag(""End"", arg);";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.IsNull);
         validator.Validate("Invocation: .ToString()", x => x.State.SymbolsWith(ObjectConstraint.NotNull).Should().ContainSingle());
         validator.TagValues("End").Should().HaveCount(2)
@@ -949,7 +949,7 @@ Tag(""End"", arg);";
                 Func<string> someFunc = () => s.ToString();
 
                 Tag("End", s);
-                """, ", string s").Validator;
+                """, "string s").Validator;
         validator.ValidateTag("End", x => x.Should().HaveNoConstraints()); // Should have NotNull constraint
     }
 
@@ -986,7 +986,7 @@ Else
     Tag(""Else"", Arg)
 End If
 Tag(""End"", Arg)";
-        var validator = SETestContext.CreateVB(code, $", Arg As {argType}").Validator;
+        var validator = SETestContext.CreateVB(code, $"Arg As {argType}").Validator;
         validator.ValidateContainsOperation(expectedOperation);
         return validator;
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -559,7 +559,7 @@ else
     Tag(""Else"", arg);
 }}
 Tag(""End"", arg);";
-        var validator = SETestContext.CreateCS(code, ", string arg").Validator;
+        var validator = SETestContext.CreateCS(code, "string arg").Validator;
         validator.TagValues("If").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.ExceptionCandidate.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.ExceptionCandidate.cs
@@ -42,7 +42,7 @@ catch
     tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", char[] c").Validator;
+        var validator = SETestContext.CreateCS(code, "char[] c").Validator;
         validator.ValidateContainsOperation(OperationKindEx.ArrayElementReference);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().HaveCount(1).And.ContainSingle(x => HasExceptionOfType(x, "IndexOutOfRangeException"));
@@ -64,7 +64,7 @@ catch
     tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", char[] c").Validator;
+        var validator = SETestContext.CreateCS(code, "char[] c").Validator;
         validator.ValidateContainsOperation(OperationKindEx.ObjectCreation);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().ContainSingle(x => HasUnknownException(x));
@@ -86,7 +86,7 @@ catch
     tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", long p").Validator;
+        var validator = SETestContext.CreateCS(code, "long p").Validator;
         validator.ValidateContainsOperation(OperationKindEx.Conversion);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().ContainSingle(x => HasExceptionOfType(x, "InvalidCastException"));
@@ -108,7 +108,7 @@ catch
     tag = ""UnreachableCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", Person p").Validator;
+        var validator = SETestContext.CreateCS(code, "Person p").Validator;
         validator.ValidateContainsOperation(OperationKindEx.Conversion);
         validator.ValidateTagOrder("BeforeTry", "InTry", "AfterCatch");
         validator.ValidateHasSingleExitStateAndNoException();
@@ -129,7 +129,7 @@ catch
     tag = ""UnreachableCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", int p").Validator;
+        var validator = SETestContext.CreateCS(code, "int p").Validator;
         validator.ValidateContainsOperation(OperationKindEx.Conversion);
         validator.ValidateTagOrder("BeforeTry", "InTry", "AfterCatch");
         validator.TagStates("AfterCatch").Should().ContainSingle(x => HasNoException(x));
@@ -150,7 +150,7 @@ catch
     tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", dynamic arg").Validator;
+        var validator = SETestContext.CreateCS(code, "dynamic arg").Validator;
         validator.ValidateContainsOperation(OperationKindEx.DynamicIndexerAccess);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().ContainSingle(x => HasExceptionOfType(x, "IndexOutOfRangeException"));
@@ -172,7 +172,7 @@ catch
     tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", dynamic arg").Validator;
+        var validator = SETestContext.CreateCS(code, "dynamic arg").Validator;
         validator.ValidateContainsOperation(OperationKindEx.DynamicInvocation);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().ContainSingle(x => HasUnknownException(x));
@@ -194,7 +194,7 @@ catch
     tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", dynamic arg").Validator;
+        var validator = SETestContext.CreateCS(code, "dynamic arg").Validator;
         validator.ValidateContainsOperation(OperationKindEx.DynamicMemberReference);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().ContainSingle(x => HasUnknownException(x));
@@ -216,7 +216,7 @@ catch
     tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", dynamic d").Validator;
+        var validator = SETestContext.CreateCS(code, "dynamic d").Validator;
         validator.ValidateContainsOperation(OperationKindEx.DynamicObjectCreation);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().ContainSingle(x => HasUnknownException(x));
@@ -238,7 +238,7 @@ catch
     tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", Person p").Validator;
+        var validator = SETestContext.CreateCS(code, "Person p").Validator;
         validator.ValidateContainsOperation(OperationKindEx.EventReference);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().ContainSingle(x => HasExceptionOfType(x, "NullReferenceException"));
@@ -283,7 +283,7 @@ catch
     tag = ""UnreachableCatch"";
 }}
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", Person p").Validator;
+        var validator = SETestContext.CreateCS(code, "Person p").Validator;
         validator.ValidateContainsOperation(OperationKindEx.EventReference);
         validator.ValidateTagOrder("BeforeTry", "InTry", "AfterCatch");
         validator.ValidateHasSingleExitStateAndNoException();
@@ -304,7 +304,7 @@ catch
     tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", Person p").Validator;
+        var validator = SETestContext.CreateCS(code, "Person p").Validator;
         validator.ValidateContainsOperation(OperationKindEx.FieldReference);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().ContainSingle(x => HasExceptionOfType(x, "NullReferenceException"));
@@ -372,7 +372,7 @@ catch
     tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", IEnumerable<string> collection").Validator;
+        var validator = SETestContext.CreateCS(code, "IEnumerable<string> collection").Validator;
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch", "InCatch", "InCatch", "InCatch", "AfterCatch", "AfterCatch", "InCatch");
         // IForEachLoopOperation is not generated. It doesn't seem to be used.
         // In the case of foreach, there are implicit method calls that in the current implementation can throw:
@@ -402,7 +402,7 @@ catch
 tag = ""AfterCatch"";";
 
         // IFunctionPointerInvocationOperation is not generated. It doesn't seem used.
-        var validator = SETestContext.CreateCS(code, ", delegate*<string, void> ptr").Validator;
+        var validator = SETestContext.CreateCS(code, "delegate*<string, void> ptr").Validator;
 
         validator.ValidateTagOrder("BeforeTry", "InTry", "AfterCatch");
         validator.ValidateHasSingleExitStateAndNoException();
@@ -424,7 +424,7 @@ catch
 }
 tag = ""AfterCatch"";";
 
-        var validator = SETestContext.CreateCS(code, ", string arg").Validator;
+        var validator = SETestContext.CreateCS(code, "string arg").Validator;
         validator.ValidateContainsOperation(OperationKindEx.PropertyReference);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().ContainSingle(x => HasExceptionOfType(x, "NullReferenceException"));
@@ -493,7 +493,7 @@ catch
 }
 tag = ""AfterCatch"";";
 
-        var validator = SETestContext.CreateCS(code, ", Person p").Validator;
+        var validator = SETestContext.CreateCS(code, "Person p").Validator;
         validator.ValidateContainsOperation(OperationKindEx.MethodReference);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().ContainSingle(x => HasExceptionOfType(x, "NullReferenceException"));
@@ -588,7 +588,7 @@ tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
 
-        var validator = SETestContext.CreateCS(code, ", int[] array").Validator;
+        var validator = SETestContext.CreateCS(code, "int[] array").Validator;
         validator.ValidateContainsOperation(OperationKindEx.MethodReference);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().ContainSingle(x => HasExceptionOfType(x, "IndexOutOfRangeException"));
@@ -643,7 +643,7 @@ tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
 
-        var validator = SETestContext.CreateCS(code, ", int[] array").Validator;
+        var validator = SETestContext.CreateCS(code, "int[] array").Validator;
         validator.ValidateContainsOperation(OperationKindEx.MethodReference);
         validator.ValidateTagOrder("BeforeTry", "InTry", "InCatch", "AfterCatch");
         validator.TagStates("InCatch").Should().ContainSingle(x => HasExceptionOfType(x, "ArgumentOutOfRangeException"));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.ExceptionType.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.ExceptionType.cs
@@ -118,7 +118,7 @@ catch
     tag = ""InCatch"";
 }
 tag = ""AfterCatch"";";
-        var validator = SETestContext.CreateCS(code, ", NotImplementedException ex").Validator;
+        var validator = SETestContext.CreateCS(code, "NotImplementedException ex").Validator;
         validator.ValidateTagOrder(
             "BeforeTry",
             "InTry",

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -514,7 +514,7 @@ Tag(""AfterStaticField"", StaticObjectField);";
     [TestMethod]
     public void Invocation_IsNullOrEmpty_ValidateOrder()
     {
-        var validator = SETestContext.CreateCS(@"var isNullOrEmpy = string.IsNullOrEmpty(arg);", ", string arg").Validator;
+        var validator = SETestContext.CreateCS(@"var isNullOrEmpy = string.IsNullOrEmpty(arg);", "string arg").Validator;
         validator.ValidateOrder(
 "LocalReference: isNullOrEmpy = string.IsNullOrEmpty(arg) (Implicit)",
 "ParameterReference: arg",
@@ -534,7 +534,7 @@ Tag(""AfterStaticField"", StaticObjectField);";
 var isNullOrEmpy = string.IsNullOrEmpty(arg);
 Tag(""IsNullOrEmpy"", isNullOrEmpy);
 Tag(""Arg"", arg);";
-        var validator = SETestContext.CreateCS(code, ", string arg").Validator;
+        var validator = SETestContext.CreateCS(code, "string arg").Validator;
         validator.TagValues("IsNullOrEmpy").Should().Equal(
             SymbolicValue.NotNull.WithConstraint(BoolConstraint.False),      // False/NotNull
             SymbolicValue.NotNull.WithConstraint(BoolConstraint.True),       // True/Null
@@ -554,7 +554,7 @@ if (!string.IsNullOrEmpty(exception?.Message))
     Tag(""ExceptionChecked"", exception);
 }
 Tag(""ExceptionAfterCheck"", exception);";
-        var validator = SETestContext.CreateCS(code, ", InvalidOperationException exception").Validator;
+        var validator = SETestContext.CreateCS(code, "InvalidOperationException exception").Validator;
         validator.ValidateTag("ExceptionChecked", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.TagValues("ExceptionAfterCheck").Should().Equal(new[]
         {
@@ -575,7 +575,7 @@ finally
 {
     Tag(""ArgInFinally"", arg);
 }";
-        var validator = SETestContext.CreateCS(code, ", string arg").Validator;
+        var validator = SETestContext.CreateCS(code, "string arg").Validator;
         validator.TagValues("ArgInFinally").Should().Equal(new[]
         {
             null,
@@ -634,10 +634,10 @@ finally
         var code = $@"
 var value = {expression};
 Tag(""Value"", value);";
-        var enumerableValidator = SETestContext.CreateCS(code, ", IEnumerable<object> arg").Validator;
+        var enumerableValidator = SETestContext.CreateCS(code, "IEnumerable<object> arg").Validator;
         enumerableValidator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
 
-        var queryableValidator = SETestContext.CreateCS(code, ", IQueryable<object> arg").Validator;
+        var queryableValidator = SETestContext.CreateCS(code, "IQueryable<object> arg").Validator;
         queryableValidator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
     }
 
@@ -650,12 +650,12 @@ Tag(""Value"", value);";
         var code = $@"
 var value = arg.{expression};
 Tag(""Value"", value);";
-        var enumerableValidator = SETestContext.CreateCS(code, $", IEnumerable<object> arg").Validator;
+        var enumerableValidator = SETestContext.CreateCS(code, $"IEnumerable<object> arg").Validator;
         enumerableValidator.TagValues("Value").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
 
-        var queryableValidator = SETestContext.CreateCS(code, $", IQueryable<object> arg").Validator;
+        var queryableValidator = SETestContext.CreateCS(code, $"IQueryable<object> arg").Validator;
         queryableValidator.TagValues("Value").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -672,7 +672,7 @@ Tag(""Value"", value);";
         var code = $@"
 var value = arg.{expression};
 Tag(""Value"", value);";
-        var validator = SETestContext.CreateCS(code, $", IEnumerable<int> arg").Validator;
+        var validator = SETestContext.CreateCS(code, $"IEnumerable<int> arg").Validator;
         validator.ValidateTag("Value", x => x.AllConstraints.Should().ContainSingle().Which.Kind.Should().Be(ConstraintKind.NotNull));
     }
 
@@ -684,7 +684,7 @@ Tag(""Value"", value);";
         var code = $@"
 var value = arg.{expression};
 Tag(""Value"", value);";
-        var validator = SETestContext.CreateCS(code, $", IEnumerable<object> arg").Validator;
+        var validator = SETestContext.CreateCS(code, $"IEnumerable<object> arg").Validator;
         validator.ValidateTag("Value", x => x.Should().BeNull());
     }
 
@@ -697,7 +697,7 @@ If Query.Count <> 0 Then
     Dim Value = Query(0)
     Tag(""Value"", Value)
 End If";
-        var validator = SETestContext.CreateVB(code, ", Items() As Object").Validator;
+        var validator = SETestContext.CreateVB(code, "Items() As Object").Validator;
         validator.ValidateTag("Value", x => x.Should().BeNull());
     }
 
@@ -745,7 +745,7 @@ End Sub";
         var code = $@"
 Dim Result As Boolean = IsNothing("""" & Arg.ToString())
 Tag(""Result"", Result)";
-        var validator = SETestContext.CreateVB(code, ", Arg As Object").Validator;
+        var validator = SETestContext.CreateVB(code, "Arg As Object").Validator;
         validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
     }
 
@@ -782,7 +782,7 @@ Tag(""Result"", Result)";
 Debug.Assert(arg1 != null && arg2 != null);
 Tag(""Arg1"", arg1);
 Tag(""Arg2"", arg2);";
-        var validator = SETestContext.CreateCS(code, $", object arg1, object arg2").Validator;
+        var validator = SETestContext.CreateCS(code, $"object arg1, object arg2").Validator;
         validator.ValidateTag("Arg1", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
         validator.ValidateTag("Arg2", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
     }
@@ -861,7 +861,7 @@ namespace System.Diagnostics
         var code = $@"
 Debug.Assert({expression});
 Tag(""Arg"", arg);";
-        return SETestContext.CreateCS(code, $", {argType} arg, bool condition").Validator.TagValues("Arg");
+        return SETestContext.CreateCS(code, $"{argType} arg, bool condition").Validator.TagValues("Arg");
     }
 
     [DataTestMethod]
@@ -890,7 +890,7 @@ if (condition)
     Tag(""Unreachable"");
 }}
 Tag(""End"");";
-        var validator = SETestContext.CreateCS(code, ", bool condition").Validator;
+        var validator = SETestContext.CreateCS(code, "bool condition").Validator;
         validator.ValidateTagOrder("Before", "End");
         validator.ValidateExitReachCount(1);
         validator.ValidateExecutionCompleted();
@@ -915,7 +915,7 @@ finally
     Tag(""Finally"");
 }}
 Tag(""End"");";
-        var validator = SETestContext.CreateCS(code, ", bool condition").Validator;
+        var validator = SETestContext.CreateCS(code, "bool condition").Validator;
         validator.ValidateTagOrder("Catch", "Finally", "Finally", "End");
         validator.ValidateExitReachCount(2);
         validator.ValidateExecutionCompleted();
@@ -985,7 +985,7 @@ Tag(""Result"", result);";
         var code = $@"
 var result = object.Equals({left}, {right});
 Tag(""End"");";
-        var validator = SETestContext.CreateCS(code, $", {argType} arg").Validator;
+        var validator = SETestContext.CreateCS(code, $"{argType} arg").Validator;
         var result = validator.Symbol("result");
         var arg = validator.Symbol("arg");
         validator.TagStates("End").Should().SatisfyRespectively(
@@ -1044,7 +1044,7 @@ Tag(""End"");";
             var result = {left}.Equals({right});
             Tag("End");
             """;
-        var validator = SETestContext.CreateCS(code, ", int? arg").Validator;
+        var validator = SETestContext.CreateCS(code, "int? arg").Validator;
         var result = validator.Symbol("result");
         var arg = validator.Symbol("arg");
         validator.TagStates("End").Should().SatisfyRespectively(
@@ -1143,7 +1143,7 @@ private static bool Equals(object a, object b, object c) => false;";
             var result = ReferenceEquals({left}, {right});
             Tag("End");
             """;
-        var validator = SETestContext.CreateCS(code, $", {argType} arg").Validator;
+        var validator = SETestContext.CreateCS(code, $"{argType} arg").Validator;
         var result = validator.Symbol("result");
         var arg = validator.Symbol("arg");
         validator.TagStates("End").Should().SatisfyRespectively(

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.IsNull.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.IsNull.cs
@@ -43,7 +43,7 @@ Tag(""NullToUnknown"", nullToUnknown);
 Tag(""NotNullToNull"", notNullToNull);
 Tag(""NotNullToNotNull"", notNullToNotNull);
 Tag(""NotNullToUnknown"", notNullToUnknown);";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.IsNull);
         validator.ValidateTag("NullToNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
         validator.ValidateTag("NullToNotNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
@@ -61,7 +61,7 @@ Tag(""NotNullToUnknown"", notNullToUnknown);";
                 var result = arg ?? nullValue;
                 Tag("End");
                 """;
-        var validator = SETestContext.CreateCS(code, ", object arg", new PreserveTestCheck("arg", "result")).Validator;
+        var validator = SETestContext.CreateCS(code, "object arg", new PreserveTestCheck("arg", "result")).Validator;
         var arg = validator.Symbol("arg");
         var result = validator.Symbol("result");
         validator.ValidateContainsOperation(OperationKind.IsNull);
@@ -86,7 +86,7 @@ Tag(""NotNullToUnknown"", notNullToUnknown);";
                 var result = arg ?? notNullValue;
                 Tag("End");
                 """;
-        var validator = SETestContext.CreateCS(code, ", object arg", new PreserveTestCheck("arg", "result")).Validator;
+        var validator = SETestContext.CreateCS(code, "object arg", new PreserveTestCheck("arg", "result")).Validator;
         var arg = validator.Symbol("arg");
         var result = validator.Symbol("result");
         validator.ValidateContainsOperation(OperationKind.IsNull);
@@ -111,7 +111,7 @@ Tag(""NotNullToUnknown"", notNullToUnknown);";
                 var result = arg ?? notNullValue;
                 Tag("End");
                 """;
-        var validator = SETestContext.CreateCS(code, ", Exception arg", new PreserveTestCheck("arg", "result")).Validator;
+        var validator = SETestContext.CreateCS(code, "Exception arg", new PreserveTestCheck("arg", "result")).Validator;
         var arg = validator.Symbol("arg");
         var result = validator.Symbol("result");
         validator.ValidateContainsOperation(OperationKind.IsNull);
@@ -134,7 +134,7 @@ Tag(""NotNullToUnknown"", notNullToUnknown);";
         const string code = @"
 var unknownToUnknown = arg1 ?? arg2;
 Tag(""UnknownToUnknown"", unknownToUnknown);";
-        var validator = SETestContext.CreateCS(code, ", object arg1, object arg2").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg1, object arg2").Validator;
         validator.ValidateContainsOperation(OperationKind.IsNull);
         validator.TagValues("UnknownToUnknown").Should().SatisfyRespectively(
             x => x.Should().HaveNoConstraints(),
@@ -148,7 +148,7 @@ Tag(""UnknownToUnknown"", unknownToUnknown);";
                 var value = arg ?? "N/A";
                 Tag("Value", value);
                 """;
-        var validator = SETestContext.CreateCS(code, ", string arg").Validator;
+        var validator = SETestContext.CreateCS(code, "string arg").Validator;
         validator.ValidateTag("Value", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
     }
 
@@ -159,7 +159,7 @@ Tag(""UnknownToUnknown"", unknownToUnknown);";
                 arg = arg ?? "N/A";
                 Tag("Arg", arg);
                 """;
-        var validator = SETestContext.CreateCS(code, ", string arg").Validator;
+        var validator = SETestContext.CreateCS(code, "string arg").Validator;
         validator.ValidateTag("Arg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
     }
 
@@ -188,7 +188,7 @@ Tag(""NotNullToNull"", notNullToNull);
 Tag(""NotNullToNotNull"", notNullToNotNull);
 Tag(""NotNullToUnknown"", notNullToUnknown);
 ";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.IsNull);
         validator.ValidateTag("NullToNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
         validator.ValidateTag("NullToNotNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
@@ -205,7 +205,7 @@ Tag(""NotNullToUnknown"", notNullToUnknown);
 object nullValue = null;
 arg ??= nullValue;
 Tag(""Arg"", arg);";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.IsNull);
         validator.TagValues("Arg").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull),
@@ -220,7 +220,7 @@ Tag(""Arg"", arg);";
                 arg ??= notNullValue;
                 Tag("End");
                 """;
-        var validator = SETestContext.CreateCS(code, ", object arg", new PreserveTestCheck("arg", "notNullValue")).Validator;
+        var validator = SETestContext.CreateCS(code, "object arg", new PreserveTestCheck("arg", "notNullValue")).Validator;
         validator.ValidateContainsOperation(OperationKind.IsNull);
         var arg = validator.Symbol("arg");
         var notNullValue = validator.Symbol("notNullValue");
@@ -235,7 +235,7 @@ Tag(""Arg"", arg);";
         const string code = @"
 arg1 ??= arg2;
 Tag(""Arg"", arg1);";
-        var validator = SETestContext.CreateCS(code, ", object arg1, object arg2").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg1, object arg2").Validator;
         validator.ValidateContainsOperation(OperationKind.IsNull);
         validator.TagValues("Arg").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull),
@@ -272,7 +272,7 @@ Tag(""End"");";
         const string code = @"
 arg?.Tag(""WasNotNull"");
 Tag(""End"", arg);";
-        var validator = SETestContext.CreateCS(code, ", Sample arg").Validator;
+        var validator = SETestContext.CreateCS(code, "Sample arg").Validator;
         validator.ValidateContainsOperation(OperationKind.IsNull);
         validator.ValidateTagOrder(
             "End",
@@ -286,7 +286,7 @@ Tag(""End"", arg);";
         var validator = SETestContext.CreateCS("""
                 (arg as Exception)?.ToString();
                 Tag("Arg", arg);
-                """, ", object arg").Validator;
+                """, "object arg").Validator;
         validator.ValidateTag("Arg", x => x.Should().HaveNoConstraints());
     }
 
@@ -296,7 +296,7 @@ Tag(""End"", arg);";
         var validator = SETestContext.CreateCS("""
                 (arg as Exception)?.ToString();
                 Tag("Arg", arg);
-                """, ", ArgumentException arg").Validator;
+                """, "ArgumentException arg").Validator;
         validator.TagValues("Arg").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null),
             x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -40,7 +40,7 @@ var value = 42;
     value--;
 }}
 Tag(""End"", value);";
-        var validator = SETestContext.CreateCS(code, ", int[] items", new AddConstraintOnInvocationCheck(), new PreserveTestCheck("value")).Validator;
+        var validator = SETestContext.CreateCS(code, "int[] items", new AddConstraintOnInvocationCheck(), new PreserveTestCheck("value")).Validator;
         validator.ValidateExitReachCount(2);
         validator.TagValues("End").Should().HaveCount(2)
             .And.SatisfyRespectively(
@@ -59,7 +59,7 @@ foreach (var i in items)
     value--;
 }}
 Tag(""End"", value);";
-        var validator = SETestContext.CreateCS(code, ", int[] items", new AddConstraintOnInvocationCheck(), new PreserveTestCheck("value")).Validator;
+        var validator = SETestContext.CreateCS(code, "int[] items", new AddConstraintOnInvocationCheck(), new PreserveTestCheck("value")).Validator;
         // In the case of foreach, there are implicit method calls that in the current implementation can throw:
         // - IEnumerable<>.GetEnumerator()
         // - System.Collections.IEnumerator.MoveNext()
@@ -87,7 +87,7 @@ do
     value.ToString(); // Add another constraint to 'value'
 } while (Condition);
 Tag(""End"", value);";
-        var validator = SETestContext.CreateCS(code, ", int[] items", new AddConstraintOnInvocationCheck(), new PreserveTestCheck("condition"), new PreserveTestCheck("value")).Validator;
+        var validator = SETestContext.CreateCS(code, "int[] items", new AddConstraintOnInvocationCheck(), new PreserveTestCheck("condition"), new PreserveTestCheck("value")).Validator;
         validator.ValidateExitReachCount(4);
         var states = validator.TagStates("End");
         var condition = validator.Symbol("condition");

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -53,7 +53,7 @@ public partial class RoslynSymbolicExecutionTest
             Tag("FalseFirst", value);
             """;
         var setter = new PreProcessTestCheck(OperationKind.Literal, x => x.Operation.Instance.ConstantValue.Value is false ? x.SetOperationConstraint(TestConstraint.First) : x.State);
-        var validator = SETestContext.CreateCS(code, ", bool? arg", setter).Validator;
+        var validator = SETestContext.CreateCS(code, "bool? arg", setter).Validator;
         validator.ValidateTag("Unknown", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("Accessing .Value would already throw, so it is NotNull by now"));
         validator.ValidateTag("True", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
         validator.ValidateTag("FalseFirst", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
@@ -75,7 +75,7 @@ public partial class RoslynSymbolicExecutionTest
             Tag("HasValueAfterNull", hasValue);
             Tag("SymbolAfterNull", arg);
             """;
-        var validator = SETestContext.CreateCS(code, ", int? arg").Validator;
+        var validator = SETestContext.CreateCS(code, "int? arg").Validator;
         var arg = validator.Symbol("arg");
         var hasValue = validator.Symbol("hasValue");
         validator.TagStates("AfterUnknown").Should().SatisfyRespectively(
@@ -110,7 +110,7 @@ public partial class RoslynSymbolicExecutionTest
             Tag("HasValueAfterNull", hasValue);
             Tag("SymbolAfterNull", arg);
             """;
-        var validator = SETestContext.CreateCS(code, ", bool? arg").Validator;
+        var validator = SETestContext.CreateCS(code, "bool? arg").Validator;
         var arg = validator.Symbol("arg");
         var hasValue = validator.Symbol("hasValue");
         validator.TagStates("AfterUnknown").Should().SatisfyRespectively(
@@ -211,7 +211,7 @@ public partial class RoslynSymbolicExecutionTest
             Tag("NotNullArg", arg);
             Tag("NotNullValue", value);
             """;
-        var validator = SETestContext.CreateCS(code, ", int? arg", new LiteralDummyTestCheck()).Validator;
+        var validator = SETestContext.CreateCS(code, "int? arg", new LiteralDummyTestCheck()).Validator;
         validator.ValidateTag("UnknownArg", x => x.Should().HaveNoConstraints());
         validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
         validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy));
@@ -238,7 +238,7 @@ public partial class RoslynSymbolicExecutionTest
             Tag("NotNullArg", arg);
             Tag("NotNullValue", value);
             """;
-        var validator = SETestContext.CreateCS(code, ", bool? arg", new LiteralDummyTestCheck()).Validator;
+        var validator = SETestContext.CreateCS(code, "bool? arg", new LiteralDummyTestCheck()).Validator;
         validator.ValidateTag("UnknownArg", x => x.Should().HaveNoConstraints());
         validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
         validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -332,15 +332,15 @@ public void Method()
 
     [TestMethod]
     public void Argument_Ref_ResetsConstraints_CS() =>
-        SETestContext.CreateCS(@"var b = true; Main(boolParameter, ref b); Tag(""B"", b);", ", ref bool outParam").Validator.ValidateTag("B", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        SETestContext.CreateCS(@"var b = true; Main(boolParameter, ref b); Tag(""B"", b);", "ref bool outParam").Validator.ValidateTag("B", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
 
     [TestMethod]
     public void Argument_Out_ResetsConstraints_CS() =>
-        SETestContext.CreateCS(@"var b = true; Main(boolParameter, out b); Tag(""B"", b); outParam = false;", ", out bool outParam").Validator.ValidateTag("B", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        SETestContext.CreateCS(@"var b = true; Main(boolParameter, out b); Tag(""B"", b); outParam = false;", "out bool outParam").Validator.ValidateTag("B", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
 
     [TestMethod]
     public void Argument_ByRef_ResetConstraints_VB() =>
-        SETestContext.CreateVB(@"Dim B As Boolean = True : Main(BoolParameter, B) : Tag(""B"", B)", ", ByRef ByRefParam As Boolean").Validator.ValidateTag("B", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        SETestContext.CreateVB(@"Dim B As Boolean = True : Main(BoolParameter, B) : Tag(""B"", B)", "ByRef ByRefParam As Boolean").Validator.ValidateTag("B", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
 
     [TestMethod]
     public void Argument_ArgList_DoesNotThrow()
@@ -367,7 +367,7 @@ public void ArgListMethod(__arglist)
             }
             return x.State;
         });
-        SETestContext.CreateCS("string a = null; a ??= arg;", ", string arg", collector);
+        SETestContext.CreateCS("string a = null; a ??= arg;", "string arg", collector);
         assertions.Should().Be(3);  // Block #3 transitive capture, Block #3 BranchValue, Block #4
     }
 
@@ -429,7 +429,7 @@ Tag(""Delegate"", del);";
         const string code = @"
 var s = new Sample(dynamicArg);
 Tag(""S"", s);";
-        var validator = SETestContext.CreateCS(code, ", dynamic dynamicArg").Validator;
+        var validator = SETestContext.CreateCS(code, "dynamic dynamicArg").Validator;
         validator.ValidateContainsOperation(OperationKind.DynamicObjectCreation);
         validator.ValidateTag("S", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
     }
@@ -514,7 +514,7 @@ Tag(""AfterObjNull"", argObjNull);
 Tag(""AfterObjDefault"", argObjDefault);
 Tag(""AfterInt"", argInt);
 Tag(""AfterNullableInt"", argNullableInt);";
-        var validator = SETestContext.CreateCS(code, ", object argObjNull, object argObjDefault, int argInt, int? argNullableInt").Validator;
+        var validator = SETestContext.CreateCS(code, "object argObjNull, object argObjDefault, int argInt, int? argNullableInt").Validator;
         validator.ValidateContainsOperation(OperationKind.Literal);
         validator.ValidateTag("BeforeObjNull", x => x.Should().HaveNoConstraints());
         validator.ValidateTag("BeforeObjDefault", x => x.Should().HaveNoConstraints());
@@ -536,7 +536,7 @@ ArgObj = Nothing
 ArgInt = Nothing
 Tag(""AfterObj"", ArgObj)
 Tag(""AfterInt"", ArgInt)";
-        var validator = SETestContext.CreateVB(code, ", ArgObj As Object, ArgInt As Integer").Validator;
+        var validator = SETestContext.CreateVB(code, "ArgObj As Object, ArgInt As Integer").Validator;
         validator.ValidateContainsOperation(OperationKind.Literal);
         validator.ValidateTag("BeforeObj", x => x.Should().HaveNoConstraints());
         validator.ValidateTag("BeforeInt", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
@@ -849,7 +849,7 @@ _ = arg.field;
 Tag(""After"", arg);
 
 Sample UntrackedSymbol() => this;";
-        var validator = SETestContext.CreateCS(code, ", Sample arg").Validator;
+        var validator = SETestContext.CreateCS(code, "Sample arg").Validator;
         validator.ValidateContainsOperation(OperationKind.FieldReference);
         validator.ValidateTag("Before", x => x.Should().BeNull());
         validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
@@ -868,7 +868,7 @@ arg.field = 42;
 Tag(""After"", arg);
 
 Sample UntrackedSymbol() => this;";
-        var validator = SETestContext.CreateCS(code, ", Sample arg").Validator;
+        var validator = SETestContext.CreateCS(code, "Sample arg").Validator;
         validator.ValidateContainsOperation(OperationKind.FieldReference);
         validator.ValidateTag("Before", x => x.Should().BeNull());
         validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
@@ -882,7 +882,7 @@ this.fieldException = new NotImplementedException();
 var argException = arg.fieldException;  // Should not propagate constraint from this.fieldException
 Tag(""This"", fieldException);
 Tag(""Arg"", argException);";
-        var validator = SETestContext.CreateCS(code, ", Sample arg").Validator;
+        var validator = SETestContext.CreateCS(code, "Sample arg").Validator;
         validator.ValidateTag("This", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("Arg", x => x.Should().BeNull());
     }
@@ -906,7 +906,7 @@ Tag(""AfterDictionary"", dictionary);
 Tag(""AfterIndexer"", indexer);
 
 Sample UntrackedSymbol() => this;";
-        var validator = SETestContext.CreateCS(code, ", Sample arg, Dictionary<int, int> dictionary, Sample indexer").Validator;
+        var validator = SETestContext.CreateCS(code, "Sample arg, Dictionary<int, int> dictionary, Sample indexer").Validator;
         validator.ValidateContainsOperation(OperationKind.PropertyReference);
         validator.ValidateTag("BeforeProperty", x => x.Should().BeNull());
         validator.ValidateTag("BeforeDictionary", x => x.Should().BeNull());
@@ -935,7 +935,7 @@ Tag(""AfterDictionary"", dictionary);
 Tag(""AfterIndexer"", indexer);
 
 Sample UntrackedSymbol() => this;";
-        var validator = SETestContext.CreateCS(code, ", Sample arg, Dictionary<int, int> dictionary, Sample indexer").Validator;
+        var validator = SETestContext.CreateCS(code, "Sample arg, Dictionary<int, int> dictionary, Sample indexer").Validator;
         validator.ValidateContainsOperation(OperationKind.PropertyReference);
         validator.ValidateTag("BeforeProperty", x => x.Should().BeNull());
         validator.ValidateTag("BeforeDictionary", x => x.Should().BeNull());
@@ -985,7 +985,7 @@ _ = array[42];
 Tag(""After"", array);
 
 int[] UntrackedSymbol() => new[] { 42 };";
-        var validator = SETestContext.CreateCS(code, ", int[] array").Validator;
+        var validator = SETestContext.CreateCS(code, "int[] array").Validator;
         validator.ValidateContainsOperation(OperationKind.ArrayElementReference);
         validator.ValidateTag("Before", x => x.Should().BeNull());
         validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
@@ -1001,7 +1001,7 @@ array[42] = 42;
 Tag(""After"", array);
 
 int[] UntrackedSymbol() => new[] { 42 };";
-        var validator = SETestContext.CreateCS(code, ", int[] array").Validator;
+        var validator = SETestContext.CreateCS(code, "int[] array").Validator;
         validator.ValidateContainsOperation(OperationKind.ArrayElementReference);
         validator.ValidateTag("Before", x => x.Should().BeNull());
         validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
@@ -1017,7 +1017,7 @@ add.Event += (sender, e) => { };
 remove.Event -= (sender, e) => { };
 Tag(""AfterAdd"", add);
 Tag(""AfterRemove"", remove);";
-        var validator = SETestContext.CreateCS(code, ", Sample add, Sample remove").Validator;
+        var validator = SETestContext.CreateCS(code, "Sample add, Sample remove").Validator;
         validator.ValidateContainsOperation(OperationKind.ArrayElementReference);
         validator.ValidateTag("BeforeAdd", x => x.Should().BeNull());
         validator.ValidateTag("BeforeRemove", x => x.Should().BeNull());
@@ -1041,7 +1041,7 @@ Tag(""AfterSecond"", Second)
 Tag(""AfterThird"", Third)
 Tag(""AfterFourth"", Fourth)
 Tag(""AfterNotTracked"", Arg.FieldArray)";
-        var validator = SETestContext.CreateVB(code, ", Arg As Sample").Validator;
+        var validator = SETestContext.CreateVB(code, "Arg As Sample").Validator;
         validator.ValidateContainsOperation(OperationKind.ReDim);
         validator.ValidateTag("BeforeFirst", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
         validator.ValidateTag("BeforeSecond", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
@@ -1064,7 +1064,7 @@ Tag(""BeforeSecond"", Second)
 ReDim Preserve First(42), Second(42)
 Tag(""AfterFirst"", First)
 Tag(""AfterSecond"", Second)";
-        var validator = SETestContext.CreateVB(code, ", Arg As Sample").Validator;
+        var validator = SETestContext.CreateVB(code, "Arg As Sample").Validator;
         validator.ValidateContainsOperation(OperationKind.ReDim);
         validator.ValidateTag("BeforeFirst", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
         validator.ValidateTag("BeforeSecond", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("has size in declaration"));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.ParameterReassignedConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.ParameterReassignedConstraint.cs
@@ -40,7 +40,7 @@ public partial class RoslynSymbolicExecutionTest
             {{methodSnippet}}
             Tag("End", arg);
             """;
-        var argumentSnippet = $", {argumentType} arg";
+        var argumentSnippet = $"{argumentType} arg";
         var validator = SETestContext.CreateCS(methodBody, argumentSnippet, new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
         validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance));
     }
@@ -52,7 +52,7 @@ public partial class RoslynSymbolicExecutionTest
             arg = Unknown<int>();
             Tag("End", arg);
             """;
-        var validator = SETestContext.CreateCS(methodBody, ", int arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
+        var validator = SETestContext.CreateCS(methodBody, "int arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
         validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance, ObjectConstraint.NotNull));
     }
 
@@ -70,7 +70,7 @@ public partial class RoslynSymbolicExecutionTest
             {{snippet}}
             Tag("End", arg);
             """;
-        var validator = SETestContext.CreateCS(methodBody, ", object arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
+        var validator = SETestContext.CreateCS(methodBody, "object arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
         validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance));
     }
 
@@ -82,7 +82,7 @@ public partial class RoslynSymbolicExecutionTest
             arg.ToString();
             Tag("End", arg);
             """;
-        var validator = SETestContext.CreateCS(methodBody, ", object arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
+        var validator = SETestContext.CreateCS(methodBody, "object arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
         validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance, ObjectConstraint.NotNull));
     }
 
@@ -96,7 +96,7 @@ public partial class RoslynSymbolicExecutionTest
             {{snippet}}
             Tag("End", arg);
             """;
-        var validator = SETestContext.CreateCS(methodBody, ", object arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
+        var validator = SETestContext.CreateCS(methodBody, "object arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
         validator.ValidateTag("End", x => x.Should().HaveNoConstraints()); // ToDo: arg should have the ParameterReassignedConstraint
     }
 
@@ -115,7 +115,7 @@ public partial class RoslynSymbolicExecutionTest
                 Tag("Else");
             }
             Tag("End");
-            """, ", string arg", new PublicMethodArgumentsShouldBeCheckedForNull(), new PreserveTestCheck("arg")).Validator;
+            """, "string arg", new PublicMethodArgumentsShouldBeCheckedForNull(), new PreserveTestCheck("arg")).Validator;
         var arg = validator.Symbol("arg");
         validator.TagStates("BeforeReassignment").Should().ContainSingle().Which[arg].Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagStates("AfterReassignment").Should().ContainSingle().Which[arg].Should().HaveOnlyConstraint(ParameterReassignedConstraint.Instance);
@@ -131,7 +131,7 @@ public partial class RoslynSymbolicExecutionTest
         var validator = SETestContext.CreateCS("""
             arg ??= Guid.NewGuid().ToString("N");
             Tag("End");
-            """, ", string arg", new PublicMethodArgumentsShouldBeCheckedForNull(), new PreserveTestCheck("arg")).Validator;
+            """, "string arg", new PublicMethodArgumentsShouldBeCheckedForNull(), new PreserveTestCheck("arg")).Validator;
         var arg = validator.Symbol("arg");
         validator.TagStates("End").Should().SatisfyRespectively(
             x => x[arg].Should().HaveOnlyConstraint(ObjectConstraint.NotNull),
@@ -144,7 +144,7 @@ public partial class RoslynSymbolicExecutionTest
         var validator = SETestContext.CreateCS("""
             arg = arg ?? throw new ArgumentNullException();
             Tag("End", arg);
-            """, ", string arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
+            """, "string arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
         validator.ValidateTag("End", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
     }
 
@@ -154,7 +154,7 @@ public partial class RoslynSymbolicExecutionTest
         var validator = SETestContext.CreateCS("""
             arg = arg ?? Unknown<string>();
             Tag("End");
-            """, ", string arg", new PublicMethodArgumentsShouldBeCheckedForNull(), new PreserveTestCheck("arg")).Validator;
+            """, "string arg", new PublicMethodArgumentsShouldBeCheckedForNull(), new PreserveTestCheck("arg")).Validator;
         var arg = validator.Symbol("arg");
         validator.TagStates("End").Should().SatisfyRespectively(
             x => x[arg].Should().HaveNoConstraints(), // ToDo: Misses ParameterReassignedConstraint
@@ -169,7 +169,7 @@ public partial class RoslynSymbolicExecutionTest
                 ? throw new ArgumentNullException()
                 : arg;
             Tag("End", arg);
-            """, ", string arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
+            """, "string arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
         validator.ValidateTag("End", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
     }
 
@@ -181,7 +181,7 @@ public partial class RoslynSymbolicExecutionTest
                 ? throw new ArgumentNullException()
                 : Unknown<string>();
             Tag("End", arg);
-            """, ", string arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
+            """, "string arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
         validator.ValidateTag("End", x => x.Should().HaveNoConstraints()); // ToDo: Misses ParameterReassignedConstraint
     }
 
@@ -195,7 +195,7 @@ public partial class RoslynSymbolicExecutionTest
         var validator = SETestContext.CreateCS($$"""
                 ArgumentNullException.{{throwIfNullMethod}}(arg);
                 Tag("End", arg);
-                """, ", string arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
+                """, "string arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
         validator.ValidateTag("End", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
     }
 
@@ -235,7 +235,7 @@ public partial class RoslynSymbolicExecutionTest
             Tag("AfterAssignmentArg1", arg1);
             Tag("AfterAssignmentArg2", arg2);
             """;
-        var validator = SETestContext.CreateCS(snippet, ", object arg1, object arg2", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
+        var validator = SETestContext.CreateCS(snippet, "object arg1, object arg2", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
         validator.ValidateTag("AfterAssignmentArg1", x => x.Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance));
         validator.ValidateTag("AfterAssignmentArg2", x => x.Should().HaveNoConstraints());
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
@@ -114,7 +114,7 @@ var value = arg switch
 };
 Tag(""Value"", value);";
         var check = new PostProcessTestCheck(x => x.Operation.Instance.Kind == OperationKind.ParameterReference ? x.SetOperationConstraint(DummyConstraint.Dummy) : x.State);
-        SETestContext.CreateCS(code, ", object arg", check).Validator.TagValues("Value").Should()
+        SETestContext.CreateCS(code, "object arg", check).Validator.TagValues("Value").Should()
             .HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(BoolConstraint.True))
             .And.ContainSingle(x => x.HasConstraint(BoolConstraint.False));
@@ -129,7 +129,7 @@ if (arg is { })
     Tag(""ArgNotNull"", arg);
 }
 Tag(""End"", arg);";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.RecursivePattern);
         validator.ValidateTag("ArgNotNull", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.TagValues("End").Should().HaveCount(2)
@@ -147,7 +147,7 @@ if (arg is { } value)
     Tag(""ArgNotNull"", arg);
 }
 Tag(""End"", arg);";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.RecursivePattern);
         validator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("ArgNotNull", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
@@ -167,7 +167,7 @@ if (arg is { } value)
 }
 Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
-        var validator = SETestContext.CreateCS(code, ", object arg", setter).Validator;
+        var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.RecursivePattern);
         validator.ValidateTag("Value", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
         validator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
@@ -189,7 +189,7 @@ if (arg is Exception { Message: { } msg } ex)
 }
 Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
-        var validator = SETestContext.CreateCS(code, ", object arg", setter).Validator;
+        var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.RecursivePattern);
         validator.ValidateTag("Msg", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("Msg", x => x.HasConstraint(TestConstraint.First).Should().BeFalse("Constraint from source value should not be propagated to child property"));
@@ -208,7 +208,7 @@ if (arg is Exception value)
     Tag(""ArgNotNull"", arg);
 }
 Tag(""End"", arg);";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
         validator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("ArgNotNull", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
@@ -228,7 +228,7 @@ if (arg is Exception value)
 }
 Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
-        var validator = SETestContext.CreateCS(code, ", object arg", setter).Validator;
+        var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
         validator.ValidateTag("Value", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
         validator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
@@ -246,7 +246,7 @@ if (arg is Exception _)
     Tag(""Arg"", arg);
 }
 Tag(""End"", arg);";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
         validator.ValidateTag("Arg", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.TagValues("End").Should().HaveCount(2)
@@ -265,7 +265,7 @@ if (arg is var value)
 }
 Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
-        var validator = SETestContext.CreateCS(code, ", object arg", setter).Validator;
+        var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
         validator.ValidateTag("Value", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
         validator.ValidateTag("Value", x => x.HasConstraint<ObjectConstraint>().Should().BeFalse("'var' only propagates existing constraints"));
@@ -290,7 +290,7 @@ if (arg is (var c, var d))
 }
 Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
-        var validator = SETestContext.CreateCS(code, ", object arg", setter).Validator;
+        var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
         validator.ValidateTag("A", x => x.Should().BeNull());
         validator.ValidateTag("B", x => x.Should().BeNull());
@@ -494,7 +494,7 @@ object value = arg switch
 }};
 
 static object Tag(string name, object value) => null;";
-        var validator = SETestContext.CreateCS(code, ", object arg").Validator;
+        var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(expectedOperation);
         validator.ValidateTag("Arg", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue()); // Should not have Null in any case
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Throw.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Throw.cs
@@ -565,7 +565,7 @@ catch (System.IO.IOException)
     tag = ""InCatchBase"";
 }
 tag = ""End"";";
-        var validator = SETestContext.CreateCS(code, ", bool condition").Validator;
+        var validator = SETestContext.CreateCS(code, "bool condition").Validator;
         validator.ValidateTagOrder(
             "BeforeTry",
             "InTry",
@@ -642,7 +642,7 @@ catch when (arg)
     tag = ""InCatch"";
 }
 tag = ""End"";";
-        var validator = SETestContext.CreateCS(code, ", bool arg").Validator;
+        var validator = SETestContext.CreateCS(code, "bool arg").Validator;
         validator.ValidateTagOrder(
             "BeforeTry",
             "InTry",
@@ -666,7 +666,7 @@ catch (FormatException)
     tag = ""UnreachableInCatch"";
 }
 tag = ""UnreachableEnd"";";
-        var validator = SETestContext.CreateCS(code, ", Exception couldBeAnything").Validator;
+        var validator = SETestContext.CreateCS(code, "Exception couldBeAnything").Validator;
         validator.ValidateTagOrder(
             "BeforeTry",
             "InTry");   // Signature returns Exception => we do not know that it is FormatException

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.cs
@@ -259,7 +259,7 @@ Tag(""End"");";
             }
             return x.State;
         });
-        var validator = SETestContext.CreateCS(code, ", string arg", collector).Validator;
+        var validator = SETestContext.CreateCS(code, "string arg", collector).Validator;
         allReferences.Should().HaveCount(3);
         var state = validator.TagStates("End").Single();
         foreach (var reference in allReferences)
@@ -307,7 +307,7 @@ if (boolParameter)
 }}";
 
         var postProcess = new PostProcessTestCheck(OperationKind.Literal, x => x.SetOperationConstraint(DummyConstraint.Dummy));
-        var validator = SETestContext.CreateCS(code, $", {refKind} int {paramName}", postProcess).Validator;
+        var validator = SETestContext.CreateCS(code, $"{refKind} int {paramName}", postProcess).Validator;
         validator.ValidateExitReachCount(2);    // Once with the constraint and once without it.
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/SETestContext.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/SETestContext.cs
@@ -86,7 +86,7 @@ Public Class Sample
 
     Private FieldArray() As Integer
 
-    Public Sub Main(BoolParameter As Boolean{additionalParameters})
+    Public Sub Main(BoolParameter As Boolean{PrependComma(additionalParameters)})
         {methodBody}
     End Sub
 
@@ -144,7 +144,7 @@ public unsafe class Sample
     public Sample(){{ }}
     public Sample(int i){{ }}
 
-    public void Main(bool boolParameter{additionalParameters})
+    public void Main(bool boolParameter{PrependComma(additionalParameters)})
     {{
         {methodBody}
     }}
@@ -176,4 +176,7 @@ public static class Tagger
     public static T Unknown<T>() => default;
 }}
 ";
+
+    private static string PrependComma(string additionalParameters) =>
+        additionalParameters is null ? null : ", " + additionalParameters;
 }


### PR DESCRIPTION
Remove the need to pass ", " explicitly for `additionalParameters`.

This was a bad idea and it's time to fix it, before we add even more UTs.
There's file-scope ns change in one of the commits for SETestContext