### PR TITLE
SE UTs: Replace ValidateTag with TagValue

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -625,7 +625,7 @@ Tag(""End"")";
         validator.ValidateContainsOperation(OperationKind.Binary);
         validator.ValidateTag("If", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("arg comparison true, hence non-null"));
         validator.ValidateTag("If", x => x.HasConstraint<NumberConstraint>().Should().BeTrue("arg inferred a value from the comparison"));
-        validator.ValidateTag("Else", x => x.Should().HaveNoConstraints("arg either null or comparison false"));
+        validator.TagValue("Else").Should().HaveNoConstraints("arg either null or comparison false");
     }
 
     [DataTestMethod]
@@ -641,7 +641,7 @@ Tag(""End"")";
             """;
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
-        validator.ValidateTag("S", x => x.Should().HaveNoConstraints()); // FIXME: s is not null here (https://github.com/SonarSource/sonar-dotnet/issues/7111)
+        validator.TagValue("S").Should().HaveNoConstraints(); // FIXME: s is not null here (https://github.com/SonarSource/sonar-dotnet/issues/7111)
     }
 
     [DataTestMethod]
@@ -657,7 +657,7 @@ Tag(""End"")";
             """;
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
-        validator.ValidateTag("S", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null)); // FIXME: s is not null here (https://github.com/SonarSource/sonar-dotnet/issues/7111)
+        validator.TagValue("S").Should().HaveOnlyConstraint(ObjectConstraint.Null); // FIXME: s is not null here (https://github.com/SonarSource/sonar-dotnet/issues/7111)
     }
 
     [DataTestMethod]
@@ -680,7 +680,7 @@ Tag(""End"")";
             Tag("Result", result);
             """;
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
+        validator.TagValue("Result").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
     }
 
     [DataTestMethod]
@@ -700,7 +700,7 @@ Tag(""End"")";
             Tag("Result", result);
             """;
         var validator = SETestContext.CreateCS(code, "int arg").Validator;
-        validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
+        validator.TagValue("Result").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
     }
 
     [DataTestMethod]
@@ -759,7 +759,7 @@ Tag(""End"")";
             Tag("Value", value);
             """;
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("Value", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expected)));
+        validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expected));
     }
 
     [DataTestMethod]
@@ -781,7 +781,7 @@ Tag(""End"")";
             var value = left * right;
             Tag("Value", value);
             """;
-        SETestContext.CreateCS(code).Validator.ValidateTag("Value", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expected)));
+        SETestContext.CreateCS(code).Validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expected));
     }
 
     [DataTestMethod]
@@ -819,7 +819,7 @@ Tag(""End"")";
             }
             """;
         var validator = SETestContext.CreateCS(code, "int i, int j").Validator;
-        validator.ValidateTag("Value", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedMin, expectedMax)));
+        validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedMin, expectedMax));
     }
 
     [DataTestMethod]
@@ -879,6 +879,6 @@ Tag(""End"")";
             }
             """;
         var validator = SETestContext.CreateCS(code, "int i, int j").Validator;
-        validator.ValidateTag("Value", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedMin, expectedMax)));
+        validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedMin, expectedMax));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -62,8 +62,8 @@ Tag(""End"");";
             "TrueTrue",
             "FalseFalse",
             "End");
-        validator.ValidateTag("True", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
-        validator.ValidateTag("False", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
+        validator.TagValue("True").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
+        validator.TagValue("False").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
     }
 
     [TestMethod]
@@ -80,8 +80,8 @@ else
 };
 Tag(""End"", boolParameter);";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("True", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
-        validator.ValidateTag("False", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
+        validator.TagValue("True").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
+        validator.TagValue("False").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
         validator.TagValues("End").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
@@ -100,7 +100,7 @@ if ((bool)(object)({unary}arg))
 }}";
         var validator = SETestContext.CreateCS(code, "int arg").Validator;
         validator.ValidateContainsOperation(OperationKind.Unary);
-        validator.ValidateTag("Arg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
+        validator.TagValue("Arg").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -116,7 +116,7 @@ Tag(""End"", collection);";
                                                              ? x.SetSymbolConstraint(x.Operation.Instance.AsPropertyReference().Value.Instance.TrackedSymbol(), DummyConstraint.Dummy)
                                                              : x.State);
         var validator = SETestContext.CreateCS(code, "ICollection<object> collection", check).Validator;
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull);
         validator.TagStates("End").Should().HaveCount(2);
     }
 
@@ -138,9 +138,9 @@ if (value = boolParameter)
     Tag(""Value"", value);
 }";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("True", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
-        validator.ValidateTag("False", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
-        validator.ValidateTag("Value", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));    // Visited only for "true" condition
+        validator.TagValue("True").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
+        validator.TagValue("False").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
+        validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);    // Visited only for "true" condition
     }
 
     [DataTestMethod]
@@ -159,8 +159,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_CS(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -180,8 +180,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_NullableInt_CS(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "int?");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -201,8 +201,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_NullableBool_CS(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "bool?");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -222,8 +222,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_Binary_Negated_CS(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -241,8 +241,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_Binary_Negated_NullableInt_CS(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "int?");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -260,8 +260,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_Binary_Negated_NullableBool_CS(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "bool?");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -271,8 +271,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_NullableBool()
     {
         var validator = CreateIfElseEndValidatorCS("(bool)arg", OperationKind.Conversion, "bool?");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
+        validator.TagValue("Else").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
         validator.TagValues("End").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
@@ -282,9 +282,9 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_Integer_VB()
     {
         var validator = CreateIfElseEndValidatorVB("arg", OperationKind.Binary, "Integer");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
+        validator.TagValue("End").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -293,9 +293,9 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_Nullable_VB(string parameterType)
     {
         var validator = CreateIfElseEndValidatorVB("arg", OperationKind.Binary, parameterType);
-        validator.ValidateTag("If", x => x.Should().HaveNoConstraints("arg.GetValueOrDefault() is called in 'if arg' and arg is not found in RoslynSymbolicExecution.SetBranchingConstraints"));
-        validator.ValidateTag("Else", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("End", x => x.Should().HaveNoConstraints());
+        validator.TagValue("If").Should().HaveNoConstraints("arg.GetValueOrDefault() is called in 'if arg' and arg is not found in RoslynSymbolicExecution.SetBranchingConstraints");
+        validator.TagValue("Else").Should().HaveNoConstraints();
+        validator.TagValue("End").Should().HaveNoConstraints();
     }
 
     [DataTestMethod]
@@ -325,8 +325,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_Binary_UndefinedInOtherBranch_CS(string expression, string argType)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, argType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().BeNull("We can't tell if it is Null or NotNull in this branch"));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().BeNull("We can't tell if it is Null or NotNull in this branch");
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -341,8 +341,8 @@ if (value = boolParameter)
     {
         var expectedBoolConstraint = BoolConstraint.From(expected);
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "bool?");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, expectedBoolConstraint));
-        validator.ValidateTag("Else", x => x.Should().BeNull("We can't tell if it is Null or NotNull in this branch"));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, expectedBoolConstraint);
+        validator.TagValue("Else").Should().BeNull("We can't tell if it is Null or NotNull in this branch");
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -356,8 +356,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_Binary_UndefinedInOtherBranch_Negated_CS(string expression, string argType)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, argType);
-        validator.ValidateTag("If", x => x.Should().BeNull("We can't tell if it is Null or NotNull in this branch"));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().BeNull("We can't tell if it is Null or NotNull in this branch");
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -372,8 +372,8 @@ if (value = boolParameter)
     {
         var expectedBoolConstraint = BoolConstraint.From(expected);
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "bool?");
-        validator.ValidateTag("If", x => x.Should().BeNull("We can't tell if it is Null or NotNull in this branch"));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, expectedBoolConstraint));
+        validator.TagValue("If").Should().BeNull("We can't tell if it is Null or NotNull in this branch");
+        validator.TagValue("Else").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, expectedBoolConstraint);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -390,8 +390,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_Binary_VB(string expression)
     {
         var validator = CreateIfElseEndValidatorVB(expression, OperationKind.Binary);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -407,8 +407,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_Binary_Negated_VB(string expression)
     {
         var validator = CreateIfElseEndValidatorVB(expression, OperationKind.Binary);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -422,8 +422,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_IsType_CS(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.IsType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().BeNull("it could be null or any other type"));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().BeNull("it could be null or any other type");
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -437,8 +437,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_IsType_Negated_CS(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.IsType);
-        validator.ValidateTag("If", x => x.Should().BeNull("it could be null or any other type"));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().BeNull("it could be null or any other type");
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -453,17 +453,17 @@ if (value = boolParameter)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.IsType);  // Check something that is known to be null
         validator.ValidateTagOrder("Else", "End");                  // Always true, else branch is not visited
-        validator.ValidateTag("Else", x => x.Should().BeNull());
-        validator.ValidateTag("End", x => x.Should().BeNull());
+        validator.TagValue("Else").Should().BeNull();
+        validator.TagValue("End").Should().BeNull();
     }
 
     [TestMethod]
     public void Branching_LearnsObjectConstraint_IsType_NoSymbol_DoesNotChangeState()
     {
         var validator = CreateIfElseEndValidatorCS("(object)(40 + 2) is Exception", OperationKind.IsType); // Check something that doesn't have a tracked symbol
-        validator.ValidateTag("If", x => x.Should().BeNull());
-        validator.ValidateTag("Else", x => x.Should().BeNull());
-        validator.ValidateTag("End", x => x.Should().BeNull());
+        validator.TagValue("If").Should().BeNull();
+        validator.TagValue("Else").Should().BeNull();
+        validator.TagValue("End").Should().BeNull();
     }
 
     [DataTestMethod]
