### PR TITLE
SE: Refactor CreateCfg method to get the SyntaxNode as input as is without having to retrieve its body.

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/Sonar/CSharpControlFlowGraph.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Sonar/CSharpControlFlowGraph.cs
@@ -34,6 +34,7 @@ namespace SonarAnalyzer.CFG.Sonar
                 IndexerDeclarationSyntax n => n.ExpressionBody?.Expression,
                 AccessorDeclarationSyntax n => (SyntaxNode)n.Body ?? n.ExpressionBody(),
                 AnonymousFunctionExpressionSyntax n => n.Body,
+                ArrowExpressionClauseSyntax n => n,
                 _ => null
             };
             if (LocalFunctionStatementSyntaxWrapper.IsInstance(node))

--- a/analyzers/src/SonarAnalyzer.CFG/Sonar/CSharpControlFlowGraph.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Sonar/CSharpControlFlowGraph.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.CFG.Sonar
                 AccessorDeclarationSyntax n => (SyntaxNode)n.Body ?? n.ExpressionBody(),
                 AnonymousFunctionExpressionSyntax n => n.Body,
                 ArrowExpressionClauseSyntax n => n,
-                _ when LocalFunctionStatementSyntaxWrapper.IsInstance(node) && (LocalFunctionStatementSyntaxWrapper)node is var local => (SyntaxNode)local.Body ?? local.ExpressionBody,
+                _ when node.IsKind(SyntaxKindEx.LocalFunctionStatement) && (LocalFunctionStatementSyntaxWrapper)node is var local => (SyntaxNode)local.Body ?? local.ExpressionBody,
                 _ => null
             };
             try

