### PR TITLE
SE: ComputeBoolConstraint for ranges of == and !=

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/NumberConstraint.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/NumberConstraint.cs
@@ -99,6 +99,9 @@ public sealed class NumberConstraint : SymbolicConstraint
         }
     }
 
+    public bool CanContain(BigInteger value) =>
+        (!Min.HasValue || Min <= value) && (!Max.HasValue || value <= Max);
+
     public override bool Equals(object obj) =>
         obj is NumberConstraint other && other.Min == Min && other.Max == Max;
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/NumberConstraint.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/NumberConstraint.cs
@@ -100,7 +100,7 @@ public sealed class NumberConstraint : SymbolicConstraint
     }
 
     public bool CanContain(BigInteger value) =>
-        (!Min.HasValue || Min <= value) && (!Max.HasValue || value <= Max);
+        !(value < Min || Max < value);
 
     public override bool Equals(object obj) =>
         obj is NumberConstraint other && other.Min == Min && other.Max == Max;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
@@ -237,6 +237,8 @@ internal sealed class Binary : BranchingProcessor<IBinaryOperationWrapper>
         kind switch
         {
             BinaryOperatorKind.Equals when left.IsSingleValue && right.IsSingleValue => BoolConstraint.From(left.Equals(right)),
+            BinaryOperatorKind.Equals when left.IsSingleValue && !right.CanContain(left.Min.Value) => BoolConstraint.False,
+            BinaryOperatorKind.Equals when right.IsSingleValue && !left.CanContain(right.Min.Value) => BoolConstraint.False,
             BinaryOperatorKind.NotEquals when left.IsSingleValue && right.IsSingleValue => BoolConstraint.From(!left.Equals(right)),
             BinaryOperatorKind.GreaterThan when left.Min > right.Max => BoolConstraint.True,
             BinaryOperatorKind.GreaterThan when left.Max <= right.Min => BoolConstraint.False,

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
@@ -244,6 +244,8 @@ internal sealed class Binary : BranchingProcessor<IBinaryOperationWrapper>
             BinaryOperatorKind.NotEquals when left.IsSingleValue && right.IsSingleValue => BoolConstraint.From(!left.Equals(right)),
             BinaryOperatorKind.NotEquals when left.IsSingleValue && !right.CanContain(left.Min.Value) => BoolConstraint.True,
             BinaryOperatorKind.NotEquals when right.IsSingleValue && !left.CanContain(right.Min.Value) => BoolConstraint.True,
+            BinaryOperatorKind.NotEquals when right.Min > left.Max => BoolConstraint.True,
+            BinaryOperatorKind.NotEquals when left.Min > right.Max => BoolConstraint.True,
             BinaryOperatorKind.GreaterThan when left.Min > right.Max => BoolConstraint.True,
             BinaryOperatorKind.GreaterThan when left.Max <= right.Min => BoolConstraint.False,
             BinaryOperatorKind.GreaterThanOrEqual when left.Min >= right.Max => BoolConstraint.True,

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
@@ -240,6 +240,8 @@ internal sealed class Binary : BranchingProcessor<IBinaryOperationWrapper>
             BinaryOperatorKind.Equals when left.IsSingleValue && !right.CanContain(left.Min.Value) => BoolConstraint.False,
             BinaryOperatorKind.Equals when right.IsSingleValue && !left.CanContain(right.Min.Value) => BoolConstraint.False,
             BinaryOperatorKind.NotEquals when left.IsSingleValue && right.IsSingleValue => BoolConstraint.From(!left.Equals(right)),
+            BinaryOperatorKind.NotEquals when left.IsSingleValue && !right.CanContain(left.Min.Value) => BoolConstraint.True,
+            BinaryOperatorKind.NotEquals when right.IsSingleValue && !left.CanContain(right.Min.Value) => BoolConstraint.True,
             BinaryOperatorKind.GreaterThan when left.Min > right.Max => BoolConstraint.True,
             BinaryOperatorKind.GreaterThan when left.Max <= right.Min => BoolConstraint.False,
             BinaryOperatorKind.GreaterThanOrEqual when left.Min >= right.Max => BoolConstraint.True,

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
@@ -239,6 +239,8 @@ internal sealed class Binary : BranchingProcessor<IBinaryOperationWrapper>
             BinaryOperatorKind.Equals when left.IsSingleValue && right.IsSingleValue => BoolConstraint.From(left.Equals(right)),
             BinaryOperatorKind.Equals when left.IsSingleValue && !right.CanContain(left.Min.Value) => BoolConstraint.False,
             BinaryOperatorKind.Equals when right.IsSingleValue && !left.CanContain(right.Min.Value) => BoolConstraint.False,
+            BinaryOperatorKind.Equals when right.Min > left.Max => BoolConstraint.False,
+            BinaryOperatorKind.Equals when left.Min > right.Max => BoolConstraint.False,
             BinaryOperatorKind.NotEquals when left.IsSingleValue && right.IsSingleValue => BoolConstraint.From(!left.Equals(right)),
             BinaryOperatorKind.NotEquals when left.IsSingleValue && !right.CanContain(left.Min.Value) => BoolConstraint.True,
             BinaryOperatorKind.NotEquals when right.IsSingleValue && !left.CanContain(right.Min.Value) => BoolConstraint.True,

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Constraints/NumberConstraintTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Constraints/NumberConstraintTest.cs
@@ -167,5 +167,28 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution
                 .And.NotBe(NumberConstraint.From(-10, 100).GetHashCode())
                 .And.NotBe(NumberConstraint.From(min, 100).GetHashCode())
                 .And.NotBe(NumberConstraint.From(-10, max).GetHashCode());
+
+        [DataTestMethod]
+        [DataRow(null, 42, 0)]
+        [DataRow(null, 42, 42)]
+        [DataRow(0, 42, 0)]
+        [DataRow(0, 42, 10)]
+        [DataRow(0, 42, 42)]
+        [DataRow(42, null, 42)]
+        [DataRow(42, null, 100)]
+        public void CanContain_True(int? min, int? max, int value) =>
+            NumberConstraint.From(min, max).CanContain(value).Should().BeTrue();
+
+        [DataTestMethod]
+        [DataRow(null, 42, 43)]
+        [DataRow(null, 42, 100)]
+        [DataRow(0, 42, -100)]
+        [DataRow(0, 42, -1)]
+        [DataRow(0, 42, 43)]
+        [DataRow(0, 42, 100)]
+        [DataRow(42, null, 0)]
+        [DataRow(42, null, 41)]
+        public void CanContain_False(int? min, int? max, int value) =>
+            NumberConstraint.From(min, max).CanContain(value).Should().BeFalse();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Constraints/NumberConstraintTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Constraints/NumberConstraintTest.cs
@@ -90,6 +90,7 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution
             NumberConstraint.From(1, 1).IsSingleValue.Should().BeTrue();
             NumberConstraint.From(null, 42).IsSingleValue.Should().BeFalse();
             NumberConstraint.From(42, null).IsSingleValue.Should().BeFalse();
+            NumberConstraint.From(1, 100).IsSingleValue.Should().BeFalse();
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -1263,6 +1263,25 @@ Tag(""End"", arg);";
         CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "int").TagStates("If").Should().BeEmpty();
 
     [DataTestMethod]
