### PR TITLE
Allocations: Remove delegate allocation from IsExcluded

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -138,6 +138,7 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
         if (ProjectConfiguration().ProjectType == ProjectType.Unknown)
         {
             var fileInclusionCache = FileInclusionCache.GetOrCreateValue(Compilation);
+            // Hotpath: GetOrAdd with the value factory parameter. It allocates a delegate which causes GC preasure.
             return fileInclusionCache.TryGetValue(filePath, out var result)
                 ? result
                 : fileInclusionCache.GetOrAdd(filePath, sonarLintXml.IsFileIncluded(filePath, IsTestProject()));

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -138,7 +138,7 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
         if (ProjectConfiguration().ProjectType == ProjectType.Unknown)
         {
             var fileInclusionCache = FileInclusionCache.GetOrCreateValue(Compilation);
-            // Hotpath: GetOrAdd with the value factory parameter. It allocates a delegate which causes GC preasure.
+            // Hotpath: Don't use GetOrAdd with the value factory parameter. It allocates a delegate which causes GC preasure.
             return fileInclusionCache.TryGetValue(filePath, out var result)
                 ? result
                 : fileInclusionCache.GetOrAdd(filePath, sonarLintXml.IsFileIncluded(filePath, IsTestProject()));

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -139,9 +139,10 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
         {
             var fileInclusionCache = FileInclusionCache.GetOrCreateValue(Compilation);
             // Hotpath: Don't use GetOrAdd with the value factory parameter. It allocates a delegate which causes GC preasure.
-            return fileInclusionCache.TryGetValue(filePath, out var result)
+            var isIncluded = fileInclusionCache.TryGetValue(filePath, out var result)
                 ? result
                 : fileInclusionCache.GetOrAdd(filePath, sonarLintXml.IsFileIncluded(filePath, IsTestProject()));
+            return !isIncluded;
         }
         return false;
     }


### PR DESCRIPTION
Small risk change that saves 165 MB of allocations (out of 41,6 GB). IsExcluded is the 20th most allocating method:

Before
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/0109214b-24f0-44bb-aae8-bd65d1cda88d)

After
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/7542572d-97a0-4108-bbe6-57c001bd6e15)


Before

![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/69d901f0-e36d-4d46-9a26-48ed38280711)

After

![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/c67c8a1e-405d-4aca-85be-c1cf425f1377)
