### PR TITLE
Performance: Add Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers to our code base

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
+++ b/analyzers/src/SonarAnalyzer.CFG/SonarAnalyzer.CFG.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" Version="3.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Composition" Version="1.0.27">
       <!-- This package is a dependency of Microsoft.CodeAnalysis.CSharp.Workspaces. It is safe to use since it's compatible with .Net Portable runtime -->
       <NoWarn>NU1701</NoWarn>

--- a/analyzers/src/SonarAnalyzer.CFG/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.CFG/packages.lock.json
@@ -12,6 +12,12 @@
           "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2]"
         }
       },
+      "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.1, )",
+        "resolved": "3.3.1",
+        "contentHash": "eT+kgNCDdTRbQ5WF6BGx1HI3D5jYfHteza/koefhWC2vNZGxObA74XxwWfg40dy3uUv7dn3OGKLK5GUPLroVog=="
+      },
       "Microsoft.Composition": {
         "type": "Direct",
         "requested": "[1.0.27, )",

--- a/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -13,6 +13,10 @@
        For instance, System.ValueTuple is not available in 4.6.1 and must be added to the final packaging if we add it here -->
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" Version="3.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.1.37">
       <!-- Downgrade System.Collections.Immutable to support VS2015 Update 3 -->
       <NoWarn>NU1605, NU1701</NoWarn>

--- a/analyzers/src/SonarAnalyzer.CSharp/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.CSharp/packages.lock.json
@@ -12,6 +12,12 @@
           "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2]"
         }
       },
+      "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.1, )",
+        "resolved": "3.3.1",
+        "contentHash": "eT+kgNCDdTRbQ5WF6BGx1HI3D5jYfHteza/koefhWC2vNZGxObA74XxwWfg40dy3uUv7dn3OGKLK5GUPLroVog=="
+      },
       "NETStandard.Library": {
         "type": "Direct",
         "requested": "[2.0.3, )",

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -21,6 +21,7 @@
 using System.Collections.Concurrent;
 using System.IO;
 using System.Runtime.CompilerServices;
+using Roslyn.Utilities;
 using static SonarAnalyzer.Helpers.DiagnosticDescriptorFactory;
 
 namespace SonarAnalyzer.AnalysisContext;
@@ -102,6 +103,10 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
             : projectType == ProjectType.Test;  // Scanner >= 5.1 does authoritative decision that we follow
     }
 
+    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7439",
+        AllowCaptures = true,
+        AllowGenericEnumeration = false,
+        AllowImplicitBoxing = false)]
     public bool IsUnchanged(SyntaxTree tree)
     {
         // Hotpath: Use TryGetValue to prevent the allocation of the GetValue factory delegate in the common case
@@ -137,6 +142,10 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
             descriptor.CustomTags.Contains(tag);
     }
 
+    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7439",
+        AllowCaptures = false,
+        AllowGenericEnumeration = false,
+        AllowImplicitBoxing = false)]
     private bool IsExcluded(SonarLintXmlReader sonarLintXml, string filePath)
     {
         // If ProjectType is not 'Unknown' it means we are in S4NET context and all files are analyzed.

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -103,10 +103,7 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
             : projectType == ProjectType.Test;  // Scanner >= 5.1 does authoritative decision that we follow
     }
 
-    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7439",
-        AllowCaptures = true,
-        AllowGenericEnumeration = false,
-        AllowImplicitBoxing = false)]
+    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7439", AllowCaptures = true, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
     public bool IsUnchanged(SyntaxTree tree)
     {
         // Hotpath: Use TryGetValue to prevent the allocation of the GetValue factory delegate in the common case
@@ -142,10 +139,7 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
             descriptor.CustomTags.Contains(tag);
     }
 
