### PR TITLE
Allocations: Unroll AdditionalFile extension method

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
@@ -33,6 +33,15 @@ public static class AnalyzerOptionsExtensions
     public static AdditionalText ProjectOutFolderPath(this AnalyzerOptions options) =>
         options.AdditionalFile("ProjectOutFolderPath.txt");
 
-    private static AdditionalText AdditionalFile(this AnalyzerOptions options, string fileName) =>
-        options.AdditionalFiles.FirstOrDefault(x => x.Path is not null && Path.GetFileName(x.Path).Equals(fileName, StringComparison.OrdinalIgnoreCase));
+    private static AdditionalText AdditionalFile(this AnalyzerOptions options, string fileName)
+    {
+        foreach (var additionalText in options.AdditionalFiles)
+        {
+            if (additionalText.Path?.EndsWith(fileName, StringComparison.OrdinalIgnoreCase) is true)
+            {
+                return additionalText;
+            }
+        }
+        return null;
+    }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
@@ -44,8 +44,7 @@ public static class AnalyzerOptionsExtensions
             {
                 // The character before the filename (if there is a character) must be a directory separator
                 var separatorPosition = path.Length - fileName.Length - 1;
-                if (separatorPosition < 0
-                    || IsDirectorySeparator(path[separatorPosition]))
+                if (separatorPosition < 0 || IsDirectorySeparator(path[separatorPosition]))
                 {
                     return additionalText;
                 }
@@ -54,6 +53,6 @@ public static class AnalyzerOptionsExtensions
         return null;
 
         static bool IsDirectorySeparator(char c) =>
-            c == Path.PathSeparator || c == Path.AltDirectorySeparatorChar;
+            c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
@@ -48,9 +48,8 @@ public static class AnalyzerOptionsExtensions
                     || path[separatorPosition] == Path.DirectorySeparatorChar
                     || path[separatorPosition] == Path.AltDirectorySeparatorChar)
                 {
-                    continue;
+                    return additionalText;
                 }
-                return additionalText;
             }
         }
         return null;

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
@@ -35,7 +35,7 @@ public static class AnalyzerOptionsExtensions
 
     private static AdditionalText AdditionalFile(this AnalyzerOptions options, string fileName)
     {
-        // HotPath: This code path needs tp be allocation free. Don't use Linq.
+        // HotPath: This code path needs to be allocation free. Don't use Linq.
         foreach (var additionalText in options.AdditionalFiles) // Uses the struct enumerator of ImmutableArray
         {
             // Don't use Path.GetFilename. It allocates a string.

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
@@ -37,8 +37,17 @@ public static class AnalyzerOptionsExtensions
     {
         foreach (var additionalText in options.AdditionalFiles)
         {
-            if (additionalText.Path?.EndsWith(fileName, StringComparison.OrdinalIgnoreCase) is true)
+            if (additionalText.Path is { } path
+                && path.EndsWith(fileName, StringComparison.OrdinalIgnoreCase))
             {
+                // The character before the filename (if there is one) must be a directory separator
+                if (path.Length > fileName.Length
+                    && path[path.Length - fileName.Length - 1] is var separator
+                    && separator != Path.DirectorySeparatorChar
+                    && separator != Path.AltDirectorySeparatorChar)
+                {
+                    continue;
+                }
                 return additionalText;
             }
         }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
@@ -35,14 +35,16 @@ public static class AnalyzerOptionsExtensions
 
     private static AdditionalText AdditionalFile(this AnalyzerOptions options, string fileName)
     {
-        foreach (var additionalText in options.AdditionalFiles)
+        // HotPath: This code path needs tp be allocation free. Don't use Linq.
+        foreach (var additionalText in options.AdditionalFiles) // Uses the struct enumerator of ImmutableArray
         {
+            // Don't use Path.GetFilename. It allocates a string.
             if (additionalText.Path is { } path
                 && path.EndsWith(fileName, StringComparison.OrdinalIgnoreCase))
             {
-                // The character before the filename (if there is one) must be a directory separator
-                if (path.Length > fileName.Length
-                    && path[path.Length - fileName.Length - 1] is var separator
+                // The character before the filename (if there is a character) must be a directory separator
+                if (path.Length - fileName.Length - 1 is >= 0 and var separatorPosition
+                    && path[separatorPosition] is var separator
                     && separator != Path.DirectorySeparatorChar
                     && separator != Path.AltDirectorySeparatorChar)
                 {

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
@@ -45,13 +45,15 @@ public static class AnalyzerOptionsExtensions
                 // The character before the filename (if there is a character) must be a directory separator
                 var separatorPosition = path.Length - fileName.Length - 1;
                 if (separatorPosition < 0
-                    || path[separatorPosition] == Path.DirectorySeparatorChar
-                    || path[separatorPosition] == Path.AltDirectorySeparatorChar)
+                    || IsDirectorySeparator(path[separatorPosition]))
                 {
                     return additionalText;
                 }
             }
         }
         return null;
+
+        static bool IsDirectorySeparator(char c) =>
+            c == Path.PathSeparator || c == Path.AltDirectorySeparatorChar;
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
@@ -43,10 +43,10 @@ public static class AnalyzerOptionsExtensions
                 && path.EndsWith(fileName, StringComparison.OrdinalIgnoreCase))
             {
                 // The character before the filename (if there is a character) must be a directory separator
-                if (path.Length - fileName.Length - 1 is >= 0 and var separatorPosition
-                    && path[separatorPosition] is var separator
-                    && separator != Path.DirectorySeparatorChar
-                    && separator != Path.AltDirectorySeparatorChar)
+                var separatorPosition = path.Length - fileName.Length - 1;
+                if (separatorPosition < 0
+                    || path[separatorPosition] == Path.DirectorySeparatorChar
+                    || path[separatorPosition] == Path.AltDirectorySeparatorChar)
                 {
                     continue;
                 }


### PR DESCRIPTION
Fixes #7440

Tested with Akka.Net in a `dotnet build` context in a SQ EE SonaryWay run.

This change safes
* 5GB of string allocations caused by calls to `Path.GetFileName`
* 3GB of delegate allocations for the FirstOrDefault lambda argument
* 1,1 GB for the capture class for the filename parameter.

The total memory allocations are down to 32,5 GB from 41,7GB = 9,2 GB savings (22%)

The number of issues reported stayed the same (3514 warnings).

Before
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/fb3c1302-1588-45c5-af2f-d9bfe6c720b2)

After
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/5979ae7a-201b-45d2-baea-f83e3b0a76ae)
