### PR TITLE
Fix S2589 FN: Infinite for-loop

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
@@ -201,8 +201,7 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
             return BinaryBoolConstraint(kind, leftBool == BoolConstraint.True, rightBool == BoolConstraint.True);
         }
         else if (left?.Constraint<NumberConstraint>() is { } leftNumber
-            && right?.Constraint<NumberConstraint>() is { } rightNumber
-            && EvaluateBranchingCondition(isLoopCondition, visitCount))
+            && right?.Constraint<NumberConstraint>() is { } rightNumber)
         {
             return BinaryNumberConstraint(kind, leftNumber, rightNumber);
         }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
@@ -41,8 +41,8 @@ internal abstract class BranchingProcessor<T> : MultiProcessor<T>
         var state = PreProcess(context.State, operation);
         if (BoolConstraintFromOperation(state, operation, context.IsLoopCondition, context.VisitCount) is { } constraint)
         {
-            state = state.SetOperationConstraint(context.Operation, constraint);    // We already know the answer from existing constraints
-            return context.VisitCount > 1
+            state = state.SetOperationConstraint(context.Operation, constraint);
+            return context.VisitCount > 1   // apply fuzzy logic on NumberConstraints in loops
                 ? LearnBranchingConstraint(state, operation, context.IsLoopCondition, context.VisitCount, constraint == BoolConstraint.False).ToArray()
                 : state.ToArray();
         }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
