### PR TITLE
Add Collection Expression syntax to the ShimLayer

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/Syntax.xml
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/Syntax.xml
@@ -1798,6 +1798,32 @@
             <summary>Creates an ImplicitStackAllocArrayCreationExpressionSyntax node.</summary>
         </FactoryComment>
     </Node>
+    <Node Name="CollectionExpressionSyntax" Base="ExpressionSyntax">
+        <Kind Name="CollectionExpression"/>
+        <Field Name="OpenBracketToken" Type="SyntaxToken">
+            <Kind Name="OpenBracketToken"/>
+        </Field>
+        <Field Name="Elements" Type="SeparatedSyntaxList&lt;CollectionElementSyntax&gt;" AllowTrailingSeparator="true">
+            <PropertyComment>
+                <summary>SeparatedSyntaxList of CollectionElementSyntax representing the list of elements in the collection expression.</summary>
+            </PropertyComment>
+        </Field>
+        <Field Name="CloseBracketToken" Type="SyntaxToken">
+            <Kind Name="CloseBracketToken"/>
+        </Field>
+    </Node>
+    <AbstractNode Name="CollectionElementSyntax" Base="CSharpSyntaxNode" />
+    <Node Name="ExpressionElementSyntax" Base="CollectionElementSyntax">
+        <Kind Name="ExpressionElement"/>
+        <Field Name="Expression" Type="ExpressionSyntax" />
+    </Node>
+    <Node Name="SpreadElementSyntax" Base="CollectionElementSyntax">
+        <Kind Name="SpreadElement"/>
+        <Field Name="OperatorToken" Type="SyntaxToken">
+            <Kind Name="DotDotToken"/>
+        </Field>
+        <Field Name="Expression" Type="ExpressionSyntax" />
+    </Node>
     <AbstractNode Name="QueryClauseSyntax" Base="CSharpSyntaxNode">
     </AbstractNode>
     <AbstractNode Name="SelectOrGroupClauseSyntax" Base="CSharpSyntaxNode">
@@ -3079,8 +3105,15 @@
             <Kind Name="UsingKeyword"/>
         </Field>
         <Choice Optional="true">
-            <Field Name="StaticKeyword" Type="SyntaxToken"/>
+            <Field Name="StaticKeyword" Type="SyntaxToken">
+                <Kind Name="StaticKeyword"/>
+            </Field>
+            <Sequence>
+                <Field Name="UnsafeKeyword" Type="SyntaxToken" Optional="true">
+                    <Kind Name="UnsafeKeyword"/>
+                </Field>
             <Field Name="Alias" Type="NameEqualsSyntax"/>
+            </Sequence>
         </Choice>
         <Field Name="Name" Type="NameSyntax"/>
         <Field Name="SemicolonToken" Type="SyntaxToken">
@@ -3359,7 +3392,7 @@
             </PropertyComment>
         </Field>
     </AbstractNode>
-    <Node Name="ClassDeclarationSyntax" Base="TypeDeclarationSyntax">
+    <Node Name="ClassDeclarationSyntax" Base="TypeDeclarationSyntax" SkipConvenienceFactories="true">
         <TypeComment>
             <summary>Class type declaration syntax.</summary>
         </TypeComment>
@@ -3376,20 +3409,21 @@
             <Kind Name="IdentifierToken"/>
         </Field>
         <Field Name="TypeParameterList" Type="TypeParameterListSyntax" Optional="true" Override="true"/>
+        <Field Name="ParameterList" Type="ParameterListSyntax" Optional="true" Override="true" />
         <Field Name="BaseList" Type="BaseListSyntax" Optional="true" Override="true"/>
         <Field Name="ConstraintClauses" Type="SyntaxList&lt;TypeParameterConstraintClauseSyntax&gt;" Override="true"/>
-        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="OpenBraceToken"/>
         </Field>
         <Field Name="Members" Type="SyntaxList&lt;MemberDeclarationSyntax&gt;" Override="true"/>
-        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="CloseBraceToken"/>
         </Field>
         <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">
             <Kind Name="SemicolonToken"/>
         </Field>
     </Node>
-    <Node Name="StructDeclarationSyntax" Base="TypeDeclarationSyntax">
+    <Node Name="StructDeclarationSyntax" Base="TypeDeclarationSyntax" SkipConvenienceFactories="true">
         <TypeComment>
             <summary>Struct type declaration syntax.</summary>
         </TypeComment>
@@ -3406,20 +3440,21 @@
             <Kind Name="IdentifierToken"/>
         </Field>
         <Field Name="TypeParameterList" Type="TypeParameterListSyntax" Optional="true" Override="true"/>
