### PR TITLE
CalculationsShouldNotOverflow.SyntaxKindWalker reduce allocations and evaluations in the hot path

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.cs
@@ -42,8 +42,9 @@ public sealed class CalculationsShouldNotOverflow : CalculationsShouldNotOverflo
 
     internal sealed class SyntaxKindWalker : SafeCSharpSyntaxWalker
     {
+        private bool isUncheckedContext;
+
         public bool HasOverflow { get; private set; }
-        private bool IsUnchecked { get; set; }
 
         public override void Visit(SyntaxNode node)
         {
@@ -51,7 +52,7 @@ public sealed class CalculationsShouldNotOverflow : CalculationsShouldNotOverflo
             {
                 return; // We have an potential overflow: stop visiting
             }
-            if (!IsUnchecked && node.Kind() is
+            if (!isUncheckedContext && node.Kind() is
                 SyntaxKind.AddExpression or
                 SyntaxKind.AddAssignmentExpression or
                 SyntaxKind.MultiplyExpression or
@@ -73,20 +74,20 @@ public sealed class CalculationsShouldNotOverflow : CalculationsShouldNotOverflo
         {
             var before = SetIsUnchecked(node.Kind() == SyntaxKind.UncheckedExpression);
             base.VisitCheckedExpression(node);
-            IsUnchecked = before;
+            isUncheckedContext = before;
         }
 
         public override void VisitCheckedStatement(CheckedStatementSyntax node)
         {
             var before = SetIsUnchecked(node.Kind() == SyntaxKind.UncheckedStatement);
             base.VisitCheckedStatement(node);
-            IsUnchecked = before;
+            isUncheckedContext = before;
         }
 
         private bool SetIsUnchecked(bool isUnchecked)
         {
-            var before = IsUnchecked;
-            IsUnchecked = isUnchecked;
+            var before = isUncheckedContext;
+            isUncheckedContext = isUnchecked;
             return before;
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.cs
@@ -43,7 +43,6 @@ public sealed class CalculationsShouldNotOverflow : CalculationsShouldNotOverflo
     internal sealed class SyntaxKindWalker : SafeCSharpSyntaxWalker
     {
         public bool IsUnchecked { get; private set; }
-
         public bool HasOverflow { get; private set; }
 
         public override void Visit(SyntaxNode node)

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.cs
@@ -28,7 +28,7 @@ public sealed class CalculationsShouldNotOverflow : CalculationsShouldNotOverflo
 
     public override bool ShouldExecute()
     {
-        if (ContainingSymbol?.Name == nameof(GetHashCode))
+        if (ContainingSymbol is IMethodSymbol method && method.IsObjectGetHashCode())
         {
             return false;
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.cs
@@ -56,35 +56,25 @@ public sealed class CalculationsShouldNotOverflow : CalculationsShouldNotOverflo
 
         public override void VisitBinaryExpression(BinaryExpressionSyntax node)
         {
-            HasOverflow |= node.Kind() is
-                SyntaxKind.AddExpression or
-                SyntaxKind.MultiplyExpression or
-                SyntaxKind.SubtractExpression;
+            HasOverflow |= node.Kind() is SyntaxKind.AddExpression or SyntaxKind.MultiplyExpression or SyntaxKind.SubtractExpression;
             base.VisitBinaryExpression(node);
         }
 
         public override void VisitAssignmentExpression(AssignmentExpressionSyntax node)
         {
-            HasOverflow |= node.Kind() is
-                SyntaxKind.AddAssignmentExpression or
-                SyntaxKind.MultiplyAssignmentExpression or
-                SyntaxKind.SubtractAssignmentExpression;
+            HasOverflow |= node.Kind() is SyntaxKind.AddAssignmentExpression or SyntaxKind.MultiplyAssignmentExpression or SyntaxKind.SubtractAssignmentExpression;
             base.VisitAssignmentExpression(node);
         }
 
         public override void VisitPostfixUnaryExpression(PostfixUnaryExpressionSyntax node)
         {
-            HasOverflow |= node.Kind() is
-                SyntaxKind.PostDecrementExpression or
-                SyntaxKind.PostIncrementExpression;
+            HasOverflow |= node.Kind() is SyntaxKind.PostDecrementExpression or SyntaxKind.PostIncrementExpression;
             base.VisitPostfixUnaryExpression(node);
         }
 
         public override void VisitPrefixUnaryExpression(PrefixUnaryExpressionSyntax node)
         {
-            HasOverflow |= node.Kind() is
-                SyntaxKind.PreDecrementExpression or
-                SyntaxKind.PreIncrementExpression;
+            HasOverflow |= node.Kind() is SyntaxKind.PreDecrementExpression or SyntaxKind.PreIncrementExpression;
             base.VisitPrefixUnaryExpression(node);
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/CalculationsShouldNotOverflow.cs
@@ -40,7 +40,7 @@ public sealed class CalculationsShouldNotOverflow : CalculationsShouldNotOverflo
         }
     }
 
-    private sealed class SyntaxKindWalker : SafeCSharpSyntaxWalker
+    internal sealed class SyntaxKindWalker : SafeCSharpSyntaxWalker
     {
         public bool IsUnchecked { get; private set; }
         public bool HasOverflow { get; private set; }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
@@ -26,9 +26,9 @@ namespace SonarAnalyzer.UnitTest.Rules;
 public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
 {
     [DataTestMethod]
-    [DataRow("_ = 1 + 1;")]
-    [DataRow("_ = 1 - 1;")]
-    [DataRow("_ = 1 * 1;")]
+    [DataRow("_ = i + i;")]
+    [DataRow("_ = i - i;")]
+    [DataRow("_ = i * i;")]
     [DataRow("_ = ++i;")]
     [DataRow("_ = --i;")]
     [DataRow("_ = i++;")]
@@ -36,7 +36,23 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
     [DataRow("i += 1;")]
     [DataRow("i -= 1;")]
     [DataRow("i *= 1;")]
-    [DataRow("_ = (1 + 1, 0);")] // Test for "Stop visiting"
+    [DataRow("_ = (i + i, 0);")] // Test for "Stop visiting"
+    [DataRow("""
+        _ = i + i;
+        _ = 1 / i;
+        """)]
+    [DataRow("""
+        _ = ++i;
+        _ = +i;
+        """)]
+    [DataRow("""
+        _ = i++;
+        _ = i!;
+        """)]
+    [DataRow("""
+        i += 1;
+        i /= 1;
+        """)]
     public void HasOverflowExpressions_True(string statement)
     {
         var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
@@ -45,7 +61,11 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """));
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.HasOverflow.Should().BeTrue();
+        sut.Should().BeEquivalentTo(new
+        {
+            HasOverflow = true,
+            IsUnchecked = false,
+        });
     }
 
     [DataTestMethod]
@@ -78,17 +98,21 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """));
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.HasOverflow.Should().BeFalse();
+        sut.Should().BeEquivalentTo(new
+        {
+            HasOverflow = false,
+            IsUnchecked = false,
+        });
     }
 
     [DataTestMethod]
     [DataRow("""
         unchecked
         {
-            _ = 1 + 1;
+            _ = i + i;
         }
         """)]
-    [DataRow("_ = unchecked(1 + 1);")]
+    [DataRow("_ = unchecked(i + i);")]
     public void HasOverflowExpressions_False_InUnchecked(string statement)
     {
         var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
@@ -97,7 +121,11 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """));
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.HasOverflow.Should().BeFalse();
+        sut.Should().BeEquivalentTo(new
+        {
+            HasOverflow = false,
+            IsUnchecked = true,
+        });
     }
 
     [DataTestMethod]
@@ -106,22 +134,23 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
         {
             _ = i + i;
         }
-        """, true)]
-    [DataRow("_ = checked(i + i);", true)]
-    [DataRow("_ = checked(unchecked(i + i));", false)]
-    [DataRow("_ = unchecked(checked(i + i));", true)]
-    [DataRow("_ = checked(unchecked(checked(i + i)));", true)]
-    [DataRow("_ = unchecked(checked(unchecked(i + i)));", false)]
-    [DataRow("_ = unchecked(i + i + checked(i + i));", true)]
-    [DataRow("_ = unchecked(i + i + checked(i / i) + i + i);", false)]
-    [DataRow("_ = unchecked(i + i + checked(i / unchecked(i + i)) + i + i);", false)]
-    [DataRow("_ = unchecked(i / checked(i + i));", true)]
-    [DataRow("_ = unchecked(i + checked(i / i));", false)]
-    [DataRow("_ = unchecked(unchecked(i / checked(checked(i + i))));", true)]
-    [DataRow("_ = unchecked(unchecked(i + checked(checked(i / i))));", false)]
-    [DataRow("_ = checked(unchecked(i / unchecked(checked(i + i))));", true)]
-    [DataRow("_ = checked(unchecked(i + unchecked(checked(i / i))));", false)]
-    [DataRow("_ = checked(unchecked(i + unchecked(i + i)) + i);", true)]
+        """, true, false)]
+    [DataRow("_ = checked(i + i);", true, false)]
+    [DataRow("_ = checked(unchecked(i + i));", false, true)]
+    [DataRow("_ = checked(unchecked(i) + i);", true, true)]
+    [DataRow("_ = unchecked(checked(i + i));", false, true)]
+    [DataRow("_ = checked(unchecked(checked(i + i)));", false, true)]
+    [DataRow("_ = unchecked(checked(unchecked(i + i)));", false, true)]
+    [DataRow("_ = unchecked(i + i + checked(i + i));", false, true)]
+    [DataRow("_ = unchecked(i + i + checked(i / i) + i + i);", false, true)]
+    [DataRow("_ = unchecked(i + i + checked(i / unchecked(i + i)) + i + i);", false, true)]
+    [DataRow("_ = unchecked(i / checked(i + i));", false, true)]
+    [DataRow("_ = unchecked(i + checked(i / i));", false, true)]
+    [DataRow("_ = unchecked(unchecked(i / checked(checked(i + i))));", false, true)]
+    [DataRow("_ = unchecked(unchecked(i + checked(checked(i / i))));", false, true)]
+    [DataRow("_ = checked(unchecked(i / unchecked(checked(i + i))));", false, true)]
+    [DataRow("_ = checked(unchecked(i + unchecked(checked(i / i))));", false, true)]
+    [DataRow("_ = checked(unchecked(i + unchecked(i + i)) + i);", true, true)]
     [DataRow("""
         unchecked
         {
@@ -132,7 +161,13 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             }
             _ = i + i;
         }
-        """, false)]
+        """, false, true)]
+    [DataRow("""
+        _ = i + i;
+        unchecked
+        {
+        }
+        """, true, true)]
     [DataRow("""
         unchecked
         {
@@ -147,7 +182,7 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             }
             _ = i + i;
         }
-        """, false)]
+        """, false, true)]
     [DataRow("""
         unchecked
         {
@@ -159,8 +194,8 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
                 _ = i + i;
             }
         }
-        """, true)]
-    public void HasOverflowExpressions_Unchecked_Nesting(string statement, bool exepected)
+        """, false, true)]
+    public void HasOverflowExpressions_Unchecked_Nesting(string statement, bool expectedHasOverflow, bool expectedIsUnchecked)
     {
         var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
             var i = 0;
@@ -168,7 +203,11 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """));
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.HasOverflow.Should().Be(exepected);
+        sut.Should().BeEquivalentTo(new
+        {
+            HasOverflow = expectedHasOverflow,
+            IsUnchecked = expectedIsUnchecked,
+        });
     }
 
     [DataTestMethod]
@@ -187,7 +226,7 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
     [DataRow("""_ = "" + s + s;""", true)] // Fix: should be false as one of the operands is a string literal
     [DataRow("""_ = s + "" + s;""", true)] // Fix: should be false as one of the operands is a string literal
     [DataRow("""_ = s + s + "";""", true)] // Fix: should be false as one of the operands is a string literal
-    public void HasOverflowExpressions_Literals(string statement, bool exepected)
+    public void HasOverflowExpressions_Literals(string statement, bool expected)
     {
         var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
             var i = 0;
@@ -196,7 +235,11 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """));
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.HasOverflow.Should().Be(exepected);
+        sut.Should().BeEquivalentTo(new
+        {
+            HasOverflow = expected,
+            IsUnchecked = false,
+        });
     }
 
     private static string WrapInMethod(string body) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
