### PR TITLE
Update TokenTypeAnalyzer to ignore .cshtml and .razor files

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Common/AnalyzerLanguage.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/AnalyzerLanguage.cs
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Common
         public static AnalyzerLanguage FromPath(string path) =>
             Path.GetExtension(path).ToUpperInvariant() switch
             {
-                ".CS" or ".RAZOR" => CSharp,
+                ".CS" or ".RAZOR" or ".CSHTML" => CSharp,
                 ".VB" => VisualBasic,
                 _ => throw new NotSupportedException("Unsupported file extension: " + Path.GetExtension(path))
             };

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/TokenTypeAnalyzerBase.cs
@@ -38,6 +38,10 @@ namespace SonarAnalyzer.Rules
         protected abstract TokenClassifierBase GetTokenClassifier(SemanticModel semanticModel, bool skipIdentifierTokens);
         protected abstract TriviaClassifierBase GetTriviaClassifier();
 
+        protected override bool ShouldGenerateMetrics(SyntaxTree tree, Compilation compilation) =>
+            !GeneratedCodeRecognizer.IsRazorGeneratedFile(tree)
+            && base.ShouldGenerateMetrics(tree, compilation);
+
         protected sealed override TokenTypeInfo CreateMessage(SyntaxTree syntaxTree, SemanticModel semanticModel)
         {
             var tokens = syntaxTree.GetRoot().DescendantTokens();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/TokenTypeAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/TokenTypeAnalyzerTest.cs
@@ -61,6 +61,14 @@ namespace SonarAnalyzer.UnitTest.Rules
                 info.Should().ContainSingle(x => x.TokenType == TokenType.NumericLiteral);
             });
 
+        [DataTestMethod]
+        [DataRow("Razor.razor")]
+        [DataRow("Razor.cshtml")]
+        public void Verify_NoMetricsAreComputedForRazorFiles(string fileName) =>
+            CreateBuilder(ProjectType.Product, fileName)
+                .WithSonarProjectConfigPath(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, ProjectType.Product))
+                .VerifyUtilityAnalyzer<TokenTypeInfo>(messages => messages.Select(x => Path.GetFileName(x.FilePath)).Should().BeEmpty());
+
 #endif
 
         [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/TokenTypeAnalyzer/Razor.cshtml
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/TokenTypeAnalyzer/Razor.cshtml
@@ -1,0 +1,7 @@
+<head>
+    <title>Title</title>
+</head>
+
+@{
+    string message = "message";
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/TokenTypeAnalyzer/Razor.razor
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/Utilities/TokenTypeAnalyzer/Razor.razor
@@ -1,0 +1,7 @@
+@page "/razor"
+
+<p>Current count: @currentCount</p>
+
+@code {
+    private int currentCount = 0;
+}


### PR DESCRIPTION
Fixes #7958

