### PR TITLE
Update target frameworks of SonarAnalyzer.UnitTest to "net48;net8"

### DIFF
--- a/analyzers/global.json
+++ b/analyzers/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.0",
+    "version": "8.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Constants.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Constants.cs
@@ -23,6 +23,7 @@ namespace SonarAnalyzer.UnitTest
     internal static class Constants
     {
         public const string NuGetLatestVersion = "LATEST";
+        public const string RazorFrameworkLatestVersion = "net8.0";
         public const string DotNet7Preview = "7.0.0-rc.1.22426.10";
         public const string DotNet7PreviewAzureAppServices = "7.0.0-rc.1.22427.2";
         public const string DotNetCore220Version = "2.2.0";

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -14,7 +14,7 @@
       -->
     <AssetTargetFallback>$(AssetTargetFallback);net40-client;portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
     <ProjectGuid>{e11606ca-a186-4fee-ba30-b1688747cd1a}</ProjectGuid>
-    <TargetFrameworks>net48;net7.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
@@ -58,6 +58,10 @@
     <None Include="TestFramework\Razor\EmptyProject\**\*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="RedundantArgument.CSharp12.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -14,7 +14,7 @@
       -->
     <AssetTargetFallback>$(AssetTargetFallback);net40-client;portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
     <ProjectGuid>{e11606ca-a186-4fee-ba30-b1688747cd1a}</ProjectGuid>
-    <TargetFrameworks>net48;net8</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SonarAnalyzer.UnitTest.csproj
@@ -61,10 +61,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="RedundantArgument.CSharp12.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\SonarAnalyzer.CFG\SonarAnalyzer.CFG.csproj" />
     <ProjectReference Include="..\..\src\SonarAnalyzer.Common\SonarAnalyzer.Common.csproj" />
     <ProjectReference Include="..\..\src\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.csproj">

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Razor/EmptyProject/EmptyProject.csproj
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Razor/EmptyProject/EmptyProject.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
@@ -41,7 +41,8 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         private readonly string[] razorSupportedFrameworks = new[]
             {
                 "net6.0",
-                "net7.0"
+                "net7.0",
+                "net8.0"
             };
         private readonly VerifierBuilder builder;
         private readonly DiagnosticAnalyzer[] analyzers;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
         public string CodeFixTitle { get; init; }
         public bool ConcurrentAnalysis { get; init; } = true;
         public CompilationErrorBehavior ErrorBehavior { get; init; } = CompilationErrorBehavior.Default;
-        public string RazorFramework { get; init; } = "net7.0";
+        public string RazorFramework { get; init; } = Constants.RazorFrameworkLatestVersion;
         public bool IsRazor { get; init; }
         public ImmutableArray<DiagnosticDescriptor> OnlyDiagnostics { get; init; } = ImmutableArray<DiagnosticDescriptor>.Empty;
         public OutputKind OutputKind { get; init; } = OutputKind.DynamicallyLinkedLibrary;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/packages.lock.json
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/packages.lock.json
@@ -444,7 +444,7 @@
         }
       }
     },
-    "net7.0": {
+    "net8.0": {
       "altcover": {
         "type": "Direct",
         "requested": "[8.6.68, )",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,8 +184,8 @@ stages:
             FrameworkMoniker: 'net48'
             CoverageArtifactName: 'DotnetCoverageNet48'
             TestResultsArtifactName: 'DotnetTestResultsNet48'
-          Net80:
-            FrameworkMoniker: 'net8'
+          Net8:
+            FrameworkMoniker: 'net8.0'
             CoverageArtifactName: 'DotnetCoverageNet8'
             TestResultsArtifactName: 'DotnetTestResultsNet8'
 
@@ -337,7 +337,7 @@ stages:
           }
 
           Update-Coverage-BasePaths 'coverage\coverage.net48.xml'
-          Update-Coverage-BasePaths 'coverage\coverage.net8.xml'
+          Update-Coverage-BasePaths 'coverage\coverage.net8.0.xml'
         displayName: Fix coverage paths
 
       - task: SonarCloudAnalyze@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,10 +184,10 @@ stages:
             FrameworkMoniker: 'net48'
             CoverageArtifactName: 'DotnetCoverageNet48'
             TestResultsArtifactName: 'DotnetTestResultsNet48'
-          Net70:
-            FrameworkMoniker: 'net7.0'
-            CoverageArtifactName: 'DotnetCoverageNet7'
-            TestResultsArtifactName: 'DotnetTestResultsNet7'
+          Net80:
+            FrameworkMoniker: 'net8'
+            CoverageArtifactName: 'DotnetCoverageNet8'
+            TestResultsArtifactName: 'DotnetTestResultsNet8'
 
       steps:
       - task: DownloadPipelineArtifact@2
@@ -306,7 +306,7 @@ stages:
       - task: DownloadPipelineArtifact@2
         displayName: 'Download coverage reports'
         inputs:
-          artifact: DotnetCoverageNet7
+          artifact: DotnetCoverageNet8
           targetPath: 'coverage'
 
       - task: DownloadPipelineArtifact@2
@@ -318,7 +318,7 @@ stages:
       - task: DownloadPipelineArtifact@2
         displayName: 'Download test results'
         inputs:
-          artifact: DotnetTestResultsNet7
+          artifact: DotnetTestResultsNet8
           targetPath: 'TestResults'
 
       - powershell: |
@@ -337,7 +337,7 @@ stages:
           }
 
           Update-Coverage-BasePaths 'coverage\coverage.net48.xml'
-          Update-Coverage-BasePaths 'coverage\coverage.net7.0.xml'
+          Update-Coverage-BasePaths 'coverage\coverage.net8.xml'
         displayName: Fix coverage paths
 
       - task: SonarCloudAnalyze@1


### PR DESCRIPTION
Required to be able to run tests using [C#12 InlineArrayAttribute](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12#inline-arrays), which is only present in .NET 8. 

The alternatives would be:
- conditionally define those UTs by `#if NET8_OR_GREATER`: that would make the code dead until we actually move the Target Framework to .NET 8
- not adding those UTs at all: we would need to remember to add them once we actually move the Target Framework to .NET 8
- support loading `MetadataReference` from a different version of the framework. A working prototype has been made by @csaba-sagi-sonarsource. However this solution requires UTs API extension and seems particularly fragile and not fully predictable (we don't know exactly how the `AdhocWorkspace` (as defined in the `SolutionBuilder`) manages to load DLLs of a different version of the framework, w.r.t. the one being used to build.

Requires every developer running UTs to have .NET 8 (Preview, for now) installed locally. That should be the case already since ITs already require .NET 8 to be run.
.NET 8 is also required by CI, for the same reason as above. The CI environment already has .NET 8 installed, for the same reason as above.

UPDATE: this is going to be closed due to the issues described in [this Trello card](https://trello.com/c/6K0EezU7/21-support-net8-uts-for-scenarios-with-inlinearrayattribute).