### PR TITLE
Change DotWriter Visibility to public

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/CfgSerializer/DotWriter.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/CfgSerializer/DotWriter.cs
@@ -22,7 +22,7 @@ using System.Text;
 
 namespace SonarAnalyzer.CFG
 {
-    internal class DotWriter
+    public class DotWriter
     {
         private readonly StringBuilder builder = new StringBuilder();
         private readonly StringBuilder edges = new StringBuilder();


### PR DESCRIPTION
Allows deleting [the class](https://github.com/SonarSource/sonar-security/blob/ce89c9d45c371c52186c6faa373262d7ca031d9f/frontend/csharp/src/SonarAnalyzer.Security/Helpers/DotWriter.cs#L11) from the security Frontend