### PR TITLE
SE: Increase VisitCount for loop conditions to 3

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -76,11 +76,7 @@ internal class RoslynSymbolicExecution
             var current = queue.Dequeue();
             if (visited.Add(current)
                 && current.AddVisit() is var visitCount
-                && (visitCount <= MaxOperationVisits
-                || (visitCount == MaxOperationVisits + 1
-                    && !current.Block.Operations.Contains(current.Operation?.Instance)
-                    && current.Block.ConditionalSuccessor is not null
-                    && syntaxClassifier.IsInLoopCondition(current.Block.BranchValue?.Syntax))))
+                && CheckVisistCount(current, visitCount))
             {
                 logger.Log(current, "Processing");
                 var successors = current.Operation == null ? ProcessBranching(current) : ProcessOperation(current);
@@ -97,6 +93,17 @@ internal class RoslynSymbolicExecution
         }
         logger.Log("Completed");
         checks.ExecutionCompleted();
+    }
+
+    private bool CheckVisistCount(ExplodedNode current, int visitCount)
+    {
+        return visitCount <= MaxOperationVisits
+            || (visitCount <= MaxOperationVisits + 1 && IsLoopCondition(current));
+
+        bool IsLoopCondition(ExplodedNode current) =>
+            current.Block.ConditionalSuccessor is not null                              // avoid further checks for non-conditional branching blocks
+            && !current.Block.Operations.Contains(current.Operation?.Instance)          // operation is `null`, `BranchValue` or one of `BranchValue`s children
+            && syntaxClassifier.IsInLoopCondition(current.Block.BranchValue?.Syntax);   // block contains a loop condition
     }
 
     private IEnumerable<ExplodedNode> ProcessBranching(ExplodedNode node)

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -99,7 +99,7 @@ internal class RoslynSymbolicExecution
             || (visitCount <= MaxOperationVisits + 1 && IsLoopCondition());
 
         bool IsLoopCondition() =>
-            node.Block.BranchValue is not null  // avoid further checks for blocks without BranchValue
+            node.Block.BranchValue is not null
             && (node.Operation is null || IsInBranchValue(node.Operation.Instance))
             && syntaxClassifier.IsInLoopCondition(node.Block.BranchValue.Syntax);
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -74,7 +74,13 @@ internal class RoslynSymbolicExecution
                 return;
             }
             var current = queue.Dequeue();
-            if (visited.Add(current) && current.AddVisit() <= MaxOperationVisits)
+            if (visited.Add(current)
+                && current.AddVisit() is var visitCount
+                && (visitCount <= MaxOperationVisits
+                || (visitCount == MaxOperationVisits + 1
+                    && !current.Block.Operations.Contains(current.Operation?.Instance)
+                    && current.Block.ConditionalSuccessor is not null
+                    && syntaxClassifier.IsInLoopCondition(current.Block.BranchValue?.Syntax))))
             {
                 logger.Log(current, "Processing");
                 var successors = current.Operation == null ? ProcessBranching(current) : ProcessOperation(current);

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -99,9 +99,9 @@ internal class RoslynSymbolicExecution
             || (visitCount <= MaxOperationVisits + 1 && IsLoopCondition());
 
         bool IsLoopCondition() =>
-            node.Block.ConditionalSuccessor is not null // avoid further checks for non-conditional branching blocks
+            node.Block.BranchValue is not null  // avoid further checks for blocks without BranchValue
             && (node.Operation is null || IsInBranchValue(node.Operation.Instance))
-            && syntaxClassifier.IsInLoopCondition(node.Block.BranchValue.Syntax);   // currently processing a loop condition
+            && syntaxClassifier.IsInLoopCondition(node.Block.BranchValue.Syntax);
 
         bool IsInBranchValue(IOperation current)
         {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -76,7 +76,7 @@ internal class RoslynSymbolicExecution
             var current = queue.Dequeue();
             if (visited.Add(current)
                 && current.AddVisit() is var visitCount
-                && CheckVisistCount(current, visitCount))
+                && CheckVisitCount(current, visitCount))
             {
                 logger.Log(current, "Processing");
                 var successors = current.Operation == null ? ProcessBranching(current) : ProcessOperation(current);
@@ -95,7 +95,7 @@ internal class RoslynSymbolicExecution
         checks.ExecutionCompleted();
     }
 
-    private bool CheckVisistCount(ExplodedNode current, int visitCount)
+    private bool CheckVisitCount(ExplodedNode current, int visitCount)
     {
         return visitCount <= MaxOperationVisits
             || (visitCount <= MaxOperationVisits + 1 && IsLoopCondition(current));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -43,10 +43,10 @@ public partial class RoslynSymbolicExecutionTest
         validator.TagValues("InLoop").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
-        validator.TagValues("End").Should().SatisfyRespectively(    // arg has only its final constraints
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull),                                              // loop was not entered
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),                        // looped once
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));  // looped twice
+        validator.TagValues("End").Should().SatisfyRespectively(
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull),
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
     }
 
     [DataTestMethod]