+    [DataRow("arg < 0 && arg == big")]
+    [DataRow("arg > 0 && arg == small")]
+    public void Branching_LearnsNumberConstraint_Unreachable_Ranges(string expression)
+    {
+        var code = $$"""
+            if (small <= -100 && big >= 100)  // Prepare ranged value to compare with
+            {
+                if ({{expression}})
+                {
+                    Tag("Unreachable");
+                }
+            }
+            Tag("End");
+            """;
+        var validator = SETestContext.CreateCS(code, "int arg, int small, int big", new PreserveTestCheck("small", "big")).Validator;
+        validator.ValidateTagOrder("End", "End", "End", "End");
+    }
+
+    [DataTestMethod]
     [DataRow("arg == 42", "arg != 0", 42, 42)]
     [DataRow("arg >  42", "arg != 0", 43, null)]
     [DataRow("arg >= 42", "arg != 0", 42, null)]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -1063,7 +1063,6 @@ Tag(""End"", arg);";
     [DataRow("arg != 42 && arg >=   0", 0, null)]   // We don't track arg != 42 in "if" branch. Actual range is 0-41, 43-oo
     [DataRow("arg != 42 && arg <  100", null, 99)]  // We don't track arg != 42 in "if" branch. Actual range is -oo-41, 43-99
     [DataRow("arg != 42 && arg <= 100", null, 100)] // We don't track arg != 42 in "if" branch. Actual range is -oo-41, 43-100
-    [DataRow("arg >  42 && arg ==   0", 0, 0)]      // ToDo: Should be unreachable
     [DataRow("arg >  42 && arg == 100", 100, 100)]
     [DataRow("arg >  42 && arg !=  43", 44, null)]
     [DataRow("arg >  42 && arg != 100", 43, null)]  // Actual value is 43-99, 101-oo
@@ -1078,7 +1077,6 @@ Tag(""End"", arg);";
     [DataRow("arg >  42 && arg >= 100", 100, null)]
     [DataRow("arg >  42 && arg <  100", 43, 99)]
     [DataRow("arg >  42 && arg <= 100", 43, 100)]
