### PR TITLE
SE: Refactor FlowCaptureReference to operation processor

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationDispatcher.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationDispatcher.cs
@@ -52,6 +52,7 @@ internal static class OperationDispatcher
         { OperationKindEx.EventReference, new EventReference() },
         { OperationKindEx.FieldReference, new FieldReference() },
         { OperationKindEx.FlowCapture, new FlowCapture() },
+        { OperationKindEx.FlowCaptureReference, new FlowCaptureReference() },
         { OperationKindEx.Increment, new IncrementOrDecrement() },
         { OperationKindEx.InstanceReference, new InstanceReference() },
         { OperationKindEx.LocalReference, new LocalReference() },

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/FlowCapture.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/FlowCapture.cs
@@ -34,9 +34,6 @@ internal sealed class FlowCaptureReference : SimpleProcessor<IFlowCaptureReferen
     protected override IFlowCaptureReferenceOperationWrapper Convert(IOperation operation) =>
         IFlowCaptureReferenceOperationWrapper.FromOperation(operation);
 
-    protected override ProgramState Process(SymbolicContext context, IFlowCaptureReferenceOperationWrapper capture)
-    {
-        var resolved = context.State.ResolveCapture(capture.WrappedOperation);
-        return context.State.SetOperationValue(capture, context.State[resolved]);
-    }
+    protected override ProgramState Process(SymbolicContext context, IFlowCaptureReferenceOperationWrapper capture) =>
+        context.State.SetOperationValue(capture, context.State[context.State.ResolveCapture(capture.WrappedOperation)]);
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/FlowCapture.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/FlowCapture.cs
@@ -28,3 +28,15 @@ internal sealed class FlowCapture : SimpleProcessor<IFlowCaptureOperationWrapper
     protected override ProgramState Process(SymbolicContext context, IFlowCaptureOperationWrapper capture) =>
         context.State.SetCapture(capture.Id, context.State.ResolveCapture(capture.Value));  // Capture can transitively reference another IFlowCaptureReference
 }
+
+internal sealed class FlowCaptureReference : SimpleProcessor<IFlowCaptureReferenceOperationWrapper>
+{
+    protected override IFlowCaptureReferenceOperationWrapper Convert(IOperation operation) =>
+        IFlowCaptureReferenceOperationWrapper.FromOperation(operation);
+
+    protected override ProgramState Process(SymbolicContext context, IFlowCaptureReferenceOperationWrapper capture)
+    {
+        var resolved = context.State.ResolveCapture(capture.WrappedOperation);
+        return context.State.SetOperationValue(capture, context.State[resolved]);
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.OperationValue.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.OperationValue.cs
@@ -207,6 +207,21 @@ public partial class ProgramStateTest
     }
 
     [TestMethod]
+    public void SetOperationValue_OnFlowCaptureReferenceOperationWrapper_SetsValueToOperation()
+    {
+        var value = SymbolicValue.Empty;
+        var cfg = TestHelper.CompileCfgBodyCS("a ??= b;", "object a, object b");
+        var capture = IFlowCaptureOperationWrapper.FromOperation(cfg.Blocks[1].Operations[0]);
+        var captureReference = IFlowCaptureReferenceOperationWrapper.FromOperation(cfg.Blocks[3].Operations[0].Children.First());
+        captureReference.Id.Should().Be(capture.Id);
+        var sut = ProgramState.Empty
+            .SetCapture(capture.Id, capture.Value)
+            .SetOperationValue(captureReference, value);
+        sut[capture.Value].Should().BeNull();
+        sut[captureReference].Should().Be(value);
+    }
+
+    [TestMethod]
     public void ResetOperations_IsImmutable()
     {
         var operation = CreateOperation();


### PR DESCRIPTION
Part of #7339 

This will eventually be a prerequisite to fix the #7339 problem, after we improve LVA (not in this sprint).
For now, it's just an engine improvement to remove the counter-intuitive flow capture reference from under the hood into a normal flow.