### PR TITLE
Ensure that utility analyzers are invoked only for .razor generated files

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Metrics/CSharpExecutableLinesMetric.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Metrics/CSharpExecutableLinesMetric.cs
@@ -30,12 +30,9 @@ namespace SonarAnalyzer.Metrics.CSharp
         }
 
         private static ExecutableLinesWalker GetWalker(SyntaxTree syntaxTree, SemanticModel semanticModel) =>
-            syntaxTree switch
-            {
-                _ when GeneratedCodeRecognizer.IsCshtml(syntaxTree) => new CshtmlExecutableLinesWalker(semanticModel),
-                _ when GeneratedCodeRecognizer.IsRazor(syntaxTree) => new RazorExecutableLinesWalker(semanticModel),
-                _ => new ExecutableLinesWalker(semanticModel)
-            };
+            GeneratedCodeRecognizer.IsRazor(syntaxTree)
+                ? new RazorExecutableLinesWalker(semanticModel)
+                : new ExecutableLinesWalker(semanticModel);
 
         private class ExecutableLinesWalker : SafeCSharpSyntaxWalker
         {
@@ -160,14 +157,6 @@ namespace SonarAnalyzer.Metrics.CSharp
                 }
                 return false;
             }
-        }
-
-        private sealed class CshtmlExecutableLinesWalker : ExecutableLinesWalker
-        {
-            public CshtmlExecutableLinesWalker(SemanticModel model) : base(model) { }
-
-            // HTML plugin is responsible to compute the metrics
-            protected override bool AddExecutableLineNumbers(Location location) => false;
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxTreeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxTreeExtensions.cs
@@ -44,9 +44,9 @@ internal static class SyntaxTreeExtensions
             : cache.GetOrAdd(tree, generatedCodeRecognizer.IsGenerated(tree));
     }
 
-    public static bool IsConsideredGenerated(this SyntaxTree tree, GeneratedCodeRecognizer generatedCodeRecognizer, Compilation compilation) =>
+    public static bool IsConsideredGenerated(this SyntaxTree tree, GeneratedCodeRecognizer generatedCodeRecognizer, Compilation compilation, bool onlyRazorExtension = false) =>
         IsRazorAnalysisEnabled()
-            ? IsGenerated(tree, generatedCodeRecognizer, compilation) && !GeneratedCodeRecognizer.IsRazorGeneratedFile(tree)
+            ? IsGenerated(tree, generatedCodeRecognizer, compilation) && !GeneratedCodeRecognizer.IsRazorGeneratedFile(tree, onlyRazorExtension)
             : IsGenerated(tree, generatedCodeRecognizer, compilation);
 
     private static bool IsRazorAnalysisEnabled()

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/GeneratedCodeRecognizer.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/GeneratedCodeRecognizer.cs
@@ -58,14 +58,22 @@ namespace SonarAnalyzer.Helpers
              !string.IsNullOrEmpty(tree.FilePath)
              && (HasGeneratedFileName(tree) || HasGeneratedCommentOrAttribute(tree));
 
-        public static bool IsRazorGeneratedFile(SyntaxTree tree) =>
-            tree is not null && (IsRazor(tree) || IsCshtml(tree));
+        public static bool IsRazorGeneratedFile(SyntaxTree tree, bool onlyRazorExtension = false)
+        {
+            if (tree is null)
+            {
+                return false;
+            }
+            return onlyRazorExtension
+                       ? IsRazor(tree)
+                       : IsRazor(tree) || IsCshtml(tree);
+        }
 
         public static bool IsRazor(SyntaxTree tree) =>
             tree.FilePath.EndsWith("razor.g.cs", StringComparison.OrdinalIgnoreCase)
             || tree.FilePath.EndsWith("razor.ide.g.cs", StringComparison.OrdinalIgnoreCase);
 
-        public static bool IsCshtml(SyntaxTree tree) =>
+        private static bool IsCshtml(SyntaxTree tree) =>
             tree.FilePath.EndsWith("cshtml.g.cs", StringComparison.OrdinalIgnoreCase)
             || tree.FilePath.EndsWith("cshtml.ide.g.cs", StringComparison.OrdinalIgnoreCase);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -114,7 +114,7 @@ namespace SonarAnalyzer.Rules
             // The results of Metrics and CopyPasteToken analyzers are not needed for Test projects yet the plugin side expects the protobuf files, so we create empty ones.
             (AnalyzeTestProjects || !IsTestProject)
             && FileExtensionWhitelist.Contains(Path.GetExtension(tree.FilePath))