+        <Field Name="ParameterList" Type="ParameterListSyntax" Optional="true" Override="true" />
         <Field Name="BaseList" Type="BaseListSyntax" Optional="true" Override="true"/>
         <Field Name="ConstraintClauses" Type="SyntaxList&lt;TypeParameterConstraintClauseSyntax&gt;" Override="true"/>
-        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="OpenBraceToken"/>
         </Field>
         <Field Name="Members" Type="SyntaxList&lt;MemberDeclarationSyntax&gt;" Override="true"/>
-        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="CloseBraceToken"/>
         </Field>
         <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">
             <Kind Name="SemicolonToken"/>
         </Field>
     </Node>
-    <Node Name="InterfaceDeclarationSyntax" Base="TypeDeclarationSyntax">
+    <Node Name="InterfaceDeclarationSyntax" Base="TypeDeclarationSyntax" SkipConvenienceFactories="true">
         <TypeComment>
             <summary>Interface type declaration syntax.</summary>
         </TypeComment>
@@ -3436,13 +3471,14 @@
             <Kind Name="IdentifierToken"/>
         </Field>
         <Field Name="TypeParameterList" Type="TypeParameterListSyntax" Optional="true" Override="true"/>
+        <Field Name="ParameterList" Type="ParameterListSyntax" Optional="true" Override="true" />
         <Field Name="BaseList" Type="BaseListSyntax" Optional="true" Override="true"/>
         <Field Name="ConstraintClauses" Type="SyntaxList&lt;TypeParameterConstraintClauseSyntax&gt;" Override="true"/>
-        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="OpenBraceToken"/>
         </Field>
         <Field Name="Members" Type="SyntaxList&lt;MemberDeclarationSyntax&gt;" Override="true"/>
-        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="CloseBraceToken"/>
         </Field>
         <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">
@@ -3479,7 +3515,7 @@
             <Kind Name="SemicolonToken"/>
         </Field>
     </Node>
-    <Node Name="EnumDeclarationSyntax" Base="BaseTypeDeclarationSyntax">
+    <Node Name="EnumDeclarationSyntax" Base="BaseTypeDeclarationSyntax" SkipConvenienceFactories="true">
         <TypeComment>
             <summary>Enum type declaration syntax.</summary>
         </TypeComment>
@@ -3497,7 +3533,7 @@
         </Field>
         <Field Name="BaseList" Type="BaseListSyntax" Optional="true" Override="true">
         </Field>
-        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="OpenBraceToken"/>
         </Field>
         <Field Name="Members" Type="SeparatedSyntaxList&lt;EnumMemberDeclarationSyntax&gt;" AllowTrailingSeparator="true">
@@ -3505,7 +3541,7 @@
                 <summary>Gets the members declaration list.</summary>
             </PropertyComment>
         </Field>
-        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="CloseBraceToken"/>
         </Field>
         <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/Syntax.xml
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/Syntax.xml
@@ -3105,15 +3105,8 @@
             <Kind Name="UsingKeyword"/>
         </Field>
         <Choice Optional="true">
-            <Field Name="StaticKeyword" Type="SyntaxToken">
-                <Kind Name="StaticKeyword"/>
-            </Field>
-            <Sequence>
-                <Field Name="UnsafeKeyword" Type="SyntaxToken" Optional="true">
-                    <Kind Name="UnsafeKeyword"/>
-                </Field>
+            <Field Name="StaticKeyword" Type="SyntaxToken"/>
             <Field Name="Alias" Type="NameEqualsSyntax"/>
-            </Sequence>
         </Choice>
         <Field Name="Name" Type="NameSyntax"/>
         <Field Name="SemicolonToken" Type="SyntaxToken">
@@ -3392,7 +3385,7 @@
             </PropertyComment>
         </Field>
     </AbstractNode>
-    <Node Name="ClassDeclarationSyntax" Base="TypeDeclarationSyntax" SkipConvenienceFactories="true">
+    <Node Name="ClassDeclarationSyntax" Base="TypeDeclarationSyntax">
         <TypeComment>
             <summary>Class type declaration syntax.</summary>
         </TypeComment>
@@ -3409,21 +3402,20 @@
             <Kind Name="IdentifierToken"/>
         </Field>
         <Field Name="TypeParameterList" Type="TypeParameterListSyntax" Optional="true" Override="true"/>
-        <Field Name="ParameterList" Type="ParameterListSyntax" Optional="true" Override="true" />
         <Field Name="BaseList" Type="BaseListSyntax" Optional="true" Override="true"/>
         <Field Name="ConstraintClauses" Type="SyntaxList&lt;TypeParameterConstraintClauseSyntax&gt;" Override="true"/>
