### PR TITLE
SE: Init integral variables to zero

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
@@ -40,6 +40,10 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
             {
                 return ObjectConstraint.Null;
             }
+            else if (type.IsAny(KnownType.IntegralNumbers))
+            {
+                return NumberConstraint.From(0);
+            }
             else
             {
                 return null;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Checks/ConstantCheck.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.Checks
             {
                 return ObjectConstraint.Null;
             }
-            else if (type.IsAny(KnownType.IntegralNumbers))
+            else if (type.IsAny(KnownType.IntegralNumbersIncludingNative))
             {
                 return NumberConstraint.From(0);
             }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Conversion.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Conversion.cs
@@ -26,7 +26,10 @@ internal sealed class Conversion : SimpleProcessor<IConversionOperationWrapper>
         operation.ToConversion();
 
     protected override ProgramState Process(SymbolicContext context, IConversionOperationWrapper conversion) =>
-        context.State[conversion.Operand] is { } value && conversion.OperatorMethod is null // Built-in conversions only
+        context.State[conversion.Operand] is { } value && IsBuildIn(conversion.OperatorMethod) // Built-in conversions only
             ? context.State.SetOperationValue(context.Operation, value)
             : context.State;
+
+    private static bool IsBuildIn(ISymbol symbol) =>
+        symbol is null || symbol.ContainingType.IsAny(KnownType.PointerTypes);
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -293,7 +293,7 @@ public partial class RoslynSymbolicExecutionTest
     public void Loops_While_NestedNumberCondition_VB()
     {
         const string code = """
-            Dim i As Integer = 0
+            Dim i As Integer
             While Condition     ' We are inside a Loop => binary operations are evaluated To True/False For 1St pass, And learn range condition For 2nd pass
                 If i < 10 Then
                     Tag("Inside", i)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -215,7 +215,7 @@ public partial class RoslynSymbolicExecutionTest
         validator.TagValue("UnknownArg").Should().HaveNoConstraints();
         validator.TagValue("UnknownValue").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValue("NullArg").Should().HaveOnlyConstraints(ObjectConstraint.Null, DummyConstraint.Dummy);
-        validator.TagValue("NullValue").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("NullValue").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0));
         validator.TagValue("NotNullArg").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy, NumberConstraint.From(42));
         validator.TagValue("NotNullValue").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy, NumberConstraint.From(42));
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -241,6 +241,8 @@ public void Method()
     [DataRow("decimal")]
     [DataRow("float")]
     [DataRow("double")]
+    [DataRow("IntPtr")]
+    [DataRow("UIntPtr")]
     public void Conversion_BuiltInConversion_PropagateState(string type)
     {
         var code = $"""
@@ -248,7 +250,26 @@ public void Method()
             {type} value = b;
             Tag("Value", value);
             """;
-        SETestContext.CreateCS(code, new LiteralDummyTestCheck()).Validator.ValidateTag("Value", x => x.HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
+        SETestContext.CreateCS(code, new LiteralDummyTestCheck()).Validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy, NumberConstraint.From(42));
+    }
+
+    [DataTestMethod]
+    [DataRow("Int16")]
+    [DataRow("Int32")]
+    [DataRow("Int64")]
+    [DataRow("Decimal")]
+    [DataRow("Single")]
+    [DataRow("Double")]
+    [DataRow("IntPtr")]
+    [DataRow("UIntPtr")]
+    public void Conversion_BuiltInConversion_PropagateState_VB(string type)
+    {
+        var code = $"""
+            Dim B As Byte = 42
+            Dim Value As {type} = B
+            Tag("Value", Value)
+            """;
+        SETestContext.CreateVB(code, new LiteralDummyTestCheck()).Validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, DummyConstraint.Dummy, NumberConstraint.From(42));
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -241,9 +241,7 @@ public void Method()
     [DataRow("decimal")]
     [DataRow("float")]
     [DataRow("double")]
-    [DataRow("IntPtr")]
-    [DataRow("UIntPtr")]
-    public void Conversion_BuiltInConversion_PropagateState(string type)
+    public void Conversion_BuiltInConversion_PropagateState_CS(string type)
     {
         var code = $"""
             byte b = 42;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.cs
@@ -272,15 +272,27 @@ Tag(""End"");";
 
     [TestMethod]
     public void Execute_LocalScopeRegion_Boolean_AssignDefaultBoolConstraint() =>
-        SETestContext.CreateVB(@"Dim Value As Boolean : Tag(""Value"", Value)").Validator.ValidateTag("Value", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
+        SETestContext.CreateVB(@"Dim Value As Boolean : Tag(""Value"", Value)").Validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.False);
 
     [TestMethod]
     public void Execute_LocalScopeRegion_ReferenceType_AssignDefaultNullConstraint() =>
-        SETestContext.CreateVB(@"Dim Value As Exception : Tag(""Value"", Value)").Validator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
+        SETestContext.CreateVB(@"Dim Value As Exception : Tag(""Value"", Value)").Validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+
+    [DataTestMethod]
+    [DataRow("SByte")]
+    [DataRow("Byte")]
+    [DataRow("Short")]
+    [DataRow("UShort")]
+    [DataRow("Integer")]
+    [DataRow("UInteger")]
+    [DataRow("Long")]
+    [DataRow("ULong")]
+    public void Execute_LocalScopeRegion_Integral_NoAction(string type) =>
+        SETestContext.CreateVB(@$"Dim Value As {type} : Tag(""Value"", Value)").Validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0));
 
     [TestMethod]
     public void Execute_LocalScopeRegion_Struct_NoAction() =>
