### PR TITLE
Deprecation: Replace ValidateTag with TagValue (BeTrue part)

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -375,12 +375,12 @@ Tag(""ForSymbolSymbolFalse"", forSymbolSymbolFalse);
 Tag(""ForSymbolSymbolNone"", forSymbolSymbolNone);";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
-        validator.ValidateTag("IsTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("IsFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-        validator.ValidateTag("ForNullNull", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());  // null == null is Literal with constant value 'true'
-        validator.ValidateTag("ForNullSymbol", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("ForSymbolSymbolTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("ForSymbolSymbolFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
+        validator.TagValue("IsTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("IsFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("ForNullNull").Should().HaveOnlyConstraint(BoolConstraint.True);  // null == null is Literal with constant value 'true'
+        validator.TagValue("ForNullSymbol").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("ForSymbolSymbolTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("ForSymbolSymbolFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
         validator.ValidateTag("ForSymbolSymbolNone", x => x.HasConstraint<BoolConstraint>().Should().BeFalse("We can't tell if two instances are equivalent."));
     }
 
@@ -430,10 +430,10 @@ Tag(""EqualsTrue"", EqualsTrue)
 Tag(""EqualsFalse"", EqualsFalse)";
         var validator = SETestContext.CreateVB(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
-        validator.ValidateTag("IsTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("IsFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-        validator.ValidateTag("EqualsTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("EqualsFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
+        validator.TagValue("IsTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("IsFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("EqualsTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("EqualsFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
     }
 
     [DataTestMethod]
@@ -475,12 +475,12 @@ Tag(""ForSymbolSymbolFalse"", forSymbolSymbolFalse);
 Tag(""ForSymbolSymbolNone"", forSymbolSymbolNone);";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
-        validator.ValidateTag("IsTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("IsFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-        validator.ValidateTag("ForNullNull", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());  // null != null is Literal with constant value 'false'
-        validator.ValidateTag("ForNullSymbol", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-        validator.ValidateTag("ForSymbolSymbolTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("ForSymbolSymbolFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
+        validator.TagValue("IsTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("IsFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("ForNullNull").Should().HaveOnlyConstraint(BoolConstraint.False);  // null != null is Literal with constant value 'false'
+        validator.TagValue("ForNullSymbol").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("ForSymbolSymbolTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("ForSymbolSymbolFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
         validator.ValidateTag("ForSymbolSymbolNone", x => x.HasConstraint<BoolConstraint>().Should().BeFalse("We can't tell if two instances are equivalent."));
     }
 
@@ -531,10 +531,10 @@ Tag(""EqualsTrue"", EqualsTrue)
 Tag(""EqualsFalse"", EqualsFalse)";
         var validator = SETestContext.CreateVB(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
-        validator.ValidateTag("IsTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("IsFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-        validator.ValidateTag("EqualsTrue", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("EqualsFalse", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
+        validator.TagValue("IsTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("IsFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("EqualsTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("EqualsFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -423,18 +423,12 @@ Dim NullValue As Object = Nothing
 Dim NotNullValue As New Object()
 Dim IsTrue As Boolean = NullValue Is Nothing
 Dim IsFalse = NotNullValue Is Nothing
-Dim EqualsTrue As Boolean = NullValue = Nothing
-Dim EqualsFalse = NotNullValue = Nothing
 Tag(""IsTrue"", IsTrue)
-Tag(""IsFalse"", IsFalse)
-Tag(""EqualsTrue"", EqualsTrue)
-Tag(""EqualsFalse"", EqualsFalse)";
+Tag(""IsFalse"", IsFalse)";
         var validator = SETestContext.CreateVB(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
         validator.TagValue("IsTrue").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
         validator.TagValue("IsFalse").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
-        validator.TagValue("EqualsTrue").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
-        validator.TagValue("EqualsFalse").Should().HaveOnlyConstraint(BoolConstraint.False); // TODO: NotNull missing
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -375,12 +375,12 @@ Tag(""ForSymbolSymbolFalse"", forSymbolSymbolFalse);
 Tag(""ForSymbolSymbolNone"", forSymbolSymbolNone);";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
-        validator.TagValue("IsTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("IsFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
-        validator.TagValue("ForNullNull").Should().HaveOnlyConstraint(BoolConstraint.True);  // null == null is Literal with constant value 'true'
-        validator.TagValue("ForNullSymbol").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("ForSymbolSymbolTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("ForSymbolSymbolFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("IsTrue").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("IsFalse").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
+        validator.TagValue("ForNullNull").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);  // null == null is Literal with constant value 'true'
+        validator.TagValue("ForNullSymbol").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("ForSymbolSymbolTrue").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("ForSymbolSymbolFalse").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
         validator.ValidateTag("ForSymbolSymbolNone", x => x.HasConstraint<BoolConstraint>().Should().BeFalse("We can't tell if two instances are equivalent."));
     }
 
@@ -430,10 +430,10 @@ Tag(""EqualsTrue"", EqualsTrue)
 Tag(""EqualsFalse"", EqualsFalse)";
         var validator = SETestContext.CreateVB(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
-        validator.TagValue("IsTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("IsFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
-        validator.TagValue("EqualsTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("EqualsFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("IsTrue").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("IsFalse").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
+        validator.TagValue("EqualsTrue").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("EqualsFalse").Should().HaveOnlyConstraint(BoolConstraint.False); // TODO: NotNull missing
     }
 
     [DataTestMethod]
@@ -475,12 +475,12 @@ Tag(""ForSymbolSymbolFalse"", forSymbolSymbolFalse);
 Tag(""ForSymbolSymbolNone"", forSymbolSymbolNone);";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
-        validator.TagValue("IsTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("IsFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
-        validator.TagValue("ForNullNull").Should().HaveOnlyConstraint(BoolConstraint.False);  // null != null is Literal with constant value 'false'
-        validator.TagValue("ForNullSymbol").Should().HaveOnlyConstraint(BoolConstraint.False);
-        validator.TagValue("ForSymbolSymbolTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("ForSymbolSymbolFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("IsTrue").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("IsFalse").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
+        validator.TagValue("ForNullNull").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);  // null != null is Literal with constant value 'false'
+        validator.TagValue("ForNullSymbol").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
+        validator.TagValue("ForSymbolSymbolTrue").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("ForSymbolSymbolFalse").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
         validator.ValidateTag("ForSymbolSymbolNone", x => x.HasConstraint<BoolConstraint>().Should().BeFalse("We can't tell if two instances are equivalent."));
     }
 
@@ -531,10 +531,10 @@ Tag(""EqualsTrue"", EqualsTrue)
 Tag(""EqualsFalse"", EqualsFalse)";
         var validator = SETestContext.CreateVB(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
-        validator.TagValue("IsTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("IsFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
-        validator.TagValue("EqualsTrue").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("EqualsFalse").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("IsTrue").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("IsFalse").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
+        validator.TagValue("EqualsTrue").Should().HaveOnlyConstraints(BoolConstraint.True); // TODO ObjectConstraint.NotNull missing
+        validator.TagValue("EqualsFalse").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -609,7 +609,7 @@ Tag(""End"")";
             """;
         var validator = SETestContext.CreateCS(code, "int? arg").Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
-        validator.TagValue("If").Should().HaveOnlyConstraints(new SymbolicConstraint[] { ObjectConstraint.NotNull, NumberConstraint.From(min, max) }, "arg comparison true, hence non-null");
+        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(min, max));
         validator.TagValue("Else").Should().HaveNoConstraints("arg either null or comparison false");
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -524,18 +524,12 @@ Dim NullValue As Object = Nothing
 Dim NotNullValue As New Object()
 Dim IsTrue = NotNullValue IsNot Nothing
 Dim IsFalse As Boolean = NullValue IsNot Nothing
-Dim EqualsTrue = NotNullValue <> Nothing
-Dim EqualsFalse As Boolean = NullValue <> Nothing
 Tag(""IsTrue"", IsTrue)
-Tag(""IsFalse"", IsFalse)
-Tag(""EqualsTrue"", EqualsTrue)
-Tag(""EqualsFalse"", EqualsFalse)";
+Tag(""IsFalse"", IsFalse)";
         var validator = SETestContext.CreateVB(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Binary);
         validator.TagValue("IsTrue").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
         validator.TagValue("IsFalse").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
-        validator.TagValue("EqualsTrue").Should().HaveOnlyConstraints(BoolConstraint.True); // TODO ObjectConstraint.NotNull missing
-        validator.TagValue("EqualsFalse").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.LearnConstraint.cs
@@ -313,7 +313,7 @@ if (value = boolParameter)
             Tag("End", b)
             """).Validator;
         validator.ValidateTagOrder(branchValue, "End");
-        validator.ValidateTag(branchValue, x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(expectedPath)));
+        validator.TagValue(branchValue).Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(expectedPath));
         validator.TagValues("End").Should().SatisfyRespectively(x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(expectedPath)));
     }
 
@@ -1283,8 +1283,8 @@ Tag(""End"", arg);";
             }
             """;
         var validator = SETestContext.CreateCS(code, "int left, int right").Validator;
-        validator.ValidateTag("Left", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedMin, expectedMax)));
-        validator.ValidateTag("Right", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedMin, expectedMax)));
+        validator.TagValue("Left").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedMin, expectedMax));
+        validator.TagValue("Right").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedMin, expectedMax));
     }
 
     [DataTestMethod]
@@ -1311,8 +1311,8 @@ Tag(""End"", arg);";
             }
             """;
         var validator = SETestContext.CreateCS(code, "int left, int right").Validator;
-        validator.ValidateTag("Left", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedLeftMin, expectedLeftMax)));
-        validator.ValidateTag("Right", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedRightMin, expectedRightMax)));
+        validator.TagValue("Left").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedLeftMin, expectedLeftMax));
+        validator.TagValue("Right").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedRightMin, expectedRightMax));
     }
 
     [DataTestMethod]
@@ -1339,8 +1339,8 @@ Tag(""End"", arg);";
             }
             """;
         var validator = SETestContext.CreateCS(code, "int left, int right").Validator;
-        validator.ValidateTag("Left", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedLeftMin, expectedLeftMax)));
-        validator.ValidateTag("Right", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedRightMin, expectedRightMax)));
+        validator.TagValue("Left").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedLeftMin, expectedLeftMax));
+        validator.TagValue("Right").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedRightMin, expectedRightMax));
     }
 
     [DataTestMethod]
@@ -1367,8 +1367,8 @@ Tag(""End"", arg);";
             }
             """;
         var validator = SETestContext.CreateCS(code, "int left, int right").Validator;
-        validator.ValidateTag("Left", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedLeftMin, expectedLeftMax)));
-        validator.ValidateTag("Right", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedRightMin, expectedRightMax)));
+        validator.TagValue("Left").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedLeftMin, expectedLeftMax));
+        validator.TagValue("Right").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedRightMin, expectedRightMax));
     }
 
     [DataTestMethod]