@@ -42,11 +42,9 @@ internal abstract class BranchingProcessor<T> : MultiProcessor<T>
         if (BoolConstraintFromOperation(state, operation, context.IsLoopCondition, context.VisitCount) is { } constraint)
         {
             state = state.SetOperationConstraint(context.Operation, constraint);    // We already know the answer from existing constraints
-            if (context.VisitCount > 1)
-            {
-                state = LearnBranchingConstraint(state, operation, context.IsLoopCondition, context.VisitCount, constraint == BoolConstraint.False);
-            }
-            return state.ToArray();
+            return context.VisitCount > 1
+                ? LearnBranchingConstraint(state, operation, context.IsLoopCondition, context.VisitCount, constraint == BoolConstraint.False).ToArray()
+                : state.ToArray();
         }
         else
         {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
@@ -30,8 +30,8 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors;
 internal abstract class BranchingProcessor<T> : MultiProcessor<T>
     where T : IOperationWrapper
 {
-    protected abstract SymbolicConstraint BoolConstraintFromOperation(ProgramState state, T operation, bool isLoopCondition, int visitCount);
-    protected abstract ProgramState LearnBranchingConstraint(ProgramState state, T operation, bool isLoopCondition, int visitCount, bool falseBranch);
+    protected abstract SymbolicConstraint BoolConstraintFromOperation(ProgramState state, T operation);
+    protected abstract ProgramState LearnBranchingConstraint(ProgramState state, T operation, int visitCount, bool falseBranch);
 
     protected virtual ProgramState PreProcess(ProgramState state, T operation) =>
         state;
@@ -39,18 +39,18 @@ internal abstract class BranchingProcessor<T> : MultiProcessor<T>
     protected override ProgramState[] Process(SymbolicContext context, T operation)
     {
         var state = PreProcess(context.State, operation);
-        if (BoolConstraintFromOperation(state, operation, context.IsLoopCondition, context.VisitCount) is { } constraint)
+        if (BoolConstraintFromOperation(state, operation) is { } constraint)
         {
             state = state.SetOperationConstraint(context.Operation, constraint);
             return context.VisitCount > 1   // apply fuzzy logic on NumberConstraints in loops
-                ? LearnBranchingConstraint(state, operation, context.IsLoopCondition, context.VisitCount, constraint == BoolConstraint.False).ToArray()
+                ? LearnBranchingConstraint(state, operation, context.VisitCount, constraint == BoolConstraint.False).ToArray()
                 : state.ToArray();
         }
         else
         {
             var beforeLearningState = state;
-            var positive = LearnBranchingConstraint(state, operation, context.IsLoopCondition, context.VisitCount, false);
-            var negative = LearnBranchingConstraint(state, operation, context.IsLoopCondition, context.VisitCount, true);
+            var positive = LearnBranchingConstraint(state, operation, context.VisitCount, false);
+            var negative = LearnBranchingConstraint(state, operation, context.VisitCount, true);
             return positive == beforeLearningState && negative == beforeLearningState
                 ? beforeLearningState.ToArray()   // We can't learn anything, just move on
                 : new[]

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
@@ -41,7 +41,12 @@ internal abstract class BranchingProcessor<T> : MultiProcessor<T>
         var state = PreProcess(context.State, operation);
         if (BoolConstraintFromOperation(state, operation, context.IsLoopCondition, context.VisitCount) is { } constraint)
         {
-            return state.SetOperationConstraint(context.Operation, constraint).ToArray();    // We already know the answer from existing constraints
+            state = state.SetOperationConstraint(context.Operation, constraint);    // We already know the answer from existing constraints
+            if (context.VisitCount > 1)
+            {
+                state = LearnBranchingConstraint(state, operation, context.IsLoopCondition, context.VisitCount, constraint == BoolConstraint.False);
+            }
+            return state.ToArray();
         }
         else
         {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsNull.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsNull.cs
@@ -27,12 +27,12 @@ internal sealed class IsNull : BranchingProcessor<IIsNullOperationWrapper>
     protected override IIsNullOperationWrapper Convert(IOperation operation) =>
         IIsNullOperationWrapper.FromOperation(operation);
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsNullOperationWrapper operation, bool isLoopCondition, int visitCount) =>
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsNullOperationWrapper operation) =>
         state[operation.Operand] is { } value && value.HasConstraint<ObjectConstraint>()
             ? BoolConstraint.From(value.HasConstraint(ObjectConstraint.Null))
             : null;
 
-    protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsNullOperationWrapper operation, bool isLoopCondition, int visitCount, bool falseBranch)
+    protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsNullOperationWrapper operation, int visitCount, bool falseBranch)
     {
         var constraint = falseBranch ? ObjectConstraint.NotNull : ObjectConstraint.Null;
         state = state.SetOperationConstraint(operation.Operand, constraint);

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsPattern.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsPattern.cs
@@ -27,10 +27,10 @@ internal sealed class IsPattern : BranchingProcessor<IIsPatternOperationWrapper>
     protected override IIsPatternOperationWrapper Convert(IOperation operation) =>
         IIsPatternOperationWrapper.FromOperation(operation);
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsPatternOperationWrapper operation, bool isLoopCondition, int visitCount) =>
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsPatternOperationWrapper operation) =>
         BoolContraintFromConstant(state, operation) ?? BoolConstraintFromPattern(state, operation);
 
-    protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsPatternOperationWrapper operation, bool isLoopCondition, int visitCount, bool falseBranch) =>
+    protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsPatternOperationWrapper operation, int visitCount, bool falseBranch) =>
         operation.Value.TrackedSymbol(state) is { } testedSymbol
         && LearnBranchingConstraint(state, operation.Pattern, falseBranch, state[testedSymbol]?.HasConstraint<ObjectConstraint>() is true) is { } constraint
             ? state.SetSymbolConstraint(testedSymbol, constraint)

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsType.cs
@@ -27,10 +27,10 @@ internal sealed class IsType : BranchingProcessor<IIsTypeOperationWrapper>
     protected override IIsTypeOperationWrapper Convert(IOperation operation) =>
         IIsTypeOperationWrapper.FromOperation(operation);
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsTypeOperationWrapper operation, bool isLoopCondition, int visitCount) =>
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsTypeOperationWrapper operation) =>
         state[operation.ValueOperand]?.HasConstraint(ObjectConstraint.Null) is true ? BoolConstraint.False : null;
 
