### PR TITLE
Fix S2583/S2589 FP: Do not raise when condition is in the body of a lock statement.

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -73,4 +73,7 @@ public class ConditionEvaluatesToConstant : ConditionEvaluatesToConstantBase
     protected override bool IsUsing(SyntaxNode syntax) =>
         (syntax.IsKind(SyntaxKind.VariableDeclaration) && syntax.Parent.IsKind(SyntaxKind.UsingStatement))
         || (syntax is LocalDeclarationStatementSyntax local && local.UsingKeyword().IsKind(SyntaxKind.UsingKeyword));
+
+    protected override bool IsLockStatement(SyntaxNode syntax) =>
+        syntax.IsKind(SyntaxKind.LockStatement);
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/ConditionEvaluatesToConstantBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/ConditionEvaluatesToConstantBase.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.CodeAnalysis.CSharp;
 using SonarAnalyzer.CFG.Roslyn;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/ConditionEvaluatesToConstantBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/ConditionEvaluatesToConstantBase.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis.CSharp;
 using SonarAnalyzer.CFG.Roslyn;
 using SonarAnalyzer.SymbolicExecution.Constraints;
 
@@ -44,6 +45,7 @@ public abstract class ConditionEvaluatesToConstantBase : SymbolicRuleCheck
     protected abstract bool IsConditionalAccessExpression(SyntaxNode syntax);
     protected abstract bool IsForLoopIncrementor(SyntaxNode syntax);
     protected abstract bool IsUsing(SyntaxNode syntax);
+    protected abstract bool IsLockStatement(SyntaxNode syntax);
 
     public override ProgramState[] PreProcess(SymbolicContext context)
     {
@@ -55,7 +57,7 @@ public abstract class ConditionEvaluatesToConstantBase : SymbolicRuleCheck
     {
         var operation = context.Operation.Instance;
         if (operation.Kind is not OperationKindEx.Literal
-            && !operation.Syntax.Ancestors().Any(IsUsing)
+            && !operation.Syntax.Ancestors().Any(x => IsUsing(x) || IsLockStatement(x))
             && operation.TrackedSymbol(context.State) is not IFieldSymbol { IsConst: true }
             && !IsDiscardPattern(operation))
         {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -73,4 +73,7 @@ public class ConditionEvaluatesToConstant : ConditionEvaluatesToConstantBase
 
     protected override bool IsUsing(SyntaxNode syntax) =>
         syntax.IsKind(SyntaxKind.VariableDeclarator) && syntax.Parent.IsKind(SyntaxKind.UsingStatement);
+
+    protected override bool IsLockStatement(SyntaxNode syntax) =>
+        syntax.IsKind(SyntaxKind.SyncLockBlock);
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp8.cs
@@ -392,7 +392,7 @@ class Repro_7088
                 continue;
             }
 
-            if (sb is null) // Noncompliant
+            if (sb is null) // Noncompliant FP
             {
                 sb = new StringBuilder();
             }
@@ -400,7 +400,7 @@ class Repro_7088
             sb.Append(i);
         }
 
-        if (sb is null) // Noncompliant
+        if (sb is null) // Noncompliant FP
         {
             Console.WriteLine("NULL");
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp8.cs
@@ -392,7 +392,7 @@ class Repro_7088
                 continue;
             }
 
-            if (sb is null) // Noncompliant FP
+            if (sb is null) // Noncompliant
             {
                 sb = new StringBuilder();
             }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -1221,7 +1221,7 @@ namespace Tests.Diagnostics
                     {
                         lock (syncRoot)
                         {
-                            if (instance == null) // Noncompliant FP
+                            if (instance == null) // We don't check conditions that are in lock statements.
                             {
                                 instance = new Singleton();
                             }
@@ -3019,7 +3019,8 @@ namespace Repro_RefParam
             {
                 lock (gate)
                 {
-                    if (field == null) // Noncompliant FP: in multithreading context it makes sense to check for null twice
+                    if (field == null) // We don't check conditions in lock statements.
+                                       // In multithreading context it makes sense to check for null twice
                     {
                         field = new object();
                     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.vb
@@ -1003,7 +1003,7 @@ End Sub
             Get
                 If instanceField Is Nothing Then
                     SyncLock syncRoot
-                        If instanceField Is Nothing Then ' Noncompliant FP
+                        If instanceField Is Nothing Then ' We don't raise in conditions in synclock blocks as it's raising many FPs.
                             instanceField = New Singleton()
                         End If
                     End SyncLock

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Sonar/ConditionEvaluatesToConstant.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Sonar/ConditionEvaluatesToConstant.CSharp8.cs
@@ -365,7 +365,7 @@ class Repro_7088
                 continue;
             }
 
-            if (sb is null) // Noncompliant
+            if (sb is null) // Noncompliant FP
             {
                 sb = new StringBuilder();
             }
@@ -373,7 +373,7 @@ class Repro_7088
             sb.Append(i);
         }
 
-        if (sb is null) // Noncompliant
+        if (sb is null) // Noncompliant FP
         {
             Console.WriteLine("NULL");
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Sonar/ConditionEvaluatesToConstant.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Sonar/ConditionEvaluatesToConstant.CSharp8.cs
@@ -365,7 +365,7 @@ class Repro_7088
                 continue;
             }
 
-            if (sb is null) // Noncompliant FP
+            if (sb is null) // Noncompliant
             {
                 sb = new StringBuilder();
             }


### PR DESCRIPTION
In a multithreading context, it makes sense to check conditions twice (before and after the lock).
That's why we are ignoring what is in the lock statement body to not create a lot of noise with false positive issues.

Related to #3353