### PR TITLE
Fix S2368 FP/FN: Don't raise for extension methods and raise for constructors

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/ISymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/ISymbolExtensions.cs
@@ -98,6 +98,7 @@ namespace SonarAnalyzer.Extensions
             {
                 AttributeArgumentSyntax x => x.NameColon?.Name.Identifier,
                 BaseTypeDeclarationSyntax x => x.Identifier,
+                ConstructorDeclarationSyntax x => x.Identifier,
                 DelegateDeclarationSyntax x => x.Identifier,
                 EnumMemberDeclarationSyntax x => x.Identifier,
                 EventDeclarationSyntax x => x.Identifier,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicMethodWithMultidimensionalArray.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PublicMethodWithMultidimensionalArray.cs
@@ -18,21 +18,16 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Rules.CSharp
+namespace SonarAnalyzer.Rules.CSharp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PublicMethodWithMultidimensionalArray : PublicMethodWithMultidimensionalArrayBase<SyntaxKind>
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class PublicMethodWithMultidimensionalArray : PublicMethodWithMultidimensionalArrayBase<SyntaxKind, MethodDeclarationSyntax>
-    {
+    protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
-        private static readonly DiagnosticDescriptor rule =
-            DescriptorFactory.Create(DiagnosticId, MessageFormat);
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
+    protected override Location GetIssueLocation(SyntaxNode node) =>
+        Language.Syntax.NodeIdentifier(node)?.GetLocation();
 
-        private static readonly ImmutableArray<SyntaxKind> kindsOfInterest = ImmutableArray.Create(SyntaxKind.MethodDeclaration);
-        public override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest => kindsOfInterest;
-
-        protected override SyntaxToken GetIdentifier(MethodDeclarationSyntax method) => method.Identifier;
-
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => CSharpGeneratedCodeRecognizer.Instance;
-    }
+    protected override string GetType(SyntaxNode node) =>
+        node is MethodDeclarationSyntax ? "method" : "constructor";
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicMethodWithMultidimensionalArray.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicMethodWithMultidimensionalArray.cs
@@ -18,21 +18,21 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Rules.VisualBasic
+namespace SonarAnalyzer.Rules.VisualBasic;
+
+[DiagnosticAnalyzer(LanguageNames.VisualBasic)]
+public sealed class PublicMethodWithMultidimensionalArray : PublicMethodWithMultidimensionalArrayBase<SyntaxKind>
 {
-    [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class PublicMethodWithMultidimensionalArray : PublicMethodWithMultidimensionalArrayBase<SyntaxKind, MethodStatementSyntax>
-    {
-        private static readonly DiagnosticDescriptor rule =
-            DescriptorFactory.Create(DiagnosticId, MessageFormat);
+    protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
+    protected override Location GetIssueLocation(SyntaxNode node) =>
+        node?.RemoveParentheses() switch
+        {
+            ConstructorBlockSyntax x => x.SubNewStatement.NewKeyword.GetLocation(),
+            MethodStatementSyntax x => x.Identifier.GetLocation(),
+            _ => null,
+        };
 
-        private static readonly ImmutableArray<SyntaxKind> kindsOfInterest = ImmutableArray.Create(SyntaxKind.SubStatement, SyntaxKind.FunctionStatement);
-        public override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest => kindsOfInterest;
-
-        protected override SyntaxToken GetIdentifier(MethodStatementSyntax method) => method.Identifier;
-
-        protected override GeneratedCodeRecognizer GeneratedCodeRecognizer => VisualBasicGeneratedCodeRecognizer.Instance;
-    }
+    protected override string GetType(SyntaxNode node) =>
+        node is MethodStatementSyntax ? "method" : "constructor";
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicMethodWithMultidimensionalArray.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PublicMethodWithMultidimensionalArray.cs
@@ -26,12 +26,9 @@ public sealed class PublicMethodWithMultidimensionalArray : PublicMethodWithMult
     protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
 
     protected override Location GetIssueLocation(SyntaxNode node) =>
-        node?.RemoveParentheses() switch
-        {
-            ConstructorBlockSyntax x => x.SubNewStatement.NewKeyword.GetLocation(),
-            MethodStatementSyntax x => x.Identifier.GetLocation(),
-            _ => null,
-        };
+        node is ConstructorBlockSyntax x
+            ? x.SubNewStatement.NewKeyword.GetLocation()
+            : Language.Syntax.NodeIdentifier(node)?.GetLocation();
 
     protected override string GetType(SyntaxNode node) =>
         node is MethodStatementSyntax ? "method" : "constructor";

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/PublicMethodWithMultidimensionalArrayTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/PublicMethodWithMultidimensionalArrayTest.cs
@@ -21,38 +21,37 @@
 using CS = SonarAnalyzer.Rules.CSharp;
 using VB = SonarAnalyzer.Rules.VisualBasic;
 
-namespace SonarAnalyzer.UnitTest.Rules
-{
-    [TestClass]
-    public class PublicMethodWithMultidimensionalArrayTest
-    {
-        private readonly VerifierBuilder builderCS = new VerifierBuilder<CS.PublicMethodWithMultidimensionalArray>();
-        private readonly VerifierBuilder builderVB = new VerifierBuilder<VB.PublicMethodWithMultidimensionalArray>();
+namespace SonarAnalyzer.UnitTest.Rules;
 
-        [TestMethod]
-        public void PublicMethodWithMultidimensionalArray_CS() =>
-            builderCS.AddPaths("PublicMethodWithMultidimensionalArray.cs")
-                .Verify();
+[TestClass]
+public class PublicMethodWithMultidimensionalArrayTest
+{
+    private readonly VerifierBuilder builderCS = new VerifierBuilder<CS.PublicMethodWithMultidimensionalArray>();
+    private readonly VerifierBuilder builderVB = new VerifierBuilder<VB.PublicMethodWithMultidimensionalArray>();
+
+    [TestMethod]
+    public void PublicMethodWithMultidimensionalArray_CS() =>
+        builderCS.AddPaths("PublicMethodWithMultidimensionalArray.cs")
+            .Verify();
 
 #if NET
 
-        [TestMethod]
-        public void PublicMethodWithMultidimensionalArray_CSharp11() =>
-            builderCS.AddPaths("PublicMethodWithMultidimensionalArray.CSharp11.cs")
-                .WithOptions(ParseOptionsHelper.FromCSharp11)
-                .Verify();
+    [TestMethod]
+    public void PublicMethodWithMultidimensionalArray_CSharp11() =>
+        builderCS.AddPaths("PublicMethodWithMultidimensionalArray.CSharp11.cs")
+            .WithOptions(ParseOptionsHelper.FromCSharp11)
+            .Verify();
 
-        [TestMethod]
-        public void PublicMethodWithMultidimensionalArray_CSharp12() =>
-            builderCS.AddPaths("PublicMethodWithMultidimensionalArray.CSharp12.cs")
-                .WithOptions(ParseOptionsHelper.FromCSharp12)
-                .Verify();
+    [TestMethod]
+    public void PublicMethodWithMultidimensionalArray_CSharp12() =>
+        builderCS.AddPaths("PublicMethodWithMultidimensionalArray.CSharp12.cs")
+            .WithOptions(ParseOptionsHelper.FromCSharp12)
+            .Verify();
 
 #endif
 
-        [TestMethod]
-        public void PublicMethodWithMultidimensionalArray_VB() =>
-            builderVB.AddPaths("PublicMethodWithMultidimensionalArray.vb")
-                .Verify();
-    }
+    [TestMethod]
+    public void PublicMethodWithMultidimensionalArray_VB() =>
+        builderVB.AddPaths("PublicMethodWithMultidimensionalArray.vb")
+            .Verify();
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PublicMethodWithMultidimensionalArray.CSharp12.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PublicMethodWithMultidimensionalArray.CSharp12.cs
@@ -14,7 +14,7 @@ namespace Repro_8083
 
     public class Aliases(IntMatrix a)                    // FN
     {
-        public Aliases(IntMatrix a, int i) : this(a) { } // FN
+        public Aliases(IntMatrix a, int i) : this(a) { } // Noncompliant
 
         public void AMethod1(IntMatrix a) { }            // Noncompliant
         public void AMethod2(params IntMatrix a) { }     // Compliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PublicMethodWithMultidimensionalArray.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PublicMethodWithMultidimensionalArray.cs
@@ -68,10 +68,16 @@ namespace Repro_8083
 {
     public class Constructors
     {
-        public Constructors(int[][] a) { }          // FN, the ctor is publicly exposed
-        public Constructors(int[,] a) { }           // FN
+        public Constructors(int[][] a) { }          // Noncompliant {{Make this constructor private or simplify its parameters to not use multidimensional/jagged arrays.}}
+        public Constructors(int[,] a) { }           // Noncompliant
         public Constructors(params int[] a) { }     // Compliant, params of int
-        public Constructors(params int[][][] a) { } // FN, params of int[][]
+        public Constructors(params int[][][] a) { } // Noncompliant
         public Constructors(int i) { }              // Compliant, not a multi-dimensional array
     }
+}
+
+public static class ExtensionMethod
+{
+    public static void Method1<T>(this T[,] dataMatrix, int a) { }
+    public static void Method2<T>(this T data, T[,] dataMatrix) { } // Noncompliant
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PublicMethodWithMultidimensionalArray.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/PublicMethodWithMultidimensionalArray.vb
@@ -65,4 +65,23 @@ Namespace Tests.Diagnostics
         End Sub
 
     End Class
+
+    Public Class Constructors
+        Public Sub New(A As Integer()()) ' Noncompliant {{Make this constructor private or simplify its parameters to not use multidimensional/jagged arrays.}}
+'                  ^^^
+        End Sub
+
+        Public Sub New(A As Integer(,)) ' Noncompliant
+        End Sub
+
+        Public Sub New(ParamArray A As Integer())
+        End Sub
+
+        Public Sub New(ParamArray A As Integer()()()) ' Noncompliant
+        End Sub
+
+        Public Sub New(I As Integer)
+        End Sub
+    End Class
+
 End Namespace


### PR DESCRIPTION
Fixes #7329
And handles ordinary constructor support from #8083