@@ -474,8 +474,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_IsType_VB(string expression)
     {
         var validator = CreateIfElseEndValidatorVB(expression, OperationKind.IsType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().BeNull("it could be null or any other type"));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().BeNull("it could be null or any other type");
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -489,8 +489,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_IsType_Negated_VB(string expression)
     {
         var validator = CreateIfElseEndValidatorVB(expression, OperationKind.IsType);
-        validator.ValidateTag("If", x => x.Should().BeNull("it could be null or any other type"));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().BeNull("it could be null or any other type");
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -506,8 +506,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_ConstantPattern_Null(string expression, string argType)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.ConstantPattern, argType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -523,8 +523,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_ConstantPattern_Null_Negated(string expression, string argType)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.ConstantPattern, argType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -540,8 +540,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_ConstantPattern_True(string expression, string argType = "object")
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.ConstantPattern, argType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(BoolConstraint.True)); // Should be NotNull, True
-        validator.ValidateTag("Else", x => x.Should().HaveNoConstraints("it could be False, null or any other type"));
+        validator.TagValue("If").Should().HaveOnlyConstraint(BoolConstraint.True); // Should be NotNull, True
+        validator.TagValue("Else").Should().HaveNoConstraints("it could be False, null or any other type");
         validator.TagValues("End").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(BoolConstraint.True),
             x => x.Should().HaveNoConstraints());
@@ -553,8 +553,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_ConstantPattern_ForBool(bool constantPattern)
     {
         var validator = CreateIfElseEndValidatorCS($"arg is {constantPattern.ToString().ToLower()}", OperationKind.ConstantPattern, "bool");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(constantPattern)));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(constantPattern));
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(constantPattern)),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
@@ -566,8 +566,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_ConstantPattern_True_Negated(string expression, string argType)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.ConstantPattern, argType);
-        validator.ValidateTag("If", x => x.Should().HaveNoConstraints("it could be False, null or any other type"));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(BoolConstraint.True));
+        validator.TagValue("If").Should().HaveNoConstraints("it could be False, null or any other type");
+        validator.TagValue("Else").Should().HaveOnlyConstraint(BoolConstraint.True);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(BoolConstraint.True));
@@ -579,8 +579,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_ConstantPattern_True_Negated_ForBool(bool constantPattern)
     {
         var validator = CreateIfElseEndValidatorCS($"arg is not {constantPattern.ToString().ToLower()}", OperationKind.ConstantPattern, "bool");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(constantPattern)));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(constantPattern));
         validator.TagValues("End").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(constantPattern)));
@@ -592,8 +592,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_ConstantPattern_False(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.ConstantPattern);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(BoolConstraint.False));
-        validator.ValidateTag("Else", x => x.Should().BeNull("it could be True, null or any other type"));
+        validator.TagValue("If").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("Else").Should().BeNull("it could be True, null or any other type");
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(BoolConstraint.False));
@@ -605,8 +605,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_ConstantPattern_ValueTypes_InputIsNotReferenceType(string expression, string argType)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.ConstantPattern, argType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveNoConstraints());
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveNoConstraints();
         validator.TagValues("End").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull),
             x => x.Should().HaveNoConstraints());
@@ -618,9 +618,9 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_ConstantPattern_ValueTypes_InputNonNullableValueType(string expression, string argType)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.ConstantPattern, argType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("End").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -634,8 +634,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_ConstantPattern_Literals(string expression, string argType = "object")
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.ConstantPattern, argType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().BeNull());
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().BeNull();
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -647,8 +647,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_TypePattern(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.TypePattern);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().BeNull("it could be null or any other type"));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().BeNull("it could be null or any other type");
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -660,8 +660,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_TypePattern_Negated(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.TypePattern);
-        validator.ValidateTag("If", x => x.Should().BeNull("it could be null or any other type"));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().BeNull("it could be null or any other type");
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -685,8 +685,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_RecursivePattern_ElseIsNull(string expression, string argType = "object")
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.RecursivePattern, argType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -706,8 +706,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_RecursivePattern_ElseIsUnknown(string expression, string argType = "object")
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.RecursivePattern, argType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().BeNull("it could be null or any other type"));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().BeNull("it could be null or any other type");
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -718,9 +718,9 @@ if (value = boolParameter)
     {
         // We don't support learning for tuples (yet). Should behave same as "arg is { }". Gets tricky when nesting (a, (b, c))
         var validator = CreateIfElseEndValidatorCS("(arg, Unknown<object>()) is ({ }, { })", OperationKind.RecursivePattern);
-        validator.ValidateTag("If", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("Else", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("End", x => x.Should().HaveNoConstraints());
+        validator.TagValue("If").Should().HaveNoConstraints();
+        validator.TagValue("Else").Should().HaveNoConstraints();
+        validator.TagValue("End").Should().HaveNoConstraints();
     }
 
     [DataTestMethod]
@@ -731,8 +731,8 @@ if (value = boolParameter)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.RecursivePattern, argType);
         validator.ValidateTagOrder("If", "End"); // Always true, else branch is not visited
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("End").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -741,8 +741,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_RecursivePattern_Negated_IfIsNotNull(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.RecursivePattern);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -754,8 +754,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_RecursivePattern_Negated_IfIsUnknown(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.RecursivePattern);
-        validator.ValidateTag("If", x => x.Should().BeNull("it could be null or any other type"));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().BeNull("it could be null or any other type");
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -772,8 +772,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_DeclarationPattern(string expression, string argType = "object")
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.DeclarationPattern, argType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().BeNull("it could be null or any other type"));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().BeNull("it could be null or any other type");
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -783,9 +783,9 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_DeclarationPattern_ValueType()
     {
         var validator = CreateIfElseEndValidatorCS("arg is object o", OperationKind.DeclarationPattern, "TStruct");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("End").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -796,8 +796,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_DeclarationPattern_ElseIsNull(string expression, string argType = "object")
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.DeclarationPattern, argType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -809,9 +809,9 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_DeclarationPattern_NoConstraints(string expression, string argType = "object")
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.DeclarationPattern, argType);
-        validator.ValidateTag("If", x => x.Should().BeNull());
-        validator.ValidateTag("Else", x => x.Should().BeNull());
-        validator.ValidateTag("End", x => x.Should().BeNull());
+        validator.TagValue("If").Should().BeNull();
+        validator.TagValue("Else").Should().BeNull();
+        validator.TagValue("End").Should().BeNull();
     }
 
     [DataTestMethod]
