### PR TITLE
SE: Learn NumberConstraint ranges for 2nd visits of conditions

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
@@ -154,11 +154,11 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
         {
             if (existingNumber is not null)
             {
-                if ((newMin is null || (existingNumber.Min > newMin && EvaluateBranchingCondition(isLoopCondition, visitCount))) && !(existingNumber.Min > newMax))
+                if ((newMin is null || (existingNumber.Min > newMin && visitCount == 1)) && !(existingNumber.Min > newMax))
                 {
                     newMin = existingNumber.Min;
                 }
-                if ((newMax is null || (existingNumber.Max < newMax && EvaluateBranchingCondition(isLoopCondition, visitCount))) && !(existingNumber.Max < newMin))
+                if ((newMax is null || (existingNumber.Max < newMax && visitCount == 1)) && !(existingNumber.Max < newMin))
                 {
                     newMax = existingNumber.Max;
                 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
@@ -28,21 +28,21 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
     protected override IBinaryOperationWrapper Convert(IOperation operation) =>
         IBinaryOperationWrapper.FromOperation(operation);
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IBinaryOperationWrapper operation, bool isLoopCondition, int visitCount) =>
-        BinaryConstraint(operation.OperatorKind, state[operation.LeftOperand], state[operation.RightOperand], isLoopCondition, visitCount);
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IBinaryOperationWrapper operation) =>
+        BinaryConstraint(operation.OperatorKind, state[operation.LeftOperand], state[operation.RightOperand]);
 
-    protected override ProgramState LearnBranchingConstraint(ProgramState state, IBinaryOperationWrapper operation, bool isLoopCondition, int visitCount, bool falseBranch)
+    protected override ProgramState LearnBranchingConstraint(ProgramState state, IBinaryOperationWrapper operation, int visitCount, bool falseBranch)
     {
         if (operation.OperatorKind.IsAnyEquality())
         {
             state = LearnBranchingEqualityConstraint<ObjectConstraint>(state, operation, falseBranch) ?? state;
             state = LearnBranchingEqualityConstraint<BoolConstraint>(state, operation, falseBranch) ?? state;
-            state = LearnBranchingNumberConstraint(state, operation, isLoopCondition, visitCount, falseBranch);
+            state = LearnBranchingNumberConstraint(state, operation, visitCount, falseBranch);
         }
         else if (operation.OperatorKind.IsAnyRelational())
         {
             state = LearnBranchingRelationalObjectConstraint(state, operation, falseBranch) ?? state;
-            state = LearnBranchingNumberConstraint(state, operation, isLoopCondition, visitCount, falseBranch);
+            state = LearnBranchingNumberConstraint(state, operation, visitCount, falseBranch);
         }
         return state;
     }
@@ -90,7 +90,7 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
             ? state.SetSymbolConstraint(testedSymbol, ObjectConstraint.NotNull)
             : null;
 
-    private static ProgramState LearnBranchingNumberConstraint(ProgramState state, IBinaryOperationWrapper binary, bool isLoopCondition, int visitCount, bool falseBranch)
+    private static ProgramState LearnBranchingNumberConstraint(ProgramState state, IBinaryOperationWrapper binary, int visitCount, bool falseBranch)
     {
         var kind = falseBranch ? Opposite(binary.OperatorKind) : binary.OperatorKind;
         var leftNumber = state[binary.LeftOperand]?.Constraint<NumberConstraint>();
@@ -107,7 +107,7 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
 
         ProgramState LearnBranching(ISymbol symbol, NumberConstraint existingNumber, BinaryOperatorKind kind, NumberConstraint comparedNumber) =>
             !(falseBranch && symbol.GetSymbolType().IsNullableValueType())  // Don't learn opposite for "nullable > 0", because it could also be <null>.
-            && RelationalNumberConstraint(existingNumber, kind, comparedNumber, isLoopCondition, visitCount) is { } newConstraint
+            && RelationalNumberConstraint(existingNumber, kind, comparedNumber, visitCount) is { } newConstraint
                 ? state.SetSymbolConstraint(symbol, newConstraint)
                 : state;
 
@@ -136,7 +136,7 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
             };
     }
 