@@ -61,8 +61,8 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.HasOverflow.Should().Be(true);
-        sut.IsUnchecked.Should().Be(false);
+        sut.HasOverflow.Should().BeTrue();
+        sut.IsUnchecked.Should().BeFalse();
     }
 
     [DataTestMethod]
@@ -95,8 +95,8 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.HasOverflow.Should().Be(false);
-        sut.IsUnchecked.Should().Be(false);
+        sut.HasOverflow.Should().BeFalse();
+        sut.IsUnchecked.Should().BeFalse();
     }
 
     [DataTestMethod]
@@ -115,8 +115,8 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.HasOverflow.Should().Be(false);
-        sut.IsUnchecked.Should().Be(true);
+        sut.HasOverflow.Should().BeFalse();
+        sut.IsUnchecked.Should().BeTrue();
     }
 
     [DataTestMethod]
@@ -199,21 +199,21 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
     }
 
     [DataTestMethod]
-    [DataRow("_ = 1 + 1;", true)]            // Fix: should be false as it is checked at compile time
+    [DataRow("_ = 1 + 1;", true)]            // Should be false as it is checked at compile time
     [DataRow("_ = int.MaxValue + 0;", true)] // OK: We would need to consult the semanticModel to learn that int.MaxValue is also a constant
     [DataRow("_ = i + 1;", true)]
