### PR TITLE
Java ITs: Update test to not take order of issues into consideration

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -2285,12 +2285,16 @@ namespace Tests.Diagnostics
                     return;
                 }
             }
+        }
 
-            steps = 0;
+        public void FP_Increment_2(List<int> list)
+        {
+            int MaxStepCount = 200;
+            int steps = 0;
             while (list.Any())
             {
                 steps = steps + 1;
-                if (steps > MaxStepCount)
+                if (steps > MaxStepCount) // Noncompliant FP
                 {
                     return;
                 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -2290,7 +2290,7 @@ namespace Tests.Diagnostics
             while (list.Any())
             {
                 steps = steps + 1;
-                if (steps > MaxStepCount) // Noncompliant FP
+                if (steps > MaxStepCount)
                 {
                     return;
                 }

--- a/its/src/test/java/com/sonar/it/csharp/SharedFilesTest.java
+++ b/its/src/test/java/com/sonar/it/csharp/SharedFilesTest.java
@@ -33,13 +33,13 @@ import static com.sonar.it.csharp.Tests.getMeasureAsInt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(Tests.class)
-public class SharedFilesTest {
+class SharedFilesTest {
 
   @TempDir
   private static Path temp;
 
   @Test
-  public void should_analyze_shared_files() throws Exception {
+  void should_analyze_shared_files() throws Exception {
     BuildResult buildResult = Tests.analyzeProject(temp, "SharedFilesTest", null, "sonar.cs.vscoveragexml.reportsPaths", "reports/visualstudio.coveragexml");
 
     assertThat(getComponent("SharedFilesTest:Class1.cs")).isNotNull();
@@ -55,7 +55,7 @@ public class SharedFilesTest {
     assertThat(issues)
       .hasSize(2)
       .extracting(Issue::getRule)
-      .containsExactly("csharpsquid:S3903", "external_roslyn:CA1050");
+      .containsExactlyInAnyOrder("csharpsquid:S3903", "external_roslyn:CA1050");
 
     assertThat(buildResult.getLogsLines(l -> l.contains("INFO"))).contains("INFO: Found 2 MSBuild C# projects: 2 MAIN projects.");
   }


### PR DESCRIPTION
Issues are not always in the same order and this breaks the pipeline.

Access modifiers were also removed to increase readability - the public modifier is not needed with junit5- default one is enough.