-    private static NumberConstraint RelationalNumberConstraint(NumberConstraint existingNumber, BinaryOperatorKind kind, NumberConstraint comparedNumber, bool isLoopCondition, int visitCount)
+    private static NumberConstraint RelationalNumberConstraint(NumberConstraint existingNumber, BinaryOperatorKind kind, NumberConstraint comparedNumber, int visitCount)
     {
         return kind switch
         {
@@ -154,6 +154,9 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
         {
             if (existingNumber is not null)
             {
+                // Fixed loops:
+                // 1st visit decides on the initial value. We don't learn from binary comparison.
+                // 2nd visit does not decide on the current value. It learns range from binary comparison instead to be able to exit the loop.
                 if ((newMin is null || (existingNumber.Min > newMin && visitCount == 1)) && !(existingNumber.Min > newMax))
                 {
                     newMin = existingNumber.Min;
@@ -179,7 +182,7 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
             ? symbol
             : null;
 
-    private static SymbolicConstraint BinaryConstraint(BinaryOperatorKind kind, SymbolicValue left, SymbolicValue right, bool isLoopCondition, int visitCount)
+    private static SymbolicConstraint BinaryConstraint(BinaryOperatorKind kind, SymbolicValue left, SymbolicValue right)
     {
         var leftBool = left?.Constraint<BoolConstraint>();
         var rightBool = right?.Constraint<BoolConstraint>();
@@ -264,10 +267,4 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
                 _ => null
             }
             : null;
-
-    // Fixed loops:
-    // 1st visit decides on the initial value. We don't learn from binary comparison.
-    // 2nd visit does not decide on the current value. It learns range from binary comparison instead to be able to exit the loop.
-    private static bool EvaluateBranchingCondition(bool isLoopCondition, int visitCount) =>
-        visitCount == 1 || !isLoopCondition;
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
@@ -190,14 +190,7 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
         var rightIsNull = right?.Constraint<ObjectConstraint>() == ObjectConstraint.Null;
         if (leftBool is null ^ rightBool is null)
         {
-            return kind switch
-            {
-                BinaryOperatorKind.Equals when leftIsNull || rightIsNull => BoolConstraint.False,
-                BinaryOperatorKind.NotEquals when leftIsNull || rightIsNull => BoolConstraint.True,
-                BinaryOperatorKind.Or or BinaryOperatorKind.ConditionalOr when (leftBool ?? rightBool) == BoolConstraint.True => BoolConstraint.True,
-                BinaryOperatorKind.And or BinaryOperatorKind.ConditionalAnd when (leftBool ?? rightBool) == BoolConstraint.False => BoolConstraint.False,
-                _ => null
-            };
+            return BinaryNullableBoolConstraint(kind, leftBool ?? rightBool, leftIsNull || rightIsNull);
         }
         else if (leftBool is not null && rightBool is not null)
         {
@@ -221,6 +214,16 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
             return null;
         }
     }
+
+    private static BoolConstraint BinaryNullableBoolConstraint(BinaryOperatorKind kind, BoolConstraint boolConstraint, bool oneIsNull) =>
+        kind switch
+        {
+            BinaryOperatorKind.Equals when oneIsNull => BoolConstraint.False,
+            BinaryOperatorKind.NotEquals when oneIsNull => BoolConstraint.True,
+            BinaryOperatorKind.Or or BinaryOperatorKind.ConditionalOr when boolConstraint == BoolConstraint.True => BoolConstraint.True,
+            BinaryOperatorKind.And or BinaryOperatorKind.ConditionalAnd when boolConstraint == BoolConstraint.False => BoolConstraint.False,
+            _ => null
+        };
 
     private static SymbolicConstraint BinaryBoolConstraint(BinaryOperatorKind kind, bool left, bool right) =>
         kind switch

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.cs
@@ -190,7 +190,7 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
         var rightIsNull = right?.Constraint<ObjectConstraint>() == ObjectConstraint.Null;
         if (leftBool is null ^ rightBool is null)
         {
-            return BinaryNullableBoolConstraint(kind, leftBool ?? rightBool, leftIsNull || rightIsNull);
+            return BinaryNullableBoolConstraint(kind, leftBool ?? rightBool, leftIsNull, rightIsNull);
         }
         else if (leftBool is not null && rightBool is not null)
         {
@@ -215,13 +215,13 @@ internal sealed partial class Binary : BranchingProcessor<IBinaryOperationWrappe
         }
     }
 
-    private static BoolConstraint BinaryNullableBoolConstraint(BinaryOperatorKind kind, BoolConstraint boolConstraint, bool oneIsNull) =>
+    private static BoolConstraint BinaryNullableBoolConstraint(BinaryOperatorKind kind, BoolConstraint constraint, bool leftIsNull, bool rightIsNull) =>
         kind switch
         {
-            BinaryOperatorKind.Equals when oneIsNull => BoolConstraint.False,
-            BinaryOperatorKind.NotEquals when oneIsNull => BoolConstraint.True,
-            BinaryOperatorKind.Or or BinaryOperatorKind.ConditionalOr when boolConstraint == BoolConstraint.True => BoolConstraint.True,
-            BinaryOperatorKind.And or BinaryOperatorKind.ConditionalAnd when boolConstraint == BoolConstraint.False => BoolConstraint.False,
+            BinaryOperatorKind.Equals when leftIsNull || rightIsNull => BoolConstraint.False,
+            BinaryOperatorKind.NotEquals when leftIsNull || rightIsNull => BoolConstraint.True,
+            BinaryOperatorKind.Or or BinaryOperatorKind.ConditionalOr when constraint == BoolConstraint.True => BoolConstraint.True,
+            BinaryOperatorKind.And or BinaryOperatorKind.ConditionalAnd when constraint == BoolConstraint.False => BoolConstraint.False,
             _ => null
         };
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/BranchingProcessor.cs
@@ -30,8 +30,8 @@ namespace SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors;
 internal abstract class BranchingProcessor<T> : MultiProcessor<T>
     where T : IOperationWrapper
 {
-    protected abstract SymbolicConstraint BoolConstraintFromOperation(ProgramState state, T operation, bool isLoopCondition, int visitCount);
-    protected abstract ProgramState LearnBranchingConstraint(ProgramState state, T operation, bool isLoopCondition, int visitCount, bool falseBranch);
+    protected abstract SymbolicConstraint BoolConstraintFromOperation(ProgramState state, T operation);
+    protected abstract ProgramState LearnBranchingConstraint(ProgramState state, T operation, int visitCount, bool falseBranch);
 
     protected virtual ProgramState PreProcess(ProgramState state, T operation) =>
         state;
@@ -39,18 +39,18 @@ internal abstract class BranchingProcessor<T> : MultiProcessor<T>
     protected override ProgramState[] Process(SymbolicContext context, T operation)
     {
         var state = PreProcess(context.State, operation);
-        if (BoolConstraintFromOperation(state, operation, context.IsLoopCondition, context.VisitCount) is { } constraint)
+        if (BoolConstraintFromOperation(state, operation) is { } constraint)
         {
             state = state.SetOperationConstraint(context.Operation, constraint);
             return context.VisitCount > 1   // apply fuzzy logic on NumberConstraints in loops
-                ? LearnBranchingConstraint(state, operation, context.IsLoopCondition, context.VisitCount, constraint == BoolConstraint.False).ToArray()
+                ? LearnBranchingConstraint(state, operation, context.VisitCount, constraint == BoolConstraint.False).ToArray()
                 : state.ToArray();
         }
         else
         {
             var beforeLearningState = state;
-            var positive = LearnBranchingConstraint(state, operation, context.IsLoopCondition, context.VisitCount, false);
-            var negative = LearnBranchingConstraint(state, operation, context.IsLoopCondition, context.VisitCount, true);
+            var positive = LearnBranchingConstraint(state, operation, context.VisitCount, false);
+            var negative = LearnBranchingConstraint(state, operation, context.VisitCount, true);
             return positive == beforeLearningState && negative == beforeLearningState
                 ? beforeLearningState.ToArray()   // We can't learn anything, just move on
                 : new[]

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsNull.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsNull.cs
@@ -27,12 +27,12 @@ internal sealed class IsNull : BranchingProcessor<IIsNullOperationWrapper>
     protected override IIsNullOperationWrapper Convert(IOperation operation) =>
         IIsNullOperationWrapper.FromOperation(operation);
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsNullOperationWrapper operation, bool isLoopCondition, int visitCount) =>
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsNullOperationWrapper operation) =>
         state[operation.Operand] is { } value && value.HasConstraint<ObjectConstraint>()
             ? BoolConstraint.From(value.HasConstraint(ObjectConstraint.Null))
             : null;
 
-    protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsNullOperationWrapper operation, bool isLoopCondition, int visitCount, bool falseBranch)
+    protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsNullOperationWrapper operation, int visitCount, bool falseBranch)
     {
         var constraint = falseBranch ? ObjectConstraint.NotNull : ObjectConstraint.Null;
         state = state.SetOperationConstraint(operation.Operand, constraint);

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsPattern.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsPattern.cs
@@ -27,10 +27,10 @@ internal sealed class IsPattern : BranchingProcessor<IIsPatternOperationWrapper>
     protected override IIsPatternOperationWrapper Convert(IOperation operation) =>
         IIsPatternOperationWrapper.FromOperation(operation);
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsPatternOperationWrapper operation, bool isLoopCondition, int visitCount) =>
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsPatternOperationWrapper operation) =>
         BoolContraintFromConstant(state, operation) ?? BoolConstraintFromPattern(state, operation);
 
-    protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsPatternOperationWrapper operation, bool isLoopCondition, int visitCount, bool falseBranch) =>
+    protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsPatternOperationWrapper operation, int visitCount, bool falseBranch) =>
         operation.Value.TrackedSymbol(state) is { } testedSymbol
         && LearnBranchingConstraint(state, operation.Pattern, falseBranch, state[testedSymbol]?.HasConstraint<ObjectConstraint>() is true) is { } constraint
             ? state.SetSymbolConstraint(testedSymbol, constraint)

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsType.cs
@@ -27,10 +27,10 @@ internal sealed class IsType : BranchingProcessor<IIsTypeOperationWrapper>
     protected override IIsTypeOperationWrapper Convert(IOperation operation) =>
         IIsTypeOperationWrapper.FromOperation(operation);
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsTypeOperationWrapper operation, bool isLoopCondition, int visitCount) =>
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IIsTypeOperationWrapper operation) =>
         state[operation.ValueOperand]?.HasConstraint(ObjectConstraint.Null) is true ? BoolConstraint.False : null;
 