-    protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsTypeOperationWrapper operation, bool isLoopCondition, int visitCount, bool falseBranch) =>
+    protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsTypeOperationWrapper operation, int visitCount, bool falseBranch) =>
         operation.ValueOperand.TrackedSymbol(state) is { } testedSymbol
         && ObjectConstraint.NotNull.ApplyOpposite(falseBranch ^ operation.IsNegated) is { } constraint
             ? state.SetSymbolConstraint(testedSymbol, constraint)

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/References.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/References.cs
@@ -87,12 +87,12 @@ internal sealed class PropertyReference : BranchingProcessor<IPropertyReferenceO
         return state;
     }
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IPropertyReferenceOperationWrapper operation, bool isLoopCondition, int visitCount) =>
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IPropertyReferenceOperationWrapper operation) =>
         IsNullableProperty(operation, "HasValue") && state[operation.Instance]?.Constraint<ObjectConstraint>() is { } objectConstraint
             ? BoolConstraint.From(objectConstraint == ObjectConstraint.NotNull)
             : null;
 
-    protected override ProgramState LearnBranchingConstraint(ProgramState state, IPropertyReferenceOperationWrapper operation, bool isLoopCondition, int visitCount, bool falseBranch) =>
+    protected override ProgramState LearnBranchingConstraint(ProgramState state, IPropertyReferenceOperationWrapper operation, int visitCount, bool falseBranch) =>
         IsNullableProperty(operation, "HasValue") && operation.Instance.TrackedSymbol(state) is { } testedSymbol
             // Can't use ObjectConstraint.ApplyOpposite() because here, we are sure that it is either Null or NotNull
             ? state.SetSymbolConstraint(testedSymbol, falseBranch ? ObjectConstraint.Null : ObjectConstraint.NotNull)

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -122,7 +122,7 @@ internal class RoslynSymbolicExecution
         if (node.Block.Kind == BasicBlockKind.Exit)
         {
             logger.Log(node.State, "Exit Reached");
-            checks.ExitReached(new(node, lva.CapturedVariables, false));
+            checks.ExitReached(new(node, lva.CapturedVariables));
         }
         else if (node.Block.Successors.Length == 1 && ThrownException(node, node.Block.Successors.Single().Semantics) is { } exception)
         {
@@ -161,7 +161,7 @@ internal class RoslynSymbolicExecution
             {
                 // If a branch has no Destination but is part of conditional branching we need to call ConditionEvaluated. This happens when a Rethrow is following a condition.
                 var state = SetBranchingConstraints(branch, node.State, branchValue);
-                checks.ConditionEvaluated(new(node.Block, branchValue.ToSonar(), state, false, node.VisitCount, lva.CapturedVariables));
+                checks.ConditionEvaluated(new(node.Block, branchValue.ToSonar(), state, node.VisitCount, lva.CapturedVariables));
             }
             return null;    // We don't know where to continue
         }
