### PR TITLE
Allocations: Move stringliteral tokens array to static field

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -116,7 +116,6 @@ namespace SonarAnalyzer.Extensions
 
         public static SyntaxNode RemoveParentheses(this SyntaxNode expression)
         {
-
             var current = expression;
             while (current is { } && current.IsAnyKind(ParenthesizedNodeKinds))
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -25,6 +25,7 @@ namespace SonarAnalyzer.Extensions
     internal static partial class SyntaxNodeExtensions
     {
         private static readonly ControlFlowGraphCache CfgCache = new();
+        private static readonly SyntaxKind[] ParenthesizedNodeKinds = new[] { SyntaxKind.ParenthesizedExpression, SyntaxKindEx.ParenthesizedPattern };
 
         public static ControlFlowGraph CreateCfg(this SyntaxNode body, SemanticModel model, CancellationToken cancel) =>
             CfgCache.FindOrCreate(body is CompilationUnitSyntax ? body : body.Parent, model, cancel);
@@ -115,8 +116,9 @@ namespace SonarAnalyzer.Extensions
 
         public static SyntaxNode RemoveParentheses(this SyntaxNode expression)
         {
+
             var current = expression;
-            while (current is { } && current.IsAnyKind(SyntaxKind.ParenthesizedExpression, SyntaxKindEx.ParenthesizedPattern))
+            while (current is { } && current.IsAnyKind(ParenthesizedNodeKinds))
             {
                 current = current.IsKind(SyntaxKindEx.ParenthesizedPattern)
                     ? ((ParenthesizedPatternSyntaxWrapper)current).Pattern

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKindEx.InterpolatedMultiLineRawStringStartToken,
                 SyntaxKind.InterpolatedStringTextToken,
                 SyntaxKind.InterpolatedStringEndToken,
-                SyntaxKindEx.InterpolatedRawStringEndToken
+                SyntaxKindEx.InterpolatedRawStringEndToken,
             };
 
             public TokenClassifier(SemanticModel semanticModel, bool skipIdentifiers) : base(semanticModel, skipIdentifiers) { }
@@ -71,11 +71,23 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private sealed class TriviaClassifier : TriviaClassifierBase
         {
+            private static readonly SyntaxKind[] RegularCommentToken = new[]
+            {
+                SyntaxKind.SingleLineCommentTrivia,
+                SyntaxKind.MultiLineCommentTrivia,
+            };
+
+            private static readonly SyntaxKind[] DocCommentToken = new[]
+            {
+                SyntaxKind.SingleLineDocumentationCommentTrivia,
+                SyntaxKind.MultiLineDocumentationCommentTrivia,
+            };
+
             protected override bool IsRegularComment(SyntaxTrivia trivia) =>
-                trivia.IsAnyKind(SyntaxKind.SingleLineCommentTrivia, SyntaxKind.MultiLineCommentTrivia);
+                trivia.IsAnyKind(RegularCommentToken);
 
             protected override bool IsDocComment(SyntaxTrivia trivia) =>
-                trivia.IsAnyKind(SyntaxKind.SingleLineDocumentationCommentTrivia, SyntaxKind.MultiLineDocumentationCommentTrivia);
+                trivia.IsAnyKind(DocCommentToken);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -33,6 +33,24 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private sealed class TokenClassifier : TokenClassifierBase
         {
+            private static readonly SyntaxKind[] StringLiteralTokens = new[]
+            {
+                SyntaxKind.StringLiteralToken,
+                SyntaxKind.CharacterLiteralToken,
+                SyntaxKindEx.SingleLineRawStringLiteralToken,
+                SyntaxKindEx.MultiLineRawStringLiteralToken,
+                SyntaxKindEx.Utf8StringLiteralToken,
+                SyntaxKindEx.Utf8SingleLineRawStringLiteralToken,
+                SyntaxKindEx.Utf8MultiLineRawStringLiteralToken,
+                SyntaxKind.InterpolatedStringStartToken,
+                SyntaxKind.InterpolatedVerbatimStringStartToken,
+                SyntaxKindEx.InterpolatedSingleLineRawStringStartToken,
+                SyntaxKindEx.InterpolatedMultiLineRawStringStartToken,
+                SyntaxKind.InterpolatedStringTextToken,
+                SyntaxKind.InterpolatedStringEndToken,
+                SyntaxKindEx.InterpolatedRawStringEndToken
+            };
+
             public TokenClassifier(SemanticModel semanticModel, bool skipIdentifiers) : base(semanticModel, skipIdentifiers) { }
 
             protected override SyntaxNode GetBindableParent(SyntaxToken token) =>
@@ -48,21 +66,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 token.IsKind(SyntaxKind.NumericLiteralToken);
 
             protected override bool IsStringLiteral(SyntaxToken token) =>
-                token.IsAnyKind(
-                    SyntaxKind.StringLiteralToken,
-                    SyntaxKind.CharacterLiteralToken,
-                    SyntaxKindEx.SingleLineRawStringLiteralToken,
-                    SyntaxKindEx.MultiLineRawStringLiteralToken,
-                    SyntaxKindEx.Utf8StringLiteralToken,
-                    SyntaxKindEx.Utf8SingleLineRawStringLiteralToken,
-                    SyntaxKindEx.Utf8MultiLineRawStringLiteralToken,
-                    SyntaxKind.InterpolatedStringStartToken,
-                    SyntaxKind.InterpolatedVerbatimStringStartToken,
-                    SyntaxKindEx.InterpolatedSingleLineRawStringStartToken,
-                    SyntaxKindEx.InterpolatedMultiLineRawStringStartToken,
-                    SyntaxKind.InterpolatedStringTextToken,
-                    SyntaxKind.InterpolatedStringEndToken,
-                    SyntaxKindEx.InterpolatedRawStringEndToken);
+                token.IsAnyKind(StringLiteralTokens);
         }
 
         private sealed class TriviaClassifier : TriviaClassifierBase


### PR DESCRIPTION
Moving some `SyntaxKind[]` arrays created by `IsAnyKind` to a static readonly field saves 350MB:
That array was the 15th most allocated type.

Before
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/c38cf732-9396-4cea-a6a4-d05b4e58ce0c)

After
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/9ac33cdc-63f6-4a73-bf9a-eeee9f539e45)
 