### PR TITLE
Fix S5693 FP: custom fileUploadSizeLimit parameter ignored when parsing Web.config files

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/RequestsWithExcessiveLengthTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/RequestsWithExcessiveLengthTest.cs
@@ -107,6 +107,18 @@ namespace SonarAnalyzer.UnitTest.Rules
         }
 
         [TestMethod]
+        // Reproducer for https://github.com/SonarSource/sonar-dotnet/issues/7867
+        public void RequestsWithExcessiveLength_CS_WebConfig_CustomValues()
+        {
+            var webConfigPath = GetWebConfigPath("TestCases\\WebConfig\\RequestsWithExcessiveLength\\Values\\ContentLength_Compliant"); // 83886080
+            DiagnosticVerifier.VerifyExternalFile(
+                CreateCompilation(),
+                new CS.RequestsWithExcessiveLength(AnalyzerConfiguration.AlwaysEnabled) { FileUploadSizeLimit = 838860800 },
+                webConfigPath,
+                AnalysisScaffolding.CreateSonarProjectConfigWithFilesToAnalyze(TestContext, webConfigPath));
+        }
+
+        [TestMethod]
         public void RequestsWithExcessiveLength_CS_CorruptAndNonExistingWebConfigs_ShouldNotFail()
         {
             const string root = @"TestCases\WebConfig\RequestsWithExcessiveLength\Corrupt";

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/RequestsWithExcessiveLengthTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Hotspots/RequestsWithExcessiveLengthTest.cs
@@ -110,7 +110,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         // Reproducer for https://github.com/SonarSource/sonar-dotnet/issues/7867
         public void RequestsWithExcessiveLength_CS_WebConfig_CustomValues()
         {
-            var webConfigPath = GetWebConfigPath("TestCases\\WebConfig\\RequestsWithExcessiveLength\\Values\\ContentLength_Compliant"); // 83886080
+            var webConfigPath = GetWebConfigPath(@"TestCases\WebConfig\RequestsWithExcessiveLength\Values\ContentLength_Compliant"); // 83886080
             DiagnosticVerifier.VerifyExternalFile(
                 CreateCompilation(),
                 new CS.RequestsWithExcessiveLength(AnalyzerConfiguration.AlwaysEnabled) { FileUploadSizeLimit = 838860800 },

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/WebConfig/RequestsWithExcessiveLength/Values/ContentLength_Compliant/Web.config
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/WebConfig/RequestsWithExcessiveLength/Values/ContentLength_Compliant/Web.config
@@ -1,0 +1,12 @@
+<configuration>
+  <system.web>
+    <httpRuntime />
+  </system.web>
+  <system.webServer>
+    <security>
+      <requestFiltering>
+        <requestLimits maxAllowedContentLength="83886080" /> <!-- Noncompliant FP -->
+      </requestFiltering>
+    </security>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
Reproducer for #7867
