### PR TITLE
SE: Fix S4158 FP: Interfaces are only half tracked

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
@@ -32,12 +32,16 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
     private static readonly KnownType[] TrackedCollectionTypes = new[]
     {
         KnownType.System_Collections_Generic_List_T,
+        KnownType.System_Collections_Generic_IList_T,
+        KnownType.System_Collections_Generic_ICollection_T,
         KnownType.System_Collections_Generic_HashSet_T,
+        KnownType.System_Collections_Generic_ISet_T,
         KnownType.System_Collections_Generic_Queue_T,
         KnownType.System_Collections_Generic_Stack_T,
         KnownType.System_Collections_ObjectModel_ObservableCollection_T,
         KnownType.System_Array,
-        KnownType.System_Collections_Generic_Dictionary_TKey_TValue
+        KnownType.System_Collections_Generic_Dictionary_TKey_TValue,
+        KnownType.System_Collections_Generic_IDictionary_TKey_TValue,
     };
 
     protected static readonly HashSet<string> RaisingMethods = new()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -492,6 +492,16 @@ class AdvancedTests
         customIList.Clear();                                // Noncompliant
         customIList.Add(5);
         customIList.Clear();                                // Compliant
+
+        IEnumerable<int> enumerable = new List<int>();
+        enumerable.GetEnumerator();                         // Noncompliant
+        enumerable = new List<int> { 5 };
+        enumerable.GetEnumerator();                         // Compliant
+
+        IReadOnlyList<int> readOnly = new List<int>();
+        readOnly.GetEnumerator();                           // Noncompliant
+        readOnly = new List<int> { 5 };
+        readOnly.GetEnumerator();                           // Compliant
     }
 
     public void UnknownExtensionMethods()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -474,7 +474,7 @@ class AdvancedTests
         public void AddMethodWithDifferentName(int item) { }
     }
 
-    public void AssignmentToDifferentType()
+    public void AssignmentToInterface()
     {
         IList<int> iList = new List<int>();
         iList.Add(5);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -478,19 +478,19 @@ class AdvancedTests
     {
         IList<int> iList = new List<int>();
         iList.Add(5);
-        iList.Clear();                                      // Noncompliant FP
+        iList.Clear();                                      // Compliant
 
         ICollection<int> iCollection = new List<int>();
         iCollection.Add(5);
-        iCollection.Clear();                                // Noncompliant FP
+        iCollection.Clear();                                // Compliant
 
         ISet<int> iSet = new HashSet<int>();
         iSet.Add(5);
-        iSet.Clear();                                       // Noncompliant FP
+        iSet.Clear();                                       // Compliant
 
         IDictionary<int, int> iDictionary = new Dictionary<int, int>();
         iDictionary.Add(1, 5);
-        iDictionary.Clear();                                // Noncompliant FP
+        iDictionary.Clear();                                // Compliant
     }
 
     public void UnknownExtensionMethods()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -468,12 +469,6 @@ class AdvancedTests
         custom.Clear();                                     // Compliant
     }
 
-    class CustomCollection
-    {
-        public void Clear() { }
-        public void AddMethodWithDifferentName(int item) { }
-    }
-
     public void AssignmentToInterface()
     {
         IList<int> iList = new List<int>();
@@ -491,6 +486,12 @@ class AdvancedTests
         IDictionary<int, int> iDictionary = new Dictionary<int, int>();
         iDictionary.Add(1, 5);
         iDictionary.Clear();                                // Compliant
+
+        IList<int> customIList = new CustomIList();
+        customIList.Clear();                                // Compliant, state is unknown
+        customIList.Clear();                                // Noncompliant
+        customIList.Add(5);
+        customIList.Clear();                                // Compliant
     }
 
     public void UnknownExtensionMethods()
@@ -723,6 +724,29 @@ class AdvancedTests
     }
 
     void Foo(List<int> items) { }
+
+    class CustomCollection
+    {
+        public void Clear() { }
+        public void AddMethodWithDifferentName(int item) { }
+    }
+
+    class CustomIList : IList<int>
+    {
+        public int this[int index] { get => 0; set => Add(value); }
+        public int Count => throw new NotImplementedException();
+        public bool IsReadOnly => throw new NotImplementedException();
+        public void Add(int item) => throw new NotImplementedException();
+        public void Clear() => throw new NotImplementedException();
+        public bool Contains(int item) => throw new NotImplementedException();
+        public void CopyTo(int[] array, int arrayIndex) => throw new NotImplementedException();
+        public IEnumerator<int> GetEnumerator() => throw new NotImplementedException();
+        public int IndexOf(int item) => throw new NotImplementedException();
+        public void Insert(int index, int item) => throw new NotImplementedException();
+        public bool Remove(int item) => throw new NotImplementedException();
+        public void RemoveAt(int index) => throw new NotImplementedException();
+        IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+    }
 }
 
 static class CustomExtensions

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -474,6 +474,25 @@ class AdvancedTests
         public void AddMethodWithDifferentName(int item) { }
     }
 
+    public void AssignmentToDifferentType()
+    {
+        IList<int> iList = new List<int>();
+        iList.Add(5);
+        iList.Clear();                                      // Noncompliant FP
+
+        ICollection<int> iCollection = new List<int>();
+        iCollection.Add(5);
+        iCollection.Clear();                                // Noncompliant FP
+
+        ISet<int> iSet = new HashSet<int>();
+        iSet.Add(5);
+        iSet.Clear();                                       // Noncompliant FP
+
+        IDictionary<int, int> iDictionary = new Dictionary<int, int>();
+        iDictionary.Add(1, 5);
+        iDictionary.Clear();                                // Noncompliant FP
+    }
+
     public void UnknownExtensionMethods()
     {
         var list = new List<int>();


### PR DESCRIPTION
```
IList<int> iList = new List<int>();
iList.Add(5);
iList.Clear();                                      // Noncompliant FP
```