-            && (AnalyzeGeneratedCode || !tree.IsConsideredGenerated(Language.GeneratedCodeRecognizer, compilation));
+            && (AnalyzeGeneratedCode || !tree.IsConsideredGenerated(Language.GeneratedCodeRecognizer, compilation, true));
 
         protected static string GetFilePath(SyntaxTree syntaxTree) =>
             // If the syntax tree is constructed for a razor generated file, we need to provide the original file path.

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Metrics/CSharpExecutableLinesMetricTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Metrics/CSharpExecutableLinesMetricTest.cs
@@ -27,7 +27,6 @@ namespace SonarAnalyzer.UnitTest.Common
     public class CSharpExecutableLinesMetricTest
     {
         private const string RazorFile = "Test.razor";
-        private const string CshtmlFile = "Test.cshtml";
 
         [TestMethod]
         public void GetLineNumbers_NoExecutableLines() =>
@@ -874,10 +873,8 @@ class Program
 
 #if NET
 
-        [DataTestMethod]
-        [DataRow(RazorFile)]
-        [DataRow(CshtmlFile)]
-        public void GetLineNumbers_Razor_NoExecutableLines(string fileName) =>
+        [TestMethod]
+        public void GetLineNumbers_Razor_NoExecutableLines() =>
             AssertLineNumbersOfExecutableLinesRazor("""
 <p>Hello world!</p>
 @* Noncompliant *@
@@ -887,12 +884,10 @@ class Program
     {
     }
 }
-""", fileName);
+""", RazorFile);
 
-        [DataTestMethod]
-        [DataRow(RazorFile, 4, 6)]
-        [DataRow(CshtmlFile)]
-        public void GetLineNumbers_Razor_FieldReference(string fileName, params int[] expectedExecutableLines) =>
+        [TestMethod]
+        public void GetLineNumbers_Razor_FieldReference() =>
             AssertLineNumbersOfExecutableLinesRazor("""
 @page "/razor"
 @using TestCases
@@ -904,12 +899,10 @@ class Program
 @code {
     private int currentCount = 0;
 }
-""", fileName, expectedExecutableLines);
+""", RazorFile, 4, 6);
 
-        [DataTestMethod]
-        [DataRow(RazorFile, 2, 10, 15)]
-        [DataRow(CshtmlFile)]
-        public void GetLineNumbers_Razor_MethodReferenceAndCall(string fileName, params int[] expectedExecutableLines) =>
+        [TestMethod]
+        public void GetLineNumbers_Razor_MethodReferenceAndCall() =>
             AssertLineNumbersOfExecutableLinesRazor("""
 <button @onclick="IncrementCount">Increment</button>    <!-- Not counted | Razor FN -->
 <p> @(ShowAmount()) </p>                                <!-- +1 -->
@@ -928,12 +921,10 @@ class Program
         return $"Amount: {IncrementAmount}";            // +1
     }
 }
-""", fileName, expectedExecutableLines);
+""", RazorFile, 2, 10, 15);
 
-        [DataTestMethod]
-        [DataRow(RazorFile, 1)]
-        [DataRow(CshtmlFile)]
-        public void GetLineNumbers_Razor_PropertyReference(string fileName, params int[] expectedExecutableLines) =>
+        [TestMethod]
+        public void GetLineNumbers_Razor_PropertyReference() =>
             AssertLineNumbersOfExecutableLinesRazor("""
 @IncrementAmount <!-- +1 -->
 
@@ -941,12 +932,10 @@ class Program
     [Parameter]
     public int IncrementAmount { get; set; } = 1;
 }
-""", fileName, expectedExecutableLines);
+""", RazorFile, 1);
 
