### PR TITLE
Fix AD0001 Bug: Old SE run without S1944 throws NullReferenceException

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InvalidCastToInterfaceSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InvalidCastToInterfaceSymbolicExecution.cs
@@ -75,7 +75,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
                     return programState;
                 }
 
-                if (!context.Equals(default(SyntaxNodeAnalysisContext)))
+                if (context is not null)
                 {
                     context.ReportIssue(Diagnostic.Create(InvalidCastToInterface.S1944, castExpression.GetLocation(), MessageDefinite));
                 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Sonar/HashesShouldHaveUnpredictableSalt.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Sonar/HashesShouldHaveUnpredictableSalt.cs
@@ -214,3 +214,15 @@ namespace Tests.Diagnostics
         }
     }
 }
+
+// https://github.com/SonarSource/sonar-dotnet/issues/7355
+public class AD0001_Repro
+{
+    // This reproduces scenario when S1944 check is not active as a rule, but still present in the exploded graph as an engine check.
+    // It must be part of another rule to reproduce the original problem
+    public void InvalidCastToInterfaceSymbolicExecution_Repro()
+    {
+        int? i = null;
+        int j = (int)i; // Compliant in this rule, would raise S1944 in the old SE
+    }
+}


### PR DESCRIPTION
Fixes #7355
