### PR TITLE
GitHub workflow: Add CreateCardForIssueFromLabel from dev

### DIFF
--- a/.github/workflows/LabelIssue.yml
+++ b/.github/workflows/LabelIssue.yml
@@ -1,0 +1,28 @@
+name: Issue Labeled
+
+on:
+  issues:
+    types: ["labeled"]
+
+jobs:
+  CreateCardForIssueFromLabel_job:
+    name: Create card from label
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    # Single quotes must be used here https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#literals
+    # Only limited global functions are available in this context https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#functions
+    if: |
+        github.event.issue.state == 'Open'
+        && startsWith(github.event.label.name, 'Type:')
+
+    steps:
+      - id: secrets
+        uses: SonarSource/vault-action-wrapper@2.5.0-4
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-kanban token | kanban_token;
+      - uses: sonarsource/gh-action-lt-backlog/CreateCardForIssueFromLabel@Pavel/Dev # FIXME: v1
+        with:
+          github-token: ${{ fromJSON(steps.secrets.outputs.vault).kanban_token }}
+          project-number: 10


### PR DESCRIPTION
Re-add CreateCardForIssueFromLabel for E2E testing.

https://github.com/SonarSource/gh-action-lt-backlog/issues/54 