-        [DataTestMethod]
-        [DataRow(RazorFile, 2, 4, 8)]
-        [DataRow(CshtmlFile)]
-        public void GetLineNumbers_Razor_Html(string fileName, params int[] expectedExecutableLines) =>
+        [TestMethod]
+        public void GetLineNumbers_Razor_Html() =>
             AssertLineNumbersOfExecutableLinesRazor("""
 <ul>
     @foreach (var todo in todos)                        <!-- +1 -->
@@ -956,12 +945,10 @@ class Program
 </ul>
 
 <h3>Todo (@todos.Count(todo => !todo.IsDone))</h3>      <!-- +1 -->
-""", fileName, expectedExecutableLines);
+""", RazorFile, 2, 4, 8);
 
-        [DataTestMethod]
-        [DataRow(RazorFile, 5)]
-        [DataRow(CshtmlFile)]
-        public void GetLineNumbers_Razor_AssignmentAndDeclarationInTheSameDeconstruction(string fileName, params int[] expectedExecutableLines) =>
+        [TestMethod]
+        public void GetLineNumbers_Razor_AssignmentAndDeclarationInTheSameDeconstruction() =>
             AssertLineNumbersOfExecutableLinesRazor("""
 @code {
     void Foo()
@@ -970,12 +957,10 @@ class Program
         (i, int j) = (42, 42);      // +1
     }
 }
-""", fileName, expectedExecutableLines);
+""", RazorFile, 5);
 
-        [DataTestMethod]
-        [DataRow(RazorFile, 4, 5)]
-        [DataRow(CshtmlFile)]
-        public void GetLineNumbers_Razor_MultiLineInvocation(string fileName, params int[] expectedExecutableLines) =>
+        [TestMethod]
+        public void GetLineNumbers_Razor_MultiLineInvocation() =>
             AssertLineNumbersOfExecutableLinesRazor("""
 @code {
     public static bool Foo(int a, int b)
@@ -986,12 +971,10 @@ class Program
 
     public static int Bar() => 42;
 }
-""", fileName, expectedExecutableLines);
+""", RazorFile, 4, 5);
 
-        [DataTestMethod]
-        [DataRow(RazorFile, 5)]
-        [DataRow(CshtmlFile)]
-        public void GetLineNumbers_Razor_NullCoalescingAssignment(string fileName, params int[] expectedExecutableLines) =>
+        [TestMethod]
+        public void GetLineNumbers_Razor_NullCoalescingAssignment() =>
             AssertLineNumbersOfExecutableLinesRazor("""
 @code {
     void Foo()
@@ -1000,12 +983,10 @@ class Program
         numbers ??= new List<int>(); // +1
     }
 }
-""", fileName, expectedExecutableLines);
+""", RazorFile, 5);
 
-        [DataTestMethod]
-        [DataRow(RazorFile, 4, 9, 11)]
-        [DataRow(CshtmlFile)]
-        public void GetLineNumbers_Razor_MultiLinePatternMatching(string fileName, params int[] expectedExecutableLines) =>
+        [TestMethod]
+        public void GetLineNumbers_Razor_MultiLinePatternMatching() =>
             AssertLineNumbersOfExecutableLinesRazor("""
 @code {
     bool IsLetter(char c)
@@ -1020,12 +1001,10 @@ class Program
         return false;                       // +1
     }
 }
-""", fileName, expectedExecutableLines);
+""", RazorFile, 4, 9, 11);
 
-        [DataTestMethod]
-        [DataRow(RazorFile, 4, 5)]
-        [DataRow(CshtmlFile)]
-        public void GetLineNumbers_Razor_NullCoalescingOperator(string fileName, params int[] expectedExecutableLines) =>
+        [TestMethod]
+        public void GetLineNumbers_Razor_NullCoalescingOperator() =>
             AssertLineNumbersOfExecutableLinesRazor("""
 @code {
     double SumNumbers(List<double[]> setsOfNumbers, int indexOfSetToSum)
@@ -1034,12 +1013,10 @@ class Program
                 ?? double.NaN; // +1
     }
 }
-""", fileName, expectedExecutableLines);
+""", RazorFile, 4, 5);
 
