### PR TITLE
S3949: Bump coverage

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.cs
@@ -297,3 +297,15 @@ class DotnetOverflow
         }
     }
 }
+
+public class CustomOperator
+{
+    public void Coverage()
+    {
+        // To cover the `Min(ITypeSymbol)` returning `null`. The char doesn't help here, because ch+ch returns int.
+        CustomOperator value = (CustomOperator)(object)42;      // Anything with NumberConstraint and + operation
+        value = value + value;                                  // Compliant
+    }
+
+    public static CustomOperator operator +(CustomOperator left, CustomOperator right) => null;
+}


### PR DESCRIPTION
`Max` is not coverable, because it would require `Min` to return value that doesn't have max defined.

Coverage is currently incorrectly computed, because `&& Max(operation.Type) is { } typeMax` cannot produce `false` answer by-design now.