### PR TITLE
Fix S4158 FN: Learn Empty on Clear

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
@@ -208,13 +208,19 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
     }
 
     private static ProgramState ProcessAddMethod(ProgramState state, IMethodSymbol method, IOperation instance) =>
-        AddMethods.Contains(method.Name) ? SetOperationAndSymbolConstraint(state, instance, CollectionConstraint.NotEmpty) : null;
+        AddMethods.Contains(method.Name)
+            ? SetOperationAndSymbolConstraint(state, instance, CollectionConstraint.NotEmpty)
+            : null;
 
     private static ProgramState ProcessRemoveMethod(ProgramState state, IMethodSymbol method, IOperation instance) =>
-        RemoveMethods.Contains(method.Name) ? SetOperationAndSymbolValue(state, instance, (state[instance] ?? SymbolicValue.Empty).WithoutConstraint(CollectionConstraint.NotEmpty)) : null;
+        RemoveMethods.Contains(method.Name)
+            ? SetOperationAndSymbolValue(state, instance, (state[instance] ?? SymbolicValue.Empty).WithoutConstraint(CollectionConstraint.NotEmpty))
+            : null;
 
     private static ProgramState ProcessClearMethod(ProgramState state, IMethodSymbol method, IOperation instance) =>
-        method.Name == nameof(ICollection<int>.Clear) ? SetOperationAndSymbolConstraint(state, instance, CollectionConstraint.Empty) : state;
+        method.Name == nameof(ICollection<int>.Clear)
+            ? SetOperationAndSymbolConstraint(state, instance, CollectionConstraint.Empty)
+            : state;
 
     private static ProgramState SetOperationAndSymbolConstraint(ProgramState state, IOperation instance, SymbolicConstraint constraint) =>
         SetOperationAndSymbolValue(state, instance, (state[instance] ?? SymbolicValue.Empty).WithConstraint(constraint));

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
@@ -176,14 +176,15 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
 
     private ProgramState ProcessInvocation(SymbolicContext context, IInvocationOperationWrapper invocation)
     {
-        if (invocation.TargetMethod.Is(KnownType.System_Linq_Enumerable, nameof(Enumerable.Count))
+        var targetMethod = invocation.TargetMethod;
+        if (targetMethod.Is(KnownType.System_Linq_Enumerable, nameof(Enumerable.Count))
             && SizeConstraint(context.State, invocation.Instance ?? invocation.Arguments[0].ToArgument().Value, HasFilteringPredicate()) is { } constraint)
         {
             return context.SetOperationConstraint(constraint);
         }
         else if (invocation.Instance is { } instance)
         {
-            if (RaisingMethods.Contains(invocation.TargetMethod.Name))
+            if (RaisingMethods.Contains(targetMethod.Name))
             {
                 if (context.State[instance]?.HasConstraint(CollectionConstraint.Empty) is true)
                 {
@@ -194,9 +195,9 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
                     nonEmptyAccess.Add(context.Operation.Instance);
                 }
             }
-            return ProcessAddMethod(context.State, invocation.TargetMethod, instance)
-                ?? ProcessRemoveMethod(context.State, invocation.TargetMethod, instance)
-                ?? ProcessClearMethod(context.State, invocation.TargetMethod, instance);
+            return ProcessAddMethod(context.State, targetMethod, instance)
+                ?? ProcessRemoveMethod(context.State, targetMethod, instance)
+                ?? ProcessClearMethod(context.State, targetMethod, instance);
         }
         else
         {

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
@@ -195,7 +195,8 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
                 }
             }
             return ProcessAddMethod(context.State, invocation.TargetMethod, instance)
-                ?? ProcessRemoveMethod(context.State, invocation.TargetMethod, instance);
+                ?? ProcessRemoveMethod(context.State, invocation.TargetMethod, instance)
+                ?? ProcessClearMethod(context.State, invocation.TargetMethod, instance);
         }
         else
         {
@@ -229,6 +230,20 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
             if (instance.TrackedSymbol(state) is { } symbol)
             {
                 state = state.SetSymbolValue(symbol, value);
+            }
+            return state;
+        }
+        return null;
+    }
+
+    private static ProgramState ProcessClearMethod(ProgramState state, IMethodSymbol method, IOperation instance)
+    {
+        if (method.Name == nameof(ICollection<int>.Clear))
+        {
+            state = state.SetOperationConstraint(instance, CollectionConstraint.Empty);
+            if (instance.TrackedSymbol(state) is { } symbol)
+            {
+                state = state.SetSymbolConstraint(symbol, CollectionConstraint.Empty);
             }
         }
         return state;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -429,18 +429,28 @@ class CollectionTests
         dict.Clear();                   // Compliant
         dict.Clear();                   // Noncompliant
 
-        var empty = new List<int>();
-        list.Add(5);
-        list.Intersect(empty);          // Compliant
-        list.Clear();                   // FN
-
         list.Add(5);
         list.RemoveAll(x => true);      // Compliant
         list.Clear();                   // FN
+        list.Add(5);
+        list.RemoveAll(x => x == 1);    // Compliant
+        list.Clear();                   // Compliant
 
         set.Add(5);
         set.RemoveWhere(x => true);     // Compliant
         set.Clear();                    // FN
+        set.Add(5);
+        set.RemoveWhere(x => x == 1);   // Compliant
+        set.Clear();                    // Compliant
+
+        var empty = new List<int>();
+        set.Add(5);
+        set.IntersectWith(empty);       // Compliant
+        set.Clear();                    // FN
+        var notEmpty = new List<int> { 1 };
+        set.Add(5);
+        set.IntersectWith(notEmpty);    // Compliant
+        set.Clear();                    // Compliant
     }
 }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -412,27 +412,35 @@ class CollectionTests
     public void Method_Set_Empty(List<int> list, HashSet<int> set, Queue<int> queue, Stack<int> stack, ObservableCollection<int> obs, Dictionary<int, int> dict)
     {
         list.Clear();                   // Compliant
-        list.Clear();                   // FN
+        list.Clear();                   // Noncompliant
 
         set.Clear();                    // Compliant
-        set.Clear();                    // FN
+        set.Clear();                    // Noncompliant
 
         queue.Clear();                  // Compliant
-        queue.Clear();                  // FN
+        queue.Clear();                  // Noncompliant
 
         stack.Clear();                  // Compliant
-        stack.Clear();                  // FN
+        stack.Clear();                  // Noncompliant
 
         obs.Clear();                    // Compliant
-        obs.Clear();                    // FN
+        obs.Clear();                    // Noncompliant
 
         dict.Clear();                   // Compliant
-        dict.Clear();                   // FN
+        dict.Clear();                   // Noncompliant
 
         var empty = new List<int>();
         list.Add(5);
         list.Intersect(empty);          // Compliant
         list.Clear();                   // FN
+
+        list.Add(5);
+        list.RemoveAll(x => true);      // Compliant
+        list.Clear();                   // FN
+
+        set.Add(5);
+        set.RemoveWhere(x => true);     // Compliant
+        set.Clear();                    // FN
     }
 }
 