@@ -182,7 +182,7 @@ internal class RoslynSymbolicExecution
         if (branch.Source.BranchValue is { } branchValue && branch.Source.ConditionalSuccessor is not null) // This branching was conditional
         {
             state = SetBranchingConstraints(branch, state, branchValue);
-            state = checks.ConditionEvaluated(new(block, branchValue.ToSonar(), state, false, visitCount, lva.CapturedVariables));
+            state = checks.ConditionEvaluated(new(block, branchValue.ToSonar(), state, visitCount, lva.CapturedVariables));
             if (state is null)
             {
                 return null;
@@ -205,7 +205,7 @@ internal class RoslynSymbolicExecution
 
     private IEnumerable<ExplodedNode> ProcessOperation(ExplodedNode node)
     {
-        foreach (var preProcessed in checks.PreProcess(new(node, lva.CapturedVariables, syntaxClassifier.IsInLoopCondition(node.Operation.Instance.Syntax))))
+        foreach (var preProcessed in checks.PreProcess(new(node, lva.CapturedVariables)))
         {
             foreach (var processed in OperationDispatcher.Process(preProcessed))
             {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicContext.cs
@@ -28,19 +28,17 @@ public class SymbolicContext
     public IOperationWrapperSonar Operation { get; }
     public ProgramState State { get; }
     public int VisitCount { get; }
-    public bool IsLoopCondition { get; }
     public IReadOnlyCollection<ISymbol> CapturedVariables { get; }
 
-    public SymbolicContext(ExplodedNode node, IReadOnlyCollection<ISymbol> capturedVariables, bool isLoopCondition)
-        : this(node.Block, node.Operation, node.State, isLoopCondition, node.VisitCount, capturedVariables) { }
+    public SymbolicContext(ExplodedNode node, IReadOnlyCollection<ISymbol> capturedVariables)
+        : this(node.Block, node.Operation, node.State, node.VisitCount, capturedVariables) { }
 
-    public SymbolicContext(BasicBlock block, IOperationWrapperSonar operation, ProgramState state, bool isLoopCondition, int visitCount, IReadOnlyCollection<ISymbol> capturedVariables)
+    public SymbolicContext(BasicBlock block, IOperationWrapperSonar operation, ProgramState state, int visitCount, IReadOnlyCollection<ISymbol> capturedVariables)
     {
         Block = block;
         Operation = operation; // Operation can be null for the branch nodes.
         State = state ?? throw new ArgumentNullException(nameof(state));
         VisitCount = visitCount;
-        IsLoopCondition = isLoopCondition;
         CapturedVariables = capturedVariables ?? throw new ArgumentNullException(nameof(capturedVariables));
     }
 
@@ -54,5 +52,5 @@ public class SymbolicContext
         State.SetOperationValue(Operation, value);
 
     public SymbolicContext WithState(ProgramState newState) =>
-        State == newState ? this : new(Block, Operation, newState, IsLoopCondition, VisitCount, CapturedVariables);
+        State == newState ? this : new(Block, Operation, newState, VisitCount, CapturedVariables);
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -162,7 +162,7 @@ public partial class RoslynSymbolicExecutionTest
             x =>
             {
                 x[i].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9));
-                x[value].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42));
+                x[value].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42, 99)); // Should be 42
             });
         validator.TagStates("Unreachable").Should().BeEmpty();
     }
@@ -193,7 +193,7 @@ public partial class RoslynSymbolicExecutionTest
             x =>
             {
                 x[i].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9));
-                x[value].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42));
+                x[value].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42, 99)); // Should be 42
             });
         validator.TagStates("Unreachable").Should().BeEmpty();
     }
@@ -329,10 +329,10 @@ public partial class RoslynSymbolicExecutionTest
         validator.ValidateTagOrder("Inside", "After", "Inside", "After");
         validator.TagValues("Inside").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0)),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)));
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9)));
         validator.TagValues("After").Should().SatisfyRespectively(
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)),    // Initial pass through "if"
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2)));   // Second pass through "if"
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)),        // Initial pass through "if"
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2, 10)));   // Second pass through "if"
     }
 
     [TestMethod]
@@ -355,10 +355,10 @@ public partial class RoslynSymbolicExecutionTest
         validator.ValidateTagOrder("Inside", "After", "Inside", "After");
         validator.TagValues("Inside").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0)),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)));
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9)));
         validator.TagValues("After").Should().SatisfyRespectively(
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)),    // Initial pass through "if"
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2)));   // Second pass through "if"
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)),        // Initial pass through "if"
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2, 10)));   // Second pass through "if"
     }
 
     [TestMethod]
@@ -516,7 +516,7 @@ Tag(""End"", arg);";
         validator.ValidateTagOrder("InLoop", "InLoop");
         validator.TagValues("InLoop").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0)),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)));
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9)));
         validator.TagStates("End").Should().BeEmpty();
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -66,7 +66,7 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var validator = SETestContext.CreateCS(code, "int arg", new AddConstraintOnInvocationCheck()).Validator;
         validator.ValidateExitReachCount(1);
-        // Loop was entered, arg has only it's final constraints after looping twice
+        // Loop was entered, arg has only its final constraints after looping twice
         validator.TagValue("End").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True);
     }
 
