### PR TITLE
Fix S3900 FP: should not consider .razor generated file parameters

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/PublicMethodArgumentsShouldBeCheckedForNullBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/PublicMethodArgumentsShouldBeCheckedForNullBase.cs
@@ -55,10 +55,6 @@ public abstract class PublicMethodArgumentsShouldBeCheckedForNullBase : Symbolic
             || (!symbolState.HasConstraint<ObjectConstraint>() && !symbolState.HasConstraint<ParameterReassignedConstraint>());
     }
 
-    private bool IsInsideRazorGeneratedCode(IOperation candidate) =>
-        GeneratedCodeRecognizer.IsRazorGeneratedFile(candidate.Syntax.SyntaxTree)
-        && candidate.Syntax.TryGetInferredMemberName().Equals("__builder", StringComparison.OrdinalIgnoreCase);
-
     protected override ProgramState PostProcessSimple(SymbolicContext context)
     {
         if (AssignmentTarget(context.Operation.Instance) is { Kind: OperationKindEx.ParameterReference } assignedParameter)
@@ -94,4 +90,8 @@ public abstract class PublicMethodArgumentsShouldBeCheckedForNullBase : Symbolic
         operation.Kind == OperationKindEx.SimpleAssignment
             ? operation.ToAssignment().Target
             : null;
+
+    private static bool IsInsideRazorGeneratedCode(IOperation candidate) =>
+        GeneratedCodeRecognizer.IsRazorGeneratedFile(candidate.Syntax.SyntaxTree)
+        && candidate.Syntax.TryGetInferredMemberName().Equals("__builder", StringComparison.OrdinalIgnoreCase);
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNullTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNullTest.cs
@@ -28,6 +28,8 @@ namespace SonarAnalyzer.UnitTest.Rules
     [TestClass]
     public class PublicMethodArgumentsShouldBeCheckedForNullTest
     {
+        public TestContext TestContext { get; set; }
+
         private readonly VerifierBuilder sonar = new VerifierBuilder()
             .AddAnalyzer(() => new CS.SymbolicExecutionRunner(AnalyzerConfiguration.AlwaysEnabledWithSonarCfg))
             .WithBasePath(@"SymbolicExecution\Sonar")
@@ -106,6 +108,14 @@ namespace SonarAnalyzer.UnitTest.Rules
             roslynCS.AddPaths("PublicMethodArgumentsShouldBeCheckedForNull.CSharp11.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp11)
                 .Verify();
+
+        [TestMethod]
+        public void PublicMethodArgumentsShouldBeCheckedForNull_Roslyn_Razor() =>
+            roslynCS.AddPaths(
+                "PublicMethodArgumentsShouldBeCheckedForNull.razor",
+                "PublicMethodArgumentsShouldBeCheckedForNull_component.razor")
+                    .WithAdditionalFilePath(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, ProjectType.Product))
+                    .Verify();
 
 #endif
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNullTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/PublicMethodArgumentsShouldBeCheckedForNullTest.cs
@@ -111,9 +111,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [TestMethod]
         public void PublicMethodArgumentsShouldBeCheckedForNull_Roslyn_Razor() =>
-            roslynCS.AddPaths(
-                "PublicMethodArgumentsShouldBeCheckedForNull.razor",
-                "PublicMethodArgumentsShouldBeCheckedForNull_component.razor")
+            roslynCS.AddPaths("PublicMethodArgumentsShouldBeCheckedForNull.razor", "PublicMethodArgumentsShouldBeCheckedForNull_component.razor")
                     .WithAdditionalFilePath(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, ProjectType.Product))
                     .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.razor
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.razor
@@ -1,0 +1,9 @@
+﻿@namespace Test
+@using Microsoft.AspNetCore.Components.Rendering
+@inherits PublicMethodArgumentsShouldBeCheckedForNull_component
+
+@Render <!-- Noncompliant FP -->
+
+@code {
+    public RenderFragment Render => base.BuildRenderTree;
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.razor
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull.razor
@@ -2,7 +2,7 @@
 @using Microsoft.AspNetCore.Components.Rendering
 @inherits PublicMethodArgumentsShouldBeCheckedForNull_component
 
-@Render <!-- Noncompliant FP -->
+@Render <!-- Compliant -->
 
 @code {
     public RenderFragment Render => base.BuildRenderTree;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull_component.razor
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/PublicMethodArgumentsShouldBeCheckedForNull_component.razor
@@ -1,0 +1,3 @@
+﻿@namespace Test
+
+<p>Component</p>


### PR DESCRIPTION
Fix #7994