### PR TITLE
Rename parameter names to match our convention

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/CopyPasteTokenAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/CopyPasteTokenAnalyzerBase.cs
@@ -41,14 +41,14 @@ namespace SonarAnalyzer.Rules
             !GeneratedCodeRecognizer.IsRazorGeneratedFile(tree)
             && base.ShouldGenerateMetrics(tree, compilation);
 
-        protected sealed override CopyPasteTokenInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override CopyPasteTokenInfo CreateMessage(SyntaxTree tree, SemanticModel model)
         {
-            var cpdTokenInfo = new CopyPasteTokenInfo { FilePath = syntaxTree.FilePath };
-            foreach (var token in syntaxTree.GetRoot().DescendantTokens(n => !IsUsingDirective(n)))
+            var cpdTokenInfo = new CopyPasteTokenInfo { FilePath = tree.FilePath };
+            foreach (var token in tree.GetRoot().DescendantTokens(n => !IsUsingDirective(n)))
             {
                 if (GetCpdValue(token) is var value && !string.IsNullOrWhiteSpace(value))
                 {
-                    cpdTokenInfo.TokenInfo.Add(new CopyPasteTokenInfo.Types.TokenInfo { TokenValue = value, TextRange = GetTextRange(Location.Create(syntaxTree, token.Span).GetLineSpan()) });
+                    cpdTokenInfo.TokenInfo.Add(new CopyPasteTokenInfo.Types.TokenInfo { TokenValue = value, TextRange = GetTextRange(Location.Create(tree, token.Span).GetLineSpan()) });
                 }
             }
             return cpdTokenInfo;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/FileMetadataAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/FileMetadataAnalyzerBase.cs
@@ -37,12 +37,12 @@ namespace SonarAnalyzer.Rules
             !GeneratedCodeRecognizer.IsRazorGeneratedFile(tree)
             && base.ShouldGenerateMetrics(tree, compilation);
 
-        protected sealed override FileMetadataInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel) =>
+        protected sealed override FileMetadataInfo CreateMessage(SyntaxTree tree, SemanticModel model) =>
             new()
             {
-                FilePath = syntaxTree.FilePath,
-                IsGenerated = Language.GeneratedCodeRecognizer.IsGenerated(syntaxTree),
-                Encoding = syntaxTree.Encoding?.WebName.ToLowerInvariant() ?? string.Empty
+                FilePath = tree.FilePath,
+                IsGenerated = Language.GeneratedCodeRecognizer.IsGenerated(tree),
+                Encoding = tree.Encoding?.WebName.ToLowerInvariant() ?? string.Empty
             };
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/LogAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/LogAnalyzerBase.cs
@@ -43,9 +43,9 @@ namespace SonarAnalyzer.Rules
                 new LogInfo { Severity = LogSeverity.Info, Text = "Concurrent execution: " + (IsConcurrentExecutionEnabled() ? "enabled" : "disabled") }
             };
 
-        protected sealed override LogInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel) =>
-            syntaxTree.IsGenerated(Language.GeneratedCodeRecognizer, semanticModel.Compilation)
-            ? CreateMessage(syntaxTree)
+        protected sealed override LogInfo CreateMessage(SyntaxTree tree, SemanticModel model) =>
+            tree.IsGenerated(Language.GeneratedCodeRecognizer, model.Compilation)
+            ? CreateMessage(tree)
             : null;
 
         private static LogInfo CreateMessage(SyntaxTree tree) =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/MetricsAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/MetricsAnalyzerBase.cs
@@ -35,13 +35,13 @@ namespace SonarAnalyzer.Rules
 
         protected MetricsAnalyzerBase() : base(DiagnosticId, Title) { }
 
