### PR TITLE
Implement caching in NetFrameworkVersionProvider

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/NetFrameworkVersionProvider.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/NetFrameworkVersionProvider.cs
@@ -35,11 +35,11 @@ namespace SonarAnalyzer.Helpers
         public NetFrameworkVersion GetDotNetFrameworkVersion(Compilation compilation)
             => compilation is null
                 ? NetFrameworkVersion.Unknown
-                : CompilationVersions.GetValue(compilation, x => new VersionContainer(Calculate(x))).Value;
+                : CompilationVersions.GetValue(compilation, x => new VersionContainer(DetectVersion(x))).Value;
 
-        private static NetFrameworkVersion Calculate(Compilation compilation)
+        private static NetFrameworkVersion DetectVersion(Compilation compilation)
         {
-            /// See https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-4.0/ee471421(v=vs.100)
+            // See https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-4.0/ee471421(v=vs.100)
             var debuggerSymbol = compilation.GetTypeByMetadataName(KnownType.System_Diagnostics_Debugger);
 
             var mscorlibAssembly = debuggerSymbol?.ContainingAssembly;


### PR DESCRIPTION
I wrote a very simple benchmark script to see if this works as expected, and the timings seem to be as expected:

```csharp
using System.Diagnostics;
using System.Runtime.CompilerServices;

ConditionalWeakTable<Key, Value> weakTable = new();

var k = new Key(15);
var k2 = new Key(16);

var sw = Stopwatch.StartNew();
Calculate(k);
var afterOne = sw.ElapsedMilliseconds;
Calculate(k);
var afterTwo = sw.ElapsedMilliseconds;
Calculate(k2);
var afterNewKey = sw.ElapsedMilliseconds;

Console.WriteLine($"First time: {afterOne}");
Console.WriteLine($"Second time: {afterTwo - afterOne}");
Console.WriteLine($"New key: {afterNewKey - afterTwo}");


Value Calculate(Key k) => weakTable.GetValue(k, Calculate);

Value Calculate(Key key)
{
    Thread.Sleep(100);
    return new Value(key.X + 1);
}

record Key(int X);
record Value(int X);
```

Results:

```
First time: 114
Second time: 0
New key: 107
```