@@ -821,8 +821,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_DeclarationPattern_Negated(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.DeclarationPattern);
-        validator.ValidateTag("If", x => x.Should().BeNull("it could be null or any other type"));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().BeNull("it could be null or any other type");
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -834,8 +834,8 @@ if (value = boolParameter)
     public void Branching_LearnsObjectConstraint_DeclarationPattern_Negated_ElseIsNull(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.DeclarationPattern);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -857,8 +857,8 @@ switch (arg)
 Tag(""End"", arg);";
         var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.FlowCaptureReference);
-        validator.ValidateTag("Null", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("Default", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("Null").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Default").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -887,8 +887,8 @@ Tag(""End"", arg);";
     public void Branching_LearnsObjectConstraint_Nullable_HasValue_True(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.DeclarationPattern, "int?");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValues("End").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull),
             x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
@@ -903,8 +903,8 @@ Tag(""End"", arg);";
     public void Branching_LearnsObjectConstraint_Nullable_HasValue_Negated(string expression)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.DeclarationPattern, "int?");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull),
             x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
@@ -917,7 +917,7 @@ Tag(""End"", arg);";
         validator.TagValues("If").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -951,7 +951,7 @@ Tag(""End"", arg);";
 
                 Tag("End", s);
                 """, "string s").Validator;
-        validator.ValidateTag("End", x => x.Should().HaveNoConstraints()); // Should have NotNull constraint
+        validator.TagValue("End").Should().HaveNoConstraints(); // Should have NotNull constraint
     }
 
     [DataTestMethod]
@@ -968,8 +968,8 @@ Tag(""End"", arg);";
     public void Branching_LearnsNumberConstraint(string argType)
     {
         var validator = CreateIfElseEndValidatorCS("arg == 42", OperationKind.Binary, argType);
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42)));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42));
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42)),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
@@ -987,8 +987,8 @@ Tag(""End"", arg);";
     public void Branching_LearnsNumberConstraint_OnlyIf_CS(string expression, int? expectedIfMin, int? expectedIfMax)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "int");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedIfMin, expectedIfMax)));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedIfMin, expectedIfMax));
+        validator.TagValue("Else").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -1003,8 +1003,8 @@ Tag(""End"", arg);";
     public void Branching_LearnsNumberConstraint_OnlyIf_VB(string expression, int? expectedIfMin, int? expectedIfMax)
     {
         var validator = CreateIfElseEndValidatorVB(expression, OperationKind.Binary, "Integer");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedIfMin, expectedIfMax)));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedIfMin, expectedIfMax));
+        validator.TagValue("Else").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -1019,8 +1019,8 @@ Tag(""End"", arg);";
     public void Branching_LearnsNumberConstraint_IfElse_CS(string expression, int? expectedIfMin, int? expectedIfMax, int? expectedElseMin, int? expectedElseMax)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "int");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedIfMin, expectedIfMax)));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedElseMin, expectedElseMax)));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedIfMin, expectedIfMax));
+        validator.TagValue("Else").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedElseMin, expectedElseMax));
     }
 
     [DataTestMethod]
@@ -1035,8 +1035,8 @@ Tag(""End"", arg);";
     public void Branching_LearnsNumberConstraint_IfElse_VB(string expression, int? expectedIfMin, int? expectedIfMax, int? expectedElseMin, int? expectedElseMax)
     {
         var validator = CreateIfElseEndValidatorVB(expression, OperationKind.Binary, "Integer");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedIfMin, expectedIfMax)));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedElseMin, expectedElseMax)));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedIfMin, expectedIfMax));
+        validator.TagValue("Else").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedElseMin, expectedElseMax));
     }
 
     [DataTestMethod]
@@ -1051,8 +1051,8 @@ Tag(""End"", arg);";
     public void Branching_LearnsNumberConstraint_IfElse_Nullable(string expression, int? expectedIfMin, int? expectedIfMax)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "int?");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedIfMin, expectedIfMax)));
-        validator.ValidateTag("Else", x => x.Should().HaveNoConstraints("arg could be opposite, or null"));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedIfMin, expectedIfMax));
+        validator.TagValue("Else").Should().HaveNoConstraints("arg could be opposite, or null");
     }
 
     [DataTestMethod]
@@ -1125,7 +1125,7 @@ Tag(""End"", arg);";
     public void Branching_LearnsNumberConstraint_IfElse_Combined(string expression, int? expectedIfMin, int? expectedIfMax)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "int");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedIfMin, expectedIfMax)));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedIfMin, expectedIfMax));
     }
 
     [DataTestMethod]
@@ -1134,8 +1134,8 @@ Tag(""End"", arg);";
     public void Branching_LearnsNumberConstraint_OnlyElse_CS(string expression, int? expectedElseMin, int? expectedElseMax)
     {
         var validator = CreateIfElseEndValidatorCS(expression, OperationKind.Binary, "int");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedElseMin, expectedElseMax)));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedElseMin, expectedElseMax));
     }
 
     [DataTestMethod]
@@ -1144,15 +1144,15 @@ Tag(""End"", arg);";
     public void Branching_LearnsNumberConstraint_OnlyElse_VB(string expression, int? expectedElseMin, int? expectedElseMax)
     {
         var validator = CreateIfElseEndValidatorVB(expression, OperationKind.Binary, "Integer");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedElseMin, expectedElseMax)));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedElseMin, expectedElseMax));
     }
 
     [TestMethod]
     public void Branching_LearnsNumberConstraint_NotEqualsTwice()
     {
         var validator = CreateIfElseEndValidatorCS("arg != 42 && arg != 100", OperationKind.Binary, "int");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));     // Visited with unknown value
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);     // Visited with unknown value
         validator.TagValues("Else").Should().SatisfyRespectively(                                       // Visited once for each failed condition
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42, 42)),      // Once we're sure it was 42
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(100, 100)));   // Once we're sure it was 100
@@ -1162,7 +1162,7 @@ Tag(""End"", arg);";
     public void Branching_LearnsNumberConstraint_Nested_Collapsed()
     {
         var validator = CreateIfElseEndValidatorCS("arg >= 42 && arg <= 100", OperationKind.Binary, "int");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42, 100)));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42, 100));
         validator.TagValues("Else").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(null, 41)),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(101, null)));
@@ -1190,10 +1190,10 @@ Tag(""End"", arg);";
             }
             """;
         var validator = SETestContext.CreateCS(code, "int arg").Validator;
-        validator.ValidateTag("IfOuter", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42, null)));
-        validator.ValidateTag("IfInner", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42, 100)));
-        validator.ValidateTag("ElseInner", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(101, null)));
-        validator.ValidateTag("ElseOuter", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(null, 41)));
+        validator.TagValue("IfOuter").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42, null));
+        validator.TagValue("IfInner").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42, 100));
+        validator.TagValue("ElseInner").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(101, null));
+        validator.TagValue("ElseOuter").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(null, 41));
     }
 
     [DataTestMethod]
@@ -1213,7 +1213,7 @@ Tag(""End"", arg);";
             }
             """;
         var validator = SETestContext.CreateCS(code, "int arg, int onlyMin, int onlyMax").Validator;
-        validator.ValidateTag("Arg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
+        validator.TagValue("Arg").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -1233,7 +1233,7 @@ Tag(""End"", arg);";
             }
             """;
         var validator = SETestContext.CreateCS(code, "int arg, int onlyMin, int onlyMax").Validator;
-        validator.ValidateTag("Arg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedMin, expectedMax)));
+        validator.TagValue("Arg").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedMin, expectedMax));
     }
 
     [DataTestMethod]
@@ -1467,7 +1467,7 @@ Tag(""End"", arg);";
             """;
         var validator = SETestContext.CreateCS(code, "int arg").Validator;
         validator.ValidateTagOrder("If");
-        validator.ValidateTag("If", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedMin, expectedMax)));
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedMin, expectedMax));
     }
 
     private static ValidatorTestCheck CreateIfElseEndValidatorCS(string expression, OperationKind expectedOperation, string argType = "object")

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Constants.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Constants.cs
@@ -53,7 +53,7 @@ public partial class RoslynSymbolicExecutionTest
             var v = {value};
             Tag("Value", v);
             """).Validator;
