### PR TITLE
Add .AddSnippet() support for .razor and .cshtml snippets

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
@@ -220,6 +220,10 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                     {
                         File.Copy(file, Path.Combine(tempPath, lang, Path.GetFileName(file)));
                     }
+                    foreach (var snippet in builder.Snippets)
+                    {
+                        File.WriteAllText(Path.Combine(tempPath, lang, snippet.FileName), snippet.Content);
+                    }
                     var csprojPath = Path.Combine(tempPath, lang, "EmptyProject.csproj");
                     var destinationXml = XElement.Load(csprojPath);
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
@@ -107,7 +107,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                         builder.ErrorBehavior,
                         builder.SonarProjectConfigPath,
                         onlyDiagnosticIds,
-                        builder.Paths.Where(x => x.EndsWith(".razor", StringComparison.OrdinalIgnoreCase) || x.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)).Select(x => TestCasePath(x)));
+                        builder.Paths.Where(builder.IsRazorOrCshtmlFile).Select(TestCasePath));
                 }
                 else
                 {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             this with
             {
                 Paths = Paths.Concat(paths).ToImmutableArray(),
-                IsRazor = IsRazor || Array.Exists(paths, x => x.EndsWith(".razor", StringComparison.OrdinalIgnoreCase) || x.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase))
+                IsRazor = IsRazor || Array.Exists(paths, IsRazorOrCshtmlFile)
             };
 
         public VerifierBuilder AddReferences(IEnumerable<MetadataReference> references) =>
@@ -76,8 +76,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public VerifierBuilder AddSnippet(string snippet, string fileName = null) =>
             this with {
                 Snippets = Snippets.Append(new(snippet, fileName)).ToImmutableArray(),
-                IsRazor = IsRazor
-                    || (!string.IsNullOrEmpty(fileName) && (fileName.EndsWith(".razor", StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)))
+                IsRazor = IsRazor || IsRazorOrCshtmlFile(fileName)
             };
 
         /// <summary>
@@ -150,6 +149,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .WithOutputKind(OutputKind.ConsoleApplication)
                 .WithConcurrentAnalysis(false);
         }
+
+        public bool IsRazorOrCshtmlFile(string fileName) =>
+            !string.IsNullOrEmpty(fileName) && (fileName.EndsWith(".razor", StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase));
 
         public Verifier Build() =>
             new(this);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
@@ -151,11 +151,11 @@ namespace SonarAnalyzer.UnitTest.TestFramework
                 .WithConcurrentAnalysis(false);
         }
 
-        public bool IsRazorOrCshtmlFile(string fileName) =>
-            !string.IsNullOrEmpty(fileName) && (fileName.EndsWith(".razor", StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase));
-
         public Verifier Build() =>
             new(this);
+
+        internal bool IsRazorOrCshtmlFile(string fileName) =>
+            !string.IsNullOrEmpty(fileName) && (fileName.EndsWith(".razor", StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase));
     }
 
     internal record VerifierBuilder<TAnalyzer> : VerifierBuilder

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
@@ -74,7 +74,10 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             this with { References = References.Concat(references).ToImmutableArray() };
 
         public VerifierBuilder AddSnippet(string snippet, string fileName = null) =>
-            this with { Snippets = Snippets.Append(new(snippet, fileName)).ToImmutableArray() };
+            this with {
+                Snippets = Snippets.Append(new(snippet, fileName)).ToImmutableArray(),
+                IsRazor = IsRazor || fileName.EndsWith(".razor", StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
+            };
 
         /// <summary>
         /// Add a test reference to change the project type to Test project.

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
@@ -74,8 +74,9 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             this with { References = References.Concat(references).ToImmutableArray() };
 
         public VerifierBuilder AddSnippet(string snippet, string fileName = null) =>
-            this with {
-                Snippets = Snippets.Append(new(snippet, fileName)).ToImmutableArray(),
+            this with
+            {
+                Snippets = Snippets.Add(new(snippet, fileName)),
                 IsRazor = IsRazor || IsRazorOrCshtmlFile(fileName)
             };
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
@@ -76,7 +76,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public VerifierBuilder AddSnippet(string snippet, string fileName = null) =>
             this with {
                 Snippets = Snippets.Append(new(snippet, fileName)).ToImmutableArray(),
-                IsRazor = IsRazor || fileName.EndsWith(".razor", StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)
+                IsRazor = IsRazor
+                    || (!string.IsNullOrEmpty(fileName) && (fileName.EndsWith(".razor", StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase)))
             };
 
         /// <summary>


### PR DESCRIPTION
Part of #7893

This way we can write UTs adding snippets of code instead of in-memory files only.
`<VerifierBuilder>.AddSnippet("""<p>Hi there!</p>""", "Test.razor").Verify();`