-    protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsTypeOperationWrapper operation, bool isLoopCondition, int visitCount, bool falseBranch) =>
+    protected override ProgramState LearnBranchingConstraint(ProgramState state, IIsTypeOperationWrapper operation, int visitCount, bool falseBranch) =>
         operation.ValueOperand.TrackedSymbol(state) is { } testedSymbol
         && ObjectConstraint.NotNull.ApplyOpposite(falseBranch ^ operation.IsNegated) is { } constraint
             ? state.SetSymbolConstraint(testedSymbol, constraint)

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/References.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/References.cs
@@ -87,12 +87,12 @@ internal sealed class PropertyReference : BranchingProcessor<IPropertyReferenceO
         return state;
     }
 
-    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IPropertyReferenceOperationWrapper operation, bool isLoopCondition, int visitCount) =>
+    protected override SymbolicConstraint BoolConstraintFromOperation(ProgramState state, IPropertyReferenceOperationWrapper operation) =>
         IsNullableProperty(operation, "HasValue") && state[operation.Instance]?.Constraint<ObjectConstraint>() is { } objectConstraint
             ? BoolConstraint.From(objectConstraint == ObjectConstraint.NotNull)
             : null;
 
-    protected override ProgramState LearnBranchingConstraint(ProgramState state, IPropertyReferenceOperationWrapper operation, bool isLoopCondition, int visitCount, bool falseBranch) =>
+    protected override ProgramState LearnBranchingConstraint(ProgramState state, IPropertyReferenceOperationWrapper operation, int visitCount, bool falseBranch) =>
         IsNullableProperty(operation, "HasValue") && operation.Instance.TrackedSymbol(state) is { } testedSymbol
             // Can't use ObjectConstraint.ApplyOpposite() because here, we are sure that it is either Null or NotNull
             ? state.SetSymbolConstraint(testedSymbol, falseBranch ? ObjectConstraint.Null : ObjectConstraint.NotNull)

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -122,7 +122,7 @@ internal class RoslynSymbolicExecution
         if (node.Block.Kind == BasicBlockKind.Exit)
         {
             logger.Log(node.State, "Exit Reached");
-            checks.ExitReached(new(node, lva.CapturedVariables, false));
+            checks.ExitReached(new(node, lva.CapturedVariables));
         }
         else if (node.Block.Successors.Length == 1 && ThrownException(node, node.Block.Successors.Single().Semantics) is { } exception)
         {
@@ -161,7 +161,7 @@ internal class RoslynSymbolicExecution
             {
                 // If a branch has no Destination but is part of conditional branching we need to call ConditionEvaluated. This happens when a Rethrow is following a condition.
                 var state = SetBranchingConstraints(branch, node.State, branchValue);
-                checks.ConditionEvaluated(new(node.Block, branchValue.ToSonar(), state, false, node.VisitCount, lva.CapturedVariables));
+                checks.ConditionEvaluated(new(node.Block, branchValue.ToSonar(), state, node.VisitCount, lva.CapturedVariables));
             }
             return null;    // We don't know where to continue
         }