@@ -69,9 +69,9 @@ public partial class RoslynSymbolicExecutionTest
         validator.TagValues("InLoop").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
-        validator.TagValues("End").Should().SatisfyRespectively(    // Loop was entered, arg has only its final constraints
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),                        // looped once
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));  // looped twice
+        validator.TagValues("End").Should().SatisfyRespectively(
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
     }
 
     [TestMethod]
@@ -91,13 +91,13 @@ public partial class RoslynSymbolicExecutionTest
         validator.TagValues("InLoop").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
-        validator.TagValues("End").Should().SatisfyRespectively(    // Loop was entered, arg has only its final constraints
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),                        // looped once
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));  // looped twice
+        validator.TagValues("End").Should().SatisfyRespectively(
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
     }
 
     [TestMethod]
-    public void Loops_EmptyLoop_DoesNotRunInfinitely()
+    public void Loops_Infinite_ConditionVisitedMaxTreeTimes()
     {
         var code = """
             int i = 1;
@@ -323,9 +323,9 @@ public partial class RoslynSymbolicExecutionTest
         validator.TagValues("After").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10, null)),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10)));
-        validator.TagValues("End").Should().SatisfyRespectively(    // arg has only its final constraints
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),                        // looped once
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));  // looped twice
+        validator.TagValues("End").Should().SatisfyRespectively(
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -43,10 +43,10 @@ public partial class RoslynSymbolicExecutionTest
         validator.TagValues("InLoop").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
-        validator.TagValues("End").Should().SatisfyRespectively(
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
+        validator.TagValues("End").Should().SatisfyRespectively(    // arg has only its final constraints
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull),                                              // loop was not entered
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),                        // looped once
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));  // looped twice
     }
 
     [DataTestMethod]
@@ -65,13 +65,13 @@ public partial class RoslynSymbolicExecutionTest
             Tag("End", arg);
             """;
         var validator = SETestContext.CreateCS(code, "int arg", new AddConstraintOnInvocationCheck(), new PreserveTestCheck("arg")).Validator;
-        validator.ValidateExitReachCount(2);
+        validator.ValidateExitReachCount(2);    // PreserveTestCheck is needed for this, otherwise, variables are thrown away by LVA when going to the Exit block
         validator.TagValues("InLoop").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
-        validator.TagValues("End").Should().SatisfyRespectively(    // Loop was entered, arg has only it's final constraints after looping once or twice
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
+        validator.TagValues("End").Should().SatisfyRespectively(    // Loop was entered, arg has only its final constraints
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),                        // looped once
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));  // looped twice
     }
 
     [TestMethod]
@@ -91,9 +91,9 @@ public partial class RoslynSymbolicExecutionTest
         validator.TagValues("InLoop").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
-        validator.TagValues("End").Should().SatisfyRespectively(
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
+        validator.TagValues("End").Should().SatisfyRespectively(    // Loop was entered, arg has only its final constraints
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),                        // looped once
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));  // looped twice
     }
 
     [DataTestMethod]