-        [DataTestMethod]
-        [DataRow(RazorFile, 4, 5)]
-        [DataRow(CshtmlFile)]
-        public void GetLineNumbers_Razor_LocalFunctions(string fileName, params int[] expectedExecutableLines) =>
+        [TestMethod]
+        public void GetLineNumbers_Razor_LocalFunctions() =>
             AssertLineNumbersOfExecutableLinesRazor("""
 @code {
     void Foo()
@@ -1049,13 +1026,13 @@ class Program
         int LocalMethod() => 42;
     }
 }
-""", fileName, expectedExecutableLines);
+""", RazorFile, 4, 5);
 
 #endif
 
         private static void AssertLineNumbersOfExecutableLines(string code, params int[] expectedExecutableLines)
         {
-            (var syntaxTree, var semanticModel) = TestHelper.CompileCS(code);
+            var (syntaxTree, semanticModel) = TestHelper.CompileCS(code);
             Metrics.CSharp.CSharpExecutableLinesMetric.GetLineNumbers(syntaxTree, semanticModel).Should().BeEquivalentTo(expectedExecutableLines);
         }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/MetricsAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/MetricsAnalyzerTest.cs
@@ -31,6 +31,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         private const string BasePath = @"Utilities\MetricsAnalyzer\";
         private const string AllMetricsFileName = "AllMetrics.cs";
         private const string RazorFileName = "Razor.razor";
+        private const string CsHtmlFileName = "Razor.cshtml";
 
         public TestContext TestContext { get; set; }
 
@@ -79,6 +80,20 @@ namespace SonarAnalyzer.UnitTest.Rules
                     metrics.NonBlankComment.Should().BeEquivalentTo(new[] {13, 20, 21, 26, 27, 30, 31, 34, 35, 36, 8});
                     metrics.StatementCount.Should().Be(31);
                 });
+        }
+
+        [TestMethod]
+        public void VerifyMetrics_CsHtml()
+        {
+            using var scope = new EnvironmentVariableScope(false) { EnableRazorAnalysis = true };
+
+            CreateBuilder(false, CsHtmlFileName)
+                .WithSonarProjectConfigPath(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, ProjectType.Product))
+                .VerifyUtilityAnalyzer<MetricsInfo>(messages =>
+                    {
+                        // There should be no metrics messages for the cshtml files.
+                        messages.Select(x => Path.GetFileName(x.FilePath)).Should().BeEquivalentTo("_Imports.razor");
+                    });
         }
 
 #endif

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
@@ -195,7 +195,6 @@ namespace SonarAnalyzer.UnitTest.Rules
         {
             using var scope = new EnvironmentVariableScope(false) { EnableRazorAnalysis = true };
 
-            // Currently only the symbols from .cs files are computed since .razor support is not yet implemented.
             CreateBuilder(ProjectType.Product, "Razor.razor", "ToDo.cs", "Razor.cshtml")
                 .WithConcurrentAnalysis(false)
                 .VerifyUtilityAnalyzer<SymbolReferenceInfo>(symbols =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
@@ -196,12 +196,12 @@ namespace SonarAnalyzer.UnitTest.Rules
             using var scope = new EnvironmentVariableScope(false) { EnableRazorAnalysis = true };
 
             // Currently only the symbols from .cs files are computed since .razor support is not yet implemented.
-            CreateBuilder(ProjectType.Product, "Razor.razor", "ToDo.cs")
+            CreateBuilder(ProjectType.Product, "Razor.razor", "ToDo.cs", "Razor.cshtml")
                 .WithConcurrentAnalysis(false)
                 .VerifyUtilityAnalyzer<SymbolReferenceInfo>(symbols =>
                     {
                         var orderedSymbols = symbols.OrderBy(x => x.FilePath, StringComparer.InvariantCulture).ToArray();
-                        orderedSymbols.Select(x => Path.GetFileName(x.FilePath)).Should().Contain("_Imports.razor", "Razor.razor", "ToDo.cs");
+                        orderedSymbols.Select(x => Path.GetFileName(x.FilePath)).Should().BeEquivalentTo("_Imports.razor", "Razor.razor", "ToDo.cs");
                         orderedSymbols[0].FilePath.Should().EndWith("_Imports.razor");
                         orderedSymbols[1].FilePath.Should().EndWith("Razor.razor");
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/MetricsAnalyzer/Razor.cshtml
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/MetricsAnalyzer/Razor.cshtml
@@ -1,8 +1,7 @@
-@page
-@{
-    Layout = null;
-}
-
 <head>
     <title>Title</title>
 </head>
+
+@{
+    string message = "message";
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/MetricsAnalyzer/Razor.cshtml
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/MetricsAnalyzer/Razor.cshtml
@@ -1,0 +1,8 @@
+@page
+@{
+    Layout = null;
+}
+
+<head>
+    <title>Title</title>
+</head>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/SymbolReferenceAnalyzer/Razor.cshtml
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/SymbolReferenceAnalyzer/Razor.cshtml
@@ -1,0 +1,7 @@
+<head>
+    <title>Title</title>
+</head>
+
+@{
+    string message = "message";
+}


### PR DESCRIPTION
- .cshtml should be excluded