-        protected sealed override MetricsInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override MetricsInfo CreateMessage(SyntaxTree tree, SemanticModel model)
         {
-            var metrics = GetMetrics(syntaxTree, semanticModel);
+            var metrics = GetMetrics(tree, model);
             var complexity = metrics.Complexity;
             var metricsInfo = new MetricsInfo
             {
-                FilePath = syntaxTree.GetRoot().GetMappedFilePathFromRoot(),
+                FilePath = tree.GetRoot().GetMappedFilePathFromRoot(),
                 ClassCount = metrics.ClassCount,
                 StatementCount = metrics.StatementCount,
                 FunctionCount = metrics.FunctionCount,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/SymbolReferenceAnalyzerBase.cs
@@ -39,11 +39,11 @@ namespace SonarAnalyzer.Rules
 
         protected SymbolReferenceAnalyzerBase() : base(DiagnosticId, Title) { }
 
-        protected sealed override SymbolReferenceInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override SymbolReferenceInfo CreateMessage(SyntaxTree tree, SemanticModel model)
         {
-            var filePath = GetFilePath(syntaxTree);
+            var filePath = GetFilePath(tree);
             var symbolReferenceInfo = new SymbolReferenceInfo { FilePath = filePath };
-            var references = GetReferences(syntaxTree.GetRoot(), semanticModel);
+            var references = GetReferences(tree.GetRoot(), model);
             foreach (var symbol in references.Keys)
             {
                 if (GetSymbolReference(references[symbol], filePath) is { } reference)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
@@ -42,16 +42,16 @@ namespace SonarAnalyzer.Rules
             !GeneratedCodeRecognizer.IsRazorGeneratedFile(tree)
             && base.ShouldGenerateMetrics(tree, compilation);
 
-        protected sealed override TokenTypeInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel)
+        protected sealed override TokenTypeInfo CreateMessage(SyntaxTree tree, SemanticModel model)
         {
-            var tokens = syntaxTree.GetRoot().DescendantTokens();
+            var tokens = tree.GetRoot().DescendantTokens();
             var identifierTokenKind = Language.SyntaxKind.IdentifierToken;  // Performance optimization
             var skipIdentifierTokens = tokens
                 .Where(token => Language.Syntax.IsKind(token, identifierTokenKind))
                 .Skip(IdentifierTokenCountThreshold)
                 .Any();
 
-            var tokenClassifier = GetTokenClassifier(semanticModel, skipIdentifierTokens);
+            var tokenClassifier = GetTokenClassifier(model, skipIdentifierTokens);
             var triviaClassifier = GetTriviaClassifier();
             var spans = new List<TokenInfo>();
             // The second iteration of the tokens is intended since there is no processing done and we want to avoid copying all the tokens to a second collection.
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules
 
             var tokenTypeInfo = new TokenTypeInfo
             {
-                FilePath = syntaxTree.FilePath
+                FilePath = tree.FilePath
             };
 
             tokenTypeInfo.TokenInfo.AddRange(spans);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules
     {
         protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract string FileName { get; }
-        protected abstract TMessage CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel);
+        protected abstract TMessage CreateMessage(SyntaxTree tree, SemanticModel model);
 
         protected virtual bool AnalyzeUnchangedFiles => false;
 
@@ -116,11 +116,11 @@ namespace SonarAnalyzer.Rules
             && FileExtensionWhitelist.Contains(Path.GetExtension(tree.FilePath))
             && ShouldGenerateMetricsByType(tree, compilation);
 
-        protected static string GetFilePath(SyntaxTree syntaxTree) =>
+        protected static string GetFilePath(SyntaxTree tree) =>
             // If the syntax tree is constructed for a razor generated file, we need to provide the original file path.
-            GeneratedCodeRecognizer.IsRazorGeneratedFile(syntaxTree) && syntaxTree.GetRoot() is var root && root.ContainsDirectives
+            GeneratedCodeRecognizer.IsRazorGeneratedFile(tree) && tree.GetRoot() is var root && root.ContainsDirectives
                 ? root.GetMappedFilePathFromRoot()
-                : syntaxTree.FilePath;
+                : tree.FilePath;
 
         private bool ShouldGenerateMetrics(SonarCompilationReportingContext context, SyntaxTree tree) =>
             (AnalyzeUnchangedFiles || !context.IsUnchanged(tree))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/FileMetadataAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/FileMetadataAnalyzerTest.cs
@@ -152,8 +152,8 @@ namespace SonarAnalyzer.UnitTest.Rules
                 IsTestProject = isTestProject;
             }
 
-            public FileMetadataInfo TestCreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel) =>
-                CreateMessage(syntaxTree, semanticModel);
+            public FileMetadataInfo TestCreateMessage(SyntaxTree tree, SemanticModel model) =>
+                CreateMessage(tree, model);
         }
     }
 }


### PR DESCRIPTION
Parameters modified:
- syntaxTree -> tree
- semanticModel -> model

Scope: utility analyzers
