### PR TITLE
 .NET 8 and C# 12: fix repros and UTs for rules starting with P in SonarWay

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParameterValidationInYieldShouldBeWrapped.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParameterValidationInYieldShouldBeWrapped.cs
@@ -144,7 +144,7 @@ class NullCoalescingAssignment
 {
     IEnumerable<int> NullableInlineArray(int? i) // FN
     {
-        _ = i ?? throw new ArgumentNullException(nameof(i));
+        i ??= throw new ArgumentNullException(nameof(i));
 
         yield return 1;
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParameterValidationInYieldShouldBeWrapped.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParameterValidationInYieldShouldBeWrapped.cs
@@ -139,13 +139,3 @@ class NullCoalescing
         IEnumerable<int> LocalFunction() { yield return 1; }
     }
 }
-
-class NullCoalescingAssignment
-{
-    IEnumerable<int> NullableInlineArray(int? i) // FN
-    {
-        i ??= throw new ArgumentNullException(nameof(i));
-
-        yield return 1;
-    }
-}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp11.cs
@@ -43,9 +43,9 @@ namespace Repro_8072
             var f1 = (int a, int b) => a + b;
             var f2 = (int a, int b, int c) => a + b + c;
 
-            int FullyInverted(int a, int b) => f1(b, a);
-            int FullyInvertedWithAdditionalParamAfter(int a, int b, string c) => f1(b, a);
-            int FullyInvertedWithAdditionalParamBefore(string c, int a, int b) => f1(b, a);
+            int FullyInverted(int a, int b) => f1(b, a);                                    // FN
+            int FullyInvertedWithAdditionalParamAfter(int a, int b, string c) => f1(b, a);  // FN
+            int FullyInvertedWithAdditionalParamBefore(string c, int a, int b) => f1(b, a); // FN
 
             int PartiallyInvertedFirstAndSecond(int a, int b, int c) => f2(b, a, c); // FN
             int PartiallyInvertedFirstAndLast(int a, int b, int c) => f2(c, b, a);   // FN

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp11.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp11.cs
@@ -21,7 +21,7 @@ namespace Tests.Diagnostics
 
 namespace Repro_8072
 {
-    public class Lambdas
+    class Lambdas
     {
         Func<int, int, int> F1 = (int a, int b) => a + b;
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp12.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp12.cs
@@ -72,22 +72,22 @@ namespace Repro_8072
     {
         void InvokedFromAnotherLambda()
         {
-            var f1 = (int a, int b) => a + b;
-            var paramsFullyInverted = (int a, int b) => f1(b, a);                                    // FN
-            var paramsFullyInvertedWithAdditionalParamAfter = (int a, int b, string s) => f1(b, a);  // FN
-            var paramsFullyInvertedWithAdditionalParamBefore = (string s, int a, int b) => f1(b, a); // FN
+            var f1 = (int a = 42, int b = 42) => a + b;
+            var paramsFullyInverted = (int a = 42, int b = 42) => f1(b, a);                                           // FN
+            var paramsFullyInvertedWithAdditionalParamAfter = (int a = 42, int b = 42, string s = "42") => f1(b, a);  // FN
+            var paramsFullyInvertedWithAdditionalParamBefore = (string s = "42", int a = 42, int b = 42) => f1(b, a); // FN
 
-            var f2 = (int a, int b, int c) => a + b + c;
-            var paramsPartiallyInvertedFirstAndSecond = (int a, int b, int c) => f2(b, a, c);        // FN
-            var paramsPartiallyInvertedFirstAndLast = (int a, int b, int c) => f2(c, b, a);          // FN
-            var paramsPartiallyInvertedSecondAndLast = (int a, int b, int c) => f2(a, c, b);         // FN
+            var f2 = (int a = 42, int b = 42, int c = 42) => a + b + c;
+            var paramsPartiallyInvertedFirstAndSecond = (int a = 42, int b = 42, int c = 42) => f2(b, a, c); // FN
+            var paramsPartiallyInvertedFirstAndLast = (int a = 42, int b = 42, int c = 42) => f2(c, b, a);   // FN
+            var paramsPartiallyInvertedSecondAndLast = (int a = 42, int b = 42, int c = 42) => f2(a, c, b);  // FN
         }
 
         void InvokedFromLocalFunction()
         {
-            var f = (int a, int b) => a + b;
+            var f = (int a = 42, int b = 42) => a + b;
 
-            int SomeLocalFunction(int a, int b) => f(b, a);
+            int SomeLocalFunction(int a = 42, int b = 42) => f(b, a); // FN
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp12.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp12.cs
@@ -1,24 +1,5 @@
 ﻿using System;
 
-namespace Tests.Diagnostics
-{
-    public interface IInterface
-    {
-        static virtual void SomeMethod(int a, int b) { } // Secondary
-    }
-
-    public class SomeClass<T> where T : IInterface
-    {
-        public SomeClass()
-        {
-            int a = 1;
-            int b = 2;
-
-            T.SomeMethod(b, a); // Noncompliant
-        }
-    }
-}
-
 // https://github.com/SonarSource/sonar-dotnet/issues/8071
 namespace Repro_8071
 {

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.cs
@@ -1,9 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using static Tests.Diagnostics.A;
 
 namespace Tests.Diagnostics
 {


### PR DESCRIPTION
Due to a glitch in the review process described [here](https://github.com/SonarSource/sonar-dotnet/pull/8093#issuecomment-1742706072) and [here](https://trello.com/c/AD7ixuIb/22-p-second-pass), we need a second pass, to address the following new comments on rules starting with P:
- https://github.com/SonarSource/sonar-dotnet/pull/8093#discussion_r1342429179
- https://github.com/SonarSource/sonar-dotnet/pull/8093#discussion_r1342434664
- https://github.com/SonarSource/sonar-dotnet/pull/8093#discussion_r1342435227
- https://github.com/SonarSource/sonar-dotnet/pull/8093#discussion_r1342439023
- https://github.com/SonarSource/sonar-dotnet/pull/8093#discussion_r1342442665
- https://github.com/SonarSource/sonar-dotnet/pull/8093#discussion_r1342448835