-        SETestContext.CreateVB(@"Dim Value As Integer : Tag(""Value"", Value)").Validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        SETestContext.CreateVB(@"Dim Value As DateTime : Tag(""Value"", Value)").Validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
 
     [TestMethod]
     public void Execute_FieldSymbolsAreNotRemovedByLva()
@@ -290,7 +302,6 @@ if (boolParameter)
 {
     field = 42;
 }";
-
         var postProcess = new PostProcessTestCheck(OperationKind.Literal, x => x.SetOperationConstraint(DummyConstraint.Dummy));
         var validator = SETestContext.CreateCS(code, postProcess).Validator;
         validator.ValidateExitReachCount(2);    // Once with the constraint and once without it.
@@ -307,7 +318,6 @@ if (boolParameter)
 {{
     {paramName} = 42;
 }}";
-
         var postProcess = new PostProcessTestCheck(OperationKind.Literal, x => x.SetOperationConstraint(DummyConstraint.Dummy));
         var validator = SETestContext.CreateCS(code, $"{refKind} int {paramName}", postProcess).Validator;
         validator.ValidateExitReachCount(2);    // Once with the constraint and once without it.

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.cs
@@ -287,7 +287,9 @@ Tag(""End"");";
     [DataRow("UInteger")]
     [DataRow("Long")]
     [DataRow("ULong")]
-    public void Execute_LocalScopeRegion_Integral_NoAction(string type) =>
+    [DataRow("IntPtr")]
+    [DataRow("UIntPtr")]
+    public void Execute_LocalScopeRegion_Integral_AssignDefaultZeroConstraint(string type) =>
         SETestContext.CreateVB(@$"Dim Value As {type} : Tag(""Value"", Value)").Validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0));
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Conditions.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Conditions.vb
@@ -273,5 +273,18 @@ Namespace Monitor_Conditions
             If Condition Then Monitor.Exit(Arg)
         End Sub
 
+        Public Sub AutoInitializedInt()
+            Dim i As Integer
+            Monitor.Enter(Obj) ' Compliant, because exit is never reached
+            If i <> 0 AndAlso Condition Then Monitor.Exit(Obj)
+        End Sub
+
+        Public Sub AutoInitializedPointeger()
+            Dim i As IntPtr
+            Monitor.Enter(Obj) ' Compliant, because exit is never reached
+            If i <> 0 AndAlso Condition Then Monitor.Exit(Obj)
+        End Sub
+
     End Class
+
 End Namespace


### PR DESCRIPTION
In VB, compiler initializes value to 0, instead of dev needing to please the compiler
```
Dim Value As Integer
```
So we need to build the constraint for locally scoped variables, same as we already do for boolean.