@@ -1395,8 +1395,8 @@ Tag(""End"", arg);";
             }
             """;
         var validator = SETestContext.CreateCS(code, "int left, int right").Validator;
-        validator.ValidateTag("Left", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedLeftMin, expectedLeftMax)));
-        validator.ValidateTag("Right", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedRightMin, expectedRightMax)));
+        validator.TagValue("Left").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedLeftMin, expectedLeftMax));
+        validator.TagValue("Right").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(expectedRightMin, expectedRightMax));
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -123,10 +123,10 @@ else
     Tag(""ElseSecond"", second);
 }";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("IfFirst", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("IfSecond", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-        validator.ValidateTag("ElseFirst", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("ElseSecond", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
+        validator.TagValue("IfFirst").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("IfSecond").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("ElseFirst").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("ElseSecond").Should().HaveOnlyConstraint(BoolConstraint.False);
     }
 
     [TestMethod]
@@ -301,7 +301,7 @@ else
                 ? x.SetSymbolConstraint(invocation.Instance.TrackedSymbol(), TestConstraint.First)
                 : x.State);
         var validator = SETestContext.CreateCS(code, postProcess).Validator;
-        validator.ValidateTag("ToString", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
+        validator.TagValue("ToString").Should().HaveOnlyConstraint(TestConstraint.First);
         validator.ValidateTag("GetHashCode", x => x.HasConstraint(TestConstraint.First).Should().BeFalse()); // Nobody set the constraint on that path
         validator.ValidateExitReachCount(1);    // Once as the states are cleaned by LVA.
     }
@@ -563,7 +563,7 @@ Tag(""End"", arg);";
         validator.TagValues("If").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
-        validator.ValidateTag("Else", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -606,8 +606,8 @@ else
 }}
 Tag(""End"", notNull);";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("If", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("Else", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("End", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Else").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("End").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -123,10 +123,10 @@ else
     Tag(""ElseSecond"", second);
 }";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.TagValue("IfFirst").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("IfSecond").Should().HaveOnlyConstraint(BoolConstraint.False);
-        validator.TagValue("ElseFirst").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("ElseSecond").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("IfFirst").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("IfSecond").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
+        validator.TagValue("ElseFirst").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("ElseSecond").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -301,7 +301,7 @@ else
                 ? x.SetSymbolConstraint(invocation.Instance.TrackedSymbol(), TestConstraint.First)
                 : x.State);
         var validator = SETestContext.CreateCS(code, postProcess).Validator;
-        validator.TagValue("ToString").Should().HaveOnlyConstraint(TestConstraint.First);
+        validator.TagValue("ToString").Should().HaveOnlyConstraints(TestConstraint.First, BoolConstraint.True, ObjectConstraint.NotNull);
         validator.ValidateTag("GetHashCode", x => x.HasConstraint(TestConstraint.First).Should().BeFalse()); // Nobody set the constraint on that path
         validator.ValidateExitReachCount(1);    // Once as the states are cleaned by LVA.
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -43,7 +43,7 @@ Dim FromMe As Sample = Me
 Tag(""Me"", FromMe)";
         var validator = SETestContext.CreateVB(code).Validator;
         validator.ValidateContainsOperation(OperationKind.InstanceReference);
-        validator.ValidateTag("Me", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Me").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -87,8 +87,8 @@ public static class Extensions
         validator.ValidateContainsOperation(OperationKind.Invocation);
         validator.TagValue("BeforeInstance").Should().BeNull();
         validator.TagValue("BeforeExtensionArg").Should().BeNull();
-        validator.ValidateTag("BeforeExtensionNull", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-        validator.ValidateTag("BeforePreserve", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
+        validator.TagValue("BeforeExtensionNull").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("BeforePreserve").Should().HaveOnlyConstraint(BoolConstraint.True);
         validator.ValidateTag("AfterInstance", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("Instance method should set NotNull constraint."));
         validator.TagValue("AfterExtensionArg").Should().BeNull("Extensions can run on null instances.");
         validator.ValidateTag("AfterExtensionNull", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue("Extensions can run on null instances."));
@@ -235,8 +235,8 @@ Tag(""Field"", ObjectField);
 Tag(""StaticField"", StaticObjectField);";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Invocation);
-        validator.ValidateTag("Field", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-        validator.ValidateTag("StaticField", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
+        validator.TagValue("Field").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("StaticField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 
     [DataTestMethod]
@@ -504,9 +504,9 @@ Tag(""AfterField"", ObjectField);
 Tag(""AfterStaticField"", StaticObjectField);";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Invocation);
-        validator.ValidateTag("BeforeField", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-        validator.ValidateTag("BeforeStaticField", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-        validator.ValidateTag("AfterField", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
+        validator.TagValue("BeforeField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("BeforeStaticField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("AfterField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.ValidateTag("AfterStaticField", x => x.Should().BeNull());
     }
 
@@ -554,7 +554,7 @@ if (!string.IsNullOrEmpty(exception?.Message))
 }
 Tag(""ExceptionAfterCheck"", exception);";
         var validator = SETestContext.CreateCS(code, "InvalidOperationException exception").Validator;
-        validator.ValidateTag("ExceptionChecked", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("ExceptionChecked").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("ExceptionAfterCheck").Should().Equal(new[]
         {
             SymbolicValue.Empty.WithConstraint(ObjectConstraint.Null),
@@ -634,10 +634,10 @@ finally
 var value = {expression};
 Tag(""Value"", value);";
         var enumerableValidator = SETestContext.CreateCS(code, "IEnumerable<object> arg").Validator;
-        enumerableValidator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        enumerableValidator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
 
         var queryableValidator = SETestContext.CreateCS(code, "IQueryable<object> arg").Validator;
-        queryableValidator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        queryableValidator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -88,7 +88,7 @@ public static class Extensions
         validator.TagValue("BeforeInstance").Should().BeNull();
         validator.TagValue("BeforeExtensionArg").Should().BeNull();
         validator.TagValue("BeforeExtensionNull").Should().HaveOnlyConstraint(ObjectConstraint.Null);
-        validator.TagValue("BeforePreserve").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("BeforePreserve").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
         validator.ValidateTag("AfterInstance", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("Instance method should set NotNull constraint."));
         validator.TagValue("AfterExtensionArg").Should().BeNull("Extensions can run on null instances.");
         validator.ValidateTag("AfterExtensionNull", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue("Extensions can run on null instances."));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using SonarAnalyzer.SymbolicExecution;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 using SonarAnalyzer.SymbolicExecution.Roslyn;
 using SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution;
@@ -89,10 +90,10 @@ public static class Extensions
         validator.TagValue("BeforeExtensionArg").Should().BeNull();
         validator.TagValue("BeforeExtensionNull").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValue("BeforePreserve").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
-        validator.ValidateTag("AfterInstance", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("Instance method should set NotNull constraint."));
+        validator.TagValue("AfterInstance").Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "Instance method should set NotNull constraint.");
         validator.TagValue("AfterExtensionArg").Should().BeNull("Extensions can run on null instances.");
-        validator.ValidateTag("AfterExtensionNull", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue("Extensions can run on null instances."));
-        validator.ValidateTag("AfterPreserve", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue("Other constraints should not be removed."));
+        validator.TagValue("AfterExtensionNull").Should().HaveOnlyConstraint(ObjectConstraint.Null, "Extensions can run on null instances.");
+        validator.TagValue("AfterPreserve").Should().HaveOnlyConstraints(new SymbolicConstraint[] { ObjectConstraint.NotNull, BoolConstraint.True }, "Other constraints should not be removed.");
     }
 
     [TestMethod]
@@ -138,7 +139,7 @@ End Module";
         validator.TagValue("BeforeInstance").Should().BeNull();
         validator.TagValue("BeforeStatic").Should().BeNull();
         validator.TagValue("BeforeExtension").Should().BeNull();
-        validator.ValidateTag("AfterInstance", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("Instance method should set NotNull constraint."));
+        validator.TagValue("AfterInstance").Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "Instance method should set NotNull constraint.");
         validator.TagValue("AfterStatic").Should().BeNull("Static method can execute from null instances.");
         validator.TagValue("AfterExtension").Should().BeNull("Extensions can run on null instances.");
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.InvocationAttribute.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.InvocationAttribute.cs
@@ -231,8 +231,8 @@ if(CustomValidator(first, second))
 
 public bool CustomValidator([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object first, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object second) => true;";
         var validator = SETestContext.CreateCSMethod(code).Validator;
-        validator.ValidateTag("First", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("Second", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("First").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Second").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -252,8 +252,8 @@ if(CustomValidator(first, second))
 
 public bool CustomValidator([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object first, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object second) => true;";
         var validator = SETestContext.CreateCSMethod(code).Validator;
-        validator.ValidateTag("First", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());   // This path should be unreachable instead
-        validator.ValidateTag("Second", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("First").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);   // This path should be unreachable instead
+        validator.TagValue("Second").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -275,7 +275,7 @@ if(CustomValidator(first, untracked.field))
 
 public bool CustomValidator([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object first, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object second) => true;";
         var validator = SETestContext.CreateCSMethod(code).Validator;
-        validator.ValidateTag("First", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("First").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValue("Second").Should().BeNull();  // We didn't learn anything. And we continued
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -500,6 +500,6 @@ Tag(""End"", lastEx);
         validator.TagValues("BeforeReturn").Should().SatisfyRespectively(
             x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue(),                              // InstanceMethod did not throw
             x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());                          // InstanceMethod did throw, was caught, and flow continued
-        validator.ValidateTag("End", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue()); // InstanceMethod did throw and was caught
+        validator.TagValue("End").Should().HaveOnlyConstraint(ObjectConstraint.NotNull); // InstanceMethod did throw and was caught
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -53,7 +53,7 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var setter = new PreProcessTestCheck(OperationKind.Literal, x => x.Operation.Instance.ConstantValue.Value is false ? x.SetOperationConstraint(TestConstraint.First) : x.State);
         var validator = SETestContext.CreateCS(code, "bool? arg", setter).Validator;
-        validator.ValidateTag("Unknown", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("Accessing .Value would already throw, so it is NotNull by now"));
+        validator.TagValue("Unknown").Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "Accessing .Value would already throw, so it is NotNull by now");
         validator.TagValue("True").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
         validator.TagValue("FalseFirst").Should().HaveOnlyConstraints(TestConstraint.First, BoolConstraint.False, ObjectConstraint.NotNull);
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -35,8 +35,8 @@ public partial class RoslynSymbolicExecutionTest
             Tag("True", value);
             """;
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("Null", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-        validator.ValidateTag("True", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
+        validator.TagValue("Null").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("True").Should().HaveOnlyConstraint(BoolConstraint.True);
     }
 
     [TestMethod]
@@ -55,9 +55,9 @@ public partial class RoslynSymbolicExecutionTest
         var setter = new PreProcessTestCheck(OperationKind.Literal, x => x.Operation.Instance.ConstantValue.Value is false ? x.SetOperationConstraint(TestConstraint.First) : x.State);
         var validator = SETestContext.CreateCS(code, "bool? arg", setter).Validator;
         validator.ValidateTag("Unknown", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("Accessing .Value would already throw, so it is NotNull by now"));
-        validator.ValidateTag("True", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("FalseFirst", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
-        validator.ValidateTag("FalseFirst", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
+        validator.TagValue("True").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("FalseFirst").Should().HaveOnlyConstraint(BoolConstraint.False);
+        validator.TagValue("FalseFirst").Should().HaveOnlyConstraint(TestConstraint.First);
     }
 
     [TestMethod]
@@ -147,10 +147,10 @@ public partial class RoslynSymbolicExecutionTest
             }
             """;
         var validator = SETestContext.CreateCSMethod(code).Validator;
-        validator.ValidateTag("ExplicitType", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
+        validator.TagValue("ExplicitType").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.ValidateTag("TargetTyped", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("new() of int produces value 0"));
         validator.ValidateTag("GenericValue", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("new() of T produces value T"));
-        validator.ValidateTag("GenericNull", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
+        validator.TagValue("GenericNull").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 
     [TestMethod]
@@ -187,10 +187,10 @@ public partial class RoslynSymbolicExecutionTest
             Tag("ToBoolExplicit", toBoolExplicit);
             """;
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("ToNullableImplicit", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("ToNullableExplicit", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("ToNullableAs", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
-        validator.ValidateTag("ToBoolExplicit", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
+        validator.TagValue("ToNullableImplicit").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("ToNullableExplicit").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("ToNullableAs").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("ToBoolExplicit").Should().HaveOnlyConstraint(BoolConstraint.True);
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -36,6 +36,7 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var validator = SETestContext.CreateCS(code).Validator;
         validator.TagValue("Null").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("True").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using SonarAnalyzer.SymbolicExecution;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 using SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution;
 
@@ -147,8 +148,8 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var validator = SETestContext.CreateCSMethod(code).Validator;
         validator.TagValue("ExplicitType").Should().HaveOnlyConstraint(ObjectConstraint.Null);
-        validator.ValidateTag("TargetTyped", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("new() of int produces value 0"));
-        validator.ValidateTag("GenericValue", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("new() of T produces value T"));
+        validator.TagValue("TargetTyped").Should().HaveOnlyConstraints(new SymbolicConstraint[] { ObjectConstraint.NotNull, NumberConstraint.From(0) }, "new() of int produces value 0");
+        validator.TagValue("GenericValue").Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "new() of T produces value T");
         validator.TagValue("GenericNull").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Nullable.cs
@@ -36,7 +36,6 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var validator = SETestContext.CreateCS(code).Validator;
         validator.TagValue("Null").Should().HaveOnlyConstraint(ObjectConstraint.Null);
-        validator.TagValue("True").Should().HaveOnlyConstraint(BoolConstraint.True);
     }
 
     [TestMethod]
@@ -55,9 +54,8 @@ public partial class RoslynSymbolicExecutionTest
         var setter = new PreProcessTestCheck(OperationKind.Literal, x => x.Operation.Instance.ConstantValue.Value is false ? x.SetOperationConstraint(TestConstraint.First) : x.State);
         var validator = SETestContext.CreateCS(code, "bool? arg", setter).Validator;
         validator.ValidateTag("Unknown", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("Accessing .Value would already throw, so it is NotNull by now"));
-        validator.TagValue("True").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("FalseFirst").Should().HaveOnlyConstraint(BoolConstraint.False);
-        validator.TagValue("FalseFirst").Should().HaveOnlyConstraint(TestConstraint.First);
+        validator.TagValue("True").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("FalseFirst").Should().HaveOnlyConstraints(TestConstraint.First, BoolConstraint.False, ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -187,10 +185,10 @@ public partial class RoslynSymbolicExecutionTest
             Tag("ToBoolExplicit", toBoolExplicit);
             """;
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.TagValue("ToNullableImplicit").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("ToNullableExplicit").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("ToNullableAs").Should().HaveOnlyConstraint(BoolConstraint.True);
-        validator.TagValue("ToBoolExplicit").Should().HaveOnlyConstraint(BoolConstraint.True);
+        validator.TagValue("ToNullableImplicit").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("ToNullableExplicit").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("ToNullableAs").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
+        validator.TagValue("ToBoolExplicit").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -36,7 +36,7 @@ public partial class RoslynSymbolicExecutionTest
         validator.Validate("Literal: true", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue("it's scaffolded"));
         validator.Validate("SimpleAssignment: a = true (Implicit)", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
         validator.Validate("SimpleAssignment: a = true (Implicit)", x => x.State[((ISimpleAssignmentOperation)x.Operation.Instance).Target].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
-        validator.ValidateTag("a", x => x.HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
+        validator.TagValue("a").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
     }
 
     [TestMethod]
@@ -46,14 +46,14 @@ public partial class RoslynSymbolicExecutionTest
         validator.Validate("Literal: true", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue("it's scaffolded"));
         validator.Validate("SimpleAssignment: b = a", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
         validator.Validate("SimpleAssignment: b = a", x => x.State[((ISimpleAssignmentOperation)x.Operation.Instance).Target].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
-        validator.ValidateTag("b", x => x.HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
+        validator.TagValue("b").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
     }
 
     [TestMethod]
     public void SimpleAssignment_ToLocalVariable_FromLocalConst()
     {
         var validator = SETestContext.CreateCS(@"const string a = null; var b = a; Tag(""b"", b);").Validator;
-        validator.ValidateTag("b", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
+        validator.TagValue("b").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 
     [TestMethod]
@@ -70,8 +70,8 @@ public void Method()
     Tag(""IsNotNull"", value);
 }";
         var validator = SETestContext.CreateCSMethod(code).Validator;
-        validator.ValidateTag("IsNull", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-        validator.ValidateTag("IsNotNull", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("IsNull").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("IsNotNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -81,7 +81,7 @@ public void Method()
         validator.Validate("Literal: true", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue("it's scaffolded"));
         validator.Validate("SimpleAssignment: c = b = a", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
         validator.Validate("SimpleAssignment: c = b = a", x => x.State[((ISimpleAssignmentOperation)x.Operation.Instance).Target].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
-        validator.ValidateTag("c", x => x.HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
+        validator.TagValue("c").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
     }
 
     [TestMethod]
@@ -91,7 +91,7 @@ public void Method()
         validator.Validate("Literal: true", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue("it's scaffolded"));
         validator.Validate("SimpleAssignment: boolParameter = true", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
         validator.Validate("SimpleAssignment: boolParameter = true", x => x.State[((ISimpleAssignmentOperation)x.Operation.Instance).Target].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
-        validator.ValidateTag("boolParameter", x => x.HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
+        validator.TagValue("boolParameter").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
     }
 
     [TestMethod]
@@ -99,7 +99,7 @@ public void Method()
     {
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetOperationConstraint(DummyConstraint.Dummy));
         var validator = SETestContext.CreateCS(@"var b = boolParameter; Tag(""b"", b);", setter).Validator;
-        validator.ValidateTag("b", x => x.HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
+        validator.TagValue("b").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
     }
 
     [TestMethod]
@@ -107,7 +107,7 @@ public void Method()
     {
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetOperationConstraint(DummyConstraint.Dummy));
         var validator = SETestContext.CreateVB(@"Dim B As Boolean = BoolParameter : Tag(""B"", B)", setter).Validator;
-        validator.ValidateTag("B", x => x.HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
+        validator.TagValue("B").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
     }
 
     [DataTestMethod]
@@ -121,7 +121,7 @@ public void Method()
         var validator = SETestContext.CreateCS(snippet, new LiteralDummyTestCheck()).Validator;
         validator.Validate("Literal: 42", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue("it's scaffolded"));
         validator.Validate(operation, x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
-        validator.ValidateTag("Target", x => x.HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
+        validator.TagValue("Target").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
     }
 
     [DataTestMethod]
@@ -210,7 +210,7 @@ public void Method()
             "Argument: c",
             @"Invocation: Tag(""c"", c)",
             @"ExpressionStatement: Tag(""c"", c);");
-        validator.ValidateTag("b", x => x.HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
+        validator.TagValue("b").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
         validator.ValidateTag("c", x => x.AllConstraints.Should().ContainSingle().Which.Should().Be(ObjectConstraint.NotNull));
     }
 
@@ -230,7 +230,7 @@ public void Method()
             "Argument: b",
             @"Invocation: Tag(""b"", b)",
             @"ExpressionStatement: Tag(""b"", b);");
-        validator.ValidateTag("b", x => x.HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
+        validator.TagValue("b").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
     }
 
     [DataTestMethod]
@@ -444,7 +444,7 @@ var anonymous = new { a = 42 };
 Tag(""Anonymous"", anonymous);";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.AnonymousObjectCreation);
-        validator.ValidateTag("Anonymous", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Anonymous").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -464,11 +464,11 @@ Tag(""ArrMulti"", arrMulti);
 Tag(""ArrJagged"", arrJagged);";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.ArrayCreation);
-        validator.ValidateTag("Arr1", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("Arr2", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("Arr3", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("ArrMulti", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("ArrJagged", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Arr1").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Arr2").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Arr3").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("ArrMulti").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("ArrJagged").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -483,9 +483,9 @@ Tag(""Lambda"", lambda);
 Tag(""Delegate"", del);";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.DelegateCreation);
-        validator.ValidateTag("Pointer", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("Lambda", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("Delegate", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Pointer").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Lambda").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Delegate").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -496,7 +496,7 @@ var s = new Sample(dynamicArg);
 Tag(""S"", s);";
         var validator = SETestContext.CreateCS(code, "dynamic dynamicArg").Validator;
         validator.ValidateContainsOperation(OperationKind.DynamicObjectCreation);
-        validator.ValidateTag("S", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("S").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -515,10 +515,10 @@ Tag(""ValueType"", valueType);
 Tag(""Object"", obj);";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.ObjectCreation);
-        validator.ValidateTag("Declared", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("Assigned", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("ValueType", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());   // This is questionable, value types should not have ObjectConstraint
-        validator.ValidateTag("Object", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Declared").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Assigned").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("ValueType").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);   // This is questionable, value types should not have ObjectConstraint
+        validator.TagValue("Object").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -532,7 +532,7 @@ public void Main<T>() where T : new()
 }";
         var validator = SETestContext.CreateCSMethod(code).Validator;
         validator.ValidateContainsOperation(OperationKind.TypeParameterObjectCreation);
-        validator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
 #if NET
@@ -662,8 +662,8 @@ int i = default(byte);
 Tag(""ObjectFromException"", o);
 Tag(""IntegerFromByte"", i);";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("ObjectFromException", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-        validator.ValidateTag("IntegerFromByte", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("ObjectFromException").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("IntegerFromByte").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -675,8 +675,8 @@ const string stringConst = ""someText"";
 Tag(""StringLocal"", stringLocal);
 Tag(""StringConst"", stringConst);";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("StringLocal", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("StringConst", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("StringLocal").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("StringConst").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -706,7 +706,7 @@ Tag(""Value"", value);";
 var value = {literal};
 Tag(""Value"", value);";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -734,7 +734,7 @@ Tag(""This"", fromThis);";
         var validator = SETestContext.CreateCS(code, implicitCheck).Validator;
         validator.ValidateContainsOperation(OperationKind.InstanceReference);
         validator.ValidateContainsOperation(OperationKind.FieldReference);  // To execute implicitCheck
-        validator.ValidateTag("This", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("This").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -802,16 +802,16 @@ public static class Guard
 }}
 ";
         var validator = new SETestContext(code, AnalyzerLanguage.CSharp, Array.Empty<SymbolicCheck>()).Validator;
-        validator.ValidateTag("AfterGuard_o1", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterGuard_o2", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterGuard_o3", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterGuard_o4", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterGuard_o5", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("AfterGuard_o1").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_o2").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_o3").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_o4").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_o5").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValue("AfterGuard_o6").Should().BeNull("parameter is not annotated");
-        validator.ValidateTag("AfterGuard_o7", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterGuard_o8", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterGuard_s1", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterGuard_s2", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("AfterGuard_o7").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_o8").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_s1").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterGuard_s2").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -917,7 +917,7 @@ Sample UntrackedSymbol() => this;";
         var validator = SETestContext.CreateCS(code, "Sample arg").Validator;
         validator.ValidateContainsOperation(OperationKind.FieldReference);
         validator.TagValue("Before").Should().BeNull();
-        validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("After").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -936,7 +936,7 @@ Sample UntrackedSymbol() => this;";
         var validator = SETestContext.CreateCS(code, "Sample arg").Validator;
         validator.ValidateContainsOperation(OperationKind.FieldReference);
         validator.TagValue("Before").Should().BeNull();
-        validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("After").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -948,7 +948,7 @@ var argException = arg.fieldException;  // Should not propagate constraint from 
 Tag(""This"", fieldException);
 Tag(""Arg"", argException);";
         var validator = SETestContext.CreateCS(code, "Sample arg").Validator;
-        validator.ValidateTag("This", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("This").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValue("Arg").Should().BeNull();
     }
 
@@ -976,9 +976,9 @@ Sample UntrackedSymbol() => this;";
         validator.TagValue("BeforeProperty").Should().BeNull();
         validator.TagValue("BeforeDictionary").Should().BeNull();
         validator.TagValue("BeforeIndexer").Should().BeNull();
-        validator.ValidateTag("AfterProperty", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterDictionary", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterIndexer", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("AfterProperty").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterDictionary").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterIndexer").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -1005,9 +1005,9 @@ Sample UntrackedSymbol() => this;";
         validator.TagValue("BeforeProperty").Should().BeNull();
         validator.TagValue("BeforeDictionary").Should().BeNull();
         validator.TagValue("BeforeIndexer").Should().BeNull();
-        validator.ValidateTag("AfterProperty", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterDictionary", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterIndexer", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("AfterProperty").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterDictionary").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterIndexer").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -1053,7 +1053,7 @@ int[] UntrackedSymbol() => new[] { 42 };";
         var validator = SETestContext.CreateCS(code, "int[] array").Validator;
         validator.ValidateContainsOperation(OperationKind.ArrayElementReference);
         validator.TagValue("Before").Should().BeNull();
-        validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("After").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -1069,7 +1069,7 @@ int[] UntrackedSymbol() => new[] { 42 };";
         var validator = SETestContext.CreateCS(code, "int[] array").Validator;
         validator.ValidateContainsOperation(OperationKind.ArrayElementReference);
         validator.TagValue("Before").Should().BeNull();
-        validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("After").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -1086,8 +1086,8 @@ Tag(""AfterRemove"", remove);";
         validator.ValidateContainsOperation(OperationKind.ArrayElementReference);
         validator.TagValue("BeforeAdd").Should().BeNull();
         validator.TagValue("BeforeRemove").Should().BeNull();
-        validator.ValidateTag("AfterAdd", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterRemove", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("AfterAdd").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterRemove").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -1108,14 +1108,14 @@ Tag(""AfterFourth"", Fourth)
 Tag(""AfterNotTracked"", Arg.FieldArray)";
         var validator = SETestContext.CreateVB(code, "Arg As Sample").Validator;
         validator.ValidateContainsOperation(OperationKind.ReDim);
-        validator.ValidateTag("BeforeFirst", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-        validator.ValidateTag("BeforeSecond", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
+        validator.TagValue("BeforeFirst").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("BeforeSecond").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.ValidateTag("BeforeThird", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("has size in declaration"));
-        validator.ValidateTag("BeforeFourth", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-        validator.ValidateTag("AfterFirst", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterSecond", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterThird", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterFourth", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("BeforeFourth").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("AfterFirst").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterSecond").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterThird").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterFourth").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValue("AfterNotTracked").Should().BeNull();
     }
 
@@ -1131,10 +1131,10 @@ Tag(""AfterFirst"", First)
 Tag(""AfterSecond"", Second)";
         var validator = SETestContext.CreateVB(code, "Arg As Sample").Validator;
         validator.ValidateContainsOperation(OperationKind.ReDim);
-        validator.ValidateTag("BeforeFirst", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
+        validator.TagValue("BeforeFirst").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.ValidateTag("BeforeSecond", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("has size in declaration"));
-        validator.ValidateTag("AfterFirst", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("AfterSecond", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("AfterFirst").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("AfterSecond").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -1152,8 +1152,8 @@ public async System.Threading.Tasks.Task Main(System.Threading.Tasks.Task T)
 }";
         var addConstraint = new PostProcessTestCheck(OperationKind.Literal, x => x.SetOperationConstraint(LockConstraint.Held));    // Persisted constraint
         var validator = SETestContext.CreateCSMethod(code, addConstraint).Validator;
-        validator.ValidateTag("Before", x => x.HasConstraint(ObjectConstraint.Null).Should().BeTrue());
-        validator.ValidateTag("Before", x => x.HasConstraint(LockConstraint.Held).Should().BeTrue());
+        validator.TagValue("Before").Should().HaveOnlyConstraint(ObjectConstraint.Null);
+        validator.TagValue("Before").Should().HaveOnlyConstraint(LockConstraint.Held);
         validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.Null).Should().BeFalse());
         validator.ValidateTag("After", x => x.HasConstraint(LockConstraint.Held).Should().BeTrue("this constraint should be preserved on fields"));
     }
@@ -1163,7 +1163,7 @@ public async System.Threading.Tasks.Task Main(System.Threading.Tasks.Task T)
     {
         var validator = SETestContext.CreateCS(@"var value = typeof(object); Tag(""Value"", value);").Validator;
         validator.ValidateContainsOperation(OperationKind.TypeOf);
-        validator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -1113,7 +1113,7 @@ Tag(""AfterNotTracked"", Arg.FieldArray)";
         validator.ValidateContainsOperation(OperationKind.ReDim);
         validator.TagValue("BeforeFirst").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValue("BeforeSecond").Should().HaveOnlyConstraint(ObjectConstraint.Null);
-        validator.ValidateTag("BeforeThird", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("has size in declaration"));
+        validator.TagValue("BeforeThird").Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "has size in declaration");
         validator.TagValue("BeforeFourth").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValue("AfterFirst").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValue("AfterSecond").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
@@ -1135,7 +1135,7 @@ Tag(""AfterSecond"", Second)";
         var validator = SETestContext.CreateVB(code, "Arg As Sample").Validator;
         validator.ValidateContainsOperation(OperationKind.ReDim);
         validator.TagValue("BeforeFirst").Should().HaveOnlyConstraint(ObjectConstraint.Null);
-        validator.ValidateTag("BeforeSecond", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue("has size in declaration"));
+        validator.TagValue("BeforeSecond").Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "has size in declaration");
         validator.TagValue("AfterFirst").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValue("AfterSecond").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
@@ -1157,7 +1157,7 @@ public async System.Threading.Tasks.Task Main(System.Threading.Tasks.Task T)
         var validator = SETestContext.CreateCSMethod(code, addConstraint).Validator;
         validator.TagValue("Before").Should().HaveOnlyConstraints(ObjectConstraint.Null, LockConstraint.Held);
         validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.Null).Should().BeFalse());
-        validator.ValidateTag("After", x => x.HasConstraint(LockConstraint.Held).Should().BeTrue("this constraint should be preserved on fields"));
+        validator.TagValue("After").Should().HaveOnlyConstraint(LockConstraint.Held, "this constraint should be preserved on fields");
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -36,7 +36,7 @@ public partial class RoslynSymbolicExecutionTest
         validator.Validate("Literal: true", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue("it's scaffolded"));
         validator.Validate("SimpleAssignment: a = true (Implicit)", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
         validator.Validate("SimpleAssignment: a = true (Implicit)", x => x.State[((ISimpleAssignmentOperation)x.Operation.Instance).Target].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
-        validator.TagValue("a").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
+        validator.TagValue("a").Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull, BoolConstraint.True);
     }
 
     [TestMethod]
@@ -46,7 +46,7 @@ public partial class RoslynSymbolicExecutionTest
         validator.Validate("Literal: true", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue("it's scaffolded"));
         validator.Validate("SimpleAssignment: b = a", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
         validator.Validate("SimpleAssignment: b = a", x => x.State[((ISimpleAssignmentOperation)x.Operation.Instance).Target].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
-        validator.TagValue("b").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
+        validator.TagValue("b").Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull, BoolConstraint.True);
     }
 
     [TestMethod]
@@ -81,7 +81,7 @@ public void Method()
         validator.Validate("Literal: true", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue("it's scaffolded"));
         validator.Validate("SimpleAssignment: c = b = a", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
         validator.Validate("SimpleAssignment: c = b = a", x => x.State[((ISimpleAssignmentOperation)x.Operation.Instance).Target].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
-        validator.TagValue("c").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
+        validator.TagValue("c").Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull, BoolConstraint.True);
     }
 
     [TestMethod]
@@ -91,7 +91,7 @@ public void Method()
         validator.Validate("Literal: true", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue("it's scaffolded"));
         validator.Validate("SimpleAssignment: boolParameter = true", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
         validator.Validate("SimpleAssignment: boolParameter = true", x => x.State[((ISimpleAssignmentOperation)x.Operation.Instance).Target].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
-        validator.TagValue("boolParameter").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
+        validator.TagValue("boolParameter").Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull, BoolConstraint.True);
     }
 
     [TestMethod]
@@ -99,7 +99,7 @@ public void Method()
     {
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetOperationConstraint(DummyConstraint.Dummy));
         var validator = SETestContext.CreateCS(@"var b = boolParameter; Tag(""b"", b);", setter).Validator;
-        validator.TagValue("b").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
+        validator.TagValue("b").Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -107,7 +107,7 @@ public void Method()
     {
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetOperationConstraint(DummyConstraint.Dummy));
         var validator = SETestContext.CreateVB(@"Dim B As Boolean = BoolParameter : Tag(""B"", B)", setter).Validator;
-        validator.TagValue("B").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
+        validator.TagValue("B").Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]
@@ -121,7 +121,7 @@ public void Method()
         var validator = SETestContext.CreateCS(snippet, new LiteralDummyTestCheck()).Validator;
         validator.Validate("Literal: 42", x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue("it's scaffolded"));
         validator.Validate(operation, x => x.State[x.Operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue());
-        validator.TagValue("Target").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
+        validator.TagValue("Target").Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull, NumberConstraint.From(42));
     }
 
     [DataTestMethod]
@@ -210,7 +210,7 @@ public void Method()
             "Argument: c",
             @"Invocation: Tag(""c"", c)",
             @"ExpressionStatement: Tag(""c"", c);");
-        validator.TagValue("b").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
+        validator.TagValue("b").Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull, NumberConstraint.From(42));
         validator.ValidateTag("c", x => x.AllConstraints.Should().ContainSingle().Which.Should().Be(ObjectConstraint.NotNull));
     }
 
@@ -230,7 +230,7 @@ public void Method()
             "Argument: b",
             @"Invocation: Tag(""b"", b)",
             @"ExpressionStatement: Tag(""b"", b);");
-        validator.TagValue("b").Should().HaveOnlyConstraint(DummyConstraint.Dummy);
+        validator.TagValue("b").Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull, NumberConstraint.From(42));
     }
 
     [DataTestMethod]
@@ -663,7 +663,7 @@ Tag(""ObjectFromException"", o);
 Tag(""IntegerFromByte"", i);";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.TagValue("ObjectFromException").Should().HaveOnlyConstraint(ObjectConstraint.Null);
-        validator.TagValue("IntegerFromByte").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("IntegerFromByte").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0));
     }
 
     [TestMethod]
@@ -693,20 +693,23 @@ Tag(""Value"", value);";
     }
 
     [DataTestMethod]
-    [DataRow("'c'")]
-    [DataRow("1")]
-    [DataRow("1u")]
-    [DataRow("1l")]
-    [DataRow("0xFF")]
-    [DataRow("1.0")]
-    [DataRow("1.0f")]
-    public void Literal_Default_OtherLiterals(string literal)
+    [DataRow("'c'", null)]
+    [DataRow("1", 1)]
+    [DataRow("1u", 1u)]
+    [DataRow("1l", 1L)]
+    [DataRow("0xFF", 255)]
+    [DataRow("1.0", 1.0)]
+    [DataRow("1.0f", 1.0f)]
+    public void Literal_Default_OtherLiterals(string literal, object expectedNumber)
     {
         var code = @$"
 var value = {literal};
 Tag(""Value"", value);";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        var expectedConstraints = expectedNumber is null
+            ? new SymbolicConstraint[] { ObjectConstraint.NotNull }
+            : new SymbolicConstraint[] { ObjectConstraint.NotNull, NumberConstraint.From(expectedNumber) };
+        validator.TagValue("Value").Should().HaveOnlyConstraints(expectedConstraints);
     }
 
     [TestMethod]
@@ -1152,8 +1155,7 @@ public async System.Threading.Tasks.Task Main(System.Threading.Tasks.Task T)
 }";
         var addConstraint = new PostProcessTestCheck(OperationKind.Literal, x => x.SetOperationConstraint(LockConstraint.Held));    // Persisted constraint
         var validator = SETestContext.CreateCSMethod(code, addConstraint).Validator;
-        validator.TagValue("Before").Should().HaveOnlyConstraint(ObjectConstraint.Null);
-        validator.TagValue("Before").Should().HaveOnlyConstraint(LockConstraint.Held);
+        validator.TagValue("Before").Should().HaveOnlyConstraints(ObjectConstraint.Null, LockConstraint.Held);
         validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.Null).Should().BeFalse());
         validator.ValidateTag("After", x => x.HasConstraint(LockConstraint.Held).Should().BeTrue("this constraint should be preserved on fields"));
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
@@ -38,7 +38,7 @@ var value = isTrue switch
     false => false
 };
 Tag(""Value"", value);";
-        SETestContext.CreateCS(code).Validator.ValidateTag("Value", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
+        SETestContext.CreateCS(code).Validator.TagValue("Value").Should().HaveOnlyConstraint(BoolConstraint.True);
     }
 
     [TestMethod]
@@ -52,7 +52,7 @@ var value = (isTrue == true) switch
     false => false
 };
 Tag(""Value"", value);";
-        SETestContext.CreateCS(code).Validator.ValidateTag("Value", x => x.HasConstraint(BoolConstraint.True).Should().BeTrue());
+        SETestContext.CreateCS(code).Validator.TagValue("Value").Should().HaveOnlyConstraint(BoolConstraint.True);
     }
 
     [TestMethod]
@@ -66,7 +66,7 @@ var value = isFalse switch
     false => false
 };
 Tag(""Value"", value);";
-        SETestContext.CreateCS(code).Validator.ValidateTag("Value", x => x.HasConstraint(BoolConstraint.False).Should().BeTrue());
+        SETestContext.CreateCS(code).Validator.TagValue("Value").Should().HaveOnlyConstraint(BoolConstraint.False);
     }
 
     [TestMethod]
@@ -131,7 +131,7 @@ if (arg is { })
 Tag(""End"", arg);";
         var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.RecursivePattern);
-        validator.ValidateTag("ArgNotNull", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -149,8 +149,8 @@ if (arg is { } value)
 Tag(""End"", arg);";
         var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.RecursivePattern);
-        validator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("ArgNotNull", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(ObjectConstraint.NotNull));
@@ -169,10 +169,10 @@ Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
         var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.RecursivePattern);
-        validator.ValidateTag("Value", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
-        validator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("ArgNotNull", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
-        validator.ValidateTag("ArgNotNull", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Value").Should().HaveOnlyConstraint(TestConstraint.First);
+        validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraint(TestConstraint.First);
+        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(TestConstraint.First) && x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(TestConstraint.First) && x.HasConstraint(ObjectConstraint.NotNull));
@@ -191,10 +191,10 @@ Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
         var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.RecursivePattern);
-        validator.ValidateTag("Msg", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Msg").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.ValidateTag("Msg", x => x.HasConstraint(TestConstraint.First).Should().BeFalse("Constraint from source value should not be propagated to child property"));
-        validator.ValidateTag("Ex", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
-        validator.ValidateTag("Ex", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Ex").Should().HaveOnlyConstraint(TestConstraint.First);
+        validator.TagValue("Ex").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2).And.OnlyContain(x => x != null && x.HasConstraint(TestConstraint.First));   // 2x because value has different states
     }
 
@@ -210,8 +210,8 @@ if (arg is Exception value)
 Tag(""End"", arg);";
         var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
-        validator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("ArgNotNull", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -230,10 +230,10 @@ Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
         var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
-        validator.ValidateTag("Value", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
-        validator.ValidateTag("Value", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("ArgNotNull", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
-        validator.ValidateTag("ArgNotNull", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Value").Should().HaveOnlyConstraint(TestConstraint.First);
+        validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraint(TestConstraint.First);
+        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2).And.OnlyContain(x => x != null && x.HasConstraint(TestConstraint.First));  // 2x because value has different states
     }
 
@@ -248,7 +248,7 @@ if (arg is Exception _)
 Tag(""End"", arg);";
         var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
-        validator.ValidateTag("Arg", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("Arg").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x == null)
             .And.ContainSingle(x => x != null && x.HasConstraint(ObjectConstraint.NotNull));
@@ -267,9 +267,10 @@ Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
         var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
-        validator.ValidateTag("Value", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
+        validator.TagValue("Value").Should().HaveOnlyConstraint(TestConstraint.First);
+        validator.TagValue("Value").Should().HaveOnlyConstraint(TestConstraint.First);
         validator.ValidateTag("Value", x => x.HasConstraint<ObjectConstraint>().Should().BeFalse("'var' only propagates existing constraints"));
-        validator.ValidateTag("Arg", x => x.HasConstraint(TestConstraint.First).Should().BeTrue());
+        validator.TagValue("Arg").Should().HaveOnlyConstraint(TestConstraint.First);
         validator.ValidateTag("Arg", x => x.HasConstraint<ObjectConstraint>().Should().BeFalse("'var' only propagates existing constraints"));
         validator.TagValues("End").Should().HaveCount(2).And.OnlyContain(x => x != null && x.HasConstraint(TestConstraint.First));     // 2x because value has different states
     }
@@ -496,7 +497,7 @@ object value = arg switch
 static object Tag(string name, object value) => null;";
         var validator = SETestContext.CreateCS(code, "object arg").Validator;
         validator.ValidateContainsOperation(expectedOperation);
-        validator.ValidateTag("Arg", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue()); // Should not have Null in any case
+        validator.TagValue("Arg").Should().HaveOnlyConstraint(ObjectConstraint.NotNull); // Should not have Null in any case
     }
 
     private static void ValidateSetBoolConstraint(string isPattern, OperationKind expectedOperation, bool? expectedBoolConstraint)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
@@ -263,7 +263,6 @@ Tag(""End"", arg);";
         var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
         validator.TagValue("Value").Should().HaveOnlyConstraint(TestConstraint.First);
-        validator.TagValue("Value").Should().HaveOnlyConstraint(TestConstraint.First);
         validator.ValidateTag("Value", x => x.HasConstraint<ObjectConstraint>().Should().BeFalse("'var' only propagates existing constraints"));
         validator.TagValue("Arg").Should().HaveOnlyConstraint(TestConstraint.First);
         validator.ValidateTag("Arg", x => x.HasConstraint<ObjectConstraint>().Should().BeFalse("'var' only propagates existing constraints"));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
@@ -227,7 +227,7 @@ Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
         var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
-        validator.TagValue("Value").Should().HaveOnlyConstraints(TestConstraint.First,ObjectConstraint.NotNull);
+        validator.TagValue("Value").Should().HaveOnlyConstraints(TestConstraint.First, ObjectConstraint.NotNull);
         validator.TagValue("ArgNotNull").Should().HaveOnlyConstraints(TestConstraint.First, ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2).And.OnlyContain(x => x != null && x.HasConstraint(TestConstraint.First));  // 2x because value has different states
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
@@ -38,7 +38,7 @@ var value = isTrue switch
     false => false
 };
 Tag(""Value"", value);";
-        SETestContext.CreateCS(code).Validator.TagValue("Value").Should().HaveOnlyConstraint(BoolConstraint.True);
+        SETestContext.CreateCS(code).Validator.TagValue("Value").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -52,7 +52,7 @@ var value = (isTrue == true) switch
     false => false
 };
 Tag(""Value"", value);";
-        SETestContext.CreateCS(code).Validator.TagValue("Value").Should().HaveOnlyConstraint(BoolConstraint.True);
+        SETestContext.CreateCS(code).Validator.TagValue("Value").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -66,7 +66,7 @@ var value = isFalse switch
     false => false
 };
 Tag(""Value"", value);";
-        SETestContext.CreateCS(code).Validator.TagValue("Value").Should().HaveOnlyConstraint(BoolConstraint.False);
+        SETestContext.CreateCS(code).Validator.TagValue("Value").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
     }
 
     [TestMethod]
@@ -169,10 +169,8 @@ Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
         var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.RecursivePattern);
-        validator.TagValue("Value").Should().HaveOnlyConstraint(TestConstraint.First);
-        validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
-        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraint(TestConstraint.First);
-        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Value").Should().HaveOnlyConstraints(TestConstraint.First, ObjectConstraint.NotNull);
+        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraints(TestConstraint.First, ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2)
             .And.ContainSingle(x => x.HasConstraint(TestConstraint.First) && x.HasConstraint(ObjectConstraint.Null))
             .And.ContainSingle(x => x.HasConstraint(TestConstraint.First) && x.HasConstraint(ObjectConstraint.NotNull));
@@ -193,8 +191,7 @@ Tag(""End"", arg);";
         validator.ValidateContainsOperation(OperationKind.RecursivePattern);
         validator.TagValue("Msg").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
         validator.ValidateTag("Msg", x => x.HasConstraint(TestConstraint.First).Should().BeFalse("Constraint from source value should not be propagated to child property"));
-        validator.TagValue("Ex").Should().HaveOnlyConstraint(TestConstraint.First);
-        validator.TagValue("Ex").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Ex").Should().HaveOnlyConstraints(TestConstraint.First, ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2).And.OnlyContain(x => x != null && x.HasConstraint(TestConstraint.First));   // 2x because value has different states
     }
 
@@ -230,10 +227,8 @@ Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
         var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
-        validator.TagValue("Value").Should().HaveOnlyConstraint(TestConstraint.First);
-        validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
-        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraint(TestConstraint.First);
-        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("Value").Should().HaveOnlyConstraints(TestConstraint.First,ObjectConstraint.NotNull);
+        validator.TagValue("ArgNotNull").Should().HaveOnlyConstraints(TestConstraint.First, ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2).And.OnlyContain(x => x != null && x.HasConstraint(TestConstraint.First));  // 2x because value has different states
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.TryCatchFinally.cs
@@ -929,8 +929,8 @@ catch(InvalidOperationException ex) when (Tag(""InFilter"", ex))
 
 static bool Tag<T>(string name, T value) => true;";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("InFilter", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
-        validator.ValidateTag("InCatch", x => x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue());
+        validator.TagValue("InFilter").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
+        validator.TagValue("InCatch").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     private static bool HasNoException(ProgramState state) =>


### PR DESCRIPTION
Notes. Search and replace
Regex used:
https://regex101.com/r/5boD7y/3

Find:
`(?<before>.*)(?<validateTag>ValidateTag)\((?<tagName>".*"), (?<paramName>.*) => (\k<paramName>)\.HasConstraint\((?<constraint>[^\)]*)\)\.Should\(\)\.BeTrue\(\)\)`

Replace:
`${before}TagValue("${tagName}").Should().HaveOnlyConstraint(${constraint})`