### PR TITLE
Allocations: Remove delegate allocation from IsGenerated

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxTreeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxTreeExtensions.cs
@@ -34,6 +34,9 @@ internal static class SyntaxTreeExtensions
             return false;
         }
         var cache = GeneratedCodeCache.GetOrCreateValue(compilation);
-        return cache.GetOrAdd(tree, generatedCodeRecognizer.IsGenerated);
+        // Hotpath: Don't use cache.GetOrAdd that takes a factory method. It allocates a delegate which causes GC preasure.
+        return cache.TryGetValue(tree, out var isGenerated)
+            ? isGenerated
+            : cache.GetOrAdd(tree, generatedCodeRecognizer.IsGenerated(tree));
     }
 }


### PR DESCRIPTION
Small risk change that saves 291 MB of allocations (out of 41,6 GB). IsGenerated is the 7th most allocating method:

Before:
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/f31c2f5c-c3f3-4c9a-82f1-99517a1dd12a)

After
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/6c5e1da4-ae96-4770-9e8b-9a11d32c1840)


Before
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/fcb71e03-3629-44b1-8c51-5c1dd23a3374)

After
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/45db3067-bc45-44d8-a837-73844b58206b)