-    [DataRow("arg >= 42 && arg ==   0", 0, 0)]      // ToDo Should be unreachable
     [DataRow("arg >= 42 && arg == 100", 100, 100)]
     [DataRow("arg >= 42 && arg !=  42", 43, null)]
     [DataRow("arg >= 42 && arg != 100", 42, null)]  // Actual value is 42-99, 101-oo
@@ -1095,7 +1093,6 @@ Tag(""End"", arg);";
     [DataRow("arg >= 42 && arg <  100", 42, 99)]
     [DataRow("arg >= 42 && arg <= 100", 42, 100)]
     [DataRow("arg <  42 && arg ==   0", 0, 0)]
-    [DataRow("arg <  42 && arg ==  42", 42, 42)]    // ToDo Should be unreachable
     [DataRow("arg <  42 && arg !=  41", null, 40)]
     [DataRow("arg <  42 && arg !=   0", null, 41)]  // Actual value is oo - -1, 1-41
     [DataRow("arg <  42 && arg >    0", 1, 41)]
@@ -1112,7 +1109,6 @@ Tag(""End"", arg);";
     [DataRow("arg <  42 && arg <=  43", null, 41)]
     [DataRow("arg <  42 && arg <= 100", null, 41)]
     [DataRow("arg <= 42 && arg ==  42", 42, 42)]
-    [DataRow("arg <= 42 && arg == 100", 100, 100)]  // ToDo Should be unreachable
     [DataRow("arg <= 42 && arg !=   0", null, 42)]  // Actual value is oo - -1, 1-42
     [DataRow("arg <= 42 && arg !=  42", null, 41)]
     [DataRow("arg <= 42 && arg >    0", 1, 42)]
@@ -1248,14 +1244,22 @@ Tag(""End"", arg);";
     [DataRow("arg == 42 && arg >= 100")]
     [DataRow("arg == 42 && arg <    0")]
     [DataRow("arg == 42 && arg <=   0")]
+    [DataRow("arg >  42 && arg ==   0")]
+    [DataRow("arg >  42 &&   0 == arg")]
     [DataRow("arg >  42 && arg <    0")]
     [DataRow("arg >  42 && arg <=   0")]
+    [DataRow("arg >= 42 && arg ==   0")]
+    [DataRow("arg >= 42 &&   0 == arg")]
     [DataRow("arg >= 42 && arg <    0")]
     [DataRow("arg >= 42 && arg <=   0")]
+    [DataRow("arg <  42 && arg ==  42")]
+    [DataRow("arg <  42 &&  42 == arg")]
     [DataRow("arg <  42 && arg >  100")]
     [DataRow("arg <  42 && arg >= 100")]
     [DataRow("arg <= 42 && arg >  100")]
     [DataRow("arg <= 42 && arg >= 100")]
+    [DataRow("arg <= 42 && arg == 100")]
+    [DataRow("arg <= 42 && 100 == arg")]
     public void Branching_LearnsNumberConstraint_Unreachable(string expression) =>
         CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "int").TagStates("If").Should().BeEmpty();
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -1265,7 +1265,7 @@ Tag(""End"", arg);";
     [DataTestMethod]
     [DataRow("arg < 0 && arg == big")]
     [DataRow("arg > 0 && arg == small")]
-    public void Branching_LearnsNumberConstraint_Unreachable_Ranges(string expression)
+    public void Branching_LearnsNumberConstraint_Unreachable_Ranges_Equals(string expression)
     {
         var code = $$"""
             if (small <= -100 && big >= 100)  // Prepare ranged value to compare with
@@ -1279,6 +1279,29 @@ Tag(""End"", arg);";
             """;
         var validator = SETestContext.CreateCS(code, "int arg, int small, int big", new PreserveTestCheck("small", "big")).Validator;
         validator.ValidateTagOrder("End", "End", "End", "End");
+    }
+
+    [DataTestMethod]
+    [DataRow("arg < 0", "arg != big")]
+    [DataRow("arg > 0", "arg != small")]
+    public void Branching_LearnsNumberConstraint_Unreachable_Ranges_NotEquals(string prepare, string expression)
+    {
+        var code = $$"""
+            if (small <= -100 && big >= 100 && {{prepare}})  // Prepare ranged value to compare with
+            {
+                if ({{expression}})
+                {
+                    Tag("If");
+                }
+                else
+                {
+                    Tag("Unreachable");
+                }
+            }
+            Tag("End");
+            """;
+        var validator = SETestContext.CreateCS(code, "int arg, int small, int big", new PreserveTestCheck("small", "big")).Validator;
+        validator.ValidateTagOrder("End", "End", "End", "If", "End");
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Numerics;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 using SonarAnalyzer.SymbolicExecution.Roslyn;
 using SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution;


### PR DESCRIPTION
Follow up of #7142 
Fixes #7143 

`Squash LearnNumberCombined` doesn't need a review, it's in #7198 
`Squash LearnNumberCombined_Existing` doesn't need a review, it's in #7203 