### PR TITLE
SE: Cache NumberConstraint

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/NumberConstraint.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/NumberConstraint.cs
@@ -72,9 +72,7 @@ public sealed class NumberConstraint : SymbolicConstraint
         }
         if (min.HasValue && max.HasValue && min.Value > max.Value)
         {
-            var tmp = min;
-            min = max;
-            max = tmp;
+            (min, max) = (max, min);
         }
         if (cache.Count > CacheLimit)
         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Constraints/NumberConstraintTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Constraints/NumberConstraintTest.cs
@@ -83,6 +83,38 @@ namespace SonarAnalyzer.UnitTest.SymbolicExecution
             NumberConstraint.From(null, null).Should().BeNull();
         }
 
+        [DataTestMethod]
+        [DataRow(0, 0)]
+        [DataRow(null, 42)]
+        [DataRow(42, null)]
+        [DataRow(0, 100)]
+        public void From_IsCached(int? min, int? max)
+        {
+            NumberConstraint.ResetCache();  // Otherwise the cache test could reset this half way through the testing
+            NumberConstraint.From(min, max).Should().BeSameAs(NumberConstraint.From(min, max));
+        }
+
+        [TestMethod]
+        public void From_Cache_ResetsAfterLimit()
+        {
+            var zero = NumberConstraint.From(0);
+            zero.Should().BeSameAs(NumberConstraint.From(0));
+            for (var i = 0; i <= 100_000; i++)
+            {
+                NumberConstraint.From(i);   // Abuse the cache
+            }
+            zero.Should().NotBeSameAs(NumberConstraint.From(0), "Cache should have been cleared and this should be a new instance");
+        }
+
+        [TestMethod]
+        public void From_ResetCache()
+        {
+            var value = NumberConstraint.From(42);
+            value.Should().BeSameAs(NumberConstraint.From(42));
+            NumberConstraint.ResetCache();
+            value.Should().NotBeSameAs(NumberConstraint.From(42));
+        }
+
         [TestMethod]
         public void IsSingleValue()
         {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -448,7 +448,7 @@ Tag(""EqualsFalse"", EqualsFalse)";
         var code = @$"
 Dim Value = {expression}
 Tag(""End"")";
-        var setter = new PreProcessTestCheck(OperationKind.Literal, x => x.SetOperationConstraint(NumberConstraint.Zero)); // Coverage of Flip local function with ObjectValueEquals
+        var setter = new PreProcessTestCheck(OperationKind.Literal, x => x.SetOperationConstraint(NumberConstraint.From(0))); // Coverage of Flip local function with ObjectValueEquals
         var validator = SETestContext.CreateVB(code, "Arg As Object", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
         validator.TagStates("End").Should().HaveCount(2)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -541,7 +541,7 @@ Tag(""AfterNullableInt"", argNullableInt);";
         validator.TagValue("BeforeNullableInt").Should().HaveNoConstraints();
         validator.TagValue("AfterObjNull").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValue("AfterObjDefault").Should().HaveOnlyConstraint(ObjectConstraint.Null);
-        validator.TagValue("AfterInt").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.Zero);
+        validator.TagValue("AfterInt").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0));
         validator.TagValue("AfterNullableInt").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 
@@ -560,7 +560,7 @@ Tag(""AfterInt"", ArgInt)";
         validator.TagValue("BeforeObj").Should().HaveNoConstraints();
         validator.TagValue("BeforeInt").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValue("AfterObj").Should().HaveOnlyConstraint(ObjectConstraint.Null);
-        validator.TagValue("AfterInt").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.Zero);
+        validator.TagValue("AfterInt").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0));
     }
 
     [TestMethod]


### PR DESCRIPTION
Fixes #7156

Uses similar trick as cache of `SymbolicConstraint`

Stats of existing NumberConstraints from build of 3 projects:
[NumberConstraint_Akka.txt](https://github.com/SonarSource/sonar-dotnet/files/11544644/NumberConstraint_Akka.txt)
[NumberConstraint_Runtime.txt](https://github.com/SonarSource/sonar-dotnet/files/11544645/NumberConstraint_Runtime.txt)
[NumberConstraint_WCF.txt](https://github.com/SonarSource/sonar-dotnet/files/11544646/NumberConstraint_WCF.txt)