@@ -531,6 +539,8 @@ class AdvancedTests
         var empty = new List<int>();
         var notEmpty = new List<int>() { 1, 2, 3 };
 
+        // the tests below are messy for as long as we unlearn CollectionConstraints on empty.Count()
+
         if ((isNull ?? empty).Count == 0)
         {
             empty.Clear();  // Noncompliant
@@ -588,11 +598,11 @@ class AdvancedTests
 
         if (notEmpty.Count(x => condition) == 0)
         {
-            empty.Clear();  // FN
+            empty.Clear();  // Noncompliant
         }
         else
         {
-            empty.Clear();  // FN
+            empty.Clear();  // Noncompliant
         }
 
         if (Enumerable.Count(empty) == 0)
@@ -736,7 +746,7 @@ class Flows
         Action<int> add = list.Add;
         list.Clear();    // FN
         add(5);
-        list.Clear();    // Compliant, but will break when we learn Empty from Clear()
+        list.Clear();    // Noncompliant FP
 
         list = new List<int>();
         Action clear = list.Clear;  // We don't raise here to avoid FPs

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.vb
@@ -181,7 +181,7 @@ Public Class CollectionTests
 
     Public Sub Method_Set_Empty(List As List(Of Integer))
         List.Clear()                    ' Compliant
-        List.Clear()                    ' FN
+        List.Clear()                    ' Noncompliant
 
         Dim Empty As New List(Of Integer)
         List.Add(5)


### PR DESCRIPTION
Part of #7457 

We do not learn `CollectionEmpty` from `list.Clear()`.
```
var list = new List<int> { 1 };
list.Clear();   // Compliant
list.Clear();   // FN
```