### PR TITLE
Deprecation: Replace ValidateTag with TagValue (Part 2)

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -382,7 +382,7 @@ Tag(""ForSymbolSymbolNone"", forSymbolSymbolNone);";
         validator.TagValue("ForNullSymbol").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
         validator.TagValue("ForSymbolSymbolTrue").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
         validator.TagValue("ForSymbolSymbolFalse").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
-        validator.ValidateTag("ForSymbolSymbolNone", x => x.HasConstraint<BoolConstraint>().Should().BeFalse("We can't tell if two instances are equivalent."));
+        validator.TagValue("ForSymbolSymbolNone").Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "BoolContraint is missing, because we can't tell if two instances are equivalent.");
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -476,7 +476,7 @@ Tag(""ForSymbolSymbolNone"", forSymbolSymbolNone);";
         validator.TagValue("ForNullSymbol").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
         validator.TagValue("ForSymbolSymbolTrue").Should().HaveOnlyConstraints(BoolConstraint.True, ObjectConstraint.NotNull);
         validator.TagValue("ForSymbolSymbolFalse").Should().HaveOnlyConstraints(BoolConstraint.False, ObjectConstraint.NotNull);
-        validator.ValidateTag("ForSymbolSymbolNone", x => x.HasConstraint<BoolConstraint>().Should().BeFalse("We can't tell if two instances are equivalent."));
+        validator.TagValue("ForSymbolSymbolNone").Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "BoolConstraint is missing, because we can't tell if two instances are equivalent.");
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -19,6 +19,7 @@
  */
 
 using Microsoft.CodeAnalysis.Operations;
+using SonarAnalyzer.SymbolicExecution;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 using SonarAnalyzer.SymbolicExecution.Roslyn;
 using SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution;
@@ -302,7 +303,7 @@ else
                 : x.State);
         var validator = SETestContext.CreateCS(code, postProcess).Validator;
         validator.TagValue("ToString").Should().HaveOnlyConstraints(TestConstraint.First, BoolConstraint.True, ObjectConstraint.NotNull);
-        validator.ValidateTag("GetHashCode", x => x.HasConstraint(TestConstraint.First).Should().BeFalse()); // Nobody set the constraint on that path
+        validator.TagValue("GetHashCode").Should().HaveOnlyConstraints(new SymbolicConstraint[] { ObjectConstraint.NotNull, BoolConstraint.True }, "nobody set the TestConstraint.First on that path");
         validator.ValidateExitReachCount(1);    // Once as the states are cleaned by LVA.
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Branching.cs
@@ -586,9 +586,9 @@ else
 }}
 Tag(""End"", isNull);";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("If", x => x.HasConstraint(ObjectConstraint.Null));
+        validator.TagValue("If").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValues("Else").Should().BeEmpty();
-        validator.ValidateTag("End", x => x.HasConstraint(ObjectConstraint.Null));
+        validator.TagValue("End").Should().HaveOnlyConstraint(ObjectConstraint.Null);
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -633,7 +633,7 @@ Tag(""Value"", value);";
 var value = arg.{expression};
 Tag(""Value"", value);";
         var validator = SETestContext.CreateCS(code, $"IEnumerable<int> arg").Validator;
-        validator.ValidateTag("Value", x => x.AllConstraints.Should().ContainSingle().Which.Kind.Should().Be(ConstraintKind.NotNull));
+        validator.TagValue("Value").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [DataTestMethod]    // Just a few examples to demonstrate that we don't set ObjectContraint for all

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -1067,9 +1067,9 @@ private static bool Equals(object a, object b, object c) => false;";
             Tag("Right", right);
             """;
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("Result", x => x.HasConstraint(BoolConstraint.From(expectedResult)).Should().BeTrue());
-        validator.ValidateTag("Left", x => x.AllConstraints.Select(x => x.Kind).Should().ContainSingle().Which.Should().Be(expectedConstraintLeft));
-        validator.ValidateTag("Right", x => x.AllConstraints.Select(x => x.Kind).Should().ContainSingle().Which.Should().Be(expectedConstraintRight));
+        validator.TagValue("Result").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(expectedResult));
+        validator.TagValue("Left").AllConstraints.Should().ContainSingle().Which.Kind.Should().Be(expectedConstraintLeft);
+        validator.TagValue("Right").AllConstraints.Should().ContainSingle().Which.Kind.Should().Be(expectedConstraintRight);
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -322,54 +322,14 @@ Tag(""AfterIfElse"", ObjectField);";
             : x.State);
         var validator = SETestContext.CreateCS(code, check).Validator;
         validator.ValidateContainsOperation(OperationKind.Invocation);
-        validator.ValidateTag("InitNull", x =>
-        {
-            x.HasConstraint(ObjectConstraint.Null).Should().BeTrue();
-            x.HasConstraint(invalidateConstraint).Should().BeTrue();
-            x.HasConstraint(dontInvalidateConstraint).Should().BeTrue();
-        });
-        validator.ValidateTag("AfterInvocationNull", x =>
-        {
-            x.HasConstraint(ObjectConstraint.Null).Should().BeFalse();
-            x.HasConstraint(invalidateConstraint).Should().BeFalse();
-            x.HasConstraint(dontInvalidateConstraint).Should().BeTrue();
-        });
-        validator.ValidateTag("InitNotNull", x =>
-        {
-            x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue();
-            x.HasConstraint(invalidateConstraint).Should().BeTrue();
-            x.HasConstraint(dontInvalidateConstraint).Should().BeTrue();
-        });
-        validator.ValidateTag("AfterInvocationNotNull", x =>
-        {
-            x.HasConstraint(ObjectConstraint.Null).Should().BeFalse();
-            x.HasConstraint(invalidateConstraint).Should().BeFalse();
-            x.HasConstraint(dontInvalidateConstraint).Should().BeTrue();
-        });
-        validator.ValidateTag("IfBefore", x =>
-        {
-            x.HasConstraint(ObjectConstraint.Null).Should().BeTrue();
-            x.HasConstraint(invalidateConstraint).Should().BeFalse();
-            x.HasConstraint(dontInvalidateConstraint).Should().BeTrue();
-        });
-        validator.ValidateTag("IfAfter", x =>
-        {
-            x.HasConstraint(ObjectConstraint.Null).Should().BeFalse();
-            x.HasConstraint(invalidateConstraint).Should().BeFalse();
-            x.HasConstraint(dontInvalidateConstraint).Should().BeTrue();
-        });
-        validator.ValidateTag("ElseBefore", x =>
-        {
-            x.HasConstraint(ObjectConstraint.NotNull).Should().BeTrue();
-            x.HasConstraint(invalidateConstraint).Should().BeFalse();
-            x.HasConstraint(dontInvalidateConstraint).Should().BeTrue();
-        });
-        validator.ValidateTag("ElseAfter", x =>
-        {
-            x.HasConstraint(ObjectConstraint.NotNull).Should().BeFalse();
-            x.HasConstraint(invalidateConstraint).Should().BeFalse();
-            x.HasConstraint(dontInvalidateConstraint).Should().BeTrue();
-        });
+        validator.TagValue("InitNull").Should().HaveOnlyConstraints(ObjectConstraint.Null, invalidateConstraint, dontInvalidateConstraint);
+        validator.TagValue("AfterInvocationNull").Should().HaveOnlyConstraint(dontInvalidateConstraint, "ObjectConstraint.Null and invalidateConstraint are reset");
+        validator.TagValue("InitNotNull").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, invalidateConstraint, dontInvalidateConstraint);
+        validator.TagValue("AfterInvocationNotNull").Should().HaveOnlyConstraint(dontInvalidateConstraint, "ObjectConstraint.NotNull and invalidateConstraint are reset");
+        validator.TagValue("IfBefore").Should().HaveOnlyConstraints(ObjectConstraint.Null, dontInvalidateConstraint);
+        validator.TagValue("IfAfter").Should().HaveOnlyConstraint(dontInvalidateConstraint, "ObjectConstraint.Null is reset");
+        validator.TagValue("ElseBefore").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, dontInvalidateConstraint);
+        validator.TagValue("ElseAfter").Should().HaveOnlyConstraint(dontInvalidateConstraint, "ObjectConstraint.NotNull is reset");
         validator.TagValues("AfterIfElse").Should().Equal(new[]
         {
             SymbolicValue.Empty.WithConstraint(dontInvalidateConstraint),

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -911,9 +911,9 @@ Tag(""Result"", result);
 Tag(""Left"", left);
 Tag(""Right"", right);";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("Result", x => x.HasConstraint(BoolConstraint.From(expectedResult)).Should().BeTrue());
-        validator.ValidateTag("Left", x => x.AllConstraints.Select(x => x.Kind).Should().ContainSingle().Which.Should().Be(expectedConstraintLeft));
-        validator.ValidateTag("Right", x => x.AllConstraints.Select(x => x.Kind).Should().ContainSingle().Which.Should().Be(expectedConstraintRight));
+        validator.TagValue("Result").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(expectedResult));
+        validator.TagValue("Left").AllConstraints.Should().ContainSingle().Which.Kind.Should().Be(expectedConstraintLeft);
+        validator.TagValue("Right").AllConstraints.Should().ContainSingle().Which.Kind.Should().Be(expectedConstraintRight);
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -676,7 +676,7 @@ Public Sub Main(Of T, TStruct As Structure)()
     Tag(""Result"", Result)
 End Sub";
         var validator = SETestContext.CreateVBMethod(code).Validator;
-        validator.ValidateTag("Result", x => x.HasConstraint(BoolConstraint.From(expected)).Should().BeTrue());
+        validator.TagValue("Result").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(expected));
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Invocation.cs
@@ -468,7 +468,7 @@ Tag(""AfterStaticField"", StaticObjectField);";
         validator.TagValue("BeforeField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValue("BeforeStaticField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
         validator.TagValue("AfterField").Should().HaveOnlyConstraint(ObjectConstraint.Null);
-        validator.ValidateTag("AfterStaticField", x => x.Should().BeNull());
+        validator.TagValue("AfterStaticField").Should().HaveNoConstraints();
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -168,7 +168,7 @@ public void Method()
             }
             """;
         var validator = SETestContext.CreateCSMethod(code).Validator;
-        validator.ValidateTag("Value", x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42)));
+        validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42));
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -1156,7 +1156,6 @@ public async System.Threading.Tasks.Task Main(System.Threading.Tasks.Task T)
         var addConstraint = new PostProcessTestCheck(OperationKind.Literal, x => x.SetOperationConstraint(LockConstraint.Held));    // Persisted constraint
         var validator = SETestContext.CreateCSMethod(code, addConstraint).Validator;
         validator.TagValue("Before").Should().HaveOnlyConstraints(ObjectConstraint.Null, LockConstraint.Held);
-        validator.ValidateTag("After", x => x.HasConstraint(ObjectConstraint.Null).Should().BeFalse());
         validator.TagValue("After").Should().HaveOnlyConstraint(LockConstraint.Held, "this constraint should be preserved on fields");
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -689,7 +689,7 @@ Tag(""StringConst"", stringConst);";
 var value = {literal};
 Tag(""Value"", value);";
         var validator = SETestContext.CreateCS(code).Validator;
-        validator.ValidateTag("Value", x => x.HasConstraint(BoolConstraint.From(expected)));
+        validator.TagValue("Value").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.From(expected));
     }
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -1180,7 +1180,7 @@ value = !value;
 Tag(""Value"", value);";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.Unary);
-        validator.ValidateTag("Value", x => x.AllConstraints.Select(y => y.Kind).Should().BeEquivalentTo(expectedConstraints));
+        validator.TagValue("Value").AllConstraints.Select(y => y.Kind).Should().BeEquivalentTo(expectedConstraints);
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -211,7 +211,7 @@ public void Method()
             @"Invocation: Tag(""c"", c)",
             @"ExpressionStatement: Tag(""c"", c);");
         validator.TagValue("b").Should().HaveOnlyConstraints(DummyConstraint.Dummy, ObjectConstraint.NotNull, NumberConstraint.From(42));
-        validator.ValidateTag("c", x => x.AllConstraints.Should().ContainSingle().Which.Should().Be(ObjectConstraint.NotNull));
+        validator.TagValue("c").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
@@ -189,8 +189,7 @@ Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
         var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.RecursivePattern);
-        validator.TagValue("Msg").Should().HaveOnlyConstraint(ObjectConstraint.NotNull);
-        validator.ValidateTag("Msg", x => x.HasConstraint(TestConstraint.First).Should().BeFalse("Constraint from source value should not be propagated to child property"));
+        validator.TagValue("Msg").Should().HaveOnlyConstraint(ObjectConstraint.NotNull, "TestConstraint.First missing, because Constraint from source value should not be propagated to child property");
         validator.TagValue("Ex").Should().HaveOnlyConstraints(TestConstraint.First, ObjectConstraint.NotNull);
         validator.TagValues("End").Should().HaveCount(2).And.OnlyContain(x => x != null && x.HasConstraint(TestConstraint.First));   // 2x because value has different states
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using SonarAnalyzer.SymbolicExecution;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 using SonarAnalyzer.SymbolicExecution.Roslyn;
 using SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution;
@@ -495,18 +496,10 @@ static object Tag(string name, object value) => null;";
     {
         var validator = CreateSetBoolConstraintValidator(isPattern);
         validator.ValidateContainsOperation(expectedOperation);
-        validator.ValidateTag("Result", x =>
-        {
-            if (expectedBoolConstraint is bool expected)
-            {
-                x.Should().NotBeNull($"we expect {expectedBoolConstraint} on the result");
-                x.HasConstraint(BoolConstraint.From(expected)).Should().BeTrue("we should have learned that result is {0}", expected);
-            }
-            else
-            {
-                x.HasConstraint<BoolConstraint>().Should().BeFalse("we should not learn about the state of result");
-            }
-        });
+        var expectedConstraints = expectedBoolConstraint is bool expected
+            ? new SymbolicConstraint[] { ObjectConstraint.NotNull, BoolConstraint.From(expected) }
+            : new SymbolicConstraint[] { ObjectConstraint.NotNull };
+        validator.TagValue("Result").Should().HaveOnlyConstraints(expectedConstraints);
     }
 
     private static void ValidateSetBoolConstraint_TwoStates(string testedSymbolName, string isPattern, OperationKind expectedOperation, ConstraintKind[] expectedForTrue, ConstraintKind[] expectedForFalse)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.PatternMatching.cs
@@ -261,10 +261,8 @@ Tag(""End"", arg);";
         var setter = new PreProcessTestCheck(OperationKind.ParameterReference, x => x.SetSymbolConstraint(x.Operation.Instance.TrackedSymbol(), TestConstraint.First));
         var validator = SETestContext.CreateCS(code, "object arg", setter).Validator;
         validator.ValidateContainsOperation(OperationKind.DeclarationPattern);
-        validator.TagValue("Value").Should().HaveOnlyConstraint(TestConstraint.First);
-        validator.ValidateTag("Value", x => x.HasConstraint<ObjectConstraint>().Should().BeFalse("'var' only propagates existing constraints"));
-        validator.TagValue("Arg").Should().HaveOnlyConstraint(TestConstraint.First);
-        validator.ValidateTag("Arg", x => x.HasConstraint<ObjectConstraint>().Should().BeFalse("'var' only propagates existing constraints"));
+        validator.TagValue("Value").Should().HaveOnlyConstraint(TestConstraint.First, "'var' only propagates existing constraints and ObjectConstraint is missing");
+        validator.TagValue("Arg").Should().HaveOnlyConstraint(TestConstraint.First, "'var' only propagates existing constraints and ObjectConstraint is missing");
         validator.TagValues("End").Should().HaveCount(2).And.OnlyContain(x => x != null && x.HasConstraint(TestConstraint.First));     // 2x because value has different states
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/ValidatorTestCheck.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/SymbolicExecution/ValidatorTestCheck.cs
@@ -67,14 +67,6 @@ namespace SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution
         public void Validate(string operation, Action<SymbolicContext> action) =>
             action(postProcessed.Single(x => TestHelper.Serialize(x.Operation) == operation));
 
-        [Obsolete(@"Use TagValue(""Name"").Should()... instead")]
-        public void ValidateTag(string tag, Action<SymbolicValue> action)
-        {
-            var values = TagValues(tag);
-            values.Should().ContainSingle();
-            action(values.Single());
-        }
-
         public ProgramState[] TagStates(string tag) =>
             tags.Where(x => x.Name == tag).Select(x => x.Context.State).ToArray();
 


### PR DESCRIPTION
Follow up to #7705

[6395edd](https://github.com/SonarSource/sonar-dotnet/pull/7741/commits/6395edd7ebd387539728c61b74afc57102060747) removes `ValidateTag`!