-        validator.ValidateTag("Value", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(value)));
+        validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(value));
     }
 
     [TestMethod]
@@ -105,7 +105,7 @@ public void Main(bool arg = true)
 {
     Tag(""Arg"", arg);
 }";
-        SETestContext.CreateCSMethod(code).Validator.ValidateTag("Arg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        SETestContext.CreateCSMethod(code).Validator.TagValue("Arg").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     private static BoolConstraint GetConstraint(bool value) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.IncrementOrDecrement.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.IncrementOrDecrement.cs
@@ -35,8 +35,8 @@ public partial class RoslynSymbolicExecutionTest
             Tag("Result", result);
             """;
         var validator = SETestContext.CreateCS(code, "Sample arg").Validator;
-        validator.ValidateTag("Target", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
+        validator.TagValue("Target").Should().HaveNoConstraints();
+        validator.TagValue("Result").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -48,7 +48,7 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var setter = new PostProcessTestCheck(OperationKind.PropertyReference, x => x.SetOperationConstraint(NumberConstraint.From(10)));
         var validator = SETestContext.CreateCS(code, "Sample arg", setter).Validator;
-        validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(11)));
+        validator.TagValue("Result").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(11));
     }
 
     [TestMethod]
@@ -60,8 +60,8 @@ public partial class RoslynSymbolicExecutionTest
             Tag("Result", result);
             """;
         var validator = SETestContext.CreateCS(code, "int arg").Validator;
-        validator.ValidateTag("Arg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
-        validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
+        validator.TagValue("Arg").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
+        validator.TagValue("Result").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -78,8 +78,8 @@ public partial class RoslynSymbolicExecutionTest
             Tag("Result", result);
             """;
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("Target", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedTarget)));
-        validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedResult)));
+        validator.TagValue("Target").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedTarget));
+        validator.TagValue("Result").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedResult));
     }
 
     [DataTestMethod]
@@ -96,8 +96,8 @@ public partial class RoslynSymbolicExecutionTest
             }
             """;
         var validator = SETestContext.CreateCS(code, "int onlyMin, int onlyMax").Validator;
-        validator.ValidateTag("OnlyMin", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2, null)));
-        validator.ValidateTag("OnlyMax", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(null, 100)));
+        validator.TagValue("OnlyMin").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2, null));
+        validator.TagValue("OnlyMax").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(null, 100));
     }
 
     [DataTestMethod]
@@ -114,7 +114,7 @@ public partial class RoslynSymbolicExecutionTest
             }
             """;
         var validator = SETestContext.CreateCS(code, "int onlyMin, int onlyMax").Validator;
-        validator.ValidateTag("OnlyMin", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0, null)));
-        validator.ValidateTag("OnlyMax", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(null, 98)));
+        validator.TagValue("OnlyMin").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0, null));
+        validator.TagValue("OnlyMax").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(null, 98));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -86,12 +86,12 @@ public static class Extensions
 }";
         var validator = new SETestContext(code, AnalyzerLanguage.CSharp, Array.Empty<SymbolicCheck>()).Validator;
         validator.ValidateContainsOperation(OperationKind.Invocation);
-        validator.ValidateTag("BeforeInstance", x => x.Should().BeNull());
-        validator.ValidateTag("BeforeExtensionArg", x => x.Should().BeNull());
+        validator.TagValue("BeforeInstance").Should().BeNull();
+        validator.TagValue("BeforeExtensionArg").Should().BeNull();
         validator.ValidateTag("BeforeExtensionNull", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
         validator.ValidateTag("BeforePreserve", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
         validator.ValidateTag("AfterInstance", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("Instance method should set NotNull constraint."));
-        validator.ValidateTag("AfterExtensionArg", x => x.Should().BeNull("Extensions can run on null instances."));
+        validator.TagValue("AfterExtensionArg").Should().BeNull("Extensions can run on null instances.");
         validator.ValidateTag("AfterExtensionNull", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue("Extensions can run on null instances."));
         validator.ValidateTag("AfterPreserve", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue("Other constraints should not be removed."));
     }
@@ -136,12 +136,12 @@ Public Module Extensions
 End Module";
         var validator = new SETestContext(code, AnalyzerLanguage.VisualBasic, Array.Empty<SymbolicCheck>()).Validator;
         validator.ValidateContainsOperation(OperationKind.ObjectCreation);
-        validator.ValidateTag("BeforeInstance", x => x.Should().BeNull());
-        validator.ValidateTag("BeforeStatic", x => x.Should().BeNull());
-        validator.ValidateTag("BeforeExtension", x => x.Should().BeNull());
+        validator.TagValue("BeforeInstance").Should().BeNull();
+        validator.TagValue("BeforeStatic").Should().BeNull();
+        validator.TagValue("BeforeExtension").Should().BeNull();
         validator.ValidateTag("AfterInstance", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("Instance method should set NotNull constraint."));
-        validator.ValidateTag("AfterStatic", x => x.Should().BeNull("Static method can execute from null instances."));
-        validator.ValidateTag("AfterExtension", x => x.Should().BeNull("Extensions can run on null instances."));
+        validator.TagValue("AfterStatic").Should().BeNull("Static method can execute from null instances.");
+        validator.TagValue("AfterExtension").Should().BeNull("Extensions can run on null instances.");
     }
 
     [DataTestMethod]
@@ -216,10 +216,10 @@ public static class Extensions
             """;
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Invocation);
-        validator.ValidateTag("BeforeField", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("BeforeStaticField", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("AfterField", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("AfterStaticField", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("BeforeField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("BeforeStaticField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("AfterField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("AfterStaticField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 
     [DataTestMethod]
@@ -685,7 +685,7 @@ Tag(""Value"", value);";
 var value = arg.{expression};
 Tag(""Value"", value);";
         var validator = SETestContext.CreateCS(code, $"IEnumerable<object> arg").Validator;
-        validator.ValidateTag("Value", x => x.Should().BeNull());
+        validator.TagValue("Value").Should().BeNull();
     }
 
     [TestMethod]
@@ -698,7 +698,7 @@ If Query.Count <> 0 Then
     Tag(""Value"", Value)
 End If";
         var validator = SETestContext.CreateVB(code, "Items() As Object").Validator;
-        validator.ValidateTag("Value", x => x.Should().BeNull());
+        validator.TagValue("Value").Should().BeNull();
     }
 
     [DataTestMethod]
@@ -746,7 +746,7 @@ End Sub";
 Dim Result As Boolean = IsNothing("""" & Arg.ToString())
 Tag(""Result"", Result)";
         var validator = SETestContext.CreateVB(code, "Arg As Object").Validator;
-        validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("Result").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -783,8 +783,8 @@ Debug.Assert(arg1 != null && arg2 != null);
 Tag(""Arg1"", arg1);
 Tag(""Arg2"", arg2);";
         var validator = SETestContext.CreateCS(code, $"object arg1, object arg2").Validator;
-        validator.ValidateTag("Arg1", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Arg2", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("Arg1").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Arg2").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -972,7 +972,7 @@ object right = {right};
 var result = object.Equals(left, right);
 Tag(""Result"", result);";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("Result").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -1013,7 +1013,7 @@ Tag(""End"");";
             var result = left.Equals(right);
             Tag("Result", result);
             """;
-        SETestContext.CreateCS(code).Validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(expectedResult)));
+        SETestContext.CreateCS(code).Validator.TagValue("Result").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(expectedResult));
     }
 
     [DataTestMethod]
@@ -1031,7 +1031,7 @@ Tag(""End"");";
             var result = left.Equals(right);
             Tag("Result", result);
             """;
-        SETestContext.CreateCS(code).Validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        SETestContext.CreateCS(code).Validator.TagValue("Result").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -1082,10 +1082,10 @@ private bool Equals(object a, object b) => false;
 private static bool Equals() => false;
 private static bool Equals(object a, object b, object c) => false;";
         var validator = SETestContext.CreateCSMethod(code).Validator;
-        validator.ValidateTag("InstanceOne", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("InstanceTwo", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("NoArgs", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("MoreArgs", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("InstanceOne").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("InstanceTwo").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("NoArgs").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("MoreArgs").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -1129,7 +1129,7 @@ private static bool Equals(object a, object b, object c) => false;";
             Tag("Result", result);
             """;
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("Result").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -1182,9 +1182,9 @@ private static bool Equals(object a, object b, object c) => false;";
                 private bool ReferenceEquals(object a, object b, object c) => false;
                 """;
         var validator = SETestContext.CreateCSMethod(code).Validator;
-        validator.ValidateTag("Args0", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Args1", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Args2", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Args3", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("Args0").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Args1").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Args2").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Args3").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.InvocationAttribute.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.InvocationAttribute.cs
@@ -133,10 +133,10 @@ Tag(""Success"", success);
 Tag(""Result"", result);
 Tag(""ObjectField"", ObjectField);";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("ByteString", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("Success", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
-        validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("ObjectField", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("ByteString").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Success").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
+        validator.TagValue("Result").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("ObjectField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 
     [TestMethod]
@@ -151,10 +151,10 @@ Tag(""Success"", success);
 Tag(""Result"", result);
 Tag(""ObjectField"", ObjectField);";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("ByteString", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Success", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Result", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("ObjectField", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("ByteString").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Success").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Result").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("ObjectField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 
     [TestMethod]
@@ -277,7 +277,7 @@ if(CustomValidator(first, untracked.field))
 public bool CustomValidator([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object first, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object second) => true;";
         var validator = SETestContext.CreateCSMethod(code).Validator;
         validator.ValidateTag("First", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("Second", x => x.Should().BeNull());  // We didn't learn anything. And we continued
+        validator.TagValue("Second").Should().BeNull();  // We didn't learn anything. And we continued
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.IsNull.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.IsNull.cs
@@ -45,12 +45,12 @@ Tag(""NotNullToNotNull"", notNullToNotNull);
 Tag(""NotNullToUnknown"", notNullToUnknown);";
         var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.IsNull);
-        validator.ValidateTag("NullToNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("NullToNotNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("NullToUnknown", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("NotNullToNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("NotNullToNotNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("NotNullToUnknown", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("NullToNull").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("NullToNotNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("NullToUnknown").Should().HaveNoConstraints();
+        validator.TagValue("NotNullToNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("NotNullToNotNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("NotNullToUnknown").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -149,7 +149,7 @@ Tag(""UnknownToUnknown"", unknownToUnknown);";
                 Tag("Value", value);
                 """;
         var validator = SETestContext.CreateCS(code, "string arg").Validator;
-        validator.ValidateTag("Value", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -160,7 +160,7 @@ Tag(""UnknownToUnknown"", unknownToUnknown);";
                 Tag("Arg", arg);
                 """;
         var validator = SETestContext.CreateCS(code, "string arg").Validator;
-        validator.ValidateTag("Arg", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("Arg").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -190,12 +190,12 @@ Tag(""NotNullToUnknown"", notNullToUnknown);
 ";
         var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.IsNull);
-        validator.ValidateTag("NullToNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("NullToNotNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("NullToUnknown", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("NotNullToNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("NotNullToNotNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("NotNullToUnknown", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("NullToNull").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("NullToNotNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("NullToUnknown").Should().HaveNoConstraints();
+        validator.TagValue("NotNullToNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("NotNullToNotNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("NotNullToUnknown").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -287,7 +287,7 @@ Tag(""End"", arg);";
                 (arg as Exception)?.ToString();
                 Tag("Arg", arg);
                 """, "object arg").Validator;
-        validator.ValidateTag("Arg", x => x.Should().HaveNoConstraints());
+        validator.TagValue("Arg").Should().HaveNoConstraints();
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -61,7 +61,7 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var validator = SETestContext.CreateCS(code, "int arg", new AddConstraintOnInvocationCheck()).Validator;
         validator.ValidateExitReachCount(1);
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First));   // Loop was entered, arg has only it's final constraints after looping once
+        validator.TagValue("End").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First);   // Loop was entered, arg has only it's final constraints after looping once
     }
 
     [TestMethod]
