### PR TITLE
Enable concurrent execution of the utility analyzers

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Collections.Concurrent;
 using System.IO;
 using Google.Protobuf;
 using SonarAnalyzer.Protobuf;
@@ -34,7 +35,7 @@ namespace SonarAnalyzer.Rules
     {
         protected static readonly ISet<string> FileExtensionWhitelist = new HashSet<string> { ".cs", ".csx", ".vb" };
         private readonly DiagnosticDescriptor rule;
-        protected override bool EnableConcurrentExecution => false;
+        protected override bool EnableConcurrentExecution => true;
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(rule);
@@ -100,7 +101,7 @@ namespace SonarAnalyzer.Rules
                     return;
                 }
 
-                var treeMessages = new List<TMessage>();
+                var treeMessages = new ConcurrentBag<TMessage>();
                 startContext.RegisterSemanticModelAction(modelContext =>
                 {
                     if (ShouldGenerateMetrics(parameters, modelContext))


### PR DESCRIPTION
Fixes #6674


I opted for `ConcurrentBag` as it had the best performance ( scenario: multiple threads writing, and a single consumer writing to disk after the threads finished their job).
Results of the benchmark:

`ConcurrentStack` | `ConcurrentQueue` | `SynchronizedStream` | `ConcurrentBag`
 455.93 ms            | 438.83 ms               | 327.23 ms                    | 221.9 ms