### PR TITLE
Add ReportIssue overload to SymbolicRuleCheck

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicRuleCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicRuleCheck.cs
@@ -59,11 +59,7 @@ public abstract class SymbolicRuleCheck : SymbolicCheck
             Property {nameof(Rule)} is null.
             Use the "void ReportIssue(DiagnosticDescriptor rule, IOperation operation, IEnumerable<Location> additionalLocations, params object[] messageArgs)" overload
             """);
-        var location = operation.Syntax.GetLocation();
-        if (reportedDiagnostics.Add(location))
-        {
-            context.ReportIssue(Diagnostic.Create(Rule, location, additionalLocations, messageArgs));
-        }
+        ReportIssue(Rule, operation, additionalLocations, messageArgs);
     }
 
     protected void ReportIssue(DiagnosticDescriptor rule, IOperation operation, IEnumerable<Location> additionalLocations, params object[] messageArgs)

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicRuleCheck.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicRuleCheck.cs
@@ -49,14 +49,29 @@ public abstract class SymbolicRuleCheck : SymbolicCheck
     protected void ReportIssue(IOperationWrapperSonar operation, params object[] messageArgs) =>
         ReportIssue(operation.Instance, messageArgs);
 
-    protected void ReportIssue(IOperation operation, params object[] messageArgs) => ReportIssue(operation, null, messageArgs);
+    protected void ReportIssue(IOperation operation, params object[] messageArgs) =>
+        ReportIssue(operation, null, messageArgs);
 
     protected void ReportIssue(IOperation operation, IEnumerable<Location> additionalLocations, params object[] messageArgs)
     {
+        _ = Rule ?? throw new InvalidOperationException(
+            $"""
+            Property {nameof(Rule)} is null.
+            Use the "void ReportIssue(DiagnosticDescriptor rule, IOperation operation, IEnumerable<Location> additionalLocations, params object[] messageArgs)" overload
+            """);
         var location = operation.Syntax.GetLocation();
         if (reportedDiagnostics.Add(location))
         {
             context.ReportIssue(Diagnostic.Create(Rule, location, additionalLocations, messageArgs));
+        }
+    }
+
+    protected void ReportIssue(DiagnosticDescriptor rule, IOperation operation, IEnumerable<Location> additionalLocations, params object[] messageArgs)
+    {
+        var location = operation.Syntax.GetLocation();
+        if (reportedDiagnostics.Add(location))
+        {
+            context.ReportIssue(Diagnostic.Create(rule, location, additionalLocations, messageArgs));
         }
     }
 }


### PR DESCRIPTION
Adding a report issue overload that accepts the DiagnosticDescriptor as a parameter.
We need this because S2589 and S2583 are reporting from the same class (issue #7646).
