### PR TITLE
Java ITs: Migrate to jUnit 5 - Remove suites

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -460,9 +460,9 @@ stages:
       strategy:
         matrix:
           CSharp:
-            testClasses: 'com.sonar.it.csharp.Tests'
+            testPattern: 'csharp/*'
           Others:
-            testClasses: 'com.sonar.it.vbnet.Tests,com.sonar.it.shared.Tests'
+            testPattern: 'vbnet/*,shared/*'
       steps:
       - task: DownloadSecureFile@1
         displayName: 'Download Maven settings'
@@ -506,7 +506,7 @@ stages:
         inputs:
           mavenPomFile: its/pom.xml
           goals: 'verify'
-          options: -Dtest=$(testClasses) -B --settings $(mavenSettings.secureFilePath)
+          options: -Dtest=$(testPattern) -B --settings $(mavenSettings.secureFilePath)
           publishJUnitResults: true
           testResultsFiles: '**/surefire-reports/TEST-*.xml'
           testRunTitle: '$(Agent.JobName)'

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -49,23 +49,8 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>${junit.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-suite-api</artifactId>
-      <version>1.9.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-suite-engine</artifactId>
-      <version>1.9.2</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -87,10 +87,6 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.1.2</version>
           <configuration>
-            <includes>
-              <!-- When run without a test filter, execute just the test suites -->
-              <include>Tests.java</include>
-            </includes>
             <systemProperties>
               <scannerMsbuild.version>${scannerMsbuild.version}</scannerMsbuild.version>
             </systemProperties>

--- a/its/src/test/java/com/sonar/it/csharp/Tests.java
+++ b/its/src/test/java/com/sonar/it/csharp/Tests.java
@@ -32,16 +32,12 @@ import javax.annotation.Nullable;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.platform.suite.api.SelectPackages;
-import org.junit.platform.suite.api.Suite;
 import org.sonarqube.ws.Components;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.Measures;
 
 import static org.sonarqube.ws.Hotspots.SearchWsResponse.Hotspot;
 
-@Suite
-@SelectPackages("com.sonar.it.csharp") // This will run all classes from current package containing @Test methods.
 public class Tests implements BeforeAllCallback, AfterAllCallback {
 
   public static final Orchestrator ORCHESTRATOR = TestUtils.prepareOrchestrator()
@@ -63,7 +59,7 @@ public class Tests implements BeforeAllCallback, AfterAllCallback {
   public void afterAll(ExtensionContext extensionContext) throws Exception {
     ORCHESTRATOR.stop();
   }
-  
+
   public static BuildResult analyzeProject(Path temp, String projectDir) throws IOException {
     return analyzeProject(projectDir, temp, projectDir);
   }

--- a/its/src/test/java/com/sonar/it/shared/Tests.java
+++ b/its/src/test/java/com/sonar/it/shared/Tests.java
@@ -30,11 +30,7 @@ import javax.annotation.Nullable;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.platform.suite.api.SelectPackages;
-import org.junit.platform.suite.api.Suite;
 
-@Suite
-@SelectPackages("com.sonar.it.shared") // This will run all classes from current package containing @Test methods.
 public class Tests implements BeforeAllCallback, AfterAllCallback {
 
   public static final Orchestrator ORCHESTRATOR = TestUtils.prepareOrchestrator()

--- a/its/src/test/java/com/sonar/it/vbnet/Tests.java
+++ b/its/src/test/java/com/sonar/it/vbnet/Tests.java
@@ -32,14 +32,10 @@ import javax.annotation.Nullable;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.platform.suite.api.SelectPackages;
-import org.junit.platform.suite.api.Suite;
 import org.sonarqube.ws.Components;
 import org.sonarqube.ws.Hotspots;
 import org.sonarqube.ws.Measures;
 
-@Suite
-@SelectPackages("com.sonar.it.vbnet") // This will run all classes from current package containing @Test methods.
 public class Tests implements BeforeAllCallback, AfterAllCallback {
 
   public static final Orchestrator ORCHESTRATOR = TestUtils.prepareOrchestrator()


### PR DESCRIPTION
Fixes #4223

This removes suites and executes all UTs based on pattern in CI.
This still creates an orchestrator for every single test class.

To properly review it, please check AzureDev Ops build and make sure that CSharp executes only CSharp UTs (and all of them), and the "Others" run executes vbnet+shared