--- a/analyzers/src/SonarAnalyzer.CFG/Sonar/CSharpControlFlowGraph.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Sonar/CSharpControlFlowGraph.cs
@@ -27,7 +27,7 @@ namespace SonarAnalyzer.CFG.Sonar
         public static bool TryGet(SyntaxNode node, SemanticModel semanticModel, out IControlFlowGraph cfg)
         {
             cfg = null;
-            var block = node switch
+            var body = node switch
             {
                 BaseMethodDeclarationSyntax n => (SyntaxNode)n.Body ?? n.ExpressionBody(),
                 PropertyDeclarationSyntax n => n.ExpressionBody?.Expression,
@@ -35,18 +35,15 @@ namespace SonarAnalyzer.CFG.Sonar
                 AccessorDeclarationSyntax n => (SyntaxNode)n.Body ?? n.ExpressionBody(),
                 AnonymousFunctionExpressionSyntax n => n.Body,
                 ArrowExpressionClauseSyntax n => n,
+                _ when LocalFunctionStatementSyntaxWrapper.IsInstance(node) && (LocalFunctionStatementSyntaxWrapper)node is var local =>
+                    (SyntaxNode)local.Body ?? local.ExpressionBody,
                 _ => null
             };
-            if (LocalFunctionStatementSyntaxWrapper.IsInstance(node))
-            {
-                var local = (LocalFunctionStatementSyntaxWrapper)node;
-                block = (SyntaxNode)local.Body ?? local.ExpressionBody;
-            }
             try
             {
-                if (block != null)
+                if (body is not null)
                 {
-                    cfg = Create(block, semanticModel);
+                    cfg = Create(body, semanticModel);
                 }
                 else
                 {

--- a/analyzers/src/SonarAnalyzer.CFG/Sonar/CSharpControlFlowGraph.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Sonar/CSharpControlFlowGraph.cs
@@ -35,8 +35,7 @@ namespace SonarAnalyzer.CFG.Sonar
                 AccessorDeclarationSyntax n => (SyntaxNode)n.Body ?? n.ExpressionBody(),
                 AnonymousFunctionExpressionSyntax n => n.Body,
                 ArrowExpressionClauseSyntax n => n,
-                _ when LocalFunctionStatementSyntaxWrapper.IsInstance(node) && (LocalFunctionStatementSyntaxWrapper)node is var local =>
-                    (SyntaxNode)local.Body ?? local.ExpressionBody,
+                _ when LocalFunctionStatementSyntaxWrapper.IsInstance(node) && (LocalFunctionStatementSyntaxWrapper)node is var local => (SyntaxNode)local.Body ?? local.ExpressionBody,
                 _ => null
             };
             try

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -27,8 +27,8 @@ namespace SonarAnalyzer.Extensions
         private static readonly ControlFlowGraphCache CfgCache = new();
         private static readonly SyntaxKind[] ParenthesizedNodeKinds = new[] { SyntaxKind.ParenthesizedExpression, SyntaxKindEx.ParenthesizedPattern };
 
-        public static ControlFlowGraph CreateCfg(this SyntaxNode body, SemanticModel model, CancellationToken cancel) =>
-            CfgCache.FindOrCreate(body is CompilationUnitSyntax ? body : body.Parent, model, cancel);
+        public static ControlFlowGraph CreateCfg(this SyntaxNode node, SemanticModel model, CancellationToken cancel) =>
+            CfgCache.FindOrCreate(node, model, cancel);
 
         public static bool ContainsConditionalConstructs(this SyntaxNode node) =>
             node != null &&

--- a/analyzers/src/SonarAnalyzer.CSharp/LiveVariableAnalysis/SonarCSharpLiveVariableAnalysis.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/LiveVariableAnalysis/SonarCSharpLiveVariableAnalysis.cs
@@ -206,7 +206,7 @@ namespace SonarAnalyzer.LiveVariableAnalysis.CSharp
                     && symbol.DeclaringSyntaxReferences.Length == 1
                     && symbol.DeclaringSyntaxReferences.Single().GetSyntax() is { } node
                     && (LocalFunctionStatementSyntaxWrapper)node is LocalFunctionStatementSyntaxWrapper function
-                    && CSharpControlFlowGraph.TryGet(function.Body ?? function.ExpressionBody as CSharpSyntaxNode, semanticModel, out var cfg))
+                    && CSharpControlFlowGraph.TryGet(function, semanticModel, out var cfg))
                 {
                     ProcessedLocalFunctions.Add(symbol);
                     foreach (var block in cfg.Blocks.Reverse())

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
@@ -47,41 +47,40 @@ namespace SonarAnalyzer.Rules.CSharp
             // No need to check for ExpressionBody as it can't contain variable assignment
             context.RegisterNodeAction(
                 c => CheckForDeadStores(c, c.SemanticModel.GetDeclaredSymbol(c.Node)),
-                SyntaxKind.MethodDeclaration,
+                SyntaxKind.AddAccessorDeclaration,
                 SyntaxKind.ConstructorDeclaration,
-                SyntaxKind.DestructorDeclaration,
                 SyntaxKind.ConversionOperatorDeclaration,
-                SyntaxKind.OperatorDeclaration,
-                SyntaxKindEx.LocalFunctionStatement,
+                SyntaxKind.DestructorDeclaration,
                 SyntaxKind.GetAccessorDeclaration,
+                SyntaxKind.MethodDeclaration,
+                SyntaxKind.OperatorDeclaration,
+                SyntaxKind.RemoveAccessorDeclaration,
                 SyntaxKind.SetAccessorDeclaration,
                 SyntaxKindEx.InitAccessorDeclaration,
-                SyntaxKind.AddAccessorDeclaration,
-                SyntaxKind.RemoveAccessorDeclaration);
+                SyntaxKindEx.LocalFunctionStatement);
 
             context.RegisterNodeAction(
                 c => CheckForDeadStores(c, c.SemanticModel.GetSymbolInfo(c.Node).Symbol),
                 SyntaxKind.AnonymousMethodExpression,
-                SyntaxKind.SimpleLambdaExpression,
-                SyntaxKind.ParenthesizedLambdaExpression);
+                SyntaxKind.ParenthesizedLambdaExpression,
+                SyntaxKind.SimpleLambdaExpression);
         }
 
         private void CheckForDeadStores(SonarSyntaxNodeReportingContext context, ISymbol symbol)
         {
-            var node = context.Node;
-            if (symbol != null && node != null)
+            if (symbol != null)
             {
                 if (useSonarCfg)
                 {
                     // Tuple expressions are not supported. See https://github.com/SonarSource/sonar-dotnet/issues/3094
-                    if (!node.DescendantNodes().AnyOfKind(SyntaxKindEx.TupleExpression) && CSharpControlFlowGraph.TryGet(node, context.SemanticModel, out var cfg))
+                    if (!context.Node.DescendantNodes().AnyOfKind(SyntaxKindEx.TupleExpression) && CSharpControlFlowGraph.TryGet(context.Node, context.SemanticModel, out var cfg))
                     {
                         var lva = new SonarCSharpLiveVariableAnalysis(cfg, symbol, context.SemanticModel, context.Cancel);
-                        var checker = new SonarChecker(context, lva, node);
+                        var checker = new SonarChecker(context, lva, context.Node);
                         checker.Analyze(cfg.Blocks);
                     }
                 }
-                else if (node.CreateCfg(context.SemanticModel, context.Cancel) is { } cfg)
+                else if (context.Node.CreateCfg(context.SemanticModel, context.Cancel) is { } cfg)
                 {
                     var lva = new RoslynLiveVariableAnalysis(cfg, context.Cancel);
                     var checker = new RoslynChecker(context, lva);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
@@ -46,15 +46,13 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             // No need to check for ExpressionBody as it can't contain variable assignment
             context.RegisterNodeAction(
-                c => CheckForDeadStores<BaseMethodDeclarationSyntax>(c, c.SemanticModel.GetDeclaredSymbol(c.Node), c.Node, x => (CSharpSyntaxNode)x.Body ?? x.ExpressionBody()),
+                c => CheckForDeadStores(c, c.SemanticModel.GetDeclaredSymbol(c.Node), c.Node),
                 SyntaxKind.MethodDeclaration,
                 SyntaxKind.ConstructorDeclaration,
                 SyntaxKind.DestructorDeclaration,
                 SyntaxKind.ConversionOperatorDeclaration,
-                SyntaxKind.OperatorDeclaration);
-
-            context.RegisterNodeAction(
-                c => CheckForDeadStores<AccessorDeclarationSyntax>(c, c.SemanticModel.GetDeclaredSymbol(c.Node), c.Node, x => x.Body != null || x.ExpressionBody() != null ? x : null),
+                SyntaxKind.OperatorDeclaration,
+                SyntaxKindEx.LocalFunctionStatement,
                 SyntaxKind.GetAccessorDeclaration,
                 SyntaxKind.SetAccessorDeclaration,
                 SyntaxKindEx.InitAccessorDeclaration,
@@ -66,18 +64,6 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.AnonymousMethodExpression,
                 SyntaxKind.SimpleLambdaExpression,
                 SyntaxKind.ParenthesizedLambdaExpression);
-
-            context.RegisterNodeAction(
-                c => CheckForDeadStores(c, c.SemanticModel.GetDeclaredSymbol(c.Node), c.Node),
-                SyntaxKindEx.LocalFunctionStatement);
-        }
-
-        private void CheckForDeadStores<T>(SonarSyntaxNodeReportingContext context, ISymbol symbol, SyntaxNode node, Func<T, CSharpSyntaxNode> hasABody) where T : SyntaxNode
-        {
-            if (hasABody((T)node) is { })
-            {
-                CheckForDeadStores(context, symbol, node);
-            }
         }
 
         private void CheckForDeadStores(SonarSyntaxNodeReportingContext context, ISymbol symbol, SyntaxNode node)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             // No need to check for ExpressionBody as it can't contain variable assignment
             context.RegisterNodeAction(
-                c => CheckForDeadStores(c, c.SemanticModel.GetDeclaredSymbol(c.Node), c.Node),
+                c => CheckForDeadStores(c, c.SemanticModel.GetDeclaredSymbol(c.Node)),
                 SyntaxKind.MethodDeclaration,
                 SyntaxKind.ConstructorDeclaration,
                 SyntaxKind.DestructorDeclaration,
@@ -60,14 +60,15 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.RemoveAccessorDeclaration);
 
             context.RegisterNodeAction(
-                c => CheckForDeadStores(c, c.SemanticModel.GetSymbolInfo(c.Node).Symbol, c.Node),
+                c => CheckForDeadStores(c, c.SemanticModel.GetSymbolInfo(c.Node).Symbol),
                 SyntaxKind.AnonymousMethodExpression,
                 SyntaxKind.SimpleLambdaExpression,
                 SyntaxKind.ParenthesizedLambdaExpression);
         }
 
-        private void CheckForDeadStores(SonarSyntaxNodeReportingContext context, ISymbol symbol, SyntaxNode node)
+        private void CheckForDeadStores(SonarSyntaxNodeReportingContext context, ISymbol symbol)
         {
+            var node = context.Node;
             if (symbol != null && node != null)
             {
                 if (useSonarCfg)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.SonarCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.SonarCfg.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 IControlFlowGraph cfg;
                 if (property.ExpressionBody?.Expression != null)
                 {
-                    if (CSharpControlFlowGraph.TryGet(property, c.SemanticModel, out cfg))
+                    if (CSharpControlFlowGraph.TryGet(property.ExpressionBody, c.SemanticModel, out cfg))
                     {
                         var walker = new RecursionSearcherForProperty(
                             new RecursionContext<IControlFlowGraph>(c, cfg, propertySymbol, property.Identifier.GetLocation(), "property's recursion"),

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.SonarCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.SonarCfg.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 IControlFlowGraph cfg;
                 if (property.ExpressionBody?.Expression != null)
                 {
-                    if (CSharpControlFlowGraph.TryGet(property.ExpressionBody, c.SemanticModel, out cfg))
+                    if (CSharpControlFlowGraph.TryGet(property, c.SemanticModel, out cfg))
                     {
                         var walker = new RecursionSearcherForProperty(
                             new RecursionContext<IControlFlowGraph>(c, cfg, propertySymbol, property.Identifier.GetLocation(), "property's recursion"),
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             private static void CheckInfiniteJumpLoop(SonarSyntaxNodeReportingContext context, SyntaxNode body, IControlFlowGraph cfg, string declarationType)
             {
-                if (body == null)
+                if (body is null)
                 {
                     return;
                 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.SonarCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.SonarCfg.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 IControlFlowGraph cfg;
                 if (property.ExpressionBody?.Expression != null)
                 {
-                    if (CSharpControlFlowGraph.TryGet(property.ExpressionBody.Expression, c.SemanticModel, out cfg))
+                    if (CSharpControlFlowGraph.TryGet(property, c.SemanticModel, out cfg))
                     {
                         var walker = new RecursionSearcherForProperty(
                             new RecursionContext<IControlFlowGraph>(c, cfg, propertySymbol, property.Identifier.GetLocation(), "property's recursion"),
@@ -47,15 +47,14 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     foreach (var accessor in accessors)
                     {
-                        var bodyNode = (CSharpSyntaxNode)accessor.Body ?? accessor.ExpressionBody();
-                        if (CSharpControlFlowGraph.TryGet(bodyNode, c.SemanticModel, out cfg))
+                        if (CSharpControlFlowGraph.TryGet(accessor, c.SemanticModel, out cfg))
                         {
                             var walker = new RecursionSearcherForProperty(
                                 new RecursionContext<IControlFlowGraph>(c, cfg, propertySymbol, accessor.Keyword.GetLocation(), "property accessor's recursion"),
                                 isSetAccessor: accessor.Keyword.IsKind(SyntaxKind.SetKeyword));
                             walker.CheckPaths();
 
-                            CheckInfiniteJumpLoop(c, bodyNode, cfg, "property accessor");
+                            CheckInfiniteJumpLoop(c, accessor, cfg, "property accessor");
                         }
                     }
                 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
@@ -44,6 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     var method = (MethodDeclarationSyntax)c.Node;
                     CheckForNoExitMethod(c, method, method.Identifier);
+
                 },
                 SyntaxKind.MethodDeclaration);
 
@@ -52,6 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     var function = (LocalFunctionStatementSyntaxWrapper)c.Node;
                     CheckForNoExitMethod(c, function, function.Identifier);
+
                 },
                 SyntaxKindEx.LocalFunctionStatement);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 c =>
                 {
                     var method = (MethodDeclarationSyntax)c.Node;
-                    CheckForNoExitMethod(c, method, method.Identifier);
+                    CheckForNoExitMethod(c, method.Identifier);
 
                 },
                 SyntaxKind.MethodDeclaration);
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 c =>
                 {
                     var function = (LocalFunctionStatementSyntaxWrapper)c.Node;
-                    CheckForNoExitMethod(c, function, function.Identifier);
+                    CheckForNoExitMethod(c, function.Identifier);
 
                 },
                 SyntaxKindEx.LocalFunctionStatement);
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 c =>
                 {
                     var @operator = (OperatorDeclarationSyntax)c.Node;
-                    CheckForNoExitMethod(c, @operator, @operator.OperatorToken);
+                    CheckForNoExitMethod(c, @operator.OperatorToken);
                 },
                 SyntaxKind.OperatorDeclaration);
 
@@ -77,11 +77,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PropertyDeclaration);
         }
 
-        private void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, CSharpSyntaxNode node, SyntaxToken identifier)
+        private void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, SyntaxToken identifier)
         {
-            if (node != null && c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol symbol)
+            if (c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol symbol)
             {
-                checker.CheckForNoExitMethod(c, node, identifier, symbol);
+                checker.CheckForNoExitMethod(c, (CSharpSyntaxNode)c.Node, identifier, symbol);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 c =>
                 {
                     var method = (MethodDeclarationSyntax)c.Node;
-                    CheckForNoExitMethod(c, (CSharpSyntaxNode)method.Body ?? method.ExpressionBody, method.Identifier);
+                    CheckForNoExitMethod(c, method, method.Identifier);
                 },
                 SyntaxKind.MethodDeclaration);
 
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 c =>
                 {
                     var function = (LocalFunctionStatementSyntaxWrapper)c.Node;
-                    CheckForNoExitMethod(c, (CSharpSyntaxNode)function.Body ?? function.ExpressionBody, function.Identifier);
+                    CheckForNoExitMethod(c, function, function.Identifier);
                 },
                 SyntaxKindEx.LocalFunctionStatement);
 
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 c =>
                 {
                     var @operator = (OperatorDeclarationSyntax)c.Node;
-                    CheckForNoExitMethod(c, (CSharpSyntaxNode)@operator.Body ?? @operator.ExpressionBody, @operator.OperatorToken);
+                    CheckForNoExitMethod(c, @operator, @operator.OperatorToken);
                 },
                 SyntaxKind.OperatorDeclaration);
 
@@ -75,11 +75,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.PropertyDeclaration);
         }
 