@@ -182,7 +182,7 @@ internal class RoslynSymbolicExecution
         if (branch.Source.BranchValue is { } branchValue && branch.Source.ConditionalSuccessor is not null) // This branching was conditional
         {
             state = SetBranchingConstraints(branch, state, branchValue);
-            state = checks.ConditionEvaluated(new(block, branchValue.ToSonar(), state, false, visitCount, lva.CapturedVariables));
+            state = checks.ConditionEvaluated(new(block, branchValue.ToSonar(), state, visitCount, lva.CapturedVariables));
             if (state is null)
             {
                 return null;
@@ -205,7 +205,7 @@ internal class RoslynSymbolicExecution
 
     private IEnumerable<ExplodedNode> ProcessOperation(ExplodedNode node)
     {
-        foreach (var preProcessed in checks.PreProcess(new(node, lva.CapturedVariables, syntaxClassifier.IsInLoopCondition(node.Operation.Instance.Syntax))))
+        foreach (var preProcessed in checks.PreProcess(new(node, lva.CapturedVariables)))
         {
             foreach (var processed in OperationDispatcher.Process(preProcessed))
             {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/SymbolicContext.cs
@@ -28,19 +28,17 @@ public class SymbolicContext
     public IOperationWrapperSonar Operation { get; }
     public ProgramState State { get; }
     public int VisitCount { get; }
-    public bool IsLoopCondition { get; }
     public IReadOnlyCollection<ISymbol> CapturedVariables { get; }
 
-    public SymbolicContext(ExplodedNode node, IReadOnlyCollection<ISymbol> capturedVariables, bool isLoopCondition)
-        : this(node.Block, node.Operation, node.State, isLoopCondition, node.VisitCount, capturedVariables) { }
+    public SymbolicContext(ExplodedNode node, IReadOnlyCollection<ISymbol> capturedVariables)
+        : this(node.Block, node.Operation, node.State, node.VisitCount, capturedVariables) { }
 
-    public SymbolicContext(BasicBlock block, IOperationWrapperSonar operation, ProgramState state, bool isLoopCondition, int visitCount, IReadOnlyCollection<ISymbol> capturedVariables)
+    public SymbolicContext(BasicBlock block, IOperationWrapperSonar operation, ProgramState state, int visitCount, IReadOnlyCollection<ISymbol> capturedVariables)
     {
         Block = block;
         Operation = operation; // Operation can be null for the branch nodes.
         State = state ?? throw new ArgumentNullException(nameof(state));
         VisitCount = visitCount;
-        IsLoopCondition = isLoopCondition;
         CapturedVariables = capturedVariables ?? throw new ArgumentNullException(nameof(capturedVariables));
     }
 
@@ -54,5 +52,5 @@ public class SymbolicContext
         State.SetOperationValue(Operation, value);
 
     public SymbolicContext WithState(ProgramState newState) =>
-        State == newState ? this : new(Block, Operation, newState, IsLoopCondition, VisitCount, CapturedVariables);
+        State == newState ? this : new(Block, Operation, newState, VisitCount, CapturedVariables);
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Loops.cs
@@ -162,7 +162,7 @@ public partial class RoslynSymbolicExecutionTest
             x =>
             {
                 x[i].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9));
-                x[value].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42));
+                x[value].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42, 99)); // Should be 42
             });
         validator.TagStates("Unreachable").Should().BeEmpty();
     }
