### PR TITLE
S3949: Remove Power operator

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/CalculationsShouldNotOverflowBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/CalculationsShouldNotOverflowBase.cs
@@ -66,7 +66,7 @@ public abstract class CalculationsShouldNotOverflowBase : SymbolicRuleCheck
         };
 
     private static bool CanOverflow(BinaryOperatorKind kind) =>
-        kind is BinaryOperatorKind.Add or BinaryOperatorKind.Subtract or BinaryOperatorKind.Multiply or BinaryOperatorKind.Power;
+        kind is BinaryOperatorKind.Add or BinaryOperatorKind.Subtract or BinaryOperatorKind.Multiply;
 
     private static NumberConstraint Bounds(ITypeSymbol type) =>
         type switch

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.vb
@@ -80,6 +80,8 @@ Public Class Sample
 
         i = 2 Mod j
         __ = i * 2147483600     ' FN
+
+        Dim Result = Integer.MaxValue ^ 2  ' Compliant, result is Double
     End Sub
 
     Public Sub AssignmentOperators()


### PR DESCRIPTION
Address https://github.com/SonarSource/sonar-dotnet/pull/7270#discussion_r1206472030

Power operator was not supported, so FP was not raised as the new value was not calculated yet.

Draft: I plan to rebase and merge this after the feature branch is merged to master.