### PR TITLE
Remove locking from utility analyzers when writing protobuf files

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/AnalysisWarningAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/AnalysisWarningAnalyzerBase.cs
@@ -28,8 +28,6 @@ public abstract class AnalysisWarningAnalyzerBase : UtilityAnalyzerBase
     private const string DiagnosticId = "S9999-warning";
     private const string Title = "Analysis Warning generator";
 
-    private static readonly object FileWriteLock = new();
-
     protected virtual int MinimalSupportedRoslynVersion => RoslynHelper.MinimalSupportedMajorVersion;   // For testing
 
     protected AnalysisWarningAnalyzerBase() : base(DiagnosticId, Title) { }
@@ -42,18 +40,15 @@ public abstract class AnalysisWarningAnalyzerBase : UtilityAnalyzerBase
                 {
                     // This can be removed after we bump Microsoft.CodeAnalysis references to 3.0 or higher.
                     var path = Path.GetFullPath(Path.Combine(OutPath, "../../AnalysisWarnings.MsBuild.json"));
-                    lock (FileWriteLock)
+                    if (!File.Exists(path))
                     {
-                        if (!File.Exists(path))
+                        try
                         {
-                            try
-                            {
-                                File.WriteAllText(path, """[{"text": "Analysis using MsBuild 14 and 15 build tools is deprecated. Please update your pipeline to MsBuild 16 or higher."}]""");
-                            }
-                            catch
-                            {
-                                // Nothing to do here. Two compilations running on two different processes are unlikely to lock each other out on a small file write.
-                            }
+                            File.WriteAllText(path, """[{"text": "Analysis using MsBuild 14 and 15 build tools is deprecated. Please update your pipeline to MsBuild 16 or higher."}]""");
+                        }
+                        catch
+                        {
+                            // Nothing to do here. Two compilations running on two different processes are unlikely to lock each other out on a small file write.
                         }
                     }
                 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -101,12 +101,13 @@ namespace SonarAnalyzer.Rules
                     .Concat(treeMessages)
                     .WhereNotNull()
                     .ToArray();
-                    Directory.CreateDirectory(OutPath);
-                    using var stream = File.Create(Path.Combine(OutPath, FileName));
-                    foreach (var message in allMessages)
-                    {
-                        message.WriteDelimitedTo(stream);
-                    }
+
+                Directory.CreateDirectory(OutPath);
+                using var stream = File.Create(Path.Combine(OutPath, FileName));
+                foreach (var message in allMessages)
+                {
+                    message.WriteDelimitedTo(stream);
+                }
             });
 
         protected virtual bool ShouldGenerateMetrics(SyntaxTree tree) =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -74,8 +74,6 @@ namespace SonarAnalyzer.Rules
         where TSyntaxKind : struct
         where TMessage : class, IMessage, new()
     {
-        private static readonly object FileWriteLock = new TMessage();
-
         protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract string FileName { get; }
         protected abstract TMessage CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel);
@@ -103,15 +101,12 @@ namespace SonarAnalyzer.Rules
                     .Concat(treeMessages)
                     .WhereNotNull()
                     .ToArray();
-                lock (FileWriteLock)
-                {
                     Directory.CreateDirectory(OutPath);
                     using var stream = File.Create(Path.Combine(OutPath, FileName));
                     foreach (var message in allMessages)
                     {
                         message.WriteDelimitedTo(stream);
                     }
-                }
             });
 
         protected virtual bool ShouldGenerateMetrics(SyntaxTree tree) =>


### PR DESCRIPTION
Fixes #7240

This locking is not needed as each of the analyzers is writing to its own file. And the action is executed only once. So there are now two threads accessing the file at the same time.