@@ -193,7 +193,7 @@ public partial class RoslynSymbolicExecutionTest
             x =>
             {
                 x[i].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9));
-                x[value].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42));
+                x[value].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(42, 99)); // Should be 42
             });
         validator.TagStates("Unreachable").Should().BeEmpty();
     }
@@ -329,10 +329,10 @@ public partial class RoslynSymbolicExecutionTest
         validator.ValidateTagOrder("Inside", "After", "Inside", "After");
         validator.TagValues("Inside").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0)),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)));
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9)));
         validator.TagValues("After").Should().SatisfyRespectively(
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)),    // Initial pass through "if"
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2)));   // Second pass through "if"
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)),        // Initial pass through "if"
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2, 10)));   // Second pass through "if"
     }
 
     [TestMethod]
@@ -355,10 +355,10 @@ public partial class RoslynSymbolicExecutionTest
         validator.ValidateTagOrder("Inside", "After", "Inside", "After");
         validator.TagValues("Inside").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0)),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)));
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9)));
         validator.TagValues("After").Should().SatisfyRespectively(
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)),    // Initial pass through "if"
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2)));   // Second pass through "if"
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)),        // Initial pass through "if"
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(2, 10)));   // Second pass through "if"
     }
 
     [TestMethod]
@@ -516,7 +516,7 @@ Tag(""End"", arg);";
         validator.ValidateTagOrder("InLoop", "InLoop");
         validator.TagValues("InLoop").Should().SatisfyRespectively(
             x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(0)),
