### PR TITLE
Fix rules that rely on `DiagnosticReportHelper.GetLineNumberToReport` for razor

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/DiagnosticReportHelper.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/DiagnosticReportHelper.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Helpers
             self.Location.GetLineNumberToReport();
 
         public static int GetLineNumberToReport(this Location self) =>
-            self.GetLineSpan().StartLinePosition.GetLineNumberToReport();
+            self.GetMappedLineSpan().StartLinePosition.GetLineNumberToReport();
 
         public static int GetLineNumberToReport(this LinePosition self) =>
             self.Line + 1;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConditionalStructureSameConditionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConditionalStructureSameConditionTest.cs
@@ -28,6 +28,8 @@ namespace SonarAnalyzer.UnitTest.Rules
     {
         private readonly VerifierBuilder builderCS = new VerifierBuilder<CS.ConditionalStructureSameCondition>();
 
+        public TestContext TestContext { get; set; }
+
         [TestMethod]
         public void ConditionalStructureSameCondition_CS() =>
             builderCS.AddPaths("ConditionalStructureSameCondition.cs").Verify();
@@ -45,6 +47,34 @@ namespace SonarAnalyzer.UnitTest.Rules
             builderCS.AddPaths("ConditionalStructureSameCondition.CSharp10.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .Verify();
+
+        [TestMethod]
+        public void ConditionalStructureSameCondition_RazorFile_CorrectMessage() =>
+            builderCS.AddSnippet(
+                """
+                @code
+                {
+                    public bool condition { get; set; }
+
+                    public void Method()
+                    {
+                        var b = true;
+                        if (b && condition)
+                        //  ^^^^^^^^^^^^^^ Secondary
+                        {
+
+                        }
+                        else if (b && condition) // Noncompliant {{This branch duplicates the one on line 8.}}
+                        //       ^^^^^^^^^^^^^^
+                        {
+
+                        }
+                    }
+                }
+                """,
+                "SomeRazorFile.razor")
+            .WithAdditionalFilePath(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, ProjectType.Product))
+            .Verify();
 
 #endif
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConditionalStructureSameImplementationTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConditionalStructureSameImplementationTest.cs
@@ -29,6 +29,8 @@ namespace SonarAnalyzer.UnitTest.Rules
         private readonly VerifierBuilder builderCS = new VerifierBuilder<CS.ConditionalStructureSameImplementation>();
         private readonly VerifierBuilder builderVB = new VerifierBuilder<VB.ConditionalStructureSameImplementation>();
 
+        public TestContext TestContext { get; set; }
+
         [TestMethod]
         public void ConditionalStructureSameImplementation_If_CSharp() =>
             builderCS.AddPaths("ConditionalStructureSameImplementation_If.cs").Verify();
@@ -44,5 +46,36 @@ namespace SonarAnalyzer.UnitTest.Rules
         [TestMethod]
         public void ConditionalStructureSameImplementation_Switch_VisualBasic() =>
             builderVB.AddPaths("ConditionalStructureSameImplementation_Switch.vb").Verify();
+
+#if NET
+
+        [TestMethod]
+        public void ConditionalStructureSameImplementation_RazorFile_CorrectMessage() =>
+            builderCS.AddSnippet(
+                """
+                @code
+                {
+                    public bool someCondition1 { get; set; }
+                    public void DoSomething1() { }
+
+                    public void Method()
+                    {
+                        if (someCondition1)
+                        { // Secondary
+                            DoSomething1();
+                            DoSomething1();
+                        }
+                        else
+                        { // Noncompliant {{Either merge this branch with the identical one on line 9 or change one of the implementations.}}
+                            DoSomething1();
+                            DoSomething1();
+                        }
+                    }
+                }
+                """,
+                "SomeRazorFile.razor")
+            .WithAdditionalFilePath(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, ProjectType.Product))
+            .Verify();
+#endif
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConditionalsWithSameConditionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ConditionalsWithSameConditionTest.cs
@@ -27,6 +27,8 @@ namespace SonarAnalyzer.UnitTest.Rules
     {
         private readonly VerifierBuilder builder = new VerifierBuilder<ConditionalsWithSameCondition>();
 
+        public TestContext TestContext { get; set; }
+
         [TestMethod]
         public void ConditionalsWithSameCondition() =>
             builder.AddPaths("ConditionalsWithSameCondition.cs").Verify();
@@ -50,6 +52,32 @@ namespace SonarAnalyzer.UnitTest.Rules
             builder.AddPaths("ConditionalsWithSameCondition.CSharp10.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp10)
                 .Verify();
+
+        [TestMethod]
+        public void ConditionalsWithSameCondition_RazorFile_CorrectMessage() =>
+            builder.AddSnippet(
+                """
+                @code
+                {
+                    public void doTheThing(object o) { }
+
+                    public void Method(int a, int b)
+                    {
+                        if (a == b)
+                        {
+                            doTheThing(b);
+                        }
+                        if (a == b) // Noncompliant {{This condition was just checked on line 7.}}
+                        //  ^^^^^^
+                        {
+                            doTheThing(b);
+                        }
+                    }
+                }
+                """,
+                "SomeRazorFile.razor")
+            .WithAdditionalFilePath(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, ProjectType.Product))
+            .Verify();
 
 #endif
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotShiftByZeroOrIntSizeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotShiftByZeroOrIntSizeTest.cs
@@ -27,6 +27,8 @@ namespace SonarAnalyzer.UnitTest.Rules
     {
         private readonly VerifierBuilder builder = new VerifierBuilder<DoNotShiftByZeroOrIntSize>();
 
+        public TestContext TestContext { get; set; }
+
         [TestMethod]
         public void DoNotShiftByZeroOrIntSize() =>
             builder.AddPaths("DoNotShiftByZeroOrIntSize.cs").Verify();
@@ -50,6 +52,31 @@ namespace SonarAnalyzer.UnitTest.Rules
             builder.AddPaths("DoNotShiftByZeroOrIntSize.CSharp11.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp11)
                 .Verify();
+
+        [TestMethod]
+        public void DoNotShiftByZeroOrIntSize_RazorFile_CorrectMessage() =>
+            builder.AddSnippet(
+                """
+                @code
+                {
+                    public void Method()
+                    {
+                        byte b = 1;
+                        b = (byte)(b << 10);
+                        b = (byte)(b << 10);
+                        b = 1 << 0;
+
+                        sbyte sb = 1;
+                        sb = (sbyte)(sb << 10);
+
+                        int i = 1 << 10;
+                        i = i << 32;  // Noncompliant
+                    }
+                }
+                """,
+                "SomeRazorFile.razor")
+            .WithAdditionalFilePath(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, ProjectType.Product))
+            .Verify();
 
 #endif
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TryStatementsWithIdenticalCatchShouldBeMergedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TryStatementsWithIdenticalCatchShouldBeMergedTest.cs
@@ -25,8 +25,42 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class TryStatementsWithIdenticalCatchShouldBeMergedTest
     {
+        private readonly VerifierBuilder builder = new VerifierBuilder<TryStatementsWithIdenticalCatchShouldBeMerged>();
+
+        public TestContext TestContext { get; set; }
+
         [TestMethod]
         public void TryStatementsWithIdenticalCatchShouldBeMerged() =>
-            new VerifierBuilder<TryStatementsWithIdenticalCatchShouldBeMerged>().AddPaths("TryStatementsWithIdenticalCatchShouldBeMerged.cs").Verify();
+            builder.AddPaths("TryStatementsWithIdenticalCatchShouldBeMerged.cs").Verify();
+
+#if NET
+
+        [TestMethod]
+        public void TryStatementsWithIdenticalCatchShouldBeMerged_RazorFile_CorrectMessage() =>
+            builder.AddSnippet(
+                """
+                @using System;
+                @code
+                {
+                    public void Method()
+                    {
+                        try { }
+                        catch (Exception)
+                        {
+                        }
+                        finally { }
+
+                        try { } // Noncompliant {{Combine this 'try' with the one starting on line 6.}}
+                        catch (Exception)
+                        {
+                        }
+                        finally { }
+                    }
+                }
+                """,
+                "SomeRazorFile.razor")
+            .WithAdditionalFilePath(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, ProjectType.Product))
+            .Verify();
+#endif
     }
 }


### PR DESCRIPTION
Fixes #8003
