### PR TITLE
Bump test dependencies

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
@@ -391,7 +391,7 @@ public class Sample
             secondCondition.SuccessorBlocks.Should().BeEquivalentTo(new[] { trueBlockY, exitBlock });
             secondCondition.BranchingNode.Kind().Should().Be(SyntaxKind.FalseLiteralExpression);
 
-            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { trueBlockX, trueBlockY, secondCondition });
+            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { trueBlockX, trueBlockY, secondCondition }, x => x.IgnoringCyclicReferences());
         }
 
         [TestMethod]
@@ -417,7 +417,7 @@ public class Sample
             trueBlockY.SuccessorBlocks.Should().Equal(exitBlock);
             falseBlockZ.SuccessorBlocks.Should().Equal(exitBlock);
 
-            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { trueBlockX, trueBlockY, falseBlockZ });
+            exitBlock.PredecessorBlocks.Should().BeEquivalentTo(new[] { trueBlockX, trueBlockY, falseBlockZ }, x => x.IgnoringCyclicReferences());
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
@@ -25,15 +25,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="altcover" Version="8.6.61" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.20.0">
+    <PackageReference Include="altcover" Version="8.6.68" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions.Analyzers" Version="0.23.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.7.0-2.final" />

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SonarExplodedGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Sonar/SonarExplodedGraphTest.cs
@@ -917,8 +917,7 @@ namespace Namespace
                 }
                 """;
             var context = new ExplodedGraphContext(testInput);
-            var walk = () => context.WalkWithInstructions(2);
-            walk.Should().Throw<Exception>().WithMessage("Expected NumberOfExitBlockReached to be 1, but found 0 (difference of -1).");
+            context.WalkWithExitBlocks(2, 0);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NonDerivedPrivateClassesShouldBeSealed.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/NonDerivedPrivateClassesShouldBeSealed.CSharp11.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 
-file class ClassNotExtended { } // Noncompliant {{File-scoped classes which are not derived in the current file should be marked as 'sealed'.}}
+file class ClassNotExtended { }             // Noncompliant {{File-scoped classes which are not derived in the current file should be marked as 'sealed'.}}
 //         ^^^^^^^^^^^^^^^^
-file record RecordNotExtended { } // Noncompliant {{File-scoped record classes which are not derived in the current file should be marked as 'sealed'.}}
+file record RecordNotExtended { }           // Noncompliant {{File-scoped record classes which are not derived in the current file should be marked as 'sealed'.}}
 //          ^^^^^^^^^^^^^^^^^
-file record class RecordNotExtended2 { } // Noncompliant {{File-scoped record classes which are not derived in the current file should be marked as 'sealed'.}}
+file record class RecordNotExtended2 { }    // Noncompliant {{File-scoped record classes which are not derived in the current file should be marked as 'sealed'.}}
 //                ^^^^^^^^^^^^^^^^^^
 
 file class FileClassVirtualMethod // Compliant, the class has a virtual member.
@@ -52,52 +52,52 @@ file class TheThirdExtension : FileDerivedClassSecondExtension { } // Noncomplia
 
 file sealed class ClassNotExtendedButFile { }
 
-file struct AStruct { } // Compliant, structs cannot be inherited.
-file record struct ARecordStruct { } // Compliant, record structs cannot be inherited.
+file struct AStruct { }                 // Compliant, structs cannot be inherited.
+file record struct ARecordStruct { }    // Compliant, record structs cannot be inherited.
 
-file static class FileStaticClass { } // Compliant, static classes cannot be inherited.
+file static class FileStaticClass { }   // Compliant, static classes cannot be inherited.
 
 file abstract class FileAbstractClass { } // Compliant, abstract classes cannot be sealed.
 
 
 namespace GenericClasses
 {
-    file class NotInheritedGenericClass<T> { } // Noncompliant
-    file class InheritedGenericClass<T> { } // Compliant
+    file class NotInheritedGenericClass<T> { }  // Noncompliant
+    file class InheritedGenericClass<T> { }     // Compliant
 
-    file class ImplementationClass : InheritedGenericClass<int> { } // Noncompliant
-    file class ImplementationClass<T> : InheritedGenericClass<T> { } // Noncompliant
+    file class ImplementationClass : InheritedGenericClass<int> { }     // Noncompliant
+    file class ImplementationClass<T> : InheritedGenericClass<T> { }    // Noncompliant
 
-    file sealed class SealedImplementationClass : InheritedGenericClass<int> { } // Compliant
-    file sealed class SealedImplementationClass<T> : InheritedGenericClass<T> { } // Compliant
-    abstract class AbstractImplementationClass : InheritedGenericClass<int> { } // Compliant
-    abstract class AbstractImplementationClass<T> : InheritedGenericClass<T> { } // Compliant 
+    file sealed class SealedImplementationClass : InheritedGenericClass<int> { }        // Compliant
+    file sealed class SealedImplementationClass<T> : InheritedGenericClass<T> { }       // Compliant
+    file abstract class AbstractImplementationClass : InheritedGenericClass<int> { }    // Compliant
+    file abstract class AbstractImplementationClass<T> : InheritedGenericClass<T> { }   // Compliant
 }
 
 namespace GenericRecords
 {
-    file record NotInheritedGenericRecord<T> { } // Noncompliant
-    file record InheritedGenericRecord<T> { } // Compliant
+    file record NotInheritedGenericRecord<T> { }    // Noncompliant
+    file record InheritedGenericRecord<T> { }       // Compliant
 
-    file record ImplementationRecord : InheritedGenericRecord<int> { } // Noncompliant
+    file record ImplementationRecord : InheritedGenericRecord<int> { }  // Noncompliant
     file record ImplementationRecord<T> : InheritedGenericRecord<T> { } // Noncompliant
 
-    file sealed record SealedImplementationRecord : InheritedGenericRecord<int> { } // Compliant
-    file sealed record SealedImplementationRecord<T> : InheritedGenericRecord<T> { } // Compliant
-    abstract record AbstractImplementationRecord : InheritedGenericRecord<int> { } // Compliant
-    abstract record AbstractImplementationRecord<T> : InheritedGenericRecord<T> { } // Compliant
+    file sealed record SealedImplementationRecord : InheritedGenericRecord<int> { }         // Compliant
+    file sealed record SealedImplementationRecord<T> : InheritedGenericRecord<T> { }        // Compliant
+    file abstract record AbstractImplementationRecord : InheritedGenericRecord<int> { }     // Compliant
+    file abstract record AbstractImplementationRecord<T> : InheritedGenericRecord<T> { }    // Compliant
 }
 
 namespace GenericRecordClasses
 {
-    file record class NotInheritedGenericRecord<T> { } // Noncompliant
-    file record class InheritedGenericRecord<T> { } // Compliant
+    file record class NotInheritedGenericRecord<T> { }  // Noncompliant
+    file record class InheritedGenericRecord<T> { }     // Compliant
 
-    file record class ImplementationRecord : InheritedGenericRecord<int> { } // Noncompliant
-    file record class ImplementationRecord<T> : InheritedGenericRecord<T> { } // Noncompliant
+    file record class ImplementationRecord : InheritedGenericRecord<int> { }    // Noncompliant
+    file record class ImplementationRecord<T> : InheritedGenericRecord<T> { }   // Noncompliant
 
-    file sealed record class SealedImplementationRecord : InheritedGenericRecord<int> { } // Compliant
-    file sealed record class SealedImplementationRecord<T> : InheritedGenericRecord<T> { } // Compliant
-    abstract record class AbstractImplementationRecord : InheritedGenericRecord<int> { } // Compliant
-    abstract record class AbstractImplementationRecord<T> : InheritedGenericRecord<T> { } // Compliant
+    file sealed record class SealedImplementationRecord : InheritedGenericRecord<int> { }       // Compliant
+    file sealed record class SealedImplementationRecord<T> : InheritedGenericRecord<T> { }      // Compliant
+    file abstract record class AbstractImplementationRecord : InheritedGenericRecord<int> { }   // Compliant
+    file abstract record class AbstractImplementationRecord<T> : InheritedGenericRecord<T> { }  // Compliant
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/packages.lock.json
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/packages.lock.json
@@ -4,24 +4,24 @@
     ".NETFramework,Version=v4.8": {
       "altcover": {
         "type": "Direct",
-        "requested": "[8.6.61, )",
-        "resolved": "8.6.61",
-        "contentHash": "BepkWBHOE6HblEPtrl0LqC8a1Zxpb50fMFhsZd1+206aRJ6LenXidUC9+HfggYweQWfccEZrHc0RMulBn7T5qA=="
+        "requested": "[8.6.68, )",
+        "resolved": "8.6.68",
+        "contentHash": "Q/9iaREaVi2RakQLiCVUYGVKuuvqog0YPsHwpkOjEG8RiCbnqp1ujmH0lQEyQGZP0v3Y2mqYvdZEaH9BjFGuFA=="
       },
       "FluentAssertions": {
         "type": "Direct",
-        "requested": "[6.11.0, )",
-        "resolved": "6.11.0",
-        "contentHash": "aBaagwdNtVKkug1F3imGXUlmoBd8ZUZX8oQ5niThaJhF79SpESe1Gzq7OFuZkQdKD5Pa4Mone+jrbas873AT4g==",
+        "requested": "[6.12.0, )",
+        "resolved": "6.12.0",
+        "contentHash": "ZXhHT2YwP9lajrwSKbLlFqsmCCvFJMoRSK9t7sImfnCyd0OB3MhgxdoMcVqxbq1iyxD6mD2fiackWmBb7ayiXQ==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.0"
         }
       },
       "FluentAssertions.Analyzers": {
         "type": "Direct",
-        "requested": "[0.20.0, )",
-        "resolved": "0.20.0",
-        "contentHash": "7p/ay2ynvdWdrhJdXeWooWcyfek3bTCS4cJvPHWk2H1t5X4nACCF3QeWFEGB7TmXdoH/sPC4moaq7mg1THDWHA=="
+        "requested": "[0.23.0, )",
+        "resolved": "0.23.0",
+        "contentHash": "NIaSIXAargF7WoHWdDjP/n48EEOP0ypTQI+7AHAtF3+aV8QQQCI6WL0q8rH2e0DM5YuBXcv0YaV7hM6bgJznBg=="
       },
       "Microsoft.Build.Locator": {
         "type": "Direct",
@@ -86,11 +86,11 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[17.6.2, )",
-        "resolved": "17.6.2",
-        "contentHash": "+WFxuoFVBG0aewD9Psw+1I90kaRToQgMIzK20xNVRO4QRWR9Bou3qGefrZvMZ/xTC+6bAmZppFbpPbiHDzrPyg==",
+        "requested": "[17.6.3, )",
+        "resolved": "17.6.3",
+        "contentHash": "MglaNTl646dC2xpHKotSk1xscmHO5uV3x3NK057IUA9BM3Wgl16WMEb9ptGczk518JfLd1+Th5OAYwnoWgHQQQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "17.6.2"
+          "Microsoft.CodeCoverage": "17.6.3"
         }
       },
       "Moq": {
@@ -105,15 +105,15 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[3.0.4, )",
-        "resolved": "3.0.4",
-        "contentHash": "18THEGVcU4fbAOZWvRtEyvQCnZ/o+3LFAiFbAkWYh63GC5TmHoJ10IUiF9L02SMmbLbWpH1/PxvO7mcInIY4/Q=="
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "kMvdO5dhrUR3o1qk0fzS0St0prlKyMQAfz1ChVAUdGGobTU5ehR60szOFto0+Q7rFG5iXMvTlVIthXM9EcNYnw=="
       },
       "MSTest.TestFramework": {
         "type": "Direct",
-        "requested": "[3.0.4, )",
-        "resolved": "3.0.4",
-        "contentHash": "hYq5xOOr2k09rtXpmcHkJ4Tdt/yS4cy8jiFPNMdDJP+lB6OY8yekOmQC4Fsvug4rhLpXGDd6zbPWYeoewqfePA=="
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "3rjkGxciNHHmPW8cl1/QVIYjOpfptjmAH5JrLBw+dnMTYDoweg3I579N7OIbar3Zd3q9dfWFrCy2LEV/AmPn3A=="
       },
       "NuGet.Protocol": {
         "type": "Direct",
@@ -203,8 +203,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "17.6.2",
-        "contentHash": "t+DjPlq7GIxIkOK/jiTmNeiEMVkfVCynBEZyV+IMg2ro43NugKExng+7a04R1fBLi+d6voxjeDxL2ozdl+XyVg=="
+        "resolved": "17.6.3",
+        "contentHash": "Gorg6F1dOxlI28yHYKhbQ3pOOfHeW6sUfsmwFQFaIV+xttUAZ+l8KarHIfsR+rBAnjY9VH71BXvPXBuObCkXsw=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
@@ -447,24 +447,24 @@
     "net7.0": {
       "altcover": {
         "type": "Direct",
-        "requested": "[8.6.61, )",
-        "resolved": "8.6.61",
-        "contentHash": "BepkWBHOE6HblEPtrl0LqC8a1Zxpb50fMFhsZd1+206aRJ6LenXidUC9+HfggYweQWfccEZrHc0RMulBn7T5qA=="
+        "requested": "[8.6.68, )",
+        "resolved": "8.6.68",
+        "contentHash": "Q/9iaREaVi2RakQLiCVUYGVKuuvqog0YPsHwpkOjEG8RiCbnqp1ujmH0lQEyQGZP0v3Y2mqYvdZEaH9BjFGuFA=="
       },
       "FluentAssertions": {
         "type": "Direct",
-        "requested": "[6.11.0, )",
-        "resolved": "6.11.0",
-        "contentHash": "aBaagwdNtVKkug1F3imGXUlmoBd8ZUZX8oQ5niThaJhF79SpESe1Gzq7OFuZkQdKD5Pa4Mone+jrbas873AT4g==",
+        "requested": "[6.12.0, )",
+        "resolved": "6.12.0",
+        "contentHash": "ZXhHT2YwP9lajrwSKbLlFqsmCCvFJMoRSK9t7sImfnCyd0OB3MhgxdoMcVqxbq1iyxD6mD2fiackWmBb7ayiXQ==",
         "dependencies": {
           "System.Configuration.ConfigurationManager": "4.4.0"
         }
       },
       "FluentAssertions.Analyzers": {
         "type": "Direct",
-        "requested": "[0.20.0, )",
-        "resolved": "0.20.0",
-        "contentHash": "7p/ay2ynvdWdrhJdXeWooWcyfek3bTCS4cJvPHWk2H1t5X4nACCF3QeWFEGB7TmXdoH/sPC4moaq7mg1THDWHA=="
+        "requested": "[0.23.0, )",
+        "resolved": "0.23.0",
+        "contentHash": "NIaSIXAargF7WoHWdDjP/n48EEOP0ypTQI+7AHAtF3+aV8QQQCI6WL0q8rH2e0DM5YuBXcv0YaV7hM6bgJznBg=="
       },
       "Microsoft.Build.Locator": {
         "type": "Direct",
@@ -529,12 +529,12 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[17.6.2, )",
-        "resolved": "17.6.2",
-        "contentHash": "+WFxuoFVBG0aewD9Psw+1I90kaRToQgMIzK20xNVRO4QRWR9Bou3qGefrZvMZ/xTC+6bAmZppFbpPbiHDzrPyg==",
+        "requested": "[17.6.3, )",
+        "resolved": "17.6.3",
+        "contentHash": "MglaNTl646dC2xpHKotSk1xscmHO5uV3x3NK057IUA9BM3Wgl16WMEb9ptGczk518JfLd1+Th5OAYwnoWgHQQQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "17.6.2",
-          "Microsoft.TestPlatform.TestHost": "17.6.2"
+          "Microsoft.CodeCoverage": "17.6.3",
+          "Microsoft.TestPlatform.TestHost": "17.6.3"
         }
       },
       "Moq": {
@@ -548,15 +548,15 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[3.0.4, )",
-        "resolved": "3.0.4",
-        "contentHash": "18THEGVcU4fbAOZWvRtEyvQCnZ/o+3LFAiFbAkWYh63GC5TmHoJ10IUiF9L02SMmbLbWpH1/PxvO7mcInIY4/Q=="
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "kMvdO5dhrUR3o1qk0fzS0St0prlKyMQAfz1ChVAUdGGobTU5ehR60szOFto0+Q7rFG5iXMvTlVIthXM9EcNYnw=="
       },
       "MSTest.TestFramework": {
         "type": "Direct",
-        "requested": "[3.0.4, )",
-        "resolved": "3.0.4",
-        "contentHash": "hYq5xOOr2k09rtXpmcHkJ4Tdt/yS4cy8jiFPNMdDJP+lB6OY8yekOmQC4Fsvug4rhLpXGDd6zbPWYeoewqfePA=="
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "3rjkGxciNHHmPW8cl1/QVIYjOpfptjmAH5JrLBw+dnMTYDoweg3I579N7OIbar3Zd3q9dfWFrCy2LEV/AmPn3A=="
       },
       "NuGet.Protocol": {
         "type": "Direct",
@@ -649,8 +649,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "17.6.2",
-        "contentHash": "t+DjPlq7GIxIkOK/jiTmNeiEMVkfVCynBEZyV+IMg2ro43NugKExng+7a04R1fBLi+d6voxjeDxL2ozdl+XyVg=="
+        "resolved": "17.6.3",
+        "contentHash": "Gorg6F1dOxlI28yHYKhbQ3pOOfHeW6sUfsmwFQFaIV+xttUAZ+l8KarHIfsR+rBAnjY9VH71BXvPXBuObCkXsw=="
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
@@ -659,8 +659,8 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "17.6.2",
-        "contentHash": "I3S/oELDAe/ckFltBnPb0PV+gADbpc8n0yGTtYfTd7q1hd0cAZKn/FrYoegA/rGws8fEFyJD/2PB6uq+nIjWsg==",
+        "resolved": "17.6.3",
+        "contentHash": "gSqtX3RvcFisaLPs6sKXdZkSwUix83NQ9nOU/w6pYrHTl+d8GsVHSL9rvDNxMgoV5BNOdyU7zK7JOfbSaVMDWQ==",
         "dependencies": {
           "NuGet.Frameworks": "6.5.0",
           "System.Reflection.Metadata": "1.6.0"
@@ -668,10 +668,10 @@
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "17.6.2",
-        "contentHash": "WszrF1CoG+Y2bA4WJFxlaPADQCWUuNP6TCxVRuScmP6DQsNvDDuOO9XiUxCA+wPmNOSyWVh9EGrPu7JoUpf2gA==",
+        "resolved": "17.6.3",
+        "contentHash": "lrgRXKFfIZSPlhuoQGLtciO/osL+4oADYEYb0d5or7n7YyJATIWespq3lRgz2IQpRh6N7cm0DnCOWeZiCRGzxA==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "17.6.2",
+          "Microsoft.TestPlatform.ObjectModel": "17.6.3",
           "Newtonsoft.Json": "13.0.1"
         }
       },

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,7 @@ stages:
 
       - powershell: |
           cd analyzers
-          & dotnet test -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=coverage/coverage.xml
+          & dotnet test -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=coverage/coverage.xml
         displayName: '.Net UTs'
 
       - task: PublishPipelineArtifact@1


### PR DESCRIPTION
Replaces #7856, #7872, #7613, #7571

Latest SDK fails due to altcover clash: https://github.com/microsoft/vstest/issues/4106
