### PR TITLE
UTs: Delete HashSet with deleted rule IDs

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeTest.cs
@@ -26,10 +26,6 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
     [TestClass]
     public class RuleTypeTest
     {
-        // Rules that have been deprecated and deleted.
-        // When changing this please do not forget to notify the product teams (SQ, SC, SL).
-        private static readonly HashSet<string> DeletedRules = new() { "S1145", "S1697", "S2070", "S2255", "S2278", "S2758", "S3693", "S4142", "S4432", "S4787", "S4818"};
-
         [TestMethod]
         public void DetectRuleTypeChanges_CS() =>
             DetectTypeChanges(csharp::SonarAnalyzer.RuleCatalog.Rules, RuleTypeMappingCS.Rules, nameof(RuleTypeMappingCS));
@@ -55,9 +51,7 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
             var newRules = items.Where(x => x.ExpectedType is null);
             newRules.Should().BeEmpty($"you need to add the rules in {expectedTypesName}");
 
-            items.Should().NotContain(
-                x => x.ActualType == null && !DeletedRules.Contains($"S{x.RuleId}"),
-                "YOU SHOULD NEVER DELETE RULES! Rules should not be deleted without careful consideration and prior deprecation. We need to notify the product teams (SQ, SC, SL) as well.");
+            items.Should().NotContain(x => x.ActualType == null);
 
             var changedRules = items.Where(x => x.ActualType != null && x.ExpectedType != null);
             changedRules.Should().BeEmpty($"you need to change the rule types in {expectedTypesName}.");

--- a/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/PackagingTests/RuleTypeTest.cs
@@ -49,17 +49,13 @@ namespace SonarAnalyzer.UnitTest.PackagingTests
                                   .ToList();
 
             var newRules = rulesWithUnmatchingType.Where(x => x.ExpectedType is null);
-            newRules
-                .Should()
-                .BeEmpty($": there are rules that exist in '{language}::SonarAnalyzer.RuleCatalog.Rules' file but not in {expectedTypesName}. You need to add them to the latter");
+            newRules.Should().BeEmpty($"there are rules that exist in '{language}::SonarAnalyzer.RuleCatalog.Rules' file but not in {expectedTypesName}. Run Rspec.ps1 or add them manually to the rule type mapping test.");
 
-            var ruleWithoutActualTypeExists = rulesWithUnmatchingType.Exists(x => x.ActualType is null);
-            ruleWithoutActualTypeExists
-                .Should()
-                .BeFalse($": there are rules that exist in {expectedTypesName} but not in '{language}::SonarAnalyzer.RuleCatalog.Rules' file. You might have forgotten to update the RSpec for sonar-dotnet");
+            var rulesWithoutImplementation = rulesWithUnmatchingType.Exists(x => x.ActualType is null);
+            rulesWithoutImplementation.Should().BeFalse($"there are rules that exist in {expectedTypesName} but not in '{language}::SonarAnalyzer.RuleCatalog.Rules' file.");
 
             var changedRules = rulesWithUnmatchingType.Where(x => x.ActualType != null && x.ExpectedType != null);
-            changedRules.Should().BeEmpty($": you need to change the rule types in {expectedTypesName}");
+            changedRules.Should().BeEmpty($"you need to change the rule type in {expectedTypesName}");
         }
     }
 }


### PR DESCRIPTION
Should be merged after https://github.com/SonarSource/sonar-dotnet/pull/7942.

This HashSet does not seem to serve as a safety net since if we delete a rule and forget to add it there it still does not fail.
Also, the comments are not particularly useful in that place.

Currently, I'm in contact with SQ, SC, and SL to understand what kind of information they need and through what channel once we delete a rule. I'll add this knowledge to an xtranet page (called "How to delete a rule in sonar-dotnet") and maybe in the read me here.


Review only [delete hashet](https://github.com/SonarSource/sonar-dotnet/pull/7948/commits/83821db43e93ad785b1af99259945bdb134ac499) commit.