### PR TITLE
Update the expected vbnet plugin file size range

### DIFF
--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -229,8 +229,8 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>4400000</maxsize>
-                  <minsize>4200000</minsize>
+                  <maxsize>4500000</maxsize>
+                  <minsize>4300000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>


### PR DESCRIPTION
Due to the  update of the [protobuf dependency ](https://github.com/SonarSource/sonar-dotnet/pull/7188) the vb.net plugin size is larger.