@@ -299,7 +299,7 @@ public partial class RoslynSymbolicExecutionTest
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2, 10)));
         validator.TagValue("After").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10));
-        // arg has only it's final constraints after looping twice
+        // arg has only its final constraints after looping twice
         validator.TagValue("End").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True);
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -64,14 +64,10 @@ public partial class RoslynSymbolicExecutionTest
             }
             Tag("End", arg);
             """;
-        var validator = SETestContext.CreateCS(code, "int arg", new AddConstraintOnInvocationCheck(), new PreserveTestCheck("arg")).Validator;
-        validator.ValidateExitReachCount(2);    // PreserveTestCheck is needed for this, otherwise, variables are thrown away by LVA when going to the Exit block
-        validator.TagValues("InLoop").Should().SatisfyRespectively(
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
-        validator.TagValues("End").Should().SatisfyRespectively(
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
+        var validator = SETestContext.CreateCS(code, "int arg", new AddConstraintOnInvocationCheck()).Validator;
+        validator.ValidateExitReachCount(1);
+        // Loop was entered, arg has only it's final constraints after looping twice
+        validator.TagValue("End").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True);
     }
 
     [TestMethod]
@@ -131,7 +127,6 @@ public partial class RoslynSymbolicExecutionTest
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0)),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9)));
         validator.TagStates("End").Should().SatisfyRespectively(    // We can assert because LVA did not kick in yet
-            x => x[validator.Symbol("i")].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10, null)),
             x => x[validator.Symbol("i")].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10)));
     }
 
@@ -153,7 +148,7 @@ public partial class RoslynSymbolicExecutionTest
             }
             """;
         var validator = SETestContext.CreateCS(code, "int arg", new AddConstraintOnInvocationCheck()).Validator;
