### PR TITLE
Add TryGetOperands helper method

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/InvocationExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/InvocationExpressionSyntaxExtensions.cs
@@ -42,16 +42,16 @@ namespace SonarAnalyzer.Extensions
         internal static bool IsEqualTo(this InvocationExpressionSyntax first, InvocationExpressionSyntax second, SemanticModel model) =>
             model.GetSymbolInfo(first).Symbol.Equals(model.GetSymbolInfo(second).Symbol);
 
-        internal static bool TryGetOperands(this InvocationExpressionSyntax invocation, out SyntaxNode leftOperand, out SyntaxNode rightOperand)
+        internal static bool TryGetOperands(this InvocationExpressionSyntax invocation, out SyntaxNode left, out SyntaxNode right)
         {
-            (leftOperand, rightOperand) = invocation switch
+            (left, right) = invocation switch
             {
                 { Expression: MemberAccessExpressionSyntax access } => (access.Expression, access.Name),
                 { Expression: MemberBindingExpressionSyntax binding } => (invocation.GetParentConditionalAccessExpression()?.Expression, binding.Name),
                 _ => (null, null)
             };
 
-            return leftOperand is not null && rightOperand is not null;
+            return left is not null && right is not null;
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/InvocationExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/InvocationExpressionSyntaxExtensions.cs
@@ -41,5 +41,17 @@ namespace SonarAnalyzer.Extensions
 
         internal static bool IsEqualTo(this InvocationExpressionSyntax first, InvocationExpressionSyntax second, SemanticModel model) =>
             model.GetSymbolInfo(first).Symbol.Equals(model.GetSymbolInfo(second).Symbol);
+
+        internal static bool TryGetOperands(this InvocationExpressionSyntax invocation, out SyntaxNode leftOperand, out SyntaxNode rightOperand)
+        {
+            (leftOperand, rightOperand) = invocation switch
+            {
+                { Expression: MemberAccessExpressionSyntax access } => (access.Expression, access.Name),
+                { Expression: MemberBindingExpressionSyntax binding } => (invocation.GetParentConditionalAccessExpression()?.Expression, binding.Name),
+                _ => (null, null)
+            };
+
+            return leftOperand is not null && rightOperand is not null;
+        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/InvocationExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/InvocationExpressionSyntaxExtensions.cs
@@ -20,7 +20,7 @@
 
 namespace SonarAnalyzer.Extensions
 {
-    public static class InvocationExpressionSyntaxExtensions
+    internal static class InvocationExpressionSyntaxExtensions
     {
         internal static bool IsMemberAccessOnKnownType(this InvocationExpressionSyntax invocation, string identifierName, KnownType knownType, SemanticModel semanticModel) =>
             invocation.Expression is MemberAccessExpressionSyntax memberAccess
@@ -28,5 +28,18 @@ namespace SonarAnalyzer.Extensions
 
         internal static IEnumerable<ISymbol> GetArgumentSymbolsOfKnownType(this InvocationExpressionSyntax invocation, KnownType knownType, SemanticModel semanticModel) =>
             invocation.ArgumentList.Arguments.GetSymbolsOfKnownType(knownType, semanticModel);
+
+        internal static bool TryGetOperands(this InvocationExpressionSyntax invocation, out SyntaxNode leftOperand, out SyntaxNode rightOperand)
+        {
+            leftOperand = rightOperand = null;
+
+            if (invocation is { Expression: MemberAccessExpressionSyntax access })
+            {
+                leftOperand = access.Expression ?? invocation.GetParentConditionalAccessExpression()?.Expression;
+                rightOperand = access.Name;
+            }
+
+            return leftOperand is not null && rightOperand is not null;
+        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/InvocationExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/InvocationExpressionSyntaxExtensions.cs
@@ -29,17 +29,17 @@ namespace SonarAnalyzer.Extensions
         internal static IEnumerable<ISymbol> GetArgumentSymbolsOfKnownType(this InvocationExpressionSyntax invocation, KnownType knownType, SemanticModel semanticModel) =>
             invocation.ArgumentList.Arguments.GetSymbolsOfKnownType(knownType, semanticModel);
 
-        internal static bool TryGetOperands(this InvocationExpressionSyntax invocation, out SyntaxNode leftOperand, out SyntaxNode rightOperand)
+        internal static bool TryGetOperands(this InvocationExpressionSyntax invocation, out SyntaxNode left, out SyntaxNode right)
         {
-            leftOperand = rightOperand = null;
+            left = right = null;
 
             if (invocation is { Expression: MemberAccessExpressionSyntax access })
             {
-                leftOperand = access.Expression ?? invocation.GetParentConditionalAccessExpression()?.Expression;
-                rightOperand = access.Name;
+                left = access.Expression ?? invocation.GetParentConditionalAccessExpression()?.Expression;
+                right = access.Name;
             }
 
-            return leftOperand is not null && rightOperand is not null;
+            return left is not null && right is not null;
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeExtensions.cs
@@ -77,8 +77,9 @@ namespace SonarAnalyzer.Extensions
         /// <summary>
         /// Returns the left hand side of a conditional access expression. Returns c in case like a?.b?[0].c?.d.e?.f if d is passed.
         /// </summary>
-        /// <remarks>Adapted from <seealso href="https://github.com/dotnet/roslyn/blob/adaa56d/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/SyntaxNodeExtensions.vb#L1003">
-        /// Roslyn SyntaxNodeExtensions VB.NET version</seealso></remarks>
+        /// <remarks>Adapted from
+        /// <seealso href="https://github.com/dotnet/roslyn/blob/adaa56d/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Extensions/SyntaxNodeExtensions.vb#L1003">
+        /// Roslyn SyntaxNodeExtensions VB.NET version</seealso>.</remarks>
         public static ConditionalAccessExpressionSyntax GetParentConditionalAccessExpression(this SyntaxNode node)
         {
             // Walk upwards based on the grammar/parser rules around ?. expressions (can be seen in

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeExtensions.cs
@@ -19,7 +19,6 @@
  */
 
 using SonarAnalyzer.CFG.Roslyn;
-using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.Extensions
 {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/InvocationExpressionSyntaxExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/InvocationExpressionSyntaxExtensionsTest.cs
@@ -1,0 +1,109 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+extern alias csharp;
+extern alias vbnet;
+
+using Microsoft.CodeAnalysis.Text;
+using CS = Microsoft.CodeAnalysis.CSharp.Syntax;
+using SyntaxNodeExtensionsCS = csharp::SonarAnalyzer.Extensions.InvocationExpressionSyntaxExtensions;
+using SyntaxNodeExtensionsVB = vbnet::SonarAnalyzer.Extensions.InvocationExpressionSyntaxExtensions;
+using VB = Microsoft.CodeAnalysis.VisualBasic.Syntax;
+
+namespace SonarAnalyzer.UnitTest.Extensions
+{
+    [TestClass]
+    public class InvocationExpressionSyntaxExtensionsTest
+    {
+        [DataTestMethod]
+        [DataRow("System.Array.$$Empty<int>()$$", "System.Array", "Empty<int>")]
+        [DataRow("this.$$M()$$", "this", "M")]
+        [DataRow("A?.$$M()$$", "A", "M")]
+        public void TryGetOperands_CS(string expression, string expectedLeft, string expectedRight)
+        {
+            var code = $$"""
+                public class X
+                {
+                    public X A { get; }
+                    public int M()
+                    {
+                        var _ = {{expression}};
+                        return 42;
+                    }
+                }
+                """;
+            var node = NodeBetweenMarkers_CS(code) as CS.InvocationExpressionSyntax;
+
+            var result = SyntaxNodeExtensionsCS.TryGetOperands(node, out var left, out var right);
+
+            result.Should().BeTrue();
+            left.Should().NotBeNull();
+            left.ToString().Should().Be(expectedLeft);
+            right.Should().NotBeNull();
+            right.ToString().Should().Be(expectedRight);
+        }
+
+        [DataTestMethod]
+        [DataRow("System.Array.$$Empty(Of Integer)()$$", "System.Array", "Empty(Of Integer)")]
+        [DataRow("Me.$$M()$$", "Me", "M")]
+        [DataRow("A?.$$M()$$", "A", "M")]
+        public void TryGetOperands_VB(string expression, string expectedLeft, string expectedRight)
+        {
+            var code = $$"""
+                Public Class X
+                    Public Property A As X
+                    Public Function M() As Integer
+                        Dim unused = {{expression}}
+                        Return 42
+                    End Function
+                End Class
+                """;
+            var node = NodeBetweenMarkers_VB(code) as VB.InvocationExpressionSyntax;
+
+            var result = SyntaxNodeExtensionsVB.TryGetOperands(node, out var left, out var right);
+
+            result.Should().BeTrue();
+            left.Should().NotBeNull();
+            left.ToString().Should().Be(expectedLeft);
+            right.Should().NotBeNull();
+            right.ToString().Should().Be(expectedRight);
+        }
+
+        private static SyntaxNode NodeBetweenMarkers_CS(string code)
+        {
+            var position = code.IndexOf("$$");
+            var length = code.LastIndexOf("$$") - position - 2;
+            code = code.Replace("$$", string.Empty);
+            var (tree, _) = TestHelper.CompileCS(code);
+            var node = tree.GetRoot().FindNode(new TextSpan(position, length));
+            return node;
+        }
+
+        private static SyntaxNode NodeBetweenMarkers_VB(string code)
+        {
+            var position = code.IndexOf("$$");
+            var length = code.LastIndexOf("$$") - position - 2;
+            code = code.Replace("$$", string.Empty);
+            var (tree, _) = TestHelper.CompileVB(code);
+            var node = tree.GetRoot().FindNode(new TextSpan(position, length));
+            return node;
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/InvocationExpressionSyntaxExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/InvocationExpressionSyntaxExtensionsTest.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
                     }
                 }
                 """;
-            var node = NodeBetweenMarkers_CS(code) as CS.InvocationExpressionSyntax;
+            var node = NodeBetweenMarkers(code, LanguageNames.CSharp) as CS.InvocationExpressionSyntax;
 
             var result = SyntaxNodeExtensionsCS.TryGetOperands(node, out var left, out var right);
 
@@ -75,7 +75,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
                     End Function
                 End Class
                 """;
-            var node = NodeBetweenMarkers_VB(code) as VB.InvocationExpressionSyntax;
+            var node = NodeBetweenMarkers(code, LanguageNames.VisualBasic) as VB.InvocationExpressionSyntax;
 
             var result = SyntaxNodeExtensionsVB.TryGetOperands(node, out var left, out var right);
 
@@ -99,7 +99,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
                     End Function
                 End Class
                 """;
-            var node = NodeBetweenMarkers_VB(code) as VB.InvocationExpressionSyntax;
+            var node = NodeBetweenMarkers(code, LanguageNames.VisualBasic) as VB.InvocationExpressionSyntax;
 
             var result = SyntaxNodeExtensionsVB.TryGetOperands(node, out var left, out var right);
 
@@ -123,7 +123,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
                     }
                 }
                 """;
-            var node = NodeBetweenMarkers_CS(code) as CS.InvocationExpressionSyntax;
+            var node = NodeBetweenMarkers(code, LanguageNames.CSharp) as CS.InvocationExpressionSyntax;
 
             var result = SyntaxNodeExtensionsCS.TryGetOperands(node, out var left, out var right);
 
@@ -132,24 +132,15 @@ namespace SonarAnalyzer.UnitTest.Extensions
             right.Should().BeNull();
         }
 
-        private static SyntaxNode NodeBetweenMarkers_CS(string code)
+        private static SyntaxNode NodeBetweenMarkers(string code, string language)
         {
             var position = code.IndexOf("$$");
             var length = code.LastIndexOf("$$") - position - 2;
             code = code.Replace("$$", string.Empty);
-            var (tree, _) = TestHelper.CompileCS(code);
+            var (tree, _) = IsCSharp() ? TestHelper.CompileCS(code) : TestHelper.CompileVB(code);
             var node = tree.GetRoot().FindNode(new TextSpan(position, length));
             return node;
-        }
-
-        private static SyntaxNode NodeBetweenMarkers_VB(string code)
-        {
-            var position = code.IndexOf("$$");
-            var length = code.LastIndexOf("$$") - position - 2;
-            code = code.Replace("$$", string.Empty);
-            var (tree, _) = TestHelper.CompileVB(code);
-            var node = tree.GetRoot().FindNode(new TextSpan(position, length));
-            return node;
+            bool IsCSharp() => language == LanguageNames.CSharp;
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/InvocationExpressionSyntaxExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/InvocationExpressionSyntaxExtensionsTest.cs
@@ -135,11 +135,13 @@ namespace SonarAnalyzer.UnitTest.Extensions
         private static SyntaxNode NodeBetweenMarkers(string code, string language)
         {
             var position = code.IndexOf("$$");
-            var length = code.LastIndexOf("$$") - position - 2;
+            var lastPosition = code.LastIndexOf("$$");
+            var length = lastPosition == position ? 0 : lastPosition - position - "$$".Length;
             code = code.Replace("$$", string.Empty);
             var (tree, _) = IsCSharp() ? TestHelper.CompileCS(code) : TestHelper.CompileVB(code);
             var node = tree.GetRoot().FindNode(new TextSpan(position, length));
             return node;
+
             bool IsCSharp() => language == LanguageNames.CSharp;
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -696,7 +696,7 @@ End Class";
         [DataRow("A[0]?.M().B?.$$C")]
         [DataRow("A?.$$B.C")]
         [DataRow("A?.$$B?.C")]
-        public void GetRootConditionalAccessExpression_CB(string expression)
+        public void GetRootConditionalAccessExpression_CS(string expression)
         {
             var code = @$"
 public class X

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -629,7 +629,7 @@ End Class";
         [DataRow("A[0]?.$$M().B?.C", "A[0]?.M().B?.C", "A[0]")]
         [DataRow("A?.$$B.C", "A?.B.C", "A")]
         [DataRow("A?.$$B?.C", "A?.B?.C", "A")]
-        public void GetParentConditionalAccessExpression(string expression, string parent, string parentExpression)
+        public void GetParentConditionalAccessExpression_CS(string expression, string parent, string parentExpression)
         {
             var code = $$"""
                 public class X
@@ -645,8 +645,44 @@ End Class";
                     }
                 }
                 """;
-            var node = NodeAtMarker(code);
+            var node = NodeAtMarker_CS(code);
             var parentConditional = SyntaxNodeExtensionsCS.GetParentConditionalAccessExpression(node);
+            parentConditional.ToString().Should().Be(parent);
+            parentConditional.Expression.ToString().Should().Be(parentExpression);
+        }
+
+        [DataTestMethod]
+        [DataRow("A?.$$M()", "A?.M()", "A")]
+        [DataRow("A?.B?.$$M()", ".B?.M()", ".B")]
+        [DataRow("A?.M()?.$$B", ".M()?.B", ".M()")]
+        [DataRow("A?.$$M()?.B", "A?.M()?.B", "A")]
+        [DataRow("A(0)?.M()?.$$B", ".M()?.B", ".M()")]
+        [DataRow("A(0)?.M().B?.$$C", ".M().B?.C", ".M().B")]
+        [DataRow("A(0)?.$$M().B?.C", "A(0)?.M().B?.C", "A(0)")]
+        [DataRow("A?.$$B.C", "A?.B.C", "A")]
+        [DataRow("A?.$$B?.C", "A?.B?.C", "A")]
+        public void GetParentConditionalAccessExpression_VB(string expression, string parent, string parentExpression)
+        {
+            var code = $$"""
+                Public Class X
+                    Public ReadOnly Property A As X
+                    Public ReadOnly Property B As X
+                    Public ReadOnly Property C As X
+
+                    Default Public ReadOnly Property Item(i As Integer) As X
+                        Get
+                            Return Nothing
+                        End Get
+                    End Property
+
+                    Public Function M() As X
+                        Dim __ = {{expression}}
+                        Return Nothing
+                    End Function
+                End Class
+                """;
+            var node = NodeAtMarker_VB(code);
+            var parentConditional = SyntaxNodeExtensionsVB.GetParentConditionalAccessExpression(node);
             parentConditional.ToString().Should().Be(parent);
             parentConditional.Expression.ToString().Should().Be(parentExpression);
         }
@@ -660,7 +696,7 @@ End Class";
         [DataRow("A[0]?.M().B?.$$C")]
         [DataRow("A?.$$B.C")]
         [DataRow("A?.$$B?.C")]
-        public void GetRootConditionalAccessExpression(string expression)
+        public void GetRootConditionalAccessExpression_CB(string expression)
         {
             var code = @$"
 public class X
@@ -677,16 +713,25 @@ public class X
     }}
 }}
 ";
-            var node = NodeAtMarker(code);
+            var node = NodeAtMarker_CS(code);
             var parentConditional = SyntaxNodeExtensionsCS.GetRootConditionalAccessExpression(node);
             parentConditional.ToString().Should().Be(expression.Replace("$$", string.Empty));
         }
 
-        private static SyntaxNode NodeAtMarker(string code)
+        private static SyntaxNode NodeAtMarker_CS(string code)
         {
             var position = code.IndexOf("$$");
             code = code.Replace("$$", string.Empty);
             var (tree, _) = TestHelper.CompileCS(code);
+            var node = tree.GetRoot().FindNode(new TextSpan(position, 0));
+            return node;
+        }
+
+        private static SyntaxNode NodeAtMarker_VB(string code)
+        {
+            var position = code.IndexOf("$$");
+            code = code.Replace("$$", string.Empty);
+            var (tree, _) = TestHelper.CompileVB(code);
             var node = tree.GetRoot().FindNode(new TextSpan(position, 0));
             return node;
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -720,11 +720,13 @@ public class X
         private static SyntaxNode NodeBetweenMarkers(string code, string language)
         {
             var position = code.IndexOf("$$");
-            var length = code.LastIndexOf("$$") - position - 2;
+            var lastPosition = code.LastIndexOf("$$");
+            var length = lastPosition == position ? 0 : lastPosition - position - "$$".Length;
             code = code.Replace("$$", string.Empty);
             var (tree, _) = IsCSharp() ? TestHelper.CompileCS(code) : TestHelper.CompileVB(code);
             var node = tree.GetRoot().FindNode(new TextSpan(position, length));
             return node;
+
             bool IsCSharp() => language == LanguageNames.CSharp;
         }
 


### PR DESCRIPTION
Add extention method `TryGetOperands` for `InvocationExpressionSyntax` in order to help the implementation of the following rules:

- S6602 (#7121) 
- S6603 (#7122)
- S6605 (#7123)
- S6608 (#7125)
- S6609 (#7126)
- S6610 (#7127)
- S6613 (#7129)
- S6617 (#7131)
