### PR TITLE
Update CopyPasteTokenAnalyzer to ignore .cshtml and .razor files

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/CopyPasteTokenAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/CopyPasteTokenAnalyzerBase.cs
@@ -37,6 +37,10 @@ namespace SonarAnalyzer.Rules
 
         protected CopyPasteTokenAnalyzerBase() : base(DiagnosticId, Title) { }
 
+        protected override bool ShouldGenerateMetrics(SyntaxTree tree, Compilation compilation) =>
+            !GeneratedCodeRecognizer.IsRazorGeneratedFile(tree)
+            && base.ShouldGenerateMetrics(tree, compilation);
+
         protected sealed override CopyPasteTokenInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel)
         {
             var cpdTokenInfo = new CopyPasteTokenInfo { FilePath = syntaxTree.FilePath };

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/CopyPasteTokenAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/CopyPasteTokenAnalyzerTest.cs
@@ -119,6 +119,18 @@ namespace SonarAnalyzer.UnitTest.Rules
                         verifyTokenInfo(info.TokenInfo);
                     });
 
+#if NET
+
+        [DataTestMethod]
+        [DataRow("Razor.razor")]
+        [DataRow("Razor.cshtml")]
+        public void Verify_NoMetricsAreComputedForRazorFiles(string fileName) =>
+            CreateBuilder(ProjectType.Product, fileName)
+                .WithSonarProjectConfigPath(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, ProjectType.Product))
+                .VerifyUtilityAnalyzer<CopyPasteTokenInfo>(messages => messages.Select(x => Path.GetFileName(x.FilePath)).Should().BeEmpty());
+
+#endif
+
         private VerifierBuilder CreateBuilder(ProjectType projectType, string fileName)
         {
             var testRoot = BasePath + TestContext.TestName;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/CopyPasteTokenAnalyzer/Razor.cshtml
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/CopyPasteTokenAnalyzer/Razor.cshtml
@@ -1,0 +1,7 @@
+<head>
+    <title>Title</title>
+</head>
+
+@{
+    string message = "message";
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/CopyPasteTokenAnalyzer/Razor.razor
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/CopyPasteTokenAnalyzer/Razor.razor
@@ -1,0 +1,7 @@
+@page "/razor"
+
+<p>Current count: @currentCount</p>
+
+@code {
+    private int currentCount = 0;
+}


### PR DESCRIPTION
Fixes #7971

