### PR TITLE
UtilityAnalyzer: Annotate with performance sensitive

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -71,7 +71,7 @@ namespace SonarAnalyzer.Rules.CSharp
             protected override bool IsStringLiteral(SyntaxToken token) =>
                 token.IsAnyKind(StringLiteralTokens);
 
-            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805")]
+            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
             protected override TokenTypeInfo.Types.TokenInfo ClassifyIdentifier(SyntaxToken token) =>
                 // Based on <Kind Name="IdentifierToken"/> in SonarAnalyzer.CFG/ShimLayer\Syntax.xml
                 token.Parent switch
@@ -106,7 +106,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     _ => base.ClassifyIdentifier(token),
                 };
 
-            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805")]
+            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
             private TokenType? ClassifySimpleName(SimpleNameSyntax x) =>
                 IsInTypeContext(x)
                     ? ClassifySimpleNameType(x)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -112,6 +112,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     ? ClassifySimpleNameType(x)
                     : ClassifySimpleNameExpression(x);
 
+            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
             private TokenType? ClassifySimpleNameExpression(SimpleNameSyntax name) =>
                 name.Parent is MemberAccessExpressionSyntax
                     ? ClassifyMemberAccess(name)
@@ -123,6 +124,7 @@ namespace SonarAnalyzer.Rules.CSharp
             /// is the member access of the <paramref name="name"/>. e.g. for A.B.C <paramref name="name"/> may
             /// refer to "B" and <paramref name="context"/> would be the parent member access expression A.B and recursively A.B.C.
             /// </summary>
+            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
             private TokenType? ClassifySimpleNameExpressionSpecialContext(SyntaxNode context, SimpleNameSyntax name) =>
                 context.Parent switch
                 {
@@ -169,6 +171,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         }
                     };
 
+            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
             private TokenType? ClassifyMemberAccess(SimpleNameSyntax name) =>
                 // Most right hand side of a member access?
                 name is
@@ -192,11 +195,13 @@ namespace SonarAnalyzer.Rules.CSharp
                     ? TokenType.TypeName
                     : TokenType.UnknownTokentype;
 
+            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
             private TokenType? ClassifySimpleNameType(SimpleNameSyntax name) =>
                 name is GenericNameSyntax
                     ? TokenType.TypeName
                     : ClassifySimpleNameTypeSpecialContext(name, name);
 
+            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
             private TokenType? ClassifySimpleNameTypeSpecialContext(SyntaxNode context, SimpleNameSyntax name) =>
                 context.Parent switch
                 {
@@ -219,6 +224,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     _ => ClassifySimpleNameTypeInTypeContext(name),
                 };
 
+            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
             private TokenType ClassifySimpleNameTypeInTypeContext(SimpleNameSyntax name) =>
                 name switch
                 {
@@ -235,7 +241,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     _ => ClassifyIdentifierByModel(name),
                 };
 
-            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805")]
+            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
             private static bool IsInTypeContext(SimpleNameSyntax name) =>
                 // Based on Syntax.xml search for Type="TypeSyntax" and Type="NameSyntax"
                 name.Parent switch

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Roslyn.Utilities;
 using SonarAnalyzer.Protobuf;
 
 namespace SonarAnalyzer.Rules.CSharp
@@ -70,6 +71,7 @@ namespace SonarAnalyzer.Rules.CSharp
             protected override bool IsStringLiteral(SyntaxToken token) =>
                 token.IsAnyKind(StringLiteralTokens);
 
+            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805")]
             protected override TokenTypeInfo.Types.TokenInfo ClassifyIdentifier(SyntaxToken token) =>
                 // Based on <Kind Name="IdentifierToken"/> in SonarAnalyzer.CFG/ShimLayer\Syntax.xml
                 token.Parent switch
@@ -104,6 +106,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     _ => base.ClassifyIdentifier(token),
                 };
 
+            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805")]
             private TokenType? ClassifySimpleName(SimpleNameSyntax x) =>
                 IsInTypeContext(x)
                     ? ClassifySimpleNameType(x)
@@ -232,6 +235,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     _ => ClassifyIdentifierByModel(name),
                 };
 
+            [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/7805")]
             private static bool IsInTypeContext(SimpleNameSyntax name) =>
                 // Based on Syntax.xml search for Type="TypeSyntax" and Type="NameSyntax"
                 name.Parent switch

--- a/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -7,6 +7,8 @@
     <!-- .NET Standard target does not copy referenced DLLs into bin folder, so we need to enable it explicitly. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <DefineConstants>TRACE;CS</DefineConstants>
+    <!-- Avoid CS0436. see also https://github.com/dotnet/roslyn-analyzers/blob/main/src/PerformanceSensitiveAnalyzers/PerformanceSensitiveAnalyzers.md -->
+    <GeneratePerformanceSensitiveAttribute>false</GeneratePerformanceSensitiveAttribute>
   </PropertyGroup>
 
   <!-- Warning: when adding a package reference, we must make sure this package is available on oldest supported .NET version (currently netstandard2.0) or packaged with the analyzer.


### PR DESCRIPTION
The code smells are due to this bug:
https://github.com/dotnet/roslyn-analyzers/issues/6851