-        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true" Optional="true">
+        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true">
             <Kind Name="OpenBraceToken"/>
         </Field>
         <Field Name="Members" Type="SyntaxList&lt;MemberDeclarationSyntax&gt;" Override="true"/>
-        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true" Optional="true">
+        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true">
             <Kind Name="CloseBraceToken"/>
         </Field>
         <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">
             <Kind Name="SemicolonToken"/>
         </Field>
     </Node>
-    <Node Name="StructDeclarationSyntax" Base="TypeDeclarationSyntax" SkipConvenienceFactories="true">
+    <Node Name="StructDeclarationSyntax" Base="TypeDeclarationSyntax">
         <TypeComment>
             <summary>Struct type declaration syntax.</summary>
         </TypeComment>
@@ -3440,21 +3432,20 @@
             <Kind Name="IdentifierToken"/>
         </Field>
         <Field Name="TypeParameterList" Type="TypeParameterListSyntax" Optional="true" Override="true"/>
-        <Field Name="ParameterList" Type="ParameterListSyntax" Optional="true" Override="true" />
         <Field Name="BaseList" Type="BaseListSyntax" Optional="true" Override="true"/>
         <Field Name="ConstraintClauses" Type="SyntaxList&lt;TypeParameterConstraintClauseSyntax&gt;" Override="true"/>
-        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true" Optional="true">
+        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true">
             <Kind Name="OpenBraceToken"/>
         </Field>
         <Field Name="Members" Type="SyntaxList&lt;MemberDeclarationSyntax&gt;" Override="true"/>
-        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true" Optional="true">
+        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true">
             <Kind Name="CloseBraceToken"/>
         </Field>
         <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">
             <Kind Name="SemicolonToken"/>
         </Field>
     </Node>
-    <Node Name="InterfaceDeclarationSyntax" Base="TypeDeclarationSyntax" SkipConvenienceFactories="true">
+    <Node Name="InterfaceDeclarationSyntax" Base="TypeDeclarationSyntax">
         <TypeComment>
             <summary>Interface type declaration syntax.</summary>
         </TypeComment>
@@ -3471,14 +3462,13 @@
             <Kind Name="IdentifierToken"/>
         </Field>
         <Field Name="TypeParameterList" Type="TypeParameterListSyntax" Optional="true" Override="true"/>
-        <Field Name="ParameterList" Type="ParameterListSyntax" Optional="true" Override="true" />
         <Field Name="BaseList" Type="BaseListSyntax" Optional="true" Override="true"/>
         <Field Name="ConstraintClauses" Type="SyntaxList&lt;TypeParameterConstraintClauseSyntax&gt;" Override="true"/>
-        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true" Optional="true">
+        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true">
             <Kind Name="OpenBraceToken"/>
         </Field>
         <Field Name="Members" Type="SyntaxList&lt;MemberDeclarationSyntax&gt;" Override="true"/>
-        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true" Optional="true">
+        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true">
             <Kind Name="CloseBraceToken"/>
         </Field>
         <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">
@@ -3515,7 +3505,7 @@
             <Kind Name="SemicolonToken"/>
         </Field>
     </Node>
-    <Node Name="EnumDeclarationSyntax" Base="BaseTypeDeclarationSyntax" SkipConvenienceFactories="true">
+    <Node Name="EnumDeclarationSyntax" Base="BaseTypeDeclarationSyntax">
         <TypeComment>
             <summary>Enum type declaration syntax.</summary>
         </TypeComment>
@@ -3533,7 +3523,7 @@
         </Field>
         <Field Name="BaseList" Type="BaseListSyntax" Optional="true" Override="true">
         </Field>
-        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true" Optional="true">
+        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true">
             <Kind Name="OpenBraceToken"/>
         </Field>
         <Field Name="Members" Type="SeparatedSyntaxList&lt;EnumMemberDeclarationSyntax&gt;" AllowTrailingSeparator="true">
@@ -3541,7 +3531,7 @@
                 <summary>Gets the members declaration list.</summary>
             </PropertyComment>
         </Field>
-        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true" Optional="true">
+        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true">
             <Kind Name="CloseBraceToken"/>
         </Field>
         <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">


### PR DESCRIPTION
Part of #8176.

This PR adds support for the new C#12 syntax introduced by [Collection Expressions](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/collection-expressions) feature:
- `CollectionExpressionSyntax`
- `CollectionElementSyntax`
- `ExpressionElementSyntax`
- `SpreadElementSyntax`