### PR TITLE
S4158 FP: Collection filled in a for loop reported to be empty

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarAnalyzer.SymbolicExecution.Sonar.Constraints;
+using SonarAnalyzer.SymbolicExecution.Constraints;
 
 namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/CollectionConstraint.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Constraints/CollectionConstraint.cs
@@ -18,9 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarAnalyzer.SymbolicExecution.Constraints;
-
-namespace SonarAnalyzer.SymbolicExecution.Sonar.Constraints;
+namespace SonarAnalyzer.SymbolicExecution.Constraints;
 
 internal sealed class CollectionConstraint : SymbolicConstraint
 {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
@@ -188,7 +188,7 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
     private static NumberConstraint PropertyReferenceConstraint(ProgramState state, IPropertyReferenceOperationWrapper propertyReference)
     {
         if (propertyReference.Property.Name is nameof(Array.Length) or nameof(List<int>.Count)
-            && propertyReference.Instance.TrackedSymbol() is { } symbol
+            && state.ResolveCapture(propertyReference.Instance).TrackedSymbol() is { } symbol
             && state[symbol]?.Constraint<CollectionConstraint>() is { } collection)
         {
             return collection == CollectionConstraint.Empty ? NumberConstraint.From(0) : NumberConstraint.From(1, null);

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
@@ -20,8 +20,7 @@
 
 using System.Collections;
 using System.Collections.ObjectModel;
-using System.Linq;
-using SonarAnalyzer.SymbolicExecution.Sonar.Constraints;
+using SonarAnalyzer.SymbolicExecution.Constraints;
 
 namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks;
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.CSharp8.cs
@@ -157,7 +157,7 @@ public interface IDecoder
 // https://github.com/SonarSource/sonar-dotnet/issues/6179
 public class Repro_6179
 {
-    public void FilledInLoop_FromAnotherCollection()
+    public void FilledInLoop_FromAnotherCollection_FromArray()
     {
         var data = new[] { 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0 };
         var list = new List<List<int>>();
@@ -181,7 +181,35 @@ public class Repro_6179
 
         for (var i = 0; i < list.Count; i++)
         {
-            list.ForEach(x => { }); // Noncompliant
+            list.ForEach(x => { }); // Compliant
+        }
+    }
+
+    public void FilledInLoop_FromAnotherCollection_FromList()
+    {
+        var data = new List<int> { 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0 };
+        var list = new List<List<int>>();
+        List<int> currentBin = null;
+        for (var i = 0; i < data.Count; i++)
+        {
+            if (data[i] == 0)
+            {
+                if (currentBin != null)
+                {
+                    list.Add(currentBin);
+                    currentBin = null;
+                }
+
+                continue;
+            }
+
+            currentBin ??= new List<int>();
+            currentBin.Add(i);
+        }
+
+        for (var i = 0; i < list.Count; i++)
+        {
+            list.ForEach(x => { }); // Compliant
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.CSharp8.cs
@@ -153,3 +153,35 @@ public interface IDecoder
 {
     bool Convert(out int i3, out int i4);
 }
+
+// https://github.com/SonarSource/sonar-dotnet/issues/6179
+public class Repro_6179
+{
+    public void FilledInLoop_FromAnotherCollection()
+    {
+        var data = new[] { 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0 };
+        var list = new List<List<int>>();
+        List<int> currentBin = null;
+        for (var i = 0; i < data.Length; i++)
+        {
+            if (data[i] == 0)
+            {
+                if (currentBin != null)
+                {
+                    list.Add(currentBin);
+                    currentBin = null;
+                }
+
+                continue;
+            }
+
+            currentBin ??= new List<int>();
+            currentBin.Add(i);
+        }
+
+        for (var i = 0; i < list.Count; i++)
+        {
+            list.ForEach(x => { }); // Noncompliant
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -498,6 +498,97 @@ class AdvancedTests
         array5.Clone(); // Compliant
     }
 
+    public void LearnConditions_Size(bool condition)
+    {
+        List<int> isNull = null;
+        var empty = new List<int>();
+        var notEmpty = new List<int>() { 1, 2, 3 };
+
+        if ((isNull ?? empty).Count == 0)
+        {
+            empty.Clear();  // Noncompliant
+        }
+
+        if ((isNull ?? notEmpty).Count == 0)
+        {
+            empty.Clear();  // Compliant, unreachable
+        }
+
+        if ((condition ? empty : empty).Count == 0)
+        {
+            empty.Clear();  // Noncompliant
+        }
+        else
+        {
+            empty.Clear();  // Compliant, unreachable
+        }
+
+        if (empty.Count == 0)
+        {
+            empty.Clear();  // Noncompliant
+        }
+        else
+        {
+            empty.Count();  // Compliant, unreachable
+        }
+
+        if (empty.Count() == 0)
+        {
+            empty.Clear();  // Noncompliant
+        }
+        else
+        {
+            empty.Clear();  // Noncompliant FP, Should be Compliant, unreachable
+        }
+
+        if (Enumerable.Count(empty) == 0)
+        {
+            empty.Clear();  // Noncompliant
+        }
+        else
+        {
+            empty.Clear();  // Noncompliant FP, Should be Compliant, unreachable
+        }
+
+        notEmpty.Clear(); // Compliant, prevents LVA from throwing notEmpty away during reference capture
+    }
+
+    public void LearnConditions_Size_Array(bool condition)
+    {
+        int[] isNull = null;
+        var empty = new int[0];
+        var notEmpty = new[] { 1, 2, 3 };
+
+        if ((condition ? empty : empty).Length == 0)
+        {
+            empty.Clone();  // Noncompliant
+        }
+        else
+        {
+            empty.Clone();  // Compliant, unreachable
+        }
+
+        if (empty.Length == 0)
+        {
+            empty.Clone();  // Noncompliant
+        }
+        else
+        {
+            empty.Clone();  // Compliant, unreachable
+        }
+
+        if (empty.Count() == 0)
+        {
+            empty.Clone();  // Noncompliant
+        }
+        else
+        {
+            empty.Clone();  // Noncompliant FP, Should be Compliant, unreachable
+        }
+
+        notEmpty.Clone(); // Compliant, prevents LVA from throwing notEmpty away during reference capture
+    }
+
     void Foo(IEnumerable<int> items) { }
 }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -529,7 +529,7 @@ class AdvancedTests
         }
         else
         {
-            empty.Count();  // Compliant, unreachable
+            empty.Clear();  // Compliant, unreachable
         }
 
         if (empty.Count() == 0)


### PR DESCRIPTION
Fixes #6179

This has two parts.
For `var arr = new int[5]` we need to learn explicitly CollectionNotEmpty, so when the `for` condition of `i<arr.Length` arrives, we're sure we go inside and do not skip the loop