-    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7439",
-        AllowCaptures = false,
-        AllowGenericEnumeration = false,
-        AllowImplicitBoxing = false)]
+    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7439", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
     private bool IsExcluded(SonarLintXmlReader sonarLintXml, string filePath)
     {
         // If ProjectType is not 'Unknown' it means we are in S4NET context and all files are analyzed.

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
@@ -19,6 +19,7 @@
  */
 
 using System.IO;
+using Roslyn.Utilities;
 
 namespace SonarAnalyzer.Extensions;
 
@@ -33,6 +34,10 @@ public static class AnalyzerOptionsExtensions
     public static AdditionalText ProjectOutFolderPath(this AnalyzerOptions options) =>
         options.AdditionalFile("ProjectOutFolderPath.txt");
 
+    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7440",
+        AllowCaptures = false,
+        AllowGenericEnumeration = false,
+        AllowImplicitBoxing = false)]
     private static AdditionalText AdditionalFile(this AnalyzerOptions options, string fileName)
     {
         // HotPath: This code path needs to be allocation free. Don't use Linq.

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/AnalyzerOptionsExtensions.cs
@@ -34,10 +34,7 @@ public static class AnalyzerOptionsExtensions
     public static AdditionalText ProjectOutFolderPath(this AnalyzerOptions options) =>
         options.AdditionalFile("ProjectOutFolderPath.txt");
 
-    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7440",
-        AllowCaptures = false,
-        AllowGenericEnumeration = false,
-        AllowImplicitBoxing = false)]
+    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7440", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
     private static AdditionalText AdditionalFile(this AnalyzerOptions options, string fileName)
     {
         // HotPath: This code path needs to be allocation free. Don't use Linq.

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxTreeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxTreeExtensions.cs
@@ -28,10 +28,7 @@ internal static class SyntaxTreeExtensions
 {
     private static readonly ConditionalWeakTable<Compilation, ConcurrentDictionary<SyntaxTree, bool>> GeneratedCodeCache = new();
 
-    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7439",
-        AllowCaptures = false,
-        AllowGenericEnumeration = false,
-        AllowImplicitBoxing = false)]
+    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7439", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
     public static bool IsGenerated(this SyntaxTree tree, GeneratedCodeRecognizer generatedCodeRecognizer, Compilation compilation)
     {
         if (tree == null)

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxTreeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxTreeExtensions.cs
@@ -20,6 +20,7 @@
 
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using Roslyn.Utilities;
 
 namespace SonarAnalyzer.Extensions;
 
@@ -27,6 +28,10 @@ internal static class SyntaxTreeExtensions
 {
     private static readonly ConditionalWeakTable<Compilation, ConcurrentDictionary<SyntaxTree, bool>> GeneratedCodeCache = new();
 
+    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7439",
+        AllowCaptures = false,
+        AllowGenericEnumeration = false,
+        AllowImplicitBoxing = false)]
     public static bool IsGenerated(this SyntaxTree tree, GeneratedCodeRecognizer generatedCodeRecognizer, Compilation compilation)
     {
         if (tree == null)

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/HashCode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/HashCode.cs
@@ -31,10 +31,7 @@ namespace SonarAnalyzer.Helpers
         private const int RotateOffset = 17;
         private const int IntSeed = 393241;
 
-        [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/pull/7012",
-            AllowCaptures = false,
-            AllowGenericEnumeration = false,
-            AllowImplicitBoxing = false)]
+        [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/pull/7012", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
         public static int DictionaryContentHash<TKey, TValue>(ImmutableDictionary<TKey, TValue> dictionary)
         {
             // Performance: Make sure this method is allocation free:

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/HashCode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/HashCode.cs
@@ -19,6 +19,7 @@
  */
 
 using System.Runtime.CompilerServices;
+using Roslyn.Utilities;
 
 namespace SonarAnalyzer.Helpers
 {
@@ -30,6 +31,10 @@ namespace SonarAnalyzer.Helpers
         private const int RotateOffset = 17;
         private const int IntSeed = 393241;
 
+        [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/pull/7012",
+            AllowCaptures = false,
+            AllowGenericEnumeration = false,
+            AllowImplicitBoxing = false)]
         public static int DictionaryContentHash<TKey, TValue>(ImmutableDictionary<TKey, TValue> dictionary)
         {
             // Performance: Make sure this method is allocation free:

--- a/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
+++ b/analyzers/src/SonarAnalyzer.Common/SonarAnalyzer.Common.csproj
@@ -10,6 +10,10 @@
     <PackageReference Include="Google.Protobuf" Version="3.6.1" />
     <!-- When changing this reference update ProtocExe property too! -->
     <PackageReference Include="Google.Protobuf.Tools" Version="3.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" Version="3.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Composition" Version="1.0.27">
       <!-- This package is a dependency of Microsoft.CodeAnalysis.CSharp.Workspaces. It is safe to use since it's compatible with .Net Portable runtime -->
       <NoWarn>NU1701</NoWarn>

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicCheckList.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicCheckList.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Roslyn.Utilities;
+
 namespace SonarAnalyzer.SymbolicExecution.Roslyn;
 
 public class SymbolicCheckList
@@ -65,6 +67,10 @@ public class SymbolicCheckList
     public SymbolicContext[] PostProcess(SymbolicContext context) =>
         InvokeChecks(context, preProcess: false);
 
+    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/pull/6982",
+        AllowCaptures = false,
+        AllowGenericEnumeration = false,
+        AllowImplicitBoxing = false)]
     private SymbolicContext[] InvokeChecks(SymbolicContext context, bool preProcess)
     {
         // Performance: Hotpath. Don't do changes here without profiling allocation impact.

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicCheckList.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicCheckList.cs
@@ -67,10 +67,7 @@ public class SymbolicCheckList
     public SymbolicContext[] PostProcess(SymbolicContext context) =>
         InvokeChecks(context, preProcess: false);
 
-    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/pull/6982",
-        AllowCaptures = false,
-        AllowGenericEnumeration = false,
-        AllowImplicitBoxing = false)]
+    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/pull/6982", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
     private SymbolicContext[] InvokeChecks(SymbolicContext context, bool preProcess)
     {
         // Performance: Hotpath. Don't do changes here without profiling allocation impact.

--- a/analyzers/src/SonarAnalyzer.Common/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.Common/packages.lock.json
@@ -17,6 +17,12 @@
         "resolved": "3.6.1",
         "contentHash": "mNgfZ1A7UtbZUOIA8+UcKOouKnbd2tu9CKctCvGXFunZGrViWk6QbNwSBc268Sle9Gwl+WQB+u6qQezp5f9y3w=="
       },