-        validator.ValidateExitReachCount(2);
+        validator.ValidateExitReachCount(1);
         var i = validator.Symbol("i");
         var value = validator.Symbol("value");
         validator.TagStates("If").Should().SatisfyRespectively(
@@ -184,7 +179,7 @@ public partial class RoslynSymbolicExecutionTest
             Next
             """;
         var validator = SETestContext.CreateVB(code, "Arg As Integer", new AddConstraintOnInvocationCheck()).Validator;
-        validator.ValidateExitReachCount(2);
+        validator.ValidateExitReachCount(1);
         var i = validator.Symbol("i");
         var value = validator.Symbol("Value");
         validator.TagStates("If").Should().SatisfyRespectively(
@@ -219,18 +214,6 @@ public partial class RoslynSymbolicExecutionTest
         validator.TagStates("End").Should().SatisfyRespectively(
             x =>
             {
-                x[i].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10, null));
-                x[j].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(9));
-                x[arg].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First);
-            },
-            x =>
-            {
-                x[i].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9));
-                x[j].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(null, 0));
-                x[arg].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First);
-            },
-            x =>
-            {
                 x[i].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10));
                 x[j].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0, 8));
                 x[arg].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True);
@@ -259,7 +242,7 @@ public partial class RoslynSymbolicExecutionTest
         var arg = validator.Symbol("arg");
         var i = validator.Symbol("i");
         validator.ValidateExitReachCount(0);
-        validator.ValidateTagOrder("InLoop", "InLoop", "InLoop");
+        validator.ValidateTagOrder("InLoop", "InLoop");
         validator.TagStates("InLoop").Should().SatisfyRespectively(
             x =>
             {
@@ -269,11 +252,6 @@ public partial class RoslynSymbolicExecutionTest
             x =>
             {
                 x[i].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9));
-                x[arg].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True);
-            },
-            x =>
-            {
-                x[i].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10, null));
                 x[arg].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True);
             });
     }
@@ -320,12 +298,9 @@ public partial class RoslynSymbolicExecutionTest
         validator.TagValues("Inside").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)),
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2, 10)));
-        validator.TagValues("After").Should().SatisfyRespectively(
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10, null)),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10)));
-        validator.TagValues("End").Should().SatisfyRespectively(
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
+        validator.TagValue("After").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(10));
+        // arg has only it's final constraints after looping twice
+        validator.TagValue("End").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True);
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -66,7 +66,9 @@ public partial class RoslynSymbolicExecutionTest
             """;
         var validator = SETestContext.CreateCS(code, "int arg", new AddConstraintOnInvocationCheck()).Validator;
         validator.ValidateExitReachCount(1);
-        // Loop was entered, arg has only its final constraints after looping twice
+        validator.TagValues("InLoop").Should().SatisfyRespectively(
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First),
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True));
         validator.TagValue("End").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, TestConstraint.First, BoolConstraint.True);
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicCheckListTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicCheckListTest.cs
@@ -36,7 +36,7 @@ public class SymbolicCheckListTest
     {
         var a = new Mock<SymbolicCheck>();
         var b = new Mock<SymbolicCheck>();
-        var context = new SymbolicContext(null, null, ProgramState.Empty, false, 0, Array.Empty<ISymbol>());
+        var context = new SymbolicContext(null, null, ProgramState.Empty, 0, Array.Empty<ISymbol>());
         a.Setup(x => x.PreProcess(context)).Returns(new[] { context.State });
         a.Setup(x => x.PostProcess(context)).Returns(new[] { context.State });
         var sut = new SymbolicCheckList(new[] { a.Object, b.Object });
@@ -71,7 +71,7 @@ public class SymbolicCheckListTest
     {
         var triple = new PostProcessTestCheck(x => new[] { x.State, x.State, x.State });
         var sut = new SymbolicCheckList(new[] { triple, triple });
-        sut.PostProcess(new(null, null, ProgramState.Empty, false, 0, Array.Empty<ISymbol>())).Should().HaveCount(9);
+        sut.PostProcess(new(null, null, ProgramState.Empty, 0, Array.Empty<ISymbol>())).Should().HaveCount(9);
     }
 
     [TestMethod]
@@ -79,6 +79,6 @@ public class SymbolicCheckListTest
     {
         var empty = new PostProcessTestCheck(x => Array.Empty<ProgramState>());
         var sut = new SymbolicCheckList(new[] { empty });
-        sut.PostProcess(new(null, null, ProgramState.Empty, false, 0, Array.Empty<ISymbol>())).Should().HaveCount(0);
+        sut.PostProcess(new(null, null, ProgramState.Empty, 0, Array.Empty<ISymbol>())).Should().HaveCount(0);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicContextTest.cs
@@ -33,7 +33,7 @@ public class SymbolicContextTest
     public void NullArgument_State_Throws()
     {
         var block = CreateBlock();
-        var create = () => new SymbolicContext(block, new IOperationWrapperSonar(block.Operations[0]), null, false, 0, Array.Empty<ISymbol>());
+        var create = () => new SymbolicContext(block, new IOperationWrapperSonar(block.Operations[0]), null, 0, Array.Empty<ISymbol>());
         create.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("state");
     }
 
@@ -41,13 +41,13 @@ public class SymbolicContextTest
     public void NullArgument_CapturedVariables_Throws()
     {
         var block = CreateBlock();
-        var create = () => new SymbolicContext(block, new IOperationWrapperSonar(block.Operations[0]), ProgramState.Empty, false, 0, null);
+        var create = () => new SymbolicContext(block, new IOperationWrapperSonar(block.Operations[0]), ProgramState.Empty, 0, null);
         create.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("capturedVariables");
     }
 
     [TestMethod]
     public void NullOperation_SetsOperationToNull() =>
-        new SymbolicContext(null, null, ProgramState.Empty, false, 0, Array.Empty<ISymbol>()).Operation.Should().Be(null);
+        new SymbolicContext(null, null, ProgramState.Empty, 0, Array.Empty<ISymbol>()).Operation.Should().Be(null);
 
     [TestMethod]
     public void PropertiesArePersisted()
@@ -55,11 +55,10 @@ public class SymbolicContextTest
         var block = CreateBlock();
         var operation = new IOperationWrapperSonar(block.Operations[0]);
         var state = ProgramState.Empty.SetOperationValue(operation, SymbolicValue.Empty);
-        var sut = new SymbolicContext(block, operation, state, true, 42, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(block, operation, state, 42, Array.Empty<ISymbol>());
         sut.Block.Should().Be(block);
         sut.Operation.Should().Be(operation);
         sut.State.Should().Be(state);
-        sut.IsLoopCondition.Should().BeTrue();
         sut.VisitCount.Should().Be(42);
     }
 
@@ -69,7 +68,7 @@ public class SymbolicContextTest
         var block = CreateBlock();
         var operation = new IOperationWrapperSonar(block.Operations[0]);
         var state = ProgramState.Empty.SetOperationValue(operation, SymbolicValue.Empty);
-        var sut = new SymbolicContext(block, operation, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(block, operation, state, 0, Array.Empty<ISymbol>());
         var result = sut.SetOperationConstraint(DummyConstraint.Dummy);
         result.Should().NotBe(state, "new ProgramState instance should be created");
         result[operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue();
@@ -81,7 +80,7 @@ public class SymbolicContextTest
         var block = CreateBlock();
         var operation = new IOperationWrapperSonar(block.Operations[0]);
         var state = ProgramState.Empty;
-        var sut = new SymbolicContext(block, operation, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(block, operation, state, 0, Array.Empty<ISymbol>());
         var result = sut.SetOperationConstraint(DummyConstraint.Dummy);
         result.Should().NotBe(state, "new ProgramState instance should be created");
         result[operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue();
@@ -94,7 +93,7 @@ public class SymbolicContextTest
         var operation = new IOperationWrapperSonar(block.Operations[0]);
         var symbol = operation.Children.First().TrackedSymbol(ProgramState.Empty);
         var state = ProgramState.Empty.SetSymbolValue(symbol, SymbolicValue.Empty);
-        var sut = new SymbolicContext(block, operation, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(block, operation, state, 0, Array.Empty<ISymbol>());
         var result = sut.SetSymbolConstraint(symbol, DummyConstraint.Dummy);
         result.Should().NotBe(state, "new ProgramState instance should be created");
         result[symbol].HasConstraint(DummyConstraint.Dummy).Should().BeTrue();
@@ -107,7 +106,7 @@ public class SymbolicContextTest
         var operation = new IOperationWrapperSonar(block.Operations[0]);
         var symbol = operation.Children.First().TrackedSymbol(ProgramState.Empty);
         var state = ProgramState.Empty;
-        var sut = new SymbolicContext(block, operation, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(block, operation, state, 0, Array.Empty<ISymbol>());
         var result = sut.SetSymbolConstraint(symbol, DummyConstraint.Dummy);
         result.Should().NotBe(state, "new ProgramState instance should be created");
         result[symbol].HasConstraint(DummyConstraint.Dummy).Should().BeTrue();
@@ -119,7 +118,7 @@ public class SymbolicContextTest
         var block = CreateBlock();
         var operation = new IOperationWrapperSonar(block.Operations[0]);
         var state = ProgramState.Empty;
-        var sut = new SymbolicContext(block, operation, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(block, operation, state, 0, Array.Empty<ISymbol>());
         var result = sut.SetOperationValue(SymbolicValue.True);
         result.Should().NotBe(state, "new ProgramState instance should be created");
         result[operation].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
@@ -129,7 +128,7 @@ public class SymbolicContextTest
     public void WithState_SameState_ReturnsThis()
     {
         var state = ProgramState.Empty;
-        var sut = new SymbolicContext(null, null, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(null, null, state, 0, Array.Empty<ISymbol>());
         sut.WithState(state).Should().Be(sut);
     }
 
@@ -137,7 +136,7 @@ public class SymbolicContextTest
     public void WithState_DifferentState_ReturnsNew()
     {
         var state = ProgramState.Empty;
-        var sut = new SymbolicContext(null, null, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(null, null, state, 0, Array.Empty<ISymbol>());
         var newState = state.SetOperationValue(CreateOperation(), SymbolicValue.Empty);
         sut.WithState(newState).Should().NotBe(sut);
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp8.cs
@@ -393,7 +393,7 @@ class Repro_7088
                 continue;
             }
 
-            if (sb is null)     // Noncompliant FP
+            if (sb is null)             // Noncompliant FP
             {
                 sb = new StringBuilder();
             }
@@ -401,9 +401,9 @@ class Repro_7088
             sb.Append(i);
         }
 
-        if (sb is null) // FN
+        if (sb is null)                 // Noncompliant
         {
-            Console.WriteLine("NULL");
+            Console.WriteLine("NULL");  // Secondary
         }
 
         Console.WriteLine(sb);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -336,6 +336,13 @@ namespace Tests.Diagnostics
             }
         }
 
+        public void InfiniteForLoop(string arg)
+        {
+            for (var i = 0; i < 10; i--)    // FN
+            {
+            }
+        }
+
         public void Method_Switch()
         {
             int i = 10;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -338,7 +338,7 @@ namespace Tests.Diagnostics
 
         public void InfiniteForLoop(string arg)
         {
-            for (var i = 0; i < 10; i--)    // FN
+            for (var i = 0; i < 10; i--)    // Noncompliant
             {
             }
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -343,6 +343,22 @@ namespace Tests.Diagnostics
             }
         }
 
+        public void LoopWithIfsInside(bool condition)
+        {
+            var done = false;
+            var i = 0;
+            while (!done)
+            {
+                if (i <= 5)                 // Noncompliant FP
+                    i++;
+                else
+                    done = true;            // Secondary FP
+
+                if (i < 3 && condition)
+                    done = true;
+            }
+        }
+
         public void Method_Switch()
         {
             int i = 10;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Loops.cs
@@ -12,7 +12,7 @@ namespace Monitor_Loops
 
         public void Method1()
         {
-            Monitor.Enter(obj);     // Noncompliant tricky FP, as the execution should always reach number 9, but we don't track that
+            Monitor.Enter(obj);
             if (condition)
             {
                 Monitor.Exit(obj);  // To release it on at least one path to activate the rule
@@ -76,7 +76,7 @@ namespace Monitor_Loops
 
         public void Method4()
         {
-            Monitor.Enter(obj); // Noncompliant tricky FP, as the execution should always reach number 9, but we don't track that
+            Monitor.Enter(obj);
             if (condition)
             {
                 Monitor.Exit(obj);  // To release it on at least one path to activate the rule

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Loops.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/LocksReleasedAllPaths.Monitor.Loops.vb
@@ -9,7 +9,7 @@ Namespace Monitor_Loops
         Private Other As New Object()
 
         Public Sub Method1()
-            Monitor.Enter(Obj)      ' Noncompliant tricky FP, as the execution should always reach number 9, but we don't track that
+            Monitor.Enter(Obj)
             For i As Integer = 0 To 9
                 If i = 9 Then Monitor.Exit(Obj)
             Next
@@ -36,7 +36,7 @@ Namespace Monitor_Loops
         End Sub
 
         Public Sub Method4()
-            Monitor.Enter(Obj)      ' Noncompliant tricky FP, as the execution should always reach number 9, but we don't track that
+            Monitor.Enter(Obj)
             For i As Integer = 0 To 9
                 If i = 10 Then Exit For
                 If i = 9 Then Monitor.Exit(Obj)


### PR DESCRIPTION
Follow-up to #7795 
Now that we visit loop conditions up to three times, one branch usually leaves the loop on the latest visit. This makes the arbitrary branching we have done before unnecessary. Removing it allows us to find infinite for-loops:

```
public void InfiniteForLoop(string arg)
{
    for (var i = 0; i < 10; i--)    // FN
    {
    }
}
```