### PR TITLE
IOperationsWrapperSonar: Use compiled expressions

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/Helpers/OperationExecutionOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/Helpers/OperationExecutionOrder.cs
@@ -86,7 +86,7 @@ namespace SonarAnalyzer.Helpers
                         return true;
                     }
                 }
-                Current = null;
+                Current = default;
                 return false;
             }
 

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/IOperationWrapperSonar.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/IOperationWrapperSonar.cs
@@ -26,28 +26,28 @@ namespace StyleCop.Analyzers.Lightup
     // This is a temporary substitute for IOperationWrapper in case StyleCop will accept PR https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3381
     public readonly struct IOperationWrapperSonar
     {
-        private static readonly Func<IOperation, IOperation> ParentPropertyAccessor;
-        private static readonly Func<IOperation, IEnumerable<IOperation>> ChildrenPropertyAccessor;
-        private static readonly Func<IOperation, string> LanguagePropertyAccessor;
-        private static readonly Func<IOperation, bool> IsImplicitPropertyAccessor;
-        private static readonly Func<IOperation, SemanticModel> SemanticModelPropertyAccessor;
+        private static readonly Func<IOperation, IOperation> ParentAccessor;
+        private static readonly Func<IOperation, IEnumerable<IOperation>> ChildrenAccessor;
+        private static readonly Func<IOperation, string> LanguageAccessor;
+        private static readonly Func<IOperation, bool> IsImplicitAccessor;
+        private static readonly Func<IOperation, SemanticModel> SemanticModelAccessor;
 
         static IOperationWrapperSonar()
         {
             var type = typeof(IOperation);
-            ParentPropertyAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, IOperation>(type, nameof(Parent));
-            ChildrenPropertyAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, IEnumerable<IOperation>>(type, nameof(Children));
-            LanguagePropertyAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, string>(type, nameof(Language));
-            IsImplicitPropertyAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, bool>(type, nameof(IsImplicit));
-            SemanticModelPropertyAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, SemanticModel>(type, nameof(SemanticModel));
+            ParentAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, IOperation>(type, nameof(Parent));
+            ChildrenAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, IEnumerable<IOperation>>(type, nameof(Children));
+            LanguageAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, string>(type, nameof(Language));
+            IsImplicitAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, bool>(type, nameof(IsImplicit));
+            SemanticModelAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, SemanticModel>(type, nameof(SemanticModel));
         }
 
         public IOperation Instance { get; }
-        public IOperation Parent => ParentPropertyAccessor(Instance);
-        public IEnumerable<IOperation> Children => ChildrenPropertyAccessor(Instance);
-        public string Language => LanguagePropertyAccessor(Instance);
-        public bool IsImplicit => IsImplicitPropertyAccessor(Instance);
-        public SemanticModel SemanticModel => SemanticModelPropertyAccessor(Instance);
+        public IOperation Parent => ParentAccessor(Instance);
+        public IEnumerable<IOperation> Children => ChildrenAccessor(Instance);
+        public string Language => LanguageAccessor(Instance);
+        public bool IsImplicit => IsImplicitAccessor(Instance);
+        public SemanticModel SemanticModel => SemanticModelAccessor(Instance);
 
         public IOperationWrapperSonar(IOperation instance) =>
             Instance = instance ?? throw new ArgumentNullException(nameof(instance));

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/IOperationWrapperSonar.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/IOperationWrapperSonar.cs
@@ -24,7 +24,7 @@ using SonarAnalyzer.CFG;
 namespace StyleCop.Analyzers.Lightup
 {
     // This is a temporary substitute for IOperationWrapper in case StyleCop will accept PR https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3381
-    public class IOperationWrapperSonar
+    public readonly struct IOperationWrapperSonar
     {
         private static readonly Func<IOperation, IOperation> ParentPropertyAccessor;
         private static readonly Func<IOperation, IEnumerable<IOperation>> ChildrenPropertyAccessor;

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/IOperationWrapperSonar.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/IOperationWrapperSonar.cs
@@ -26,34 +26,28 @@ namespace StyleCop.Analyzers.Lightup
     // This is a temporary substitute for IOperationWrapper in case StyleCop will accept PR https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3381
     public class IOperationWrapperSonar
     {
-        private static readonly PropertyInfo ParentProperty;
-        private static readonly PropertyInfo ChildrenProperty;
-        private static readonly PropertyInfo LanguageProperty;
-        private static readonly PropertyInfo IsImplicitProperty;
-        private static readonly PropertyInfo SemanticModelProperty;
-
-        private IOperation parent;
-        private IEnumerable<IOperation> children;
-        private string language;
-        private bool? isImplicit;
-        private SemanticModel semanticModel;
-
-        public IOperation Instance { get; }
-        public IOperation Parent => ParentProperty.ReadCached(Instance, ref parent);
-        public IEnumerable<IOperation> Children => ChildrenProperty.ReadCached(Instance, ref children);
-        public string Language => LanguageProperty.ReadCached(Instance, ref language);
-        public bool IsImplicit => IsImplicitProperty.ReadCached(Instance, ref isImplicit);
-        public SemanticModel SemanticModel => SemanticModelProperty.ReadCached(Instance, ref semanticModel);
+        private static readonly Func<IOperation, IOperation> ParentPropertyAccessor;
+        private static readonly Func<IOperation, IEnumerable<IOperation>> ChildrenPropertyAccessor;
+        private static readonly Func<IOperation, string> LanguagePropertyAccessor;
+        private static readonly Func<IOperation, bool> IsImplicitPropertyAccessor;
+        private static readonly Func<IOperation, SemanticModel> SemanticModelPropertyAccessor;
 
         static IOperationWrapperSonar()
         {
             var type = typeof(IOperation);
-            ParentProperty = type.GetProperty(nameof(Parent));
-            ChildrenProperty = type.GetProperty(nameof(Children));
-            LanguageProperty = type.GetProperty(nameof(Language));
-            IsImplicitProperty = type.GetProperty(nameof(IsImplicit));
-            SemanticModelProperty = type.GetProperty(nameof(SemanticModel));
+            ParentPropertyAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, IOperation>(type, nameof(Parent));
+            ChildrenPropertyAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, IEnumerable<IOperation>>(type, nameof(Children));
+            LanguagePropertyAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, string>(type, nameof(Language));
+            IsImplicitPropertyAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, bool>(type, nameof(IsImplicit));
+            SemanticModelPropertyAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IOperation, SemanticModel>(type, nameof(SemanticModel));
         }
+
+        public IOperation Instance { get; }
+        public IOperation Parent => ParentPropertyAccessor(Instance);
+        public IEnumerable<IOperation> Children => ChildrenPropertyAccessor(Instance);
+        public string Language => LanguagePropertyAccessor(Instance);
+        public bool IsImplicit => IsImplicitPropertyAccessor(Instance);
+        public SemanticModel SemanticModel => SemanticModelPropertyAccessor(Instance);
 
         public IOperationWrapperSonar(IOperation instance) =>
             Instance = instance ?? throw new ArgumentNullException(nameof(instance));

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.RoslynCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.RoslynCfg.cs
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                 protected override bool IsValid(BasicBlock block)
                 {
-                    if (block.OperationsAndBranchValue.ToReversedExecutionOrder().FirstOrDefault(x => context.AnalyzedSymbol.Equals(MemberSymbol(x.Instance))) is { } operation)
+                    if (block.OperationsAndBranchValue.ToReversedExecutionOrder().FirstOrDefault(x => context.AnalyzedSymbol.Equals(MemberSymbol(x.Instance))) is { Instance: { } } operation)
                     {
                         var isWrite = operation.Parent is { Kind: OperationKindEx.SimpleAssignment } parent
                                       && ISimpleAssignmentOperationWrapper.FromOperation(parent).Target == operation.Instance;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ExplodedNode.cs
@@ -31,7 +31,7 @@ public sealed class ExplodedNode : IEquatable<ExplodedNode>
     public ProgramState State { get; private set; }
     public BasicBlock Block { get; }
     public FinallyPoint FinallyPoint { get; }
-    public IOperationWrapperSonar Operation => index < operations.Length ? operations[index] : null;
+    public IOperationWrapperSonar Operation => index < operations.Length ? operations[index] : default;
     public int VisitCount => State.GetVisitCount(programPointHash);
 
     public ExplodedNode(BasicBlock block, ProgramState state, FinallyPoint finallyPoint)
@@ -69,7 +69,7 @@ public sealed class ExplodedNode : IEquatable<ExplodedNode>
         && other.State.Equals(State);
 
     public override string ToString() =>
-        Operation is null
-            ? $"Block #{Block.Ordinal}, Branching{Environment.NewLine}{State}"
-            : $"Block #{Block.Ordinal}, Operation #{index}, {Operation.Instance.Serialize()}{Environment.NewLine}{State}";
+        Operation.Instance is { } operation
+            ? $"Block #{Block.Ordinal}, Operation #{index}, {operation.Serialize()}{Environment.NewLine}{State}"
+            : $"Block #{Block.Ordinal}, Branching{Environment.NewLine}{State}";
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -69,7 +69,7 @@ public sealed record ProgramState : IEquatable<ProgramState>
             : SetOperationValue(operation.WrappedOperation, value);
 
     public ProgramState SetOperationValue(IOperationWrapperSonar operation, SymbolicValue value) =>
-        operation is null
+        operation.Instance is null
             ? throw new ArgumentNullException(nameof(operation))
             : SetOperationValue(operation.Instance, value);
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RoslynSymbolicExecution.cs
@@ -78,7 +78,7 @@ internal class RoslynSymbolicExecution
                 }
 
                 logger.Log(current, "Processing");
-                var successors = current.Operation == null ? ProcessBranching(current) : ProcessOperation(current);
+                var successors = current.Operation.Instance == null ? ProcessBranching(current) : ProcessOperation(current);
                 foreach (var node in successors)
                 {
                     logger.Log(node, "Enqueuing", true);
@@ -101,7 +101,7 @@ internal class RoslynSymbolicExecution
 
         bool IsLoopCondition() =>
             node.Block.BranchValue is not null
-            && (node.Operation is null || IsInBranchValue(node.Operation.Instance))
+            && (node.Operation.Instance is null || IsInBranchValue(node.Operation.Instance))
             && syntaxClassifier.IsInLoopCondition(node.Block.BranchValue.Syntax);
 
         bool IsInBranchValue(IOperation current)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/OperationExecutionOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Helpers/OperationExecutionOrderTest.cs
@@ -96,14 +96,17 @@ Method(4);";
             var enumerator = Compile("Method(0);", false).GetEnumerator();
             enumerator.MoveNext().Should().BeTrue();
             enumerator.Current.Should().NotBeNull();
+            enumerator.Current.Instance.Should().NotBeNull();
 
             enumerator.Reset();
             enumerator.MoveNext().Should().BeTrue();
             enumerator.Current.Should().NotBeNull();
+            enumerator.Current.Instance.Should().NotBeNull();
 
             enumerator.Dispose();
             enumerator.MoveNext().Should().BeFalse();
-            enumerator.Current.Should().BeNull();
+            enumerator.Current.Should().NotBeNull();
+            enumerator.Current.Instance.Should().BeNull();
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ExplodedNodeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ExplodedNodeTest.cs
@@ -47,7 +47,7 @@ public class ExplodedNodeTest
     {
         var cfg = TestHelper.CompileCfgBodyCS();
         var sut = new ExplodedNode(cfg.EntryBlock, ProgramState.Empty, null);
-        sut.Operation.Should().BeNull();
+        sut.Operation.Instance.Should().BeNull();
     }
 
     [TestMethod]
@@ -70,7 +70,7 @@ public class ExplodedNodeTest
         TestHelper.Serialize(current.Operation).Should().Be("SimpleAssignment: value = 42 (Implicit)");
 
         current = current.CreateNext(ProgramState.Empty);
-        current.Operation.Should().BeNull();
+        current.Operation.Instance.Should().BeNull();
     }
 
     [TestMethod]
@@ -93,7 +93,7 @@ public class ExplodedNodeTest
         TestHelper.Serialize(sut.Operation).Should().Be("SimpleAssignment: Value As Integer = 42 (Implicit)");
 
         sut = sut.CreateNext(ProgramState.Empty);
-        sut.Operation.Should().BeNull();
+        sut.Operation.Instance.Should().BeNull();
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.OperationValue.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.OperationValue.cs
@@ -190,7 +190,7 @@ public partial class ProgramStateTest
 
     [TestMethod]
     public void SetOperationValue_WithWrapperSonar_NullOperation_Throws() =>
-        ProgramState.Empty.Invoking(x => x.SetOperationValue((IOperationWrapperSonar)null, SymbolicValue.Empty)).Should().Throw<ArgumentNullException>();
+        ProgramState.Empty.Invoking(x => x.SetOperationValue((IOperationWrapperSonar)default, SymbolicValue.Empty)).Should().Throw<ArgumentNullException>();
 
     [TestMethod]
     public void SetOperationValue_OnCaptureReference_SetsValueToCapturedOperation()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicCheckListTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicCheckListTest.cs
@@ -36,7 +36,7 @@ public class SymbolicCheckListTest
     {
         var a = new Mock<SymbolicCheck>();
         var b = new Mock<SymbolicCheck>();
-        var context = new SymbolicContext(null, null, ProgramState.Empty, false, 0, Array.Empty<ISymbol>());
+        var context = new SymbolicContext(null, default, ProgramState.Empty, false, 0, Array.Empty<ISymbol>());
         a.Setup(x => x.PreProcess(context)).Returns(new[] { context.State });
         a.Setup(x => x.PostProcess(context)).Returns(new[] { context.State });
         var sut = new SymbolicCheckList(new[] { a.Object, b.Object });
@@ -71,7 +71,7 @@ public class SymbolicCheckListTest
     {
         var triple = new PostProcessTestCheck(x => new[] { x.State, x.State, x.State });
         var sut = new SymbolicCheckList(new[] { triple, triple });
-        sut.PostProcess(new(null, null, ProgramState.Empty, false, 0, Array.Empty<ISymbol>())).Should().HaveCount(9);
+        sut.PostProcess(new(null, default, ProgramState.Empty, false, 0, Array.Empty<ISymbol>())).Should().HaveCount(9);
     }
 
     [TestMethod]
@@ -79,6 +79,6 @@ public class SymbolicCheckListTest
     {
         var empty = new PostProcessTestCheck(x => Array.Empty<ProgramState>());
         var sut = new SymbolicCheckList(new[] { empty });
-        sut.PostProcess(new(null, null, ProgramState.Empty, false, 0, Array.Empty<ISymbol>())).Should().HaveCount(0);
+        sut.PostProcess(new(null, default, ProgramState.Empty, false, 0, Array.Empty<ISymbol>())).Should().HaveCount(0);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/SymbolicContextTest.cs
@@ -47,7 +47,7 @@ public class SymbolicContextTest
 
     [TestMethod]
     public void NullOperation_SetsOperationToNull() =>
-        new SymbolicContext(null, null, ProgramState.Empty, false, 0, Array.Empty<ISymbol>()).Operation.Should().Be(null);
+        new SymbolicContext(null, default, ProgramState.Empty, false, 0, Array.Empty<ISymbol>()).Operation.Instance.Should().BeNull();
 
     [TestMethod]
     public void PropertiesArePersisted()
@@ -129,7 +129,7 @@ public class SymbolicContextTest
     public void WithState_SameState_ReturnsThis()
     {
         var state = ProgramState.Empty;
-        var sut = new SymbolicContext(null, null, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(null, default, state, false, 0, Array.Empty<ISymbol>());
         sut.WithState(state).Should().Be(sut);
     }
 
@@ -137,7 +137,7 @@ public class SymbolicContextTest
     public void WithState_DifferentState_ReturnsNew()
     {
         var state = ProgramState.Empty;
-        var sut = new SymbolicContext(null, null, state, false, 0, Array.Empty<ISymbol>());
+        var sut = new SymbolicContext(null, default, state, false, 0, Array.Empty<ISymbol>());
         var newState = state.SetOperationValue(CreateOperation(), SymbolicValue.Empty);
         sut.WithState(newState).Should().NotBe(sut);
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/TestHelper.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/TestHelper.cs
@@ -125,7 +125,7 @@ End Class", AnalyzerLanguage.VisualBasic);
 
         public static string Serialize(IOperationWrapperSonar operation)
         {
-            _ = operation ?? throw new ArgumentNullException(nameof(operation));
+            _ = operation.Instance ?? throw new ArgumentNullException(nameof(operation));
             return operation.Instance.Kind + ": " + operation.Instance.Syntax + (operation.IsImplicit ? " (Implicit)" : null);
         }
 


### PR DESCRIPTION
The IOperationWrapperSonar does not follow the pattern used for the other wrappers. This PR rewrites the wrapper to
* Use compiled expressions instead of cached reflection
* Use a readonly struct instead of a class

Before
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/3adaf88c-45dc-478a-912b-d1752b98bd00)

After
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/a481b8eb-bc9e-44b8-b005-76e3f85c755e)
