### PR TITLE
Bump sonar-orchestrator from 3.42.0.312 to 4.0.0.404

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -27,8 +27,8 @@
   <dependencies>
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
-      <artifactId>sonar-orchestrator</artifactId>
-      <version>3.42.0.312</version>
+      <artifactId>sonar-orchestrator-junit5</artifactId>
+      <version>4.0.0.404</version>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.scanner.msbuild</groupId>

--- a/its/src/test/java/com/sonar/it/csharp/IncrementalAnalysisTest.java
+++ b/its/src/test/java/com/sonar/it/csharp/IncrementalAnalysisTest.java
@@ -39,7 +39,7 @@ import org.sonarqube.ws.Issues;
 
 import static com.sonar.it.csharp.Tests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(Tests.class)
 public class IncrementalAnalysisTest {

--- a/its/src/test/java/com/sonar/it/shared/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/shared/TestUtils.java
@@ -20,11 +20,12 @@
 package com.sonar.it.shared;
 
 import com.sonar.orchestrator.Orchestrator;
-import com.sonar.orchestrator.OrchestratorBuilder;
 import com.sonar.orchestrator.build.Build;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.ScannerForMSBuild;
 import com.sonar.orchestrator.container.Edition;
+import com.sonar.orchestrator.junit5.OrchestratorExtension;
+import com.sonar.orchestrator.junit5.OrchestratorExtensionBuilder;
 import com.sonar.orchestrator.locator.FileLocation;
 import com.sonar.orchestrator.locator.Location;
 import com.sonar.orchestrator.locator.MavenLocation;
@@ -68,8 +69,8 @@ public class TestUtils {
   private static final String MSBUILD_PATH = "MSBUILD_PATH";
   private static final String MSBUILD_PATH_DEFAULT = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\MSBuild\\Current\\Bin\\msbuild.exe";
 
-  public static OrchestratorBuilder prepareOrchestrator() {
-    return Orchestrator.builderEnv()
+  public static OrchestratorExtensionBuilder prepareOrchestrator() {
+    return OrchestratorExtension.builderEnv()
       .useDefaultAdminCredentialsForBuilds(true)
       // See https://github.com/SonarSource/orchestrator#version-aliases
       .setSonarVersion(System.getProperty("sonar.runtimeVersion", "DEV"))


### PR DESCRIPTION
Fixes #7274 

Just bumping the reference. We won't use the new jUnit5 capabilities, because it doesn't suite our use case.

I'm ignoring the failed IT, it will get resolved by a rebase