@@ -305,9 +305,9 @@ public partial class RoslynSymbolicExecutionTest
         validator.TagValues("After").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10, null)),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10)));
-        validator.TagValues("End").Should().SatisfyRespectively(    // arg has only it's final constraints after looping once or twice
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
+        validator.TagValues("End").Should().SatisfyRespectively(    // arg has only its final constraints
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),                        // looped once
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));  // looped twice
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -96,6 +96,24 @@ public partial class RoslynSymbolicExecutionTest
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));  // looped twice
     }
 
+    [TestMethod]
+    public void Loops_EmptyLoop_DoesNotRunInfinitely()
+    {
+        var code = """
+            int i = 1;
+            while (i.Equals(1))
+            {
+            }
+            Tag("End", i);
+            """;
+        var validator = SETestContext.CreateCS(code, "int arg", new AddConstraintOnInvocationCheck(), new PreserveTestCheck("i")).Validator;
+        validator.ValidateExitReachCount(3);
+        validator.TagValues("End").Should().SatisfyRespectively(
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1), TestConstraint.First),
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1), TestConstraint.First, BoolConstraint.True),
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1), TestConstraint.First, BoolConstraint.True, DummyConstraint.Dummy));
+    }
+
     [DataTestMethod]
     [DataRow("i < 10")]
     [DataRow("!(i >= 10)")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -28,7 +28,7 @@ public partial class RoslynSymbolicExecutionTest
     [DataTestMethod]
     [DataRow("for (var i = 0; i < items.Length; i++)")]
     [DataRow("while (Condition)")]
-    public void Loops_InstructionVisitedMaxTwice(string loop)
+    public void Loops_BodyVisitedMaxTwice(string loop)
     {
         var code = $$"""
             {{loop}}
@@ -54,7 +54,7 @@ public partial class RoslynSymbolicExecutionTest
     [DataRow("for (var i = 0; i < 10; ++i)")]
     [DataRow("for (var i = 10; i > 0; i--)")]
     [DataRow("for (var i = 10; i > 0; --i)")]
-    public void Loops_InstructionVisitedMaxTwice_For_FixedCount(string loop)
+    public void Loops_BodyVisitedMaxTwice_For_FixedCount(string loop)
     {
         var code = $$"""
             {{loop}}
@@ -75,7 +75,7 @@ public partial class RoslynSymbolicExecutionTest
     }
 
     [TestMethod]
-    public void Loops_InstructionVisitedMaxTwice_Do_While()
+    public void Loops_BodyVisitedMaxTwice_Do_While()
     {
         var code = """
             do
@@ -99,7 +99,7 @@ public partial class RoslynSymbolicExecutionTest
     [DataTestMethod]
     [DataRow("i < 10")]
     [DataRow("!(i >= 10)")]
-    public void Loops_InstructionVisitedMaxTwice_For_FixedCount_Expanded(string condition)
+    public void Loops_BodyVisitedMaxTwice_For_FixedCount_Expanded(string condition)
     {
         var code = $$"""
             for (var i = 0; {{condition}}; i++)
@@ -118,7 +118,7 @@ public partial class RoslynSymbolicExecutionTest
     }
 
     [TestMethod]
-    public void Loops_InstructionVisitedMaxTwice_For_FixedCount_NestedNumberCondition_CS()
+    public void Loops_BodyVisitedMaxTwice_For_FixedCount_NestedNumberCondition_CS()
     {
         const string code = """
             for (var i = 0; i < 10; i++)
@@ -153,7 +153,7 @@ public partial class RoslynSymbolicExecutionTest
     }
 
     [TestMethod]
-    public void Loops_InstructionVisitedMaxTwice_For_FixedCount_NestedNumberCondition_VB()
+    public void Loops_BodyVisitedMaxTwice_For_FixedCount_NestedNumberCondition_VB()
     {
         const string code = """
             For i As Integer = 0 To 9
@@ -367,7 +367,7 @@ public partial class RoslynSymbolicExecutionTest
     }
 
     [TestMethod]
-    public void Loops_InstructionVisitedMaxTwice_ForEach()
+    public void Loops_BodyVisitedMaxTwice_ForEach()
     {
         const string code = @"
 foreach (var i in items)
@@ -390,7 +390,7 @@ Tag(""End"", arg);";
     }
 
     [TestMethod]
-    public void Loops_InstructionVisitedMaxTwice_EvenWithMultipleStates()
+    public void Loops_BodyVisitedMaxTwice_EvenWithMultipleStates()
     {
         const string code = """
             bool condition;
@@ -433,7 +433,7 @@ Tag(""End"", arg);";
     }
 
     [TestMethod]
-    public void DoLoop_InstructionVisitedMaxTwice()
+    public void DoLoop_BodyVisitedMaxTwice()
     {
         var code = """
             do
@@ -453,7 +453,7 @@ Tag(""End"", arg);";
     [DataTestMethod]
     [DataRow("for( ; ; )")]
     [DataRow("while (true)")]
-    public void InfiniteLoopWithNoExitBranch_InstructionVisitedMaxTwice(string loop)
+    public void InfiniteLoopWithNoExitBranch_BodyVisitedMaxTwice(string loop)
     {
         var code = @$"
 {loop}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp8.cs
@@ -392,7 +392,7 @@ class Repro_7088
                 continue;
             }
 
-            if (sb is null) // Noncompliant FP
+            if (sb is null)     // Noncompliant FP
             {
                 sb = new StringBuilder();
             }
@@ -400,7 +400,7 @@ class Repro_7088
             sb.Append(i);
         }
 
-        if (sb is null) // Noncompliant FP
+        if (sb is null) // FN
         {
             Console.WriteLine("NULL");
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -322,9 +322,9 @@ namespace Tests.Diagnostics
                 if (i > 5)
                     b = arg;
             }
-            if (b)                      // Noncompliant FP
+            if (b)
             {
-                Console.WriteLine();    // Secondary FP
+                Console.WriteLine();
             }
         }
 