+      "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.1, )",
+        "resolved": "3.3.1",
+        "contentHash": "eT+kgNCDdTRbQ5WF6BGx1HI3D5jYfHteza/koefhWC2vNZGxObA74XxwWfg40dy3uUv7dn3OGKLK5GUPLroVog=="
+      },
       "Microsoft.CodeAnalysis.Workspaces.Common": {
         "type": "Direct",
         "requested": "[1.3.2, )",

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" Version="3.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.3.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.1.37">
       <!-- Downgrade System.Collections.Immutable to support VS2015 Update 3 -->

--- a/analyzers/src/SonarAnalyzer.VisualBasic/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     ".NETStandard,Version=v2.0": {
+      "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.1, )",
+        "resolved": "3.3.1",
+        "contentHash": "eT+kgNCDdTRbQ5WF6BGx1HI3D5jYfHteza/koefhWC2vNZGxObA74XxwWfg40dy3uUv7dn3OGKLK5GUPLroVog=="
+      },
       "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
         "type": "Direct",
         "requested": "[1.3.2, )",


### PR DESCRIPTION
Fixes #7690

From what I can tell, the rules are only activated if the `PerformanceSensitive` attribute is applied (I took a brief look at the implementation and it [seems to be the case](
https://github.com/dotnet/roslyn-analyzers/blob/633ade7a83c2b6918c10035247d93fbe1520463d/src/PerformanceSensitiveAnalyzers/Core/AbstractAllocationAnalyzer.cs#L49)).

The attribute is included via the `Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.targets` targets file in [the nuget package](https://nuget.info/packages/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers/3.3.1)

```xml
  <PropertyGroup>
    <GeneratePerformanceSensitiveAttribute Condition="'$(GeneratePerformanceSensitiveAttribute)' == ''">true</GeneratePerformanceSensitiveAttribute>
    <PerformanceSensitiveAttributePath Condition="'$(PerformanceSensitiveAttributePath)' == ''">$(MSBuildThisFileDirectory)PerformanceSensitiveAttribute$(DefaultLanguageSourceExtension)</PerformanceSensitiveAttributePath>
  </PropertyGroup>

  <ItemGroup Condition="'$(GeneratePerformanceSensitiveAttribute)' == 'true' and Exists($(PerformanceSensitiveAttributePath))">
    <Compile Include="$(PerformanceSensitiveAttributePath)" Visible="false" />
    
    <!-- Make sure the source file is embedded in PDB to support Source Link -->
    <EmbeddedFiles Condition="'$(DebugType)' != 'none'" Include="$(PerformanceSensitiveAttributePath)" />
  </ItemGroup>
```

Look at the code smells in SQ to see the analyzer in action. I left some comments about possible FPs.