### PR TITLE
Rename CFG NuGet to SonarAnalyzer.CFG

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.cs.nuspec
+++ b/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.cs.nuspec
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-    <id>SonarAnalyzer.CFG.CSharp</id>
+    <id>SonarAnalyzer.CFG</id>
     <version>9.6.0.0</version>
-    <title>C# CFG library for SonarAnalyzer</title>
+    <title>CFG library for SonarAnalyzer</title>
     <authors>SonarSource</authors>
     <owners>SonarSource</owners>
     <license type="expression">LGPL-3.0-only</license>
     <repository type="git" url="https://github.com/SonarSource/sonar-dotnet" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>CFG library for SonarSource C# plugins</description>
+    <description>SonarSource CFG library</description>
     <language>en-US</language>
     <copyright>Copyright © 2015-2023 SonarSource SA</copyright>
     <frameworkAssemblies>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,12 +120,12 @@ stages:
           artifactName: 'NuGet Packages'
 
       - task: ArtifactoryNuGet@1
-        displayName: 'Publish SonarAnalyzer.CFG.CSharp NuGet on repox'
+        displayName: 'Publish SonarAnalyzer.CFG NuGet on repox'
         inputs:
           command: 'push'
           artifactoryService: 'Repox artifactory'
           targetDeployRepo: '$(ARTIFACTORY_NUGET_REPO)'
-          pathToNupkg: '$(Build.ArtifactStagingDirectory)/packages/SonarAnalyzer.CFG.CSharp.*.nupkg'
+          pathToNupkg: '$(Build.ArtifactStagingDirectory)/packages/SonarAnalyzer.CFG.*.nupkg'
 
       - task: PublishPipelineArtifact@1
         displayName: 'Publish analyzer binaries as pipeline artifact'
@@ -520,7 +520,7 @@ stages:
   condition: succeeded()
   jobs:
     - job: promoteRepox
-      displayName: 'SonarAnalyzer.CFG.CSharp'
+      displayName: 'SonarAnalyzer.CFG'
       workspace:
         clean: all
       steps:
@@ -551,7 +551,7 @@ stages:
               else:
                 targetRepo = sourceRepo.replace('qa', 'public')
 
-              artifact = f'SonarAnalyzer.CFG.CSharp.{version}.nupkg'
+              artifact = f'SonarAnalyzer.CFG.{version}.nupkg'
               print(f'Promoting nuget {artifact} from {sourceRepo} to {targetRepo}')
 
               url = f'$(ARTIFACTORY_URL)/api/move/{sourceRepo}/{artifact}?to=/{targetRepo}/{artifact}'


### PR DESCRIPTION
Make the name language agnostic and align it with the project and DLL name.