@@ -467,7 +467,7 @@ namespace Tests.Diagnostics
                 {
                     if (x)
                     {
-                        if (y) // Noncompliant FP: loop is only analyzed twice
+                        if (y)
                         {
                         }
                     }
@@ -3188,9 +3188,9 @@ public class Repro_5601
             return false;
         }
 
-        if (foundA)                 // Noncompliant FP, we run the loop twice but the second branch never leaves the loop
+        if (foundA)
         {
-            return true;            // Secondary FP
+            return true;
         }
         return false;
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -314,6 +314,20 @@ namespace Tests.Diagnostics
             }
         }
 
+        public void FixedCountLoop(bool arg)
+        {
+            var b = false;
+            for (var i = 0; i < 10; i++)
+            {
+                if (i > 5)
+                    b = arg;
+            }
+            if (b)                      // Noncompliant FP
+            {
+                Console.WriteLine();    // Secondary FP
+            }
+        }
+
         public void Method_Switch()
         {
             int i = 10;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.vb
@@ -340,7 +340,7 @@ End Sub
         While GetCondition()
             While GetCondition()
                 If x Then
-                    If y Then ' Noncompliant FP: loop is only analyzed twice
+                    If y Then
                     End If
                 End If
                 y = True

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -1012,7 +1012,7 @@ public class Repro_7582
 
         if (flag)
         {
-            foreach (var item in list)   // Noncompliant FP
+            foreach (var item in list)  // Noncompliant FP
             {
                 // do something with items that were <= 10
                 // only when items > 10 were found.


### PR DESCRIPTION
Fixing this FP:
```
var b = false;
for (var i = 0; i < 10; i++)
{
    if (i > 5)
        b = arg;
}
if (b) // FP
{
    Console.WriteLine();
}
```
The loop is explored twice. The second iteration can learn interesting constraints because `i` has `NumberConstraint.From(1, 9)`. Only visiting the loop condition twice would mean losing that information. If we visit it one more time, we can bring the information out of the loop.

There is a follow-up PR which will simplify a lot of the branching: #7797

Also:
Fixes #5601 