-    [DataRow("_ = 1 - 1;", true)]            // Fix: should be false as it is checked at compile time
-    [DataRow("_ = 1 * 1;", true)]            // Fix: should be false as it is checked at compile time
-    [DataRow("_ = i + 0;", true)]            // Fix: should be false as one operand is the identity element of addition
-    [DataRow("_ = i - 0;", true)]            // Fix: should be false as one operand is the identity element of subtraction
-    [DataRow("_ = i * 1;", true)]            // Fix: should be false as one operand is the identity element of multiplication
-    [DataRow("_ = i * 0;", true)]            // Fix: should be false as the result is always 0
-    [DataRow("""_ = "" + "";""", true)]      // Fix: should be false as both sides are string literals
-    [DataRow("""_ = s + "";""", true)]       // Fix: should be false as right side is a string literal
-    [DataRow("""_ = "" + s;""", true)]       // Fix: should be false as left side is a string literal
-    [DataRow("""_ = "" + s + s;""", true)]   // Fix: should be false as one of the operands is a string literal
-    [DataRow("""_ = s + "" + s;""", true)]   // Fix: should be false as one of the operands is a string literal
-    [DataRow("""_ = s + s + "";""", true)]   // Fix: should be false as one of the operands is a string literal
+    [DataRow("_ = 1 - 1;", true)]            // Should be false as it is checked at compile time
+    [DataRow("_ = 1 * 1;", true)]            // Should be false as it is checked at compile time
+    [DataRow("_ = i + 0;", true)]            // Should be false as one operand is the identity element of addition
+    [DataRow("_ = i - 0;", true)]            // Should be false as one operand is the identity element of subtraction
+    [DataRow("_ = i * 1;", true)]            // Should be false as one operand is the identity element of multiplication
+    [DataRow("_ = i * 0;", true)]            // Should be false as the result is always 0
+    [DataRow("""_ = "" + "";""", true)]      // Should be false as both sides are string literals
+    [DataRow("""_ = s + "";""", true)]       // Should be false as right side is a string literal
+    [DataRow("""_ = "" + s;""", true)]       // Should be false as left side is a string literal
+    [DataRow("""_ = "" + s + s;""", true)]   // Should be false as one of the operands is a string literal
+    [DataRow("""_ = s + "" + s;""", true)]   // Should be false as one of the operands is a string literal
+    [DataRow("""_ = s + s + "";""", true)]   // Should be false as one of the operands is a string literal
     public void HasOverflowExpressions_Literals(string statement, bool expected)
     {
         var tree = TestHelper.CompileCS(WrapInMethod($"""
@@ -223,7 +223,7 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
         sut.HasOverflow.Should().Be(expected);
-        sut.IsUnchecked.Should().Be(false);
+        sut.IsUnchecked.Should().BeFalse();
     }
 
     private static string WrapInMethod(string body) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
@@ -61,11 +61,8 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.Should().BeEquivalentTo(new
-        {
-            HasOverflow = true,
-            IsUnchecked = false,
-        });
+        sut.HasOverflow.Should().Be(true);
+        sut.IsUnchecked.Should().Be(false);
     }
 
     [DataTestMethod]
@@ -98,11 +95,8 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.Should().BeEquivalentTo(new
-        {
-            HasOverflow = false,
-            IsUnchecked = false,
-        });
+        sut.HasOverflow.Should().Be(false);
+        sut.IsUnchecked.Should().Be(false);
     }
 
     [DataTestMethod]
@@ -121,11 +115,8 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.Should().BeEquivalentTo(new
-        {
-            HasOverflow = false,
-            IsUnchecked = true,
-        });
+        sut.HasOverflow.Should().Be(false);
+        sut.IsUnchecked.Should().Be(true);
     }
 
     [DataTestMethod]
@@ -203,11 +194,8 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.Should().BeEquivalentTo(new
-        {
-            HasOverflow = expectedHasOverflow,
-            IsUnchecked = expectedIsUnchecked,
-        });
+        sut.HasOverflow.Should().Be(expectedHasOverflow);
+        sut.IsUnchecked.Should().Be(expectedIsUnchecked);
     }
 
     [DataTestMethod]
@@ -234,11 +222,8 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
             """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
-        sut.Should().BeEquivalentTo(new
-        {
-            HasOverflow = expected,
-            IsUnchecked = false,
-        });
+        sut.HasOverflow.Should().Be(expected);
+        sut.IsUnchecked.Should().Be(false);
     }
 
     private static string WrapInMethod(string body) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
@@ -55,10 +55,10 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
         """)]
     public void HasOverflowExpressions_True(string statement)
     {
-        var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
+        var tree = TestHelper.CompileCS(WrapInMethod($"""
             var i = 0;
-            {{statement}}
-            """));
+            {statement}
+            """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
         sut.Should().BeEquivalentTo(new
@@ -92,11 +92,10 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
     [DataRow("i %= 1;")]
     public void HasOverflowExpressions_False(string statement)
     {
-        var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
-            var i = 0;
-            var b = true;
-            {{statement}}
-            """));
+        var tree = TestHelper.CompileCS(WrapInMethod($"""
+            var i = 0; var b = true;
+            {statement}
+            """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
         sut.Should().BeEquivalentTo(new
@@ -116,10 +115,10 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
     [DataRow("_ = unchecked(i + i);")]
     public void HasOverflowExpressions_IsUnchecked_True(string statement)
     {
-        var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
+        var tree = TestHelper.CompileCS(WrapInMethod($"""
             var i = 0;
-            {{statement}}
-            """));
+            {statement}
+            """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
         sut.Should().BeEquivalentTo(new
@@ -198,10 +197,10 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
         """, false, true)]
     public void HasOverflowExpressions_Unchecked_Nesting(string statement, bool expectedHasOverflow, bool expectedIsUnchecked)
     {
-        var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
+        var tree = TestHelper.CompileCS(WrapInMethod($"""
             var i = 0;
-            {{statement}}
-            """));
+            {statement}
+            """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
         sut.Should().BeEquivalentTo(new
@@ -229,11 +228,10 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
     [DataRow("""_ = s + s + "";""", true)]   // Fix: should be false as one of the operands is a string literal
     public void HasOverflowExpressions_Literals(string statement, bool expected)
     {
-        var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
-            var i = 0;
-            var s = "";
-            {{statement}}
-            """));
+        var tree = TestHelper.CompileCS(WrapInMethod($"""
+            var i = 0; var s = "";
+            {statement}
+            """)).Tree;
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
         sut.Should().BeEquivalentTo(new

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
@@ -23,7 +23,7 @@ using CalculationsShouldNotOverflow = SonarAnalyzer.SymbolicExecution.Roslyn.Rul
 namespace SonarAnalyzer.UnitTest.Rules;
 
 [TestClass]
-public class CalculationsShouldNotOverflowSyntaxWalkerTest
+public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
 {
     [DataTestMethod]
     [DataRow("_ = 1 + 1;")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
@@ -178,8 +178,8 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
     [DataRow("_ = 1 - 1;", true)] // Fix: should be false as it is checked at compile time
     [DataRow("_ = 1 * 1;", true)] // Fix: should be false as it is checked at compile time
     [DataRow("_ = i + 0;", true)] // Fix: should be false as one operand is the identity element of addition
-    [DataRow("_ = i - 0;", true)] // Fix: should be false as one operand is the identity element of substruction
-    [DataRow("_ = i * 1;", true)] // Fix: should be false as one operand is the identity element of multipliction
+    [DataRow("_ = i - 0;", true)] // Fix: should be false as one operand is the identity element of subtraction
+    [DataRow("_ = i * 1;", true)] // Fix: should be false as one operand is the identity element of multiplication
     [DataRow("_ = i * 0;", true)] // Fix: should be false as the result is always 0
     [DataRow("""_ = "" + "";""", true)] // Fix: should be false as both sides are string literals
     [DataRow("""_ = s + "";""", true)] // Fix: should be false as right side is a string literal

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxKindWalkerTest.cs
@@ -36,7 +36,7 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
     [DataRow("i += 1;")]
     [DataRow("i -= 1;")]
     [DataRow("i *= 1;")]
-    [DataRow("_ = (i + i, 0);")] // Test for "Stop visiting"
+    [DataRow("_ = (i + i, 0);")]
     [DataRow("""
         _ = i + i;
         _ = 1 / i;
@@ -82,9 +82,9 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
     [DataRow("_ = i << 1;")]
     [DataRow("_ = i | 1;")]
     [DataRow("_ = i & 1;")]
-    [DataRow("_ = true && true;")]
-    [DataRow("_ = true || true;")]
-    [DataRow("_ = true ^ true;")]
+    [DataRow("_ = b && b;")]
+    [DataRow("_ = b || b;")]
+    [DataRow("_ = b ^ b;")]
     [DataRow("_ = null ?? new object();")]
     [DataRow("_ = i is int;")]
     [DataRow("_ = i as int?;")]
@@ -94,6 +94,7 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
     {
         var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
             var i = 0;
+            var b = true;
             {{statement}}
             """));
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
@@ -113,7 +114,7 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
         }
         """)]
     [DataRow("_ = unchecked(i + i);")]
-    public void HasOverflowExpressions_False_InUnchecked(string statement)
+    public void HasOverflowExpressions_IsUnchecked_True(string statement)
     {
         var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
             var i = 0;
@@ -211,21 +212,21 @@ public class CalculationsShouldNotOverflowSyntaxKindWalkerTest
     }
 
     [DataTestMethod]
-    [DataRow("_ = 1 + 1;", true)] // Fix: should be false as it is checked at compile time
+    [DataRow("_ = 1 + 1;", true)]            // Fix: should be false as it is checked at compile time
     [DataRow("_ = int.MaxValue + 0;", true)] // OK: We would need to consult the semanticModel to learn that int.MaxValue is also a constant
     [DataRow("_ = i + 1;", true)]
-    [DataRow("_ = 1 - 1;", true)] // Fix: should be false as it is checked at compile time
-    [DataRow("_ = 1 * 1;", true)] // Fix: should be false as it is checked at compile time
-    [DataRow("_ = i + 0;", true)] // Fix: should be false as one operand is the identity element of addition
-    [DataRow("_ = i - 0;", true)] // Fix: should be false as one operand is the identity element of subtraction
-    [DataRow("_ = i * 1;", true)] // Fix: should be false as one operand is the identity element of multiplication
-    [DataRow("_ = i * 0;", true)] // Fix: should be false as the result is always 0
-    [DataRow("""_ = "" + "";""", true)] // Fix: should be false as both sides are string literals
-    [DataRow("""_ = s + "";""", true)] // Fix: should be false as right side is a string literal
-    [DataRow("""_ = "" + s;""", true)] // Fix: should be false as left side is a string literal
-    [DataRow("""_ = "" + s + s;""", true)] // Fix: should be false as one of the operands is a string literal
-    [DataRow("""_ = s + "" + s;""", true)] // Fix: should be false as one of the operands is a string literal
-    [DataRow("""_ = s + s + "";""", true)] // Fix: should be false as one of the operands is a string literal
+    [DataRow("_ = 1 - 1;", true)]            // Fix: should be false as it is checked at compile time
+    [DataRow("_ = 1 * 1;", true)]            // Fix: should be false as it is checked at compile time
+    [DataRow("_ = i + 0;", true)]            // Fix: should be false as one operand is the identity element of addition
+    [DataRow("_ = i - 0;", true)]            // Fix: should be false as one operand is the identity element of subtraction
+    [DataRow("_ = i * 1;", true)]            // Fix: should be false as one operand is the identity element of multiplication
+    [DataRow("_ = i * 0;", true)]            // Fix: should be false as the result is always 0
+    [DataRow("""_ = "" + "";""", true)]      // Fix: should be false as both sides are string literals
+    [DataRow("""_ = s + "";""", true)]       // Fix: should be false as right side is a string literal
+    [DataRow("""_ = "" + s;""", true)]       // Fix: should be false as left side is a string literal
+    [DataRow("""_ = "" + s + s;""", true)]   // Fix: should be false as one of the operands is a string literal
+    [DataRow("""_ = s + "" + s;""", true)]   // Fix: should be false as one of the operands is a string literal
+    [DataRow("""_ = s + s + "";""", true)]   // Fix: should be false as one of the operands is a string literal
     public void HasOverflowExpressions_Literals(string statement, bool expected)
     {
         var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxWalkerTest.cs
@@ -100,6 +100,27 @@ public class CalculationsShouldNotOverflowSyntaxWalkerTest
         sut.HasOverflow.Should().BeFalse();
     }
 
+    [DataTestMethod]
+    [DataRow("""
+        checked
+        {
+            _ = 1 + 1;
+        }
+        """, true)]
+    [DataRow("_ = checked(1 + 1);", true)]
+    [DataRow("_ = checked(unchecked(1 + 1));", false)]
+    [DataRow("_ = unchecked(checked(1 + 1));", true)]
+    public void HasOverflowExpressions_Unchecked_Nesting(string statement, bool exepected)
+    {
+        var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
+            var i = 0;
+            {{statement}}
+            """));
+        var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
+        sut.SafeVisit(tree.GetRoot());
+        sut.HasOverflow.Should().Be(exepected);
+    }
+
     private static string WrapInMethod(string body) =>
         $$"""
         using System;

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxWalkerTest.cs
@@ -50,14 +50,14 @@ public class CalculationsShouldNotOverflowSyntaxWalkerTest
 
     [DataTestMethod]
     [DataRow("")]
-    [DataRow("_ = 1 / 1;")]
-    [DataRow("_ = 1 % 1;")]
-    [DataRow("_ = 1 == 1;")]
-    [DataRow("_ = 1 != 1;")]
-    [DataRow("_ = 1 > 1;")]
-    [DataRow("_ = 1 >= 1;")]
-    [DataRow("_ = 1 < 1;")]
-    [DataRow("_ = 1 <= 1;")]
+    [DataRow("_ = i / 1;")]
+    [DataRow("_ = i % 1;")]
+    [DataRow("_ = i == 1;")]
+    [DataRow("_ = i != 1;")]
+    [DataRow("_ = i > 1;")]
+    [DataRow("_ = i >= 1;")]
+    [DataRow("_ = i < 1;")]
+    [DataRow("_ = i <= 1;")]
     [DataRow("_ = i >>> 1;")]
     [DataRow("_ = i << 1;")]
     [DataRow("_ = i | 1;")]
@@ -104,12 +104,62 @@ public class CalculationsShouldNotOverflowSyntaxWalkerTest
     [DataRow("""
         checked
         {
-            _ = 1 + 1;
+            _ = i + i;
         }
         """, true)]
-    [DataRow("_ = checked(1 + 1);", true)]
-    [DataRow("_ = checked(unchecked(1 + 1));", false)]
-    [DataRow("_ = unchecked(checked(1 + 1));", true)]
+    [DataRow("_ = checked(i + i);", true)]
+    [DataRow("_ = checked(unchecked(i + i));", false)]
+    [DataRow("_ = unchecked(checked(i + i));", true)]
+    [DataRow("_ = checked(unchecked(checked(i + i)));", true)]
+    [DataRow("_ = unchecked(checked(unchecked(i + i)));", false)]
+    [DataRow("_ = unchecked(i + i + checked(i + i));", true)]
+    [DataRow("_ = unchecked(i + i + checked(i / i) + i + i);", false)]
+    [DataRow("_ = unchecked(i + i + checked(i / unchecked(i + i)) + i + i);", false)]
+    [DataRow("_ = unchecked(i / checked(i + i));", true)]
+    [DataRow("_ = unchecked(i + checked(i / i));", false)]
+    [DataRow("_ = unchecked(unchecked(i / checked(checked(i + i))));", true)]
+    [DataRow("_ = unchecked(unchecked(i + checked(checked(i / i))));", false)]
+    [DataRow("_ = checked(unchecked(i / unchecked(checked(i + i))));", true)]
+    [DataRow("_ = checked(unchecked(i + unchecked(checked(i / i))));", false)]
+    [DataRow("_ = checked(unchecked(i + unchecked(i + i)) + i);", true)]
+    [DataRow("""
+        unchecked
+        {
+            _ = i + i;
+            checked
+            {
+                _ = i / i;
+            }
+            _ = i + i;
+        }
+        """, false)]
+    [DataRow("""
+        unchecked
+        {
+            _ = i + i;
+            checked
+            {
+                unchecked
+                {
+                    _ = i + i;
+                }
+                _ = i / i;
+            }
+            _ = i + i;
+        }
+        """, false)]
+    [DataRow("""
+        unchecked
+        {
+            checked
+            {
+                unchecked
+                {
+                }
+                _ = i + i;
+            }
+        }
+        """, true)]
     public void HasOverflowExpressions_Unchecked_Nesting(string statement, bool exepected)
     {
         var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxWalkerTest.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using CalculationsShouldNotOverflow = SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.CSharp.CalculationsShouldNotOverflow;
+
+namespace SonarAnalyzer.UnitTest.Rules;
+
+[TestClass]
+public class CalculationsShouldNotOverflowSyntaxWalkerTest
+{
+    [DataTestMethod]
+    [DataRow("_ = 1 + 1;")]
+    [DataRow("_ = 1 - 1;")]
+    [DataRow("_ = 1 * 1;")]
+    [DataRow("_ = ++i;")]
+    [DataRow("_ = --i;")]
+    [DataRow("_ = i++;")]
+    [DataRow("_ = i--;")]
+    [DataRow("i += 1;")]
+    [DataRow("i -= 1;")]
+    [DataRow("i *= 1;")]
+    public void HasOverflowExpressions(string statement)
+    {
+        var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
+            var i = 0;
+            {{statement}}
+            """));
+        var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
+        sut.SafeVisit(tree.GetRoot());
+        sut.HasOverflow.Should().BeTrue();
+    }
+
+    private static string WrapInMethod(string body) =>
+        $$"""
+        using System;
+
+        public class Test
+        {
+            public void M()
+            {
+                {{body}}
+            }
+        }
+        """;
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxWalkerTest.cs
@@ -36,7 +36,7 @@ public class CalculationsShouldNotOverflowSyntaxWalkerTest
     [DataRow("i += 1;")]
     [DataRow("i -= 1;")]
     [DataRow("i *= 1;")]
-    public void HasOverflowExpressions(string statement)
+    public void HasOverflowExpressions_True(string statement)
     {
         var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
             var i = 0;
@@ -45,6 +45,58 @@ public class CalculationsShouldNotOverflowSyntaxWalkerTest
         var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
         sut.SafeVisit(tree.GetRoot());
         sut.HasOverflow.Should().BeTrue();
+    }
+
+    [DataTestMethod]
+    [DataRow("")]
+    [DataRow("_ = 1 / 1;")]
+    [DataRow("_ = 1 % 1;")]
+    [DataRow("_ = 1 == 1;")]
+    [DataRow("_ = 1 != 1;")]
+    [DataRow("_ = 1 > 1;")]
+    [DataRow("_ = 1 >= 1;")]
+    [DataRow("_ = 1 < 1;")]
+    [DataRow("_ = 1 <= 1;")]
+    [DataRow("_ = i >>> 1;")]
+    [DataRow("_ = i << 1;")]
+    [DataRow("_ = i | 1;")]
+    [DataRow("_ = i & 1;")]
+    [DataRow("_ = true && true;")]
+    [DataRow("_ = true || true;")]
+    [DataRow("_ = true ^ true;")]
+    [DataRow("_ = null ?? new object();")]
+    [DataRow("_ = i is int;")]
+    [DataRow("_ = i as int?;")]
+    [DataRow("i /= 1;")]
+    [DataRow("i %= 1;")]
+    public void HasOverflowExpressions_False(string statement)
+    {
+        var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
+            var i = 0;
+            {{statement}}
+            """));
+        var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
+        sut.SafeVisit(tree.GetRoot());
+        sut.HasOverflow.Should().BeFalse();
+    }
+
+    [DataTestMethod]
+    [DataRow("""
+        unchecked
+        {
+            _ = 1 + 1;
+        }
+        """)]
+    [DataRow("_ = unchecked(1 + 1);")]
+    public void HasOverflowExpressions_False_InUnchecked(string statement)
+    {
+        var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""
+            var i = 0;
+            {{statement}}
+            """));
+        var sut = new CalculationsShouldNotOverflow.SyntaxKindWalker();
+        sut.SafeVisit(tree.GetRoot());
+        sut.HasOverflow.Should().BeFalse();
     }
 
     private static string WrapInMethod(string body) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxWalkerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/CalculationsShouldNotOverflowSyntaxWalkerTest.cs
@@ -36,6 +36,7 @@ public class CalculationsShouldNotOverflowSyntaxWalkerTest
     [DataRow("i += 1;")]
     [DataRow("i -= 1;")]
     [DataRow("i *= 1;")]
+    [DataRow("_ = (1 + 1, 0);")] // Test for "Stop visiting"
     public void HasOverflowExpressions_True(string statement)
     {
         var (tree, _) = TestHelper.CompileCS(WrapInMethod($$"""


### PR DESCRIPTION
Fixes #8103