-            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1)));
+            x => x.Should().HaveOnlyConstraints(ObjectConstraint.NotNull, NumberConstraint.From(1, 9)));
         validator.TagStates("End").Should().BeEmpty();
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicCheckListTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicCheckListTest.cs
@@ -36,7 +36,7 @@ public class SymbolicCheckListTest
     {
         var a = new Mock<SymbolicCheck>();
         var b = new Mock<SymbolicCheck>();
-        var context = new SymbolicContext(null, null, ProgramState.Empty, false, 0, Array.Empty<ISymbol>());
+        var context = new SymbolicContext(null, null, ProgramState.Empty, 0, Array.Empty<ISymbol>());
         a.Setup(x => x.PreProcess(context)).Returns(new[] { context.State });
         a.Setup(x => x.PostProcess(context)).Returns(new[] { context.State });
         var sut = new SymbolicCheckList(new[] { a.Object, b.Object });
@@ -71,7 +71,7 @@ public class SymbolicCheckListTest
     {
         var triple = new PostProcessTestCheck(x => new[] { x.State, x.State, x.State });
         var sut = new SymbolicCheckList(new[] { triple, triple });
-        sut.PostProcess(new(null, null, ProgramState.Empty, false, 0, Array.Empty<ISymbol>())).Should().HaveCount(9);
+        sut.PostProcess(new(null, null, ProgramState.Empty, 0, Array.Empty<ISymbol>())).Should().HaveCount(9);
     }
 
     [TestMethod]
@@ -79,6 +79,6 @@ public class SymbolicCheckListTest
     {
         var empty = new PostProcessTestCheck(x => Array.Empty<ProgramState>());
         var sut = new SymbolicCheckList(new[] { empty });
-        sut.PostProcess(new(null, null, ProgramState.Empty, false, 0, Array.Empty<ISymbol>())).Should().HaveCount(0);
+        sut.PostProcess(new(null, null, ProgramState.Empty, 0, Array.Empty<ISymbol>())).Should().HaveCount(0);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicContextTest.cs
@@ -33,7 +33,7 @@ public class SymbolicContextTest
     public void NullArgument_State_Throws()
     {
         var block = CreateBlock();
-        var create = () => new SymbolicContext(block, new IOperationWrapperSonar(block.Operations[0]), null, false, 0, Array.Empty<ISymbol>());
+        var create = () => new SymbolicContext(block, new IOperationWrapperSonar(block.Operations[0]), null, 0, Array.Empty<ISymbol>());
         create.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("state");
     }
 
@@ -41,13 +41,13 @@ public class SymbolicContextTest
     public void NullArgument_CapturedVariables_Throws()
     {
         var block = CreateBlock();
-        var create = () => new SymbolicContext(block, new IOperationWrapperSonar(block.Operations[0]), ProgramState.Empty, false, 0, null);
+        var create = () => new SymbolicContext(block, new IOperationWrapperSonar(block.Operations[0]), ProgramState.Empty, 0, null);
         create.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("capturedVariables");
     }
 
     [TestMethod]
     public void NullOperation_SetsOperationToNull() =>
-        new SymbolicContext(null, null, ProgramState.Empty, false, 0, Array.Empty<ISymbol>()).Operation.Should().Be(null);
+        new SymbolicContext(null, null, ProgramState.Empty, 0, Array.Empty<ISymbol>()).Operation.Should().Be(null);
 
     [TestMethod]
     public void PropertiesArePersisted()
@@ -55,11 +55,10 @@ public class SymbolicContextTest
         var block = CreateBlock();
         var operation = new IOperationWrapperSonar(block.Operations[0]);
         var state = ProgramState.Empty.SetOperationValue(operation, SymbolicValue.Empty);
-        var sut = new SymbolicContext(block, operation, state, true, 42, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(block, operation, state, 42, Array.Empty<ISymbol>());
         sut.Block.Should().Be(block);
         sut.Operation.Should().Be(operation);
         sut.State.Should().Be(state);
-        sut.IsLoopCondition.Should().BeTrue();
         sut.VisitCount.Should().Be(42);
     }
 
@@ -69,7 +68,7 @@ public class SymbolicContextTest
         var block = CreateBlock();
         var operation = new IOperationWrapperSonar(block.Operations[0]);
         var state = ProgramState.Empty.SetOperationValue(operation, SymbolicValue.Empty);
-        var sut = new SymbolicContext(block, operation, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(block, operation, state, 0, Array.Empty<ISymbol>());
         var result = sut.SetOperationConstraint(DummyConstraint.Dummy);
         result.Should().NotBe(state, "new ProgramState instance should be created");
         result[operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue();
@@ -81,7 +80,7 @@ public class SymbolicContextTest
         var block = CreateBlock();
         var operation = new IOperationWrapperSonar(block.Operations[0]);
         var state = ProgramState.Empty;
-        var sut = new SymbolicContext(block, operation, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(block, operation, state, 0, Array.Empty<ISymbol>());
         var result = sut.SetOperationConstraint(DummyConstraint.Dummy);
         result.Should().NotBe(state, "new ProgramState instance should be created");
         result[operation].HasConstraint(DummyConstraint.Dummy).Should().BeTrue();
@@ -94,7 +93,7 @@ public class SymbolicContextTest
         var operation = new IOperationWrapperSonar(block.Operations[0]);
         var symbol = operation.Children.First().TrackedSymbol(ProgramState.Empty);
         var state = ProgramState.Empty.SetSymbolValue(symbol, SymbolicValue.Empty);
-        var sut = new SymbolicContext(block, operation, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(block, operation, state, 0, Array.Empty<ISymbol>());
         var result = sut.SetSymbolConstraint(symbol, DummyConstraint.Dummy);
         result.Should().NotBe(state, "new ProgramState instance should be created");
         result[symbol].HasConstraint(DummyConstraint.Dummy).Should().BeTrue();
@@ -107,7 +106,7 @@ public class SymbolicContextTest
         var operation = new IOperationWrapperSonar(block.Operations[0]);
         var symbol = operation.Children.First().TrackedSymbol(ProgramState.Empty);
         var state = ProgramState.Empty;
-        var sut = new SymbolicContext(block, operation, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(block, operation, state, 0, Array.Empty<ISymbol>());
         var result = sut.SetSymbolConstraint(symbol, DummyConstraint.Dummy);
         result.Should().NotBe(state, "new ProgramState instance should be created");
         result[symbol].HasConstraint(DummyConstraint.Dummy).Should().BeTrue();
@@ -119,7 +118,7 @@ public class SymbolicContextTest
         var block = CreateBlock();
         var operation = new IOperationWrapperSonar(block.Operations[0]);
         var state = ProgramState.Empty;
-        var sut = new SymbolicContext(block, operation, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(block, operation, state, 0, Array.Empty<ISymbol>());
         var result = sut.SetOperationValue(SymbolicValue.True);
         result.Should().NotBe(state, "new ProgramState instance should be created");
         result[operation].Should().HaveOnlyConstraints(ObjectConstraint.NotNull, BoolConstraint.True);
@@ -129,7 +128,7 @@ public class SymbolicContextTest
     public void WithState_SameState_ReturnsThis()
     {
         var state = ProgramState.Empty;
-        var sut = new SymbolicContext(null, null, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(null, null, state, 0, Array.Empty<ISymbol>());
         sut.WithState(state).Should().Be(sut);
     }
 
@@ -137,7 +136,7 @@ public class SymbolicContextTest
     public void WithState_DifferentState_ReturnsNew()
     {
         var state = ProgramState.Empty;
-        var sut = new SymbolicContext(null, null, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(null, null, state, 0, Array.Empty<ISymbol>());
         var newState = state.SetOperationValue(CreateOperation(), SymbolicValue.Empty);
         sut.WithState(newState).Should().NotBe(sut);
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -354,7 +354,7 @@ namespace Tests.Diagnostics
                 else
                     done = true;            // Secondary FP
 
-                if (i < 3 && condition)     // Noncompliant FP
+                if (i < 3 && condition)
                     done = true;
             }
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -343,6 +343,22 @@ namespace Tests.Diagnostics
             }
         }
 
+        public void LoopWithIfsInside(bool condition)
+        {
+            var done = false;
+            var i = 0;
+            while (!done)
+            {
+                if (i <= 5)                 // Noncompliant FP
+                    i++;
+                else
+                    done = true;            // Secondary FP
+
+                if (i < 3 && condition)     // Noncompliant FP
+                    done = true;
+            }
+        }
+
         public void Method_Switch()
         {
             int i = 10;


### PR DESCRIPTION
Follow-up to #7797
By applying the special treatment for binary number operations to not just loop conditions but also operations inside a loop, we simplify the code and fix some arcane FPs.