@@ -189,8 +189,8 @@ public partial class RoslynSymbolicExecutionTest
         validator.TagValues("Inside").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2, 10)));
-        validator.ValidateTag("After", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10, null)));
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First));   // arg has only it's final constraints after looping once
+        validator.TagValue("After").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10, null));
+        validator.TagValue("End").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First);   // arg has only it's final constraints after looping once
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -89,10 +89,10 @@ public partial class RoslynSymbolicExecutionTest
                 x[hasValue].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
                 x[arg].Should().HaveOnlyConstraint(ObjectConstraint.Null);
             });
-        validator.ValidateTag("HasValueAfter42", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
-        validator.ValidateTag("SymbolAfter42", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42)));
-        validator.ValidateTag("HasValueAfterNull", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
-        validator.ValidateTag("SymbolAfterNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("HasValueAfter42").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
+        validator.TagValue("SymbolAfter42").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42));
+        validator.TagValue("HasValueAfterNull").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
+        validator.TagValue("SymbolAfterNull").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 
     [TestMethod]
@@ -124,10 +124,10 @@ public partial class RoslynSymbolicExecutionTest
                 x[hasValue].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
                 x[arg].Should().HaveOnlyConstraint(ObjectConstraint.Null);
             });
-        validator.ValidateTag("HasValueAfterTrue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
-        validator.ValidateTag("SymbolAfterTrue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
-        validator.ValidateTag("HasValueAfterNull", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
-        validator.ValidateTag("SymbolAfterNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("HasValueAfterTrue").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
+        validator.TagValue("SymbolAfterTrue").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
+        validator.TagValue("HasValueAfterNull").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
+        validator.TagValue("SymbolAfterNull").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 
     [TestMethod]
@@ -167,9 +167,9 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var setter = new PreProcessTestCheck(OperationKind.Literal, x => x.Operation.Instance.ConstantValue.Value is false ? x.SetOperationConstraint(TestConstraint.First) : x.State);
         var validator = SETestContext.CreateCS(code, setter).Validator;
-        validator.ValidateTag("IsTrue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True));
-        validator.ValidateTag("IsFalse", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False, TestConstraint.First));
-        validator.ValidateTag("IsInt", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42)));
+        validator.TagValue("IsTrue").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
+        validator.TagValue("IsFalse").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False, TestConstraint.First);
+        validator.TagValue("IsInt").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42));
     }
 
     [TestMethod]
@@ -212,12 +212,12 @@ public partial class RoslynSymbolicExecutionTest
             Tag("NotNullValue", value);
             """;
         var validator = SETestContext.CreateCS(code, "int? arg", new LiteralDummyTestCheck()).Validator;
-        validator.ValidateTag("UnknownArg", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy));
-        validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy, NumberConstraint.From(42)));
-        validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy, NumberConstraint.From(42)));
+        validator.TagValue("UnknownArg").Should().HaveNoConstraints();
+        validator.TagValue("UnknownValue").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("NullArg").Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy);
+        validator.TagValue("NullValue").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("NotNullArg").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy, NumberConstraint.From(42));
+        validator.TagValue("NotNullValue").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy, NumberConstraint.From(42));
     }
 
     [TestMethod]
@@ -239,12 +239,12 @@ public partial class RoslynSymbolicExecutionTest
             Tag("NotNullValue", value);
             """;
         var validator = SETestContext.CreateCS(code, "bool? arg", new LiteralDummyTestCheck()).Validator;
-        validator.ValidateTag("UnknownArg", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("UnknownValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
-        validator.ValidateTag("NullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy));
-        validator.ValidateTag("NullValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False));
-        validator.ValidateTag("NotNullArg", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True, DummyConstraint.Dummy));
-        validator.ValidateTag("NotNullValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True, DummyConstraint.Dummy));
+        validator.TagValue("UnknownArg").Should().HaveNoConstraints();
+        validator.TagValue("UnknownValue").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
+        validator.TagValue("NullArg").Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy);
+        validator.TagValue("NullValue").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
+        validator.TagValue("NotNullArg").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True, DummyConstraint.Dummy);
+        validator.TagValue("NotNullValue").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True, DummyConstraint.Dummy);
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -134,7 +134,7 @@ public void Method()
     {
         var validator = SETestContext.CreateCS(snippet, new LiteralDummyTestCheck()).Validator;
         validator.Validate("Literal: 42", x => x.State[x.Operation].Should().HaveOnlyConstraints(new SymbolicConstraint[] { ObjectConstraint.NotNull, NumberConstraint.From(42), DummyConstraint.Dummy }, "it's scaffolded"));
-        validator.ValidateTag("Target", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42), DummyConstraint.Dummy));
+        validator.TagValue("Target").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42), DummyConstraint.Dummy);
     }
 
     [DataTestMethod]
