### PR TITLE
S4158: Add fixed FP repro for #2147

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -758,3 +758,17 @@ public class Repro_4478
         }
     }
 }
+
+// https://github.com/SonarSource/sonar-dotnet/issues/2147
+public class Repro_2147
+{
+    private List<string> _lines;
+
+    public virtual object Clone()
+    {
+        var clonedEntry = (Repro_2147)MemberwiseClone();
+        clonedEntry._lines = new List<string>();
+        _lines.ForEach(x => { });   // Compliant, different field
+        return clonedEntry;
+    }
+}


### PR DESCRIPTION
Fixes #2147

This only adds a reproducer. The actual fix was done by rule migration to the new engine in #7300 