-        private void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, CSharpSyntaxNode body, SyntaxToken identifier)
+        private void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, CSharpSyntaxNode node, SyntaxToken identifier)
         {
-            if (body != null && c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol symbol)
+            if (node != null && c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol symbol)
             {
-                checker.CheckForNoExitMethod(c, body, identifier, symbol);
+                checker.CheckForNoExitMethod(c, node, identifier, symbol);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
@@ -44,7 +44,6 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     var method = (MethodDeclarationSyntax)c.Node;
                     CheckForNoExitMethod(c, method.Identifier);
-
                 },
                 SyntaxKind.MethodDeclaration);
 
@@ -53,7 +52,6 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     var function = (LocalFunctionStatementSyntaxWrapper)c.Node;
                     CheckForNoExitMethod(c, function.Identifier);
-
                 },
                 SyntaxKindEx.LocalFunctionStatement);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializerRedundant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializerRedundant.cs
@@ -137,10 +137,9 @@ namespace SonarAnalyzer.Rules.CSharp
         /// </summary>
         private bool IsSymbolFirstSetInCfg(ISymbol classMember, BaseMethodDeclarationSyntax constructorOrInitializer, SemanticModel semanticModel, CancellationToken cancel)
         {
-            var body = (CSharpSyntaxNode)constructorOrInitializer.Body ?? constructorOrInitializer.ExpressionBody();
             if (useSonarCfg)
             {
-                if (!CSharpControlFlowGraph.TryGet(body, semanticModel, out var cfg))
+                if (!CSharpControlFlowGraph.TryGet(constructorOrInitializer, semanticModel, out var cfg))
                 {
                     return false;
                 }
@@ -150,7 +149,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
             else
             {
-                var cfg = ControlFlowGraph.Create(body.Parent, semanticModel, cancel);
+                var cfg = ControlFlowGraph.Create(constructorOrInitializer, semanticModel, cancel);
                 var checker = new RoslynChecker(cfg, classMember, cancel);
                 return checker.CheckAllPaths();
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
@@ -173,15 +173,12 @@ namespace SonarAnalyzer.Rules.CSharp
                 .Select(x => new NodeAndSymbol(x, declaration.Context.SemanticModel.GetDeclaredSymbol(x)))
                 .Where(x => x.Symbol is not null);
 
-            foreach (var parameter in parameters)
+            foreach (var parameter in parameters.Where(x => parametersToReportOn.Contains(x.Symbol)))
             {
-                if (parametersToReportOn.Contains(parameter.Symbol))
-                {
-                    declaration.Context.ReportIssue(
-                        Diagnostic.Create(Rule, parameter.Node.GetLocation(),
-                        ImmutableDictionary<string, string>.Empty.Add(IsRemovableKey, isRemovable.ToString()),
-                        string.Format(messagePattern, parameter.Symbol.Name)));
-                }
+                declaration.Context.ReportIssue(
+                    Diagnostic.Create(Rule, parameter.Node.GetLocation(),
+                    ImmutableDictionary<string, string>.Empty.Add(IsRemovableKey, isRemovable.ToString()),
+                    string.Format(messagePattern, parameter.Symbol.Name)));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
@@ -45,20 +45,20 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(c =>
+            {
+                var declaration = CreateContext(c);
+                if ((declaration.Body == null && declaration.ExpressionBody == null)
+                    || declaration.Body?.Statements.Count == 0  // Don't report on empty methods
+                    || declaration.Symbol == null
+                    || !declaration.Symbol.ContainingType.IsClassOrStruct()
+                    || declaration.Symbol.IsMainMethod()
+                    || OnlyThrowsNotImplementedException(declaration))
                 {
-                    var declaration = CreateContext(c);
-                    if ((declaration.Body == null && declaration.ExpressionBody == null)
-                        || declaration.Body?.Statements.Count == 0  // Don't report on empty methods
-                        || declaration.Symbol == null
-                        || !declaration.Symbol.ContainingType.IsClassOrStruct()
-                        || declaration.Symbol.IsMainMethod()
-                        || OnlyThrowsNotImplementedException(declaration))
-                    {
-                        return;
-                    }
+                    return;
+                }
 
-                    ReportUnusedParametersOnMethod(declaration);
-                },
+                ReportUnusedParametersOnMethod(declaration);
+            },
                 SyntaxKind.MethodDeclaration,
                 SyntaxKind.ConstructorDeclaration,
                 SyntaxKindEx.LocalFunctionStatement);
@@ -126,8 +126,8 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private void ReportOnDeadParametersAtEntry(MethodContext declaration, IImmutableList<IParameterSymbol> noReportOnParameters)
         {
-            var bodyNode = (CSharpSyntaxNode)declaration.Body ?? declaration.ExpressionBody;
-            if (bodyNode == null || declaration.Context.Node.IsKind(SyntaxKind.ConstructorDeclaration))
+            var declarationNode = (CSharpSyntaxNode)declaration.MethodDeclaration ?? declaration.LocalFunctionDeclaration;
+            if (declarationNode == null || declaration.Context.Node.IsKind(SyntaxKind.ConstructorDeclaration))
             {
                 return;
             }
@@ -140,23 +140,23 @@ namespace SonarAnalyzer.Rules.CSharp
             excludedParameters = excludedParameters.AddRange(declaration.Symbol.Parameters.Where(p => p.RefKind != RefKind.None));
 
             var candidateParameters = declaration.Symbol.Parameters.Except(excludedParameters);
-            if (candidateParameters.Any() && ComputeLva(declaration, bodyNode) is { } lva)
+            if (candidateParameters.Any() && ComputeLva(declaration, declarationNode) is { } lva)
             {
                 ReportOnUnusedParameters(declaration, candidateParameters.Except(lva.LiveInEntryBlock).Except(lva.CapturedVariables), MessageDead, isRemovable: false);
             }
         }
 
-        private LvaResult ComputeLva(MethodContext declaration, CSharpSyntaxNode body)
+        private LvaResult ComputeLva(MethodContext declaration, CSharpSyntaxNode declarationNode)
         {
             if (useSonarCfg)
             {
-                return CSharpControlFlowGraph.TryGet(body, declaration.Context.SemanticModel, out var cfg)
+                return CSharpControlFlowGraph.TryGet(declarationNode, declaration.Context.SemanticModel, out var cfg)
                     ? new LvaResult(declaration, cfg)
                     : null;
             }
             else
             {
-                return body.CreateCfg(declaration.Context.SemanticModel, declaration.Context.Cancel) is { } cfg
+                return declarationNode.CreateCfg(declaration.Context.SemanticModel, declaration.Context.Cancel) is { } cfg
                     ? new LvaResult(cfg, declaration.Context.Cancel)
                     : null;
             }
@@ -256,15 +256,23 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             public readonly SonarSyntaxNodeReportingContext Context;
             public readonly IMethodSymbol Symbol;
+            public readonly BaseMethodDeclarationSyntax MethodDeclaration;
+            public readonly LocalFunctionStatementSyntaxWrapper LocalFunctionDeclaration;
             public readonly ParameterListSyntax ParameterList;
             public readonly BlockSyntax Body;
             public readonly ArrowExpressionClauseSyntax ExpressionBody;
 
             public MethodContext(SonarSyntaxNodeReportingContext context, BaseMethodDeclarationSyntax declaration)
-                : this(context, declaration.ParameterList, declaration.Body, declaration.ExpressionBody()) { }
+                : this(context, declaration.ParameterList, declaration.Body, declaration.ExpressionBody())
+            {
+                MethodDeclaration = declaration;
+            }
 
             public MethodContext(SonarSyntaxNodeReportingContext context, LocalFunctionStatementSyntaxWrapper declaration)
-                : this(context, declaration.ParameterList, declaration.Body, declaration.ExpressionBody) { }
+                : this(context, declaration.ParameterList, declaration.Body, declaration.ExpressionBody)
+            {
+                LocalFunctionDeclaration = declaration;
+            }
 
             private MethodContext(SonarSyntaxNodeReportingContext context, ParameterListSyntax parameterList, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
@@ -67,12 +67,12 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             if (c.Node is BaseMethodDeclarationSyntax method)
             {
-                return new MethodContext(c, method.ParameterList, method.Body, method.ExpressionBody());
+                return new MethodContext(c, method);
             }
-            else if (LocalFunctionStatementSyntaxWrapper.IsInstance(c.Node))
+            else if (c.Node.IsKind(SyntaxKindEx.LocalFunctionStatement))
             {
                 var localFunction = (LocalFunctionStatementSyntaxWrapper)c.Node;
-                return new MethodContext(c, localFunction.ParameterList, localFunction.Body, localFunction.ExpressionBody);
+                return new MethodContext(c, localFunction);
             }
             else
             {
@@ -253,13 +253,18 @@ namespace SonarAnalyzer.Rules.CSharp
             && methodSymbol.Parameters[0].IsType(KnownType.System_Runtime_Serialization_SerializationInfo)
             && methodSymbol.Parameters[1].IsType(KnownType.System_Runtime_Serialization_StreamingContext);
 
-        private class MethodContext
+        private sealed class MethodContext
         {
             public readonly SonarSyntaxNodeReportingContext Context;
             public readonly IMethodSymbol Symbol;
             public readonly ParameterListSyntax ParameterList;
             public readonly BlockSyntax Body;
             public readonly ArrowExpressionClauseSyntax ExpressionBody;
+            public MethodContext(SonarSyntaxNodeReportingContext context, BaseMethodDeclarationSyntax declaration)
+                : this(context, declaration.ParameterList, declaration.Body, declaration.ExpressionBody()) { }
+
+            public MethodContext(SonarSyntaxNodeReportingContext context, LocalFunctionStatementSyntaxWrapper declaration)
+                : this(context, declaration.ParameterList, declaration.Body, declaration.ExpressionBody) { }
 
             public MethodContext(SonarSyntaxNodeReportingContext context, ParameterListSyntax parameterList, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody)
             {
@@ -271,7 +276,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private class LvaResult
+        private sealed class LvaResult
         {
             public readonly IReadOnlyCollection<ISymbol> LiveInEntryBlock;
             public readonly IReadOnlyCollection<ISymbol> CapturedVariables;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Xml.Linq;
 using SonarAnalyzer.CFG.LiveVariableAnalysis;
 using SonarAnalyzer.CFG.Roslyn;
 using SonarAnalyzer.CFG.Sonar;
@@ -83,13 +82,13 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static bool OnlyThrowsNotImplementedException(MethodContext declaration)
         {
-            if (declaration.Body != null && declaration.Body.Statements.Count != 1)
+            if (declaration.Body is not null && declaration.Body.Statements.Count != 1)
             {
                 return false;
             }
 
             var throwExpressions = Enumerable.Empty<ExpressionSyntax>();
-            if (declaration.ExpressionBody != null)
+            if (declaration.ExpressionBody is not null)
             {
                 if (ThrowExpressionSyntaxWrapper.IsInstance(declaration.ExpressionBody.Expression))
                 {
@@ -105,7 +104,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 .OfType<ObjectCreationExpressionSyntax>()
                 .Select(x => declaration.Context.SemanticModel.GetSymbolInfo(x).Symbol)
                 .OfType<IMethodSymbol>()
-                .Any(x => x != null && x.ContainingType.Is(KnownType.System_NotImplementedException));
+                .Any(x => x is not null && x.ContainingType.Is(KnownType.System_NotImplementedException));
         }
 
         private void ReportUnusedParametersOnMethod(MethodContext declaration)
@@ -173,7 +172,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             var parameters = declaration.ParameterList.Parameters
                 .Select(x => new NodeAndSymbol(x, declaration.Context.SemanticModel.GetDeclaredSymbol(x)))
-                .Where(x => x.Symbol != null);
+                .Where(x => x.Symbol is not null);
 
             foreach (var parameter in parameters)
             {
@@ -218,7 +217,7 @@ namespace SonarAnalyzer.Rules.CSharp
             body.DescendantNodes()
                 .Where(x => x.IsKind(SyntaxKind.IdentifierName))
                 .Select(x => semanticModel.GetSymbolInfo(x).Symbol as IParameterSymbol)
-                .Where(x => x != null && parameters.Contains(x))
+                .Where(x => x is not null && parameters.Contains(x))
                 .ToHashSet();
 
         private static bool IsUsedAsEventHandlerFunctionOrAction(MethodContext declaration) =>
@@ -232,7 +231,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static bool IsMethodUsedAsEventHandlerFunctionOrActionInExpression(IMethodSymbol methodSymbol, ExpressionSyntax expression, SemanticModel semanticModel) =>
             !expression.IsKind(SyntaxKind.InvocationExpression)
-            && semanticModel != null
+            && semanticModel is not null
             && IsStandaloneExpression(expression)
             && methodSymbol.Equals(semanticModel.GetSymbolInfo(expression).Symbol?.OriginalDefinition);
 
@@ -241,7 +240,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var parentAsAssignment = expression.Parent as AssignmentExpressionSyntax;
 
             return expression.Parent is not ExpressionSyntax
-                || (parentAsAssignment != null && ReferenceEquals(expression, parentAsAssignment.Right));
+                || (parentAsAssignment is not null && ReferenceEquals(expression, parentAsAssignment.Right));
         }
 
         private static bool IsCandidateSerializableConstructor(IImmutableList<IParameterSymbol> unusedParameters, IMethodSymbol methodSymbol) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnused.cs
@@ -71,8 +71,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
             else if (c.Node.IsKind(SyntaxKindEx.LocalFunctionStatement))
             {
-                var localFunction = (LocalFunctionStatementSyntaxWrapper)c.Node;
-                return new MethodContext(c, localFunction);
+                return new MethodContext(c, (LocalFunctionStatementSyntaxWrapper)c.Node);
             }
             else
             {
@@ -256,6 +255,7 @@ namespace SonarAnalyzer.Rules.CSharp
             public readonly ParameterListSyntax ParameterList;
             public readonly BlockSyntax Body;
             public readonly ArrowExpressionClauseSyntax ExpressionBody;
+
             public MethodContext(SonarSyntaxNodeReportingContext context, BaseMethodDeclarationSyntax declaration)
                 : this(context, declaration.ParameterList, declaration.Body, declaration.ExpressionBody()) { }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
@@ -63,13 +63,12 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private static void CheckForRedundantJumps(SonarSyntaxNodeReportingContext context)
         {
-            var node = context.Node;
-            if (!CSharpControlFlowGraph.TryGet(node, context.SemanticModel, out var cfg))
+            if (!CSharpControlFlowGraph.TryGet(context.Node, context.SemanticModel, out var cfg))
             {
                 return;
             }
 
-            var yieldStatementCount = node.DescendantNodes().OfType<YieldStatementSyntax>().Count();
+            var yieldStatementCount = context.Node.DescendantNodes().OfType<YieldStatementSyntax>().Count();
 
             var removableJumps = cfg.Blocks
                                     .OfType<JumpBlock>()

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context)
         {
             context.RegisterNodeAction(
-                c => CheckForRedundantJumps(c, ((BaseMethodDeclarationSyntax)c.Node).Body),
+                c => CheckForRedundantJumps(c, ((BaseMethodDeclarationSyntax)c.Node)),
                 SyntaxKind.MethodDeclaration,
                 SyntaxKind.ConstructorDeclaration,
                 SyntaxKind.DestructorDeclaration,
@@ -43,11 +43,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.OperatorDeclaration);
 
             context.RegisterNodeAction(
-                c => CheckForRedundantJumps(c, ((LocalFunctionStatementSyntaxWrapper)c.Node).Body),
+                c => CheckForRedundantJumps(c, ((LocalFunctionStatementSyntaxWrapper)c.Node)),
                 SyntaxKindEx.LocalFunctionStatement);
 
             context.RegisterNodeAction(
-                c => CheckForRedundantJumps(c, ((AccessorDeclarationSyntax)c.Node).Body),
+                c => CheckForRedundantJumps(c, ((AccessorDeclarationSyntax)c.Node)),
                 SyntaxKind.GetAccessorDeclaration,
                 SyntaxKind.SetAccessorDeclaration,
                 SyntaxKindEx.InitAccessorDeclaration,
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.RemoveAccessorDeclaration);
 
             context.RegisterNodeAction(
-                c => CheckForRedundantJumps(c, ((AnonymousFunctionExpressionSyntax)c.Node).Body),
+                c => CheckForRedundantJumps(c, ((AnonymousFunctionExpressionSyntax)c.Node)),
                 SyntaxKind.AnonymousMethodExpression,
                 SyntaxKind.SimpleLambdaExpression,
                 SyntaxKind.ParenthesizedLambdaExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarAnalysisContext context)
         {
             context.RegisterNodeAction(
-                c => CheckForRedundantJumps(c, ((BaseMethodDeclarationSyntax)c.Node)),
+                CheckForRedundantJumps,
                 SyntaxKind.MethodDeclaration,
                 SyntaxKind.ConstructorDeclaration,
                 SyntaxKind.DestructorDeclaration,
@@ -43,11 +43,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.OperatorDeclaration);
 
             context.RegisterNodeAction(
-                c => CheckForRedundantJumps(c, ((LocalFunctionStatementSyntaxWrapper)c.Node)),
+                CheckForRedundantJumps,
                 SyntaxKindEx.LocalFunctionStatement);
 
             context.RegisterNodeAction(
-                c => CheckForRedundantJumps(c, ((AccessorDeclarationSyntax)c.Node)),
+                CheckForRedundantJumps,
                 SyntaxKind.GetAccessorDeclaration,
                 SyntaxKind.SetAccessorDeclaration,
                 SyntaxKindEx.InitAccessorDeclaration,
@@ -55,14 +55,15 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.RemoveAccessorDeclaration);
 
             context.RegisterNodeAction(
-                c => CheckForRedundantJumps(c, ((AnonymousFunctionExpressionSyntax)c.Node)),
+                CheckForRedundantJumps,
                 SyntaxKind.AnonymousMethodExpression,
                 SyntaxKind.SimpleLambdaExpression,
                 SyntaxKind.ParenthesizedLambdaExpression);
         }
 
-        private static void CheckForRedundantJumps(SonarSyntaxNodeReportingContext context, CSharpSyntaxNode node)
+        private static void CheckForRedundantJumps(SonarSyntaxNodeReportingContext context)
         {
+            var node = context.Node;
             if (!CSharpControlFlowGraph.TryGet(node, context.SemanticModel, out var cfg))
             {
                 return;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -65,13 +65,13 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
                 var compilationUnit = (CompilationUnitSyntax)c.Node;
                 if (compilationUnit.IsTopLevelMain() && c.SemanticModel.GetDeclaredSymbol(compilationUnit) is { } symbol)
                 {
-                    Analyze(context, c, compilationUnit, symbol);
+                    Analyze(context, c, symbol);
                 }
             },
             SyntaxKind.CompilationUnit);
 
         context.RegisterNodeAction(
-            c => Analyze(context, c, c.Node),
+            c => Analyze(context, c),
             SyntaxKind.AddAccessorDeclaration,
             SyntaxKind.ConstructorDeclaration,
             SyntaxKind.ConversionOperatorDeclaration,
@@ -92,7 +92,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
                 var declaration = (AnonymousFunctionExpressionSyntax)c.Node;
                 if (c.SemanticModel.GetSymbolInfo(declaration).Symbol is { } symbol && !c.IsInExpressionTree())
                 {
-                    Analyze(context, c, declaration, symbol);
+                    Analyze(context, c, symbol);
                 }
             },
             SyntaxKind.AnonymousMethodExpression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -71,32 +71,27 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
             SyntaxKind.CompilationUnit);
 
         context.RegisterNodeAction(
-            c => Analyze<BaseMethodDeclarationSyntax>(context, c, c.Node),
+            c => Analyze(context, c, c.Node),
             SyntaxKind.ConstructorDeclaration,
             SyntaxKind.DestructorDeclaration,
             SyntaxKind.ConversionOperatorDeclaration,
             SyntaxKind.OperatorDeclaration,
-            SyntaxKind.MethodDeclaration);
-
-        context.RegisterNodeAction(
-            c => Analyze<SyntaxNode>(context, c, c.Node),
-            SyntaxKindEx.LocalFunctionStatement);
-
-        context.RegisterNodeAction(
-            c => Analyze<PropertyDeclarationSyntax>(context, c, ((PropertyDeclarationSyntax)c.Node).ExpressionBody),
-            SyntaxKind.PropertyDeclaration);
-
-        context.RegisterNodeAction(
-            c => Analyze<IndexerDeclarationSyntax>(context, c, ((IndexerDeclarationSyntax)c.Node).ExpressionBody),
-            SyntaxKind.IndexerDeclaration);
-
-        context.RegisterNodeAction(
-            c => Analyze<AccessorDeclarationSyntax>(context, c, c.Node),
+            SyntaxKind.MethodDeclaration,
+            SyntaxKindEx.LocalFunctionStatement,
             SyntaxKind.GetAccessorDeclaration,
             SyntaxKind.SetAccessorDeclaration,
             SyntaxKindEx.InitAccessorDeclaration,
             SyntaxKind.AddAccessorDeclaration,
             SyntaxKind.RemoveAccessorDeclaration);
+
+
+        context.RegisterNodeAction(
+            c => Analyze(context, c, ((PropertyDeclarationSyntax)c.Node).ExpressionBody),
+            SyntaxKind.PropertyDeclaration);
+
+        context.RegisterNodeAction(
+            c => Analyze(context, c, ((IndexerDeclarationSyntax)c.Node).ExpressionBody),
+            SyntaxKind.IndexerDeclaration);
 
         context.RegisterNodeAction(
             c =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -108,7 +108,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
                 var declaration = (AnonymousFunctionExpressionSyntax)c.Node;
                 if (c.SemanticModel.GetSymbolInfo(declaration).Symbol is { } symbol && !c.IsInExpressionTree())
                 {
-                    Analyze(context, c, declaration.Body, symbol);
+                    Analyze(context, c, declaration, symbol);
                 }
             },
             SyntaxKind.AnonymousMethodExpression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -82,15 +82,8 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
             SyntaxKind.SetAccessorDeclaration,
             SyntaxKindEx.InitAccessorDeclaration,
             SyntaxKind.AddAccessorDeclaration,
-            SyntaxKind.RemoveAccessorDeclaration);
-
-
-        context.RegisterNodeAction(
-            c => Analyze(context, c, ((PropertyDeclarationSyntax)c.Node).ExpressionBody),
-            SyntaxKind.PropertyDeclaration);
-
-        context.RegisterNodeAction(
-            c => Analyze(context, c, ((IndexerDeclarationSyntax)c.Node).ExpressionBody),
+            SyntaxKind.RemoveAccessorDeclaration,
+            SyntaxKind.PropertyDeclaration,
             SyntaxKind.IndexerDeclaration);
 
         context.RegisterNodeAction(

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -71,7 +71,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
             SyntaxKind.CompilationUnit);
 
         context.RegisterNodeAction(
-            c => Analyze<BaseMethodDeclarationSyntax>(context, c, c.Node, x => (SyntaxNode)x.Body ?? x.ExpressionBody()),
+            c => Analyze<BaseMethodDeclarationSyntax>(context, c, c.Node),
             SyntaxKind.ConstructorDeclaration,
             SyntaxKind.DestructorDeclaration,
             SyntaxKind.ConversionOperatorDeclaration,
@@ -79,23 +79,19 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
             SyntaxKind.MethodDeclaration);
 
         context.RegisterNodeAction(
-            c => Analyze<SyntaxNode>(context, c, c.Node, x =>
-            {
-                var localFunction = (LocalFunctionStatementSyntaxWrapper)x;
-                return (SyntaxNode)localFunction.Body ?? localFunction.ExpressionBody;
-            }),
+            c => Analyze<SyntaxNode>(context, c, c.Node),
             SyntaxKindEx.LocalFunctionStatement);
 
         context.RegisterNodeAction(
-            c => Analyze<PropertyDeclarationSyntax>(context, c, ((PropertyDeclarationSyntax)c.Node).ExpressionBody, x => x.ExpressionBody?.Expression),
+            c => Analyze<PropertyDeclarationSyntax>(context, c, ((PropertyDeclarationSyntax)c.Node).ExpressionBody),
             SyntaxKind.PropertyDeclaration);
 
         context.RegisterNodeAction(
-            c => Analyze<IndexerDeclarationSyntax>(context, c, ((IndexerDeclarationSyntax)c.Node).ExpressionBody, x => x.ExpressionBody?.Expression),
+            c => Analyze<IndexerDeclarationSyntax>(context, c, ((IndexerDeclarationSyntax)c.Node).ExpressionBody),
             SyntaxKind.IndexerDeclaration);
 
         context.RegisterNodeAction(
-            c => Analyze<AccessorDeclarationSyntax>(context, c, c.Node, x => (SyntaxNode)x.Body ?? x.ExpressionBody()),
+            c => Analyze<AccessorDeclarationSyntax>(context, c, c.Node),
             SyntaxKind.GetAccessorDeclaration,
             SyntaxKind.SetAccessorDeclaration,
             SyntaxKindEx.InitAccessorDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -71,7 +71,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
             SyntaxKind.CompilationUnit);
 
         context.RegisterNodeAction(
-            c => Analyze<BaseMethodDeclarationSyntax>(context, c, x => (SyntaxNode)x.Body ?? x.ExpressionBody()),
+            c => Analyze<BaseMethodDeclarationSyntax>(context, c, c.Node, x => (SyntaxNode)x.Body ?? x.ExpressionBody()),
             SyntaxKind.ConstructorDeclaration,
             SyntaxKind.DestructorDeclaration,
             SyntaxKind.ConversionOperatorDeclaration,
@@ -79,7 +79,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
             SyntaxKind.MethodDeclaration);
 
         context.RegisterNodeAction(
-            c => Analyze<SyntaxNode>(context, c, x =>
+            c => Analyze<SyntaxNode>(context, c, c.Node, x =>
             {
                 var localFunction = (LocalFunctionStatementSyntaxWrapper)x;
                 return (SyntaxNode)localFunction.Body ?? localFunction.ExpressionBody;
@@ -87,15 +87,15 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
             SyntaxKindEx.LocalFunctionStatement);
 
         context.RegisterNodeAction(
-            c => Analyze<PropertyDeclarationSyntax>(context, c, x => x.ExpressionBody?.Expression),
+            c => Analyze<PropertyDeclarationSyntax>(context, c, ((PropertyDeclarationSyntax)c.Node).ExpressionBody, x => x.ExpressionBody?.Expression),
             SyntaxKind.PropertyDeclaration);
 
         context.RegisterNodeAction(
-            c => Analyze<IndexerDeclarationSyntax>(context, c, x => x.ExpressionBody?.Expression),
+            c => Analyze<IndexerDeclarationSyntax>(context, c, ((IndexerDeclarationSyntax)c.Node).ExpressionBody, x => x.ExpressionBody?.Expression),
             SyntaxKind.IndexerDeclaration);
 
         context.RegisterNodeAction(
-            c => Analyze<AccessorDeclarationSyntax>(context, c, x => (SyntaxNode)x.Body ?? x.ExpressionBody()),
+            c => Analyze<AccessorDeclarationSyntax>(context, c, c.Node, x => (SyntaxNode)x.Body ?? x.ExpressionBody()),
             SyntaxKind.GetAccessorDeclaration,
             SyntaxKind.SetAccessorDeclaration,
             SyntaxKindEx.InitAccessorDeclaration,

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
@@ -72,16 +72,17 @@ public abstract class SymbolicExecutionRunnerBase : SonarDiagnosticAnalyzer
         }
     }
 
-    protected void Analyze(SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext context, SyntaxNode node)
+    protected void Analyze(SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext context)
     {
         if (context.SemanticModel.GetDeclaredSymbol(context.Node) is { } symbol)
         {
-            Analyze(analysisContext, context, node, symbol);
+            Analyze(analysisContext, context, symbol);
         }
     }
 
-    protected void Analyze(SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext nodeContext, SyntaxNode node, ISymbol symbol)
+    protected void Analyze(SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext nodeContext, ISymbol symbol)
     {
+        var node = nodeContext.Node;
         if (node is { ContainsDiagnostics: false })
         {
             AnalyzeSonar(nodeContext, node, symbol);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
@@ -72,9 +72,9 @@ public abstract class SymbolicExecutionRunnerBase : SonarDiagnosticAnalyzer
         }
     }
 
-    protected void Analyze<TNode>(SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext context, SyntaxNode toAnalyze, Func<TNode, SyntaxNode> getBody) where TNode : SyntaxNode
+    protected void Analyze<TNode>(SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext context, SyntaxNode toAnalyze) where TNode : SyntaxNode
     {
-        if (getBody((TNode)context.Node) is { } && context.SemanticModel.GetDeclaredSymbol(context.Node) is { } symbol)
+        if (context.SemanticModel.GetDeclaredSymbol(context.Node) is { } symbol)
         {
             Analyze(analysisContext, context, toAnalyze, symbol);
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SymbolicExecutionRunnerBase.cs
@@ -72,11 +72,11 @@ public abstract class SymbolicExecutionRunnerBase : SonarDiagnosticAnalyzer
         }
     }
 
-    protected void Analyze<TNode>(SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext context, Func<TNode, SyntaxNode> getBody) where TNode : SyntaxNode
+    protected void Analyze<TNode>(SonarAnalysisContext analysisContext, SonarSyntaxNodeReportingContext context, SyntaxNode toAnalyze, Func<TNode, SyntaxNode> getBody) where TNode : SyntaxNode
     {
         if (getBody((TNode)context.Node) is { } && context.SemanticModel.GetDeclaredSymbol(context.Node) is { } symbol)
         {
-            Analyze(analysisContext, context, context.Node, symbol);
+            Analyze(analysisContext, context, toAnalyze, symbol);
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -78,7 +78,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
     protected override ControlFlowGraph CreateCfg(SemanticModel model, SyntaxNode node, CancellationToken cancel) =>
         node.CreateCfg(model, cancel);
 
-    protected override void AnalyzeSonar(SonarSyntaxNodeReportingContext context, SyntaxNode body, ISymbol symbol)
+    protected override void AnalyzeSonar(SonarSyntaxNodeReportingContext context, ISymbol symbol)
     {
         // There are no old Sonar rules in VB.NET
     }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -49,7 +49,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
     protected override void Initialize(SonarAnalysisContext context)
     {
         context.RegisterNodeAction(
-            c => Analyze(context, c, c.Node),
+            c => Analyze(context, c),
             SyntaxKind.ConstructorBlock,
             SyntaxKind.OperatorBlock,
             SyntaxKind.SubBlock,
@@ -66,7 +66,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
                 var declaration = (LambdaExpressionSyntax)c.Node;
                 if (c.SemanticModel.GetSymbolInfo(declaration).Symbol is { } symbol && !c.IsInExpressionTree())
                 {
-                    Analyze(context, c, declaration, symbol);
+                    Analyze(context, c, symbol);
                 }
             },
             SyntaxKind.SingleLineFunctionLambdaExpression,

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -49,7 +49,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
     protected override void Initialize(SonarAnalysisContext context)
     {
         context.RegisterNodeAction(
-            c => Analyze<MethodBlockBaseSyntax>(context, c, x => x),
+            c => Analyze<MethodBlockBaseSyntax>(context, c, c.Node, x => x),
             SyntaxKind.ConstructorBlock,
             SyntaxKind.OperatorBlock,
             SyntaxKind.SubBlock,

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -49,7 +49,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
     protected override void Initialize(SonarAnalysisContext context)
     {
         context.RegisterNodeAction(
-            c => Analyze<MethodBlockBaseSyntax>(context, c, c.Node),
+            c => Analyze(context, c, c.Node),
             SyntaxKind.ConstructorBlock,
             SyntaxKind.OperatorBlock,
             SyntaxKind.SubBlock,

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -49,7 +49,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
     protected override void Initialize(SonarAnalysisContext context)
     {
         context.RegisterNodeAction(
-            c => Analyze<MethodBlockBaseSyntax>(context, c, c.Node, x => x),
+            c => Analyze<MethodBlockBaseSyntax>(context, c, c.Node),
             SyntaxKind.ConstructorBlock,
             SyntaxKind.OperatorBlock,
             SyntaxKind.SubBlock,

--- a/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/CFG/Sonar/SonarControlFlowGraphTest.cs
@@ -227,7 +227,7 @@ public class Sample
             var (tree, semanticModel) = TestHelper.CompileCS(input);
             var method = FirstMethod(tree);
             CSharpControlFlowGraph.Create(method.ExpressionBody, semanticModel).Should().NotBeNull();
-            CSharpControlFlowGraph.TryGet(method.ExpressionBody, semanticModel, out _).Should().BeTrue();
+            CSharpControlFlowGraph.TryGet(method, semanticModel, out _).Should().BeTrue();
         }
 
         [TestMethod]
@@ -243,7 +243,7 @@ public class Sample
             var (tree, semanticModel) = TestHelper.CompileCS(input);
             var method = FirstMethod(tree);
             CSharpControlFlowGraph.Create(method.ExpressionBody, semanticModel).Should().NotBeNull();
-            CSharpControlFlowGraph.TryGet(method.ExpressionBody, semanticModel, out _).Should().BeTrue();
+            CSharpControlFlowGraph.TryGet(method, semanticModel, out _).Should().BeTrue();
         }
 
         #endregion

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
@@ -50,8 +50,8 @@ namespace SonarAnalyzer.UnitTest.Common
             var analyzers = RuleFinder.CreateAnalyzers(AnalyzerLanguage.CSharp, true).ToArray();
 
             VerifyNoExceptionThrown(@"TestCases\RuleFailure\InvalidSyntax.cs", analyzers, CompilationErrorBehavior.Ignore);
-            VerifyNoExceptionThrown(@"TestCases\RuleFailure\SpecialCases.cs", analyzers, CompilationErrorBehavior.Ignore);
-            VerifyNoExceptionThrown(@"TestCases\RuleFailure\PerformanceTestCases.cs", analyzers, CompilationErrorBehavior.Ignore);
+           // VerifyNoExceptionThrown(@"TestCases\RuleFailure\SpecialCases.cs", analyzers, CompilationErrorBehavior.Ignore);
+          //  VerifyNoExceptionThrown(@"TestCases\RuleFailure\PerformanceTestCases.cs", analyzers, CompilationErrorBehavior.Ignore);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Common/RuleTest.cs
@@ -50,8 +50,8 @@ namespace SonarAnalyzer.UnitTest.Common
             var analyzers = RuleFinder.CreateAnalyzers(AnalyzerLanguage.CSharp, true).ToArray();
 
             VerifyNoExceptionThrown(@"TestCases\RuleFailure\InvalidSyntax.cs", analyzers, CompilationErrorBehavior.Ignore);
-           // VerifyNoExceptionThrown(@"TestCases\RuleFailure\SpecialCases.cs", analyzers, CompilationErrorBehavior.Ignore);
-          //  VerifyNoExceptionThrown(@"TestCases\RuleFailure\PerformanceTestCases.cs", analyzers, CompilationErrorBehavior.Ignore);
+            VerifyNoExceptionThrown(@"TestCases\RuleFailure\SpecialCases.cs", analyzers, CompilationErrorBehavior.Ignore);
+            VerifyNoExceptionThrown(@"TestCases\RuleFailure\PerformanceTestCases.cs", analyzers, CompilationErrorBehavior.Ignore);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -174,7 +174,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
         [TestMethod]
         public void CreateCfg_MethodDeclaration_ReturnsCfg_CS()
         {
-            var code = """
+            const string code = """
                 public class Sample
                 {
                     public void Main()
@@ -192,7 +192,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
         [TestMethod]
         public void CreateCfg_PropertyDeclartion_ReturnsCfg_CS()
         {
-            var code = """
+            const string code = """
                 public class Sample
                 {
                     public int Property => 42;
@@ -207,7 +207,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
         [TestMethod]
         public void CreateCfg_PropertyDeclartionWithoutExpressionBody_ReturnsNull_CS()
         {
-            var code = """
+            const string code = """
                 public class Sample
                 {
                     public int Property {get; set;}
@@ -222,7 +222,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
         [TestMethod]
         public void CreateCfg_IndexerDeclartion_ReturnsCfg_CS()
         {
-            var code = """
+            const string code = """
                 public class Sample
                 {
                     private string field;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -174,7 +174,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
         [TestMethod]
         public void CreateCfg_MethodDeclaration_ReturnsCfg_CS()
         {
-            const string code = """
+            var code = """
                 public class Sample
                 {
                     public void Main()
@@ -192,11 +192,10 @@ namespace SonarAnalyzer.UnitTest.Extensions
         [TestMethod]
         public void CreateCfg_PropertyDeclartion_ReturnsCfg_CS()
         {
-            const string code = """
+            var code = """
                 public class Sample
                 {
-                    int field;
-                    public int Property => field + 42;
+                    public int Property => 42;
                 }
                 """;
             var (tree, semanticModel) = TestHelper.CompileCS(code);
@@ -208,7 +207,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
         [TestMethod]
         public void CreateCfg_PropertyDeclartionWithoutExpressionBody_ReturnsNull_CS()
         {
-            const string code = """
+            var code = """
                 public class Sample
                 {
                     public int Property {get; set;}
@@ -223,7 +222,7 @@ namespace SonarAnalyzer.UnitTest.Extensions
         [TestMethod]
         public void CreateCfg_IndexerDeclartion_ReturnsCfg_CS()
         {
-            const string code = """
+            var code = """
                 public class Sample
                 {
                     private string field;
@@ -788,7 +787,7 @@ public class X
         public void ArgumentList_CS_InvocationObjectCreation(string statement)
         {
             var code = $$"""
-                public class C(int p) {    
+                public class C(int p) {
                     public void M(int p) {
                         {{statement}}
                     }
@@ -811,9 +810,9 @@ public class X
                 public class C: Base
                 {
                     public C(): $${{keyword}}(1)$$ { }
-                    public C(int  p): base(p) { }   
+                    public C(int  p): base(p) { }
                 }
-                
+
                 """;
             var node = NodeBetweenMarkers(code, LanguageNames.CSharp);
             var argumentList = ExtensionsCS.ArgumentList(node).Arguments;
@@ -839,7 +838,7 @@ public class X
         public void ArgumentList_CS_NoList(string statement)
         {
             var code = $$"""
-                public class C {    
+                public class C {
                     public void M() {
                         {{statement}}
                     }
@@ -859,7 +858,7 @@ public class X
         public void ArgumentList_CS_UnsupportedNodeKinds(string statement)
         {
             var code = $$"""
-                public class C {    
+                public class C {
                     public void M() {
                         {{statement}}
                     }
@@ -1061,7 +1060,7 @@ public class X
             var node = NodeBetweenMarkers($$"""
                 $$public {{type}} C(int p)
                 {
-                    
+
                 }$$
                 """, LanguageNames.CSharp);
             var actual = ExtensionsCS.ParameterList(node);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -185,7 +185,7 @@ public class Sample
             var (tree, semanticModel) = TestHelper.CompileCS(code);
             var node = tree.Single<SyntaxCS.MethodDeclarationSyntax>();
 
-            ExtensionsCS.CreateCfg(node.Body, semanticModel, default).Should().NotBeNull();
+            ExtensionsCS.CreateCfg(node, semanticModel, default).Should().NotBeNull();
         }
 
         [TestMethod]
@@ -251,7 +251,7 @@ public class Sample
             var (tree, semanticModel) = TestHelper.CompileCS(code);
             var lambda = tree.Single<SyntaxCS.ParenthesizedLambdaExpressionSyntax>();
 
-            ExtensionsCS.CreateCfg(lambda.Body, semanticModel, default).Should().NotBeNull();
+            ExtensionsCS.CreateCfg(lambda, semanticModel, default).Should().NotBeNull();
         }
 
         [TestMethod]
@@ -267,7 +267,7 @@ End Class
             var (tree, semanticModel) = TestHelper.CompileVB(code);
             var lambda = tree.Single<SyntaxVB.SingleLineLambdaExpressionSyntax>();
 
-            ExtensionsVB.CreateCfg(lambda.Body, semanticModel, default).Should().NotBeNull();
+            ExtensionsVB.CreateCfg(lambda, semanticModel, default).Should().NotBeNull();
         }
 
         [TestMethod]
@@ -310,7 +310,7 @@ public class Sample
             var innerLambda = tree.Single<SyntaxCS.SimpleLambdaExpressionSyntax>();
             innerLambda.Parent.Parent.Should().BeOfType<SyntaxCS.VariableDeclaratorSyntax>().Subject.Identifier.ValueText.Should().Be("innerLambda");
 
-            var cfg = ExtensionsCS.CreateCfg(innerLambda.Body, semanticModel, default);
+            var cfg = ExtensionsCS.CreateCfg(innerLambda, semanticModel, default);
             cfg.Should().NotBeNull("It's innerLambda");
             cfg.Parent.Should().NotBeNull("It's InnerLocalFunction");
             cfg.Parent.Parent.Should().NotBeNull("Lambda iniside Lazy<int> constructor");
@@ -371,7 +371,7 @@ public class Sample
 }";
             var (tree, model) = TestHelper.CompileIgnoreErrorsCS(code);
             var lambda = tree.Single<SyntaxCS.ParenthesizedLambdaExpressionSyntax>();
-            ExtensionsCS.CreateCfg(lambda.Body, model, default).Should().NotBeNull();
+            ExtensionsCS.CreateCfg(lambda, model, default).Should().NotBeNull();
         }
 
         [TestMethod]
@@ -398,7 +398,7 @@ End Class";
             var (tree, model) = TestHelper.CompileIgnoreErrorsCS(code);
             var lambda = tree.Single<SyntaxCS.ParenthesizedLambdaExpressionSyntax>();
 
-            ExtensionsCS.CreateCfg(lambda.Body, model, default).Should().NotBeNull();
+            ExtensionsCS.CreateCfg(lambda, model, default).Should().NotBeNull();
         }
 
         [TestMethod]
@@ -477,8 +477,8 @@ public class Sample
             var compilation2 = compilation1.WithAssemblyName("Different-Compilation-Reusing-Same-Nodes");
             var method1 = compilation1.SyntaxTrees.Single().Single<SyntaxCS.MethodDeclarationSyntax>();
             var method2 = compilation2.SyntaxTrees.Single().Single<SyntaxCS.MethodDeclarationSyntax>();
-            var cfg1 = ExtensionsCS.CreateCfg(method1.Body, compilation1.GetSemanticModel(method1.SyntaxTree), default);
-            var cfg2 = ExtensionsCS.CreateCfg(method2.Body, compilation2.GetSemanticModel(method2.SyntaxTree), default);
+            var cfg1 = ExtensionsCS.CreateCfg(method1, compilation1.GetSemanticModel(method1.SyntaxTree), default);
+            var cfg2 = ExtensionsCS.CreateCfg(method2, compilation2.GetSemanticModel(method2.SyntaxTree), default);
 
             ReferenceEquals(cfg1, cfg2).Should().BeFalse("Different compilations should not reuse cache. They do not share semantic model and symbols.");
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -172,18 +172,66 @@ namespace SonarAnalyzer.UnitTest.Extensions
             ExtensionsCS.GetDeclarationTypeName(SyntaxFactory.StructDeclaration("MyStruct")).Should().Be("struct");
 
         [TestMethod]
-        public void CreateCfg_MethodBody_ReturnsCfg_CS()
+        public void CreateCfg_MethodDeclaration_ReturnsCfg_CS()
         {
-            const string code = @"
-public class Sample
-{
-    public void Main()
-    {
-        var x = 42;
-    }
-}";
+            const string code = """
+                public class Sample
+                {
+                    public void Main()
+                    {
+                        var x = 42;
+                    }
+                }
+                """;
             var (tree, semanticModel) = TestHelper.CompileCS(code);
             var node = tree.Single<SyntaxCS.MethodDeclarationSyntax>();
+
+            ExtensionsCS.CreateCfg(node, semanticModel, default).Should().NotBeNull();
+        }
+
+        [TestMethod]
+        public void CreateCfg_PropertyDeclartion_ReturnsCfg_CS()
+        {
+            const string code = """
+                public class Sample
+                {
+                    int field;
+                    public int Property => field + 42;
+                }
+                """;
+            var (tree, semanticModel) = TestHelper.CompileCS(code);
+            var node = tree.Single<SyntaxCS.PropertyDeclarationSyntax>();
+
+            ExtensionsCS.CreateCfg(node, semanticModel, default).Should().NotBeNull();
+        }
+
+        [TestMethod]
+        public void CreateCfg_PropertyDeclartionWithoutExpressionBody_ReturnsNull_CS()
+        {
+            const string code = """
+                public class Sample
+                {
+                    public int Property {get; set;}
+                }
+                """;
+            var (tree, semanticModel) = TestHelper.CompileCS(code);
+            var node = tree.Single<SyntaxCS.PropertyDeclarationSyntax>();
+
+            ExtensionsCS.CreateCfg(node, semanticModel, default).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void CreateCfg_IndexerDeclartion_ReturnsCfg_CS()
+        {
+            const string code = """
+                public class Sample
+                {
+                    private string field;
+                    public string this[int index] => field = null;
+                }
+                """;
+            var (tree, semanticModel) = TestHelper.CompileCS(code);
+            var node = tree.Single<SyntaxCS.IndexerDeclarationSyntax>();
 
             ExtensionsCS.CreateCfg(node, semanticModel, default).Should().NotBeNull();
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/LiveVariableAnalysis/RoslynLiveVariableAnalysisTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/LiveVariableAnalysis/RoslynLiveVariableAnalysisTest.cs
@@ -942,7 +942,7 @@ public class Sample
             return captureMe;
         };
 }";
-            new Context(code, SyntaxKind.Block).ValidateAllEmpty();
+            new Context(code, SyntaxKind.ParenthesizedLambdaExpression).ValidateAllEmpty();
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionRunnerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/SymbolicExecutionRunnerTest.cs
@@ -462,7 +462,7 @@ public class Sample
         var compilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.CSharp).AddSnippet(code).Solution.Compile(ParseOptionsHelper.CSharpLatest.ToArray()).Single();
         var diagnostics = DiagnosticVerifier.GetDiagnosticsIgnoreExceptions(compilation, sut);
         diagnostics.Should().ContainSingle(x => x.Id == "AD0001").Which.GetMessage().Should()
-            .StartWith("Analyzer 'SonarAnalyzer.UnitTest.Rules.SymbolicExecutionRunnerTest+ConfigurableSERunnerCS' threw an exception of type 'SonarAnalyzer.SymbolicExecution.SymbolicExecutionException' with message 'Error processing method: Method ## Method file: snippet1.cs ## Method line: 4,4 ## Inner exception: System.InvalidOperationException: This check is not useful. ##    at SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution.ThrowAssignmentRuleCheck.PostProcessSimple(SymbolicContext context)");
+            .StartWith("Analyzer 'SonarAnalyzer.UnitTest.Rules.SymbolicExecutionRunnerTest+ConfigurableSERunnerCS' threw an exception of type 'SonarAnalyzer.SymbolicExecution.SymbolicExecutionException' with message 'Error processing method: Method ## Method file: snippet1.cs ## Method line: 3,4 ## Inner exception: System.InvalidOperationException: This check is not useful.");
     }
 
     [TestMethod]


### PR DESCRIPTION
Better review commit by commit.