### PR TITLE
VB.NET HasExactlyNArguments method considers null argument list and 0 arguments the same.

### DIFF
--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/InvocationExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/InvocationExpressionSyntaxExtensions.cs
@@ -18,9 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Drawing;
-using SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors;
-
 namespace SonarAnalyzer.Extensions
 {
     internal static class InvocationExpressionSyntaxExtensions

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/InvocationExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/InvocationExpressionSyntaxExtensions.cs
@@ -18,6 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Drawing;
+using SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors;
+
 namespace SonarAnalyzer.Extensions
 {
     internal static class InvocationExpressionSyntaxExtensions
@@ -30,9 +33,9 @@ namespace SonarAnalyzer.Extensions
             invocation.ArgumentList.Arguments.GetSymbolsOfKnownType(knownType, semanticModel);
 
         internal static bool HasExactlyNArguments(this InvocationExpressionSyntax invocation, int count) =>
-            count == 0
-                ? invocation?.ArgumentList == null || invocation.ArgumentList.Arguments.Count == 0
-                : invocation?.ArgumentList != null && invocation.ArgumentList.Arguments.Count == count;
+            invocation?.ArgumentList == null
+            ? count == 0
+            : invocation.ArgumentList.Arguments.Count == count;
 
         internal static bool TryGetOperands(this InvocationExpressionSyntax invocation, out SyntaxNode left, out SyntaxNode right)
         {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/InvocationExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/InvocationExpressionSyntaxExtensions.cs
@@ -30,7 +30,9 @@ namespace SonarAnalyzer.Extensions
             invocation.ArgumentList.Arguments.GetSymbolsOfKnownType(knownType, semanticModel);
 
         internal static bool HasExactlyNArguments(this InvocationExpressionSyntax invocation, int count) =>
-            invocation?.ArgumentList != null && invocation.ArgumentList.Arguments.Count == count;
+            count == 0
+                ? invocation?.ArgumentList == null || invocation.ArgumentList.Arguments.Count == 0
+                : invocation?.ArgumentList != null && invocation.ArgumentList.Arguments.Count == count;
 
         internal static bool TryGetOperands(this InvocationExpressionSyntax invocation, out SyntaxNode left, out SyntaxNode right)
         {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/InvocationExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/InvocationExpressionSyntaxExtensions.cs
@@ -30,9 +30,9 @@ namespace SonarAnalyzer.Extensions
             invocation.ArgumentList.Arguments.GetSymbolsOfKnownType(knownType, semanticModel);
 
         internal static bool HasExactlyNArguments(this InvocationExpressionSyntax invocation, int count) =>
-            invocation?.ArgumentList == null
-            ? count == 0
-            : invocation.ArgumentList.Arguments.Count == count;
+            invocation?.ArgumentList is null
+                ? count == 0
+                : invocation.ArgumentList.Arguments.Count == count;
 
         internal static bool TryGetOperands(this InvocationExpressionSyntax invocation, out SyntaxNode left, out SyntaxNode right)
         {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/ObjectsShouldNotBeDisposedMoreThanOnce.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/ObjectsShouldNotBeDisposedMoreThanOnce.cs
@@ -50,6 +50,6 @@ public sealed class ObjectsShouldNotBeDisposedMoreThanOnce : ObjectsShouldNotBeD
         }
 
         public override void VisitInvocationExpression(InvocationExpressionSyntax node) =>
-            Result = node.HasExactlyNArguments(0) || node.ArgumentList is null;
+            Result = node.HasExactlyNArguments(0);
     }
 }


### PR DESCRIPTION
In VB.NET a method can be called by invocation, for example,  `d.Dispose()`, but it can be called also without the parentheses via member access `d.Dispose`.
So having an argument list with 0 arguments and having no argument list at all is the same thing in VB.NET context.