### PR TITLE
Deduplicate Java dependency versioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
     <commons.lang.version>2.6</commons.lang.version>
     <junit.version>4.13.2</junit.version>
     <logback.classic.version>1.4.8</logback.classic.version>
+    <mockito.version>5.3.1</mockito.version>
   </properties>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -61,15 +61,16 @@
     <sonar.version>9.17.0.587</sonar.version>
     <sonar.api.impl.version>10.0.0.68432</sonar.api.impl.version>
     <jdk.min.version>11</jdk.min.version>
-    <maven.compiler.release>${jdk.min.version}</maven.compiler.release>
     <findbugs.version>3.0.2</findbugs.version>
+    <maven.compiler.release>${jdk.min.version}</maven.compiler.release>
     <slf4j.version>2.0.7</slf4j.version>
     <guava.version>32.0.0-jre</guava.version>
 
     <!-- Test dependencies -->
-    <logback.classic.version>1.4.8</logback.classic.version>
-    <junit.version>4.13.2</junit.version>
     <assertj.core.version>3.24.2</assertj.core.version>
+    <commons.lang.version>2.6</commons.lang.version>
+    <junit.version>4.13.2</junit.version>
+    <logback.classic.version>1.4.8</logback.classic.version>
   </properties>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <artifactsToDownload>${project.groupId}:SonarAnalyzer.CSharp:nupkg,${project.groupId}:SonarAnalyzer.VisualBasic:nupkg</artifactsToDownload>
     <!-- We are ignoring java doc warnings - this is because we are using JDK 11. Ideally we should not do that. -->
     <doclint>none</doclint>
-    <sonar.analyzer.commons>2.5.0.1358</sonar.analyzer.commons>
+    <sonar.analyzer.commons.version>2.5.0.1358</sonar.analyzer.commons.version>
     <sonar.version>9.17.0.587</sonar.version>
     <sonar.api.impl.version>10.0.0.68432</sonar.api.impl.version>
     <jdk.min.version>11</jdk.min.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <sonar.api.impl.version>10.0.0.68432</sonar.api.impl.version>
     <jdk.min.version>11</jdk.min.version>
     <maven.compiler.release>${jdk.min.version}</maven.compiler.release>
+    <findbugs.version>3.0.2</findbugs.version>
     <slf4j.version>2.0.7</slf4j.version>
     <guava.version>32.0.0-jre</guava.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,8 @@
     <junit.version>4.13.2</junit.version>
     <logback.classic.version>1.4.8</logback.classic.version>
     <mockito.version>5.3.1</mockito.version>
+    <stax2.api.version>4.2.1</stax2.api.version>
+    <staxmate.version>2.0.1</staxmate.version>
   </properties>
 
   <profiles>

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <version>${commons.lang.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>org.codehaus.woodstox</groupId>
       <artifactId>stax2-api</artifactId>
-      <version>4.2.1</version>
+      <version>${stax2.api.version}</version>
       <exclusions>
         <exclusion>
           <groupId>stax</groupId>
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.codehaus.staxmate</groupId>
       <artifactId>staxmate</artifactId>
-      <version>2.0.1</version>
+      <version>${staxmate.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.woodstox</groupId>

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.3.1</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
+      <version>${findbugs.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.sonarsource.analyzer-commons</groupId>
       <artifactId>sonar-analyzer-commons</artifactId>
-      <version>${sonar.analyzer.commons}</version>
+      <version>${sonar.analyzer.commons.version}</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/sonar-dotnet-shared-library/pom.xml
+++ b/sonar-dotnet-shared-library/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.sonarsource.analyzer-commons</groupId>
       <artifactId>sonar-xml-parsing</artifactId>
-      <version>${sonar.analyzer.commons}</version>
+      <version>${sonar.analyzer.commons.version}</version>
     </dependency>
 
     <!-- unit tests -->
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <version>${commons.lang.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-dotnet-shared-library/pom.xml
+++ b/sonar-dotnet-shared-library/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.3.1</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-dotnet-shared-library/pom.xml
+++ b/sonar-dotnet-shared-library/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.sonarsource.analyzer-commons</groupId>
       <artifactId>sonar-analyzer-commons</artifactId>
-      <version>${sonar.analyzer.commons}</version>
+      <version>${sonar.analyzer.commons.version}</version>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.analyzer-commons</groupId>

--- a/sonar-dotnet-shared-library/pom.xml
+++ b/sonar-dotnet-shared-library/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
+      <version>${findbugs.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <version>${commons.lang.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>org.codehaus.woodstox</groupId>
       <artifactId>stax2-api</artifactId>
-      <version>4.2.1</version>
+      <version>${stax2.api.version}</version>
       <exclusions>
         <exclusion>
           <groupId>stax</groupId>
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.codehaus.staxmate</groupId>
       <artifactId>staxmate</artifactId>
-      <version>2.0.1</version>
+      <version>${staxmate.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.woodstox</groupId>

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.3.1</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
+      <version>${findbugs.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.sonarsource.analyzer-commons</groupId>
       <artifactId>sonar-analyzer-commons</artifactId>
-      <version>${sonar.analyzer.commons}</version>
+      <version>${sonar.analyzer.commons.version}</version>
     </dependency>
 
     <!-- test dependencies -->


### PR DESCRIPTION
`guava` is refactored in #7464
`gson` and `commons-io` is not shared with other POMs