@@ -150,7 +150,7 @@ public void Method()
     {
         var validator = SETestContext.CreateCS(snippet, new LiteralDummyTestCheck()).Validator;
         validator.Validate("Literal: 42", x => x.State[x.Operation].Should().HaveOnlyConstraints(new SymbolicConstraint[] { ObjectConstraint.NotNull, NumberConstraint.From(42), DummyConstraint.Dummy }, "it's scaffolded"));
-        validator.ValidateTag("Target", x => x.Should().HaveNoConstraints());
+        validator.TagValue("Target").Should().HaveNoConstraints();
     }
 
     [TestMethod]
@@ -274,8 +274,8 @@ public void Method()
             }
             """;
         var validator = SETestContext.CreateCSMethod(code, new LiteralDummyTestCheck()).Validator;
-        validator.ValidateTag("WithImplicit", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("WithExplicit", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("WithImplicit").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("WithExplicit").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
 #if NET
@@ -289,7 +289,7 @@ public void Method()
             Tag("Half", h);
             """;
         var validator = SETestContext.CreateCS(code, new LiteralDummyTestCheck()).Validator;
-        validator.ValidateTag("Half", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));    // While it would be better to propagate constraints here, Half has custom conversion operators
+        validator.TagValue("Half").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);    // While it would be better to propagate constraints here, Half has custom conversion operators
     }
 
 #endif
@@ -312,12 +312,12 @@ public void Method()
                 Tag("AsBoxing", asBoxing);
                 Tag("UnboxingBoxing", unboxingBoxing);
                 """, new LiteralDummyTestCheck()).Validator;
-        validator.ValidateTag("Object", x => x.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy));
-        validator.ValidateTag("Convert", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
-        validator.ValidateTag("Explicit", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy));
-        validator.ValidateTag("ImplicitBoxing", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy));
-        validator.ValidateTag("AsBoxing", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy));
-        validator.ValidateTag("UnboxingBoxing", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy));
+        validator.TagValue("Object").Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy);
+        validator.TagValue("Convert").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
+        validator.TagValue("Explicit").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy);
+        validator.TagValue("ImplicitBoxing").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy);
+        validator.TagValue("AsBoxing").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy);
+        validator.TagValue("UnboxingBoxing").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy);
     }
 
     [TestMethod]
@@ -340,26 +340,26 @@ public void Method()
                 Tag("TryCast", iTryCast)
                 Tag("TryCastBoxing", iTryCastBoxing)
                 """, new LiteralDummyTestCheck()).Validator;
-        validator.ValidateTag("Object", x => x.Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy));
-        validator.ValidateTag("CType", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy));
-        validator.ValidateTag("CInt", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy));
-        validator.ValidateTag("DirectCast", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy));
-        validator.ValidateTag("Implicit", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy));
-        validator.ValidateTag("TryCast", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy));
-        validator.ValidateTag("TryCastBoxing", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy));
+        validator.TagValue("Object").Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy);
+        validator.TagValue("CType").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy);
+        validator.TagValue("CInt").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy);
+        validator.TagValue("DirectCast").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy);
+        validator.TagValue("Implicit").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy);
+        validator.TagValue("TryCast").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy);
+        validator.TagValue("TryCastBoxing").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy);
     }
 
     [TestMethod]
     public void Argument_Ref_ResetsConstraints_CS() =>
-        SETestContext.CreateCS(@"var b = true; Main(boolParameter, ref b); Tag(""B"", b);", "ref bool outParam").Validator.ValidateTag("B", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        SETestContext.CreateCS(@"var b = true; Main(boolParameter, ref b); Tag(""B"", b);", "ref bool outParam").Validator.TagValue("B").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
 
     [TestMethod]
     public void Argument_Out_ResetsConstraints_CS() =>
-        SETestContext.CreateCS(@"var b = true; Main(boolParameter, out b); Tag(""B"", b); outParam = false;", "out bool outParam").Validator.ValidateTag("B", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        SETestContext.CreateCS(@"var b = true; Main(boolParameter, out b); Tag(""B"", b); outParam = false;", "out bool outParam").Validator.TagValue("B").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
 
     [TestMethod]
     public void Argument_ByRef_ResetConstraints_VB() =>
-        SETestContext.CreateVB(@"Dim B As Boolean = True : Main(BoolParameter, B) : Tag(""B"", B)", "ByRef ByRefParam As Boolean").Validator.ValidateTag("B", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        SETestContext.CreateVB(@"Dim B As Boolean = True : Main(BoolParameter, B) : Tag(""B"", B)", "ByRef ByRefParam As Boolean").Validator.TagValue("B").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
 
     [TestMethod]
     public void Argument_ArgList_DoesNotThrow()
@@ -500,7 +500,7 @@ public void Main<T>() where T : new()
             """;
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Unary);
-        validator.ValidateTag("Index", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("Index").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -512,7 +512,7 @@ public void Main<T>() where T : new()
             """;
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Range);
-        validator.ValidateTag("Range", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("Range").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
 #endif
@@ -535,14 +535,14 @@ Tag(""AfterInt"", argInt);
 Tag(""AfterNullableInt"", argNullableInt);";
         var validator = SETestContext.CreateCS(code, "object argObjNull, object argObjDefault, int argInt, int? argNullableInt").Validator;
         validator.ValidateContainsOperation(OperationKind.Literal);
-        validator.ValidateTag("BeforeObjNull", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("BeforeObjDefault", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("BeforeInt", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("BeforeNullableInt", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("AfterObjNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("AfterObjDefault", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("AfterInt", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.Zero));
-        validator.ValidateTag("AfterNullableInt", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("BeforeObjNull").Should().HaveNoConstraints();
+        validator.TagValue("BeforeObjDefault").Should().HaveNoConstraints();
+        validator.TagValue("BeforeInt").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("BeforeNullableInt").Should().HaveNoConstraints();
+        validator.TagValue("AfterObjNull").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("AfterObjDefault").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("AfterInt").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.Zero);
+        validator.TagValue("AfterNullableInt").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 
     [TestMethod]
@@ -557,10 +557,10 @@ Tag(""AfterObj"", ArgObj)
 Tag(""AfterInt"", ArgInt)";
         var validator = SETestContext.CreateVB(code, "ArgObj As Object, ArgInt As Integer").Validator;
         validator.ValidateContainsOperation(OperationKind.Literal);
-        validator.ValidateTag("BeforeObj", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("BeforeInt", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("AfterObj", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("AfterInt", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.Zero));
+        validator.TagValue("BeforeObj").Should().HaveNoConstraints();
+        validator.TagValue("BeforeInt").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterObj").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("AfterInt").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.Zero);
     }
 
     [TestMethod]
@@ -597,14 +597,14 @@ Tag(""AfterInt"", ArgInt)";
                 """;
         var validator = SETestContext.CreateCSMethod(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Literal);
-        validator.ValidateTag("Class", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("Struct", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "struct cannot be null."));
-        validator.ValidateTag("Unknown", x => x.Should().HaveNoConstraints("it can be struct."));
-        validator.ValidateTag("Type", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
-        validator.ValidateTag("Interface", x => x.Should().HaveNoConstraints("interfaces can be implemented by a struct."));
-        validator.ValidateTag("Unmanaged", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "unmanaged implies struct and cannot be null."));
-        validator.ValidateTag("Enum", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "Enum cannot be null."));
-        validator.ValidateTag("Delegate", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
+        validator.TagValue("Class").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Struct").Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "struct cannot be null.");
+        validator.TagValue("Unknown").Should().HaveNoConstraints("it can be struct.");
+        validator.TagValue("Type").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Interface").Should().HaveNoConstraints("interfaces can be implemented by a struct.");
+        validator.TagValue("Unmanaged").Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "unmanaged implies struct and cannot be null.");
+        validator.TagValue("Enum").Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "Enum cannot be null.");
+        validator.TagValue("Delegate").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 
     [TestMethod]
@@ -699,7 +699,7 @@ Tag(""This"", fromThis);";
                 Tag("Size", size);
                 """;
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("Size", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(4)));
+        validator.TagValue("Size").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(4));
     }
 
     [DataTestMethod]
@@ -761,7 +761,7 @@ public static class Guard
         validator.ValidateTag("AfterGuard_o3", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("AfterGuard_o4", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("AfterGuard_o5", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterGuard_o6", x => x.Should().BeNull("parameter is not annotated"));
+        validator.TagValue("AfterGuard_o6").Should().BeNull("parameter is not annotated");
         validator.ValidateTag("AfterGuard_o7", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("AfterGuard_o8", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("AfterGuard_s1", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
@@ -842,17 +842,17 @@ public static class Guard
             End Module
             """;
         var validator = new SETestContext(code, AnalyzerLanguage.VisualBasic, Array.Empty<SymbolicCheck>()).Validator;
-        validator.ValidateTag("AfterGuard_o1", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("AfterGuard_o2", x => x.Should().HaveNoConstraints("extension method invoked on Object type is DynamicInvocationOperation that we don't support."));
-        validator.ValidateTag("AfterGuard_o3", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("AfterGuard_o4", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("AfterGuard_o5", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("AfterGuard_o6", x => x.Should().HaveNoConstraints("parameter is not annotated"));
-        validator.ValidateTag("AfterGuard_o7", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("AfterGuard_o8", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("AfterGuard_s1", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("AfterGuard_s2", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("AfterGuard_ex", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("AfterGuard_o1").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_o2").Should().HaveNoConstraints("extension method invoked on Object type is DynamicInvocationOperation that we don't support.");
+        validator.TagValue("AfterGuard_o3").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_o4").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_o5").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_o6").Should().HaveNoConstraints("parameter is not annotated");
+        validator.TagValue("AfterGuard_o7").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_o8").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_s1").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_s2").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_ex").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -870,7 +870,7 @@ Tag(""After"", arg);
 Sample UntrackedSymbol() => this;";
         var validator = SETestContext.CreateCS(code, "Sample arg").Validator;
         validator.ValidateContainsOperation(OperationKind.FieldReference);
-        validator.ValidateTag("Before", x => x.Should().BeNull());
+        validator.TagValue("Before").Should().BeNull();
         validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
     }
 
@@ -889,7 +889,7 @@ Tag(""After"", arg);
 Sample UntrackedSymbol() => this;";
         var validator = SETestContext.CreateCS(code, "Sample arg").Validator;
         validator.ValidateContainsOperation(OperationKind.FieldReference);
-        validator.ValidateTag("Before", x => x.Should().BeNull());
+        validator.TagValue("Before").Should().BeNull();
         validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
     }
 
@@ -903,7 +903,7 @@ Tag(""This"", fieldException);
 Tag(""Arg"", argException);";
         var validator = SETestContext.CreateCS(code, "Sample arg").Validator;
         validator.ValidateTag("This", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("Arg", x => x.Should().BeNull());
+        validator.TagValue("Arg").Should().BeNull();
     }
 
     [TestMethod]
@@ -927,9 +927,9 @@ Tag(""AfterIndexer"", indexer);
 Sample UntrackedSymbol() => this;";
         var validator = SETestContext.CreateCS(code, "Sample arg, Dictionary<int, int> dictionary, Sample indexer").Validator;
         validator.ValidateContainsOperation(OperationKind.PropertyReference);
-        validator.ValidateTag("BeforeProperty", x => x.Should().BeNull());
-        validator.ValidateTag("BeforeDictionary", x => x.Should().BeNull());
-        validator.ValidateTag("BeforeIndexer", x => x.Should().BeNull());
+        validator.TagValue("BeforeProperty").Should().BeNull();
+        validator.TagValue("BeforeDictionary").Should().BeNull();
+        validator.TagValue("BeforeIndexer").Should().BeNull();
         validator.ValidateTag("AfterProperty", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("AfterDictionary", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("AfterIndexer", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
@@ -956,9 +956,9 @@ Tag(""AfterIndexer"", indexer);
 Sample UntrackedSymbol() => this;";
         var validator = SETestContext.CreateCS(code, "Sample arg, Dictionary<int, int> dictionary, Sample indexer").Validator;
         validator.ValidateContainsOperation(OperationKind.PropertyReference);
-        validator.ValidateTag("BeforeProperty", x => x.Should().BeNull());
-        validator.ValidateTag("BeforeDictionary", x => x.Should().BeNull());
-        validator.ValidateTag("BeforeIndexer", x => x.Should().BeNull());
+        validator.TagValue("BeforeProperty").Should().BeNull();
+        validator.TagValue("BeforeDictionary").Should().BeNull();
+        validator.TagValue("BeforeIndexer").Should().BeNull();
         validator.ValidateTag("AfterProperty", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("AfterDictionary", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("AfterIndexer", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
@@ -975,8 +975,8 @@ Sample UntrackedSymbol() => this;";
                 """;
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.PropertyReference);
-        validator.ValidateTag("AfterSetNull", x => x.Should().HaveOnlyConstraints(ObjectConstraint.Null));
-        validator.ValidateTag("AfterReadReference", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull));
+        validator.TagValue("AfterSetNull").Should().HaveOnlyConstraints(ObjectConstraint.Null);
+        validator.TagValue("AfterReadReference").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -990,8 +990,8 @@ Sample UntrackedSymbol() => this;";
                 """;
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.PropertyReference);
-        validator.ValidateTag("AfterSetNull", x => x.Should().HaveNoConstraints());
-        validator.ValidateTag("AfterReadReference", x => x.Should().HaveNoConstraints());
+        validator.TagValue("AfterSetNull").Should().HaveNoConstraints();
+        validator.TagValue("AfterReadReference").Should().HaveNoConstraints();
     }
 
     [TestMethod]
@@ -1006,7 +1006,7 @@ Tag(""After"", array);
 int[] UntrackedSymbol() => new[] { 42 };";
         var validator = SETestContext.CreateCS(code, "int[] array").Validator;
         validator.ValidateContainsOperation(OperationKind.ArrayElementReference);
-        validator.ValidateTag("Before", x => x.Should().BeNull());
+        validator.TagValue("Before").Should().BeNull();
         validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
     }
 
@@ -1022,7 +1022,7 @@ Tag(""After"", array);
 int[] UntrackedSymbol() => new[] { 42 };";
         var validator = SETestContext.CreateCS(code, "int[] array").Validator;
         validator.ValidateContainsOperation(OperationKind.ArrayElementReference);
-        validator.ValidateTag("Before", x => x.Should().BeNull());
+        validator.TagValue("Before").Should().BeNull();
         validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
     }
 
@@ -1038,8 +1038,8 @@ Tag(""AfterAdd"", add);
 Tag(""AfterRemove"", remove);";
         var validator = SETestContext.CreateCS(code, "Sample add, Sample remove").Validator;
         validator.ValidateContainsOperation(OperationKind.ArrayElementReference);
-        validator.ValidateTag("BeforeAdd", x => x.Should().BeNull());
-        validator.ValidateTag("BeforeRemove", x => x.Should().BeNull());
+        validator.TagValue("BeforeAdd").Should().BeNull();
+        validator.TagValue("BeforeRemove").Should().BeNull();
         validator.ValidateTag("AfterAdd", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("AfterRemove", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
     }
@@ -1070,7 +1070,7 @@ Tag(""AfterNotTracked"", Arg.FieldArray)";
         validator.ValidateTag("AfterSecond", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("AfterThird", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
         validator.ValidateTag("AfterFourth", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterNotTracked", x => x.Should().BeNull());
+        validator.TagValue("AfterNotTracked").Should().BeNull();
     }
 
     [TestMethod]
@@ -1152,6 +1152,6 @@ Tag(""Value"", value);";
                     Tag("Value", value);
                 }
                 """;
-        SETestContext.CreateCSMethod(code).Validator.ValidateTag("Value", x => x.Should().BeNull());
+        SETestContext.CreateCSMethod(code).Validator.TagValue("Value").Should().BeNull();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.ParameterReassignedConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.ParameterReassignedConstraint.cs
@@ -42,7 +42,7 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var argumentSnippet = $"{argumentType} arg";
         var validator = SETestContext.CreateCS(methodBody, argumentSnippet, new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance));
+        validator.TagValue("End").Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance);
     }
 
     [TestMethod]
@@ -53,7 +53,7 @@ public partial class RoslynSymbolicExecutionTest
             Tag("End", arg);
             """;
         var validator = SETestContext.CreateCS(methodBody, "int arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance, ObjectConstraint.NotNull));
+        validator.TagValue("End").Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance, ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -71,7 +71,7 @@ public partial class RoslynSymbolicExecutionTest
             Tag("End", arg);
             """;
         var validator = SETestContext.CreateCS(methodBody, "object arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance));
+        validator.TagValue("End").Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance);
     }
 
     [TestMethod]
@@ -83,7 +83,7 @@ public partial class RoslynSymbolicExecutionTest
             Tag("End", arg);
             """;
         var validator = SETestContext.CreateCS(methodBody, "object arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance, ObjectConstraint.NotNull));
+        validator.TagValue("End").Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance, ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -97,7 +97,7 @@ public partial class RoslynSymbolicExecutionTest
             Tag("End", arg);
             """;
         var validator = SETestContext.CreateCS(methodBody, "object arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("End", x => x.Should().HaveNoConstraints()); // ToDo: arg should have the ParameterReassignedConstraint
+        validator.TagValue("End").Should().HaveNoConstraints(); // ToDo: arg should have the ParameterReassignedConstraint
     }
 
     [TestMethod]
@@ -145,7 +145,7 @@ public partial class RoslynSymbolicExecutionTest
             arg = arg ?? throw new ArgumentNullException();
             Tag("End", arg);
             """, "string arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("End").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -170,7 +170,7 @@ public partial class RoslynSymbolicExecutionTest
                 : arg;
             Tag("End", arg);
             """, "string arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("End").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -182,7 +182,7 @@ public partial class RoslynSymbolicExecutionTest
                 : Unknown<string>();
             Tag("End", arg);
             """, "string arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("End", x => x.Should().HaveNoConstraints()); // ToDo: Misses ParameterReassignedConstraint
+        validator.TagValue("End").Should().HaveNoConstraints(); // ToDo: Misses ParameterReassignedConstraint
     }
 
 #if NET
@@ -196,7 +196,7 @@ public partial class RoslynSymbolicExecutionTest
                 ArgumentNullException.{{throwIfNullMethod}}(arg);
                 Tag("End", arg);
                 """, "string arg", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        validator.TagValue("End").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
 #endif
@@ -222,9 +222,9 @@ public partial class RoslynSymbolicExecutionTest
                 local {{compoundAssigment}} 1;
                 Tag("AfterUnknown", local);
                 """, new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("AfterNull", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null)); // ToDo: Misses ParameterReassignedConstraint in all cases
-        validator.ValidateTag("AfterValue", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42)));    // ToDo: Value 42 is wrong, should be result of the operation
-        validator.ValidateTag("AfterUnknown", x => x.Should().HaveNoConstraints());
+        validator.TagValue("AfterNull").Should().HaveOnlyConstraint(ObjectConstraint.Null); // ToDo: Misses ParameterReassignedConstraint in all cases
+        validator.TagValue("AfterValue").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42));    // ToDo: Value 42 is wrong, should be result of the operation
+        validator.TagValue("AfterUnknown").Should().HaveNoConstraints();
     }
 
     [TestMethod]
@@ -236,8 +236,8 @@ public partial class RoslynSymbolicExecutionTest
             Tag("AfterAssignmentArg2", arg2);
             """;
         var validator = SETestContext.CreateCS(snippet, "object arg1, object arg2", new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("AfterAssignmentArg1", x => x.Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance));
-        validator.ValidateTag("AfterAssignmentArg2", x => x.Should().HaveNoConstraints());
+        validator.TagValue("AfterAssignmentArg1").Should().HaveOnlyConstraints(ParameterReassignedConstraint.Instance);
+        validator.TagValue("AfterAssignmentArg2").Should().HaveNoConstraints();
     }
 
     [DataTestMethod]
@@ -247,7 +247,7 @@ public partial class RoslynSymbolicExecutionTest
     public void ParameterReassignedConstraint_IgnoreNonParameters(string snippet)
     {
         var validator = SETestContext.CreateCS(snippet, new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("AfterAssignment", x => x.Should().HaveNoConstraints());
+        validator.TagValue("AfterAssignment").Should().HaveNoConstraints();
     }
 
     [TestMethod]
@@ -278,6 +278,6 @@ public partial class RoslynSymbolicExecutionTest
             }
             """;
         var validator = SETestContext.CreateCSMethod(methodCode, new PublicMethodArgumentsShouldBeCheckedForNull()).Validator;
-        validator.ValidateTag("End", x => x.Should().HaveOnlyConstraints(expectedConstraints));
+        validator.TagValue("End").Should().HaveOnlyConstraints(expectedConstraints);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
@@ -292,10 +292,10 @@ Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
         var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
-        validator.ValidateTag("A", x => x.Should().BeNull());
-        validator.ValidateTag("B", x => x.Should().BeNull());
-        validator.ValidateTag("C", x => x.Should().BeNull());
-        validator.ValidateTag("D", x => x.Should().BeNull());
+        validator.TagValue("A").Should().BeNull();
+        validator.TagValue("B").Should().BeNull();
+        validator.TagValue("C").Should().BeNull();
+        validator.TagValue("D").Should().BeNull();
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(TestConstraint.First) && x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(TestConstraint.First) && x.HasConstraint(ObjectConstraint.NotNull));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.cs
@@ -278,7 +278,7 @@ Tag(""End"");";
 
     [TestMethod]
     public void Execute_LocalScopeRegion_Struct_NoAction() =>
-        SETestContext.CreateVB(@"Dim Value As Integer : Tag(""Value"", Value)").Validator.ValidateTag("Value", x => x.Should().HaveOnlyConstraint(ObjectConstraint.NotNull));
+        SETestContext.CreateVB(@"Dim Value As Integer : Tag(""Value"", Value)").Validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
 
     [TestMethod]
     public void Execute_FieldSymbolsAreNotRemovedByLva()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/ValidatorTestCheck.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/ValidatorTestCheck.cs
@@ -67,6 +67,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution
         public void Validate(string operation, Action<SymbolicContext> action) =>
             action(postProcessed.Single(x => TestHelper.Serialize(x.Operation) == operation));
 
+        [Obsolete(@"Use TagValue(""Name"").Should()... instead")]
         public void ValidateTag(string tag, Action<SymbolicValue> action)
         {
             var values = TagValues(tag);
@@ -76,6 +77,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution
 
         public ProgramState[] TagStates(string tag) =>
             tags.Where(x => x.Name == tag).Select(x => x.Context.State).ToArray();
+
+        public SymbolicValue TagValue(string tag) =>
+            TagValues(tag).Should().ContainSingle().Subject;
 
         public SymbolicValue[] TagValues(string tag) =>
             tags.Where(x => x.Name == tag).Select(x => TagValue(x.Context)).ToArray();


### PR DESCRIPTION
`ValidatorTestCheck.ValidateTag` is now obsolete, because we can fluently assert symbolic value constraints.

Using `TagValue("Name")` also gives better error message when assertion fails, because we can see what tagname failed in the message.

Before:
```
validator.ValidateTag("If", x => x.Should().HaveOnlyConstraint(ObjectConstraint.Null));
```

After:
```
 validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.Null);
 ```

All usages were replaced using regex:
Find: `ValidateTag\((?<Name>"[^"]+"), x => x.Should\(\)\.(?<Action>.*)\);`
Replace: `TagValue(${Name}).Should().${Action};`