### PR TITLE
Exclude test cases from code analysis

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -228,7 +228,7 @@ stages:
             sonar.verbose=true
             sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/coverage/**.xml"
             sonar.cs.vstest.reportsPaths="$(Build.SourcesDirectory)/TestResults/*.trx"
-            sonar.exclusions="$(UnitTestExclusionsPattern)"
+            sonar.test.exclusions="$(UnitTestExclusionsPattern)"
             sonar.analysis.buildNumber=$(Build.BuildId)
             sonar.analysis.pipeline=$(Build.BuildId)
             sonar.analysis.sha1=$(System.PullRequest.SourceCommitId)
@@ -249,7 +249,7 @@ stages:
             sonar.verbose=true
             sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/coverage/**.xml"
             sonar.cs.vstest.reportsPaths="$(Build.SourcesDirectory)/TestResults/*.trx"
-            sonar.exclusions="$(UnitTestExclusionsPattern)"
+            sonar.test.exclusions="$(UnitTestExclusionsPattern)"
             sonar.analysis.buildNumber=$(Build.BuildId)
             sonar.analysis.pipeline=$(Build.BuildId)
             sonar.analysis.sha1=$(Build.SourceVersion)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,8 @@ variables:
     value: 'analyzers\tests\SonarAnalyzer.UnitTest\'
   - name: UnitTestResultsPath
     value: '$(UnitTestProjectPath)\TestResults'
+  - name: UnitTestExclusionsPattern
+    value: 'analyzers/tests/SonarAnalyzer.UnitTest/TestCases/**/*'
   - name: isReleaseBranch
     value: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/branch-')) }}
   - name: vsVersion
@@ -226,6 +228,7 @@ stages:
             sonar.verbose=true
             sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/coverage/**.xml"
             sonar.cs.vstest.reportsPaths="$(Build.SourcesDirectory)/TestResults/*.trx"
+            sonar.exclusions="$(UnitTestExclusionsPattern)"
             sonar.analysis.buildNumber=$(Build.BuildId)
             sonar.analysis.pipeline=$(Build.BuildId)
             sonar.analysis.sha1=$(System.PullRequest.SourceCommitId)
@@ -246,6 +249,7 @@ stages:
             sonar.verbose=true
             sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/coverage/**.xml"
             sonar.cs.vstest.reportsPaths="$(Build.SourcesDirectory)/TestResults/*.trx"
+            sonar.exclusions="$(UnitTestExclusionsPattern)"
             sonar.analysis.buildNumber=$(Build.BuildId)
             sonar.analysis.pipeline=$(Build.BuildId)
             sonar.analysis.sha1=$(Build.SourceVersion)


### PR DESCRIPTION
To avoid the false positives we intentionally introduce in the unit tests.
