### PR TITLE
ClearTextProtocolsAreSensitive: Reuse compiled regex

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
@@ -97,9 +97,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         public ClearTextProtocolsAreSensitive() : this(AnalyzerConfiguration.Hotspot) { }
 
-        public ClearTextProtocolsAreSensitive(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration)
-        {
-        }
+        public ClearTextProtocolsAreSensitive(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration) { }
 
         static ClearTextProtocolsAreSensitive()
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
@@ -86,11 +86,11 @@ namespace SonarAnalyzer.Rules.CSharp
                                                   ImmutableArray.Create(KnownType.System_Net_Mail_SmtpClient, KnownType.System_Net_FtpWebRequest),
                                                   propertyName => propertyName == EnableSslName);
 
-        private readonly Regex httpRegex;
-        private readonly Regex ftpRegex;
-        private readonly Regex telnetRegex;
-        private readonly Regex telnetRegexForIdentifier;
-        private readonly Regex validServerRegex;
+        private static readonly Regex HttpRegex;
+        private static readonly Regex FtpRegex;
+        private static readonly Regex TelnetRegex;
+        private static readonly Regex TelnetRegexForIdentifier;
+        private static readonly Regex ValidServerRegex;
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(DefaultRule, EnableSslRule);
@@ -98,6 +98,10 @@ namespace SonarAnalyzer.Rules.CSharp
         public ClearTextProtocolsAreSensitive() : this(AnalyzerConfiguration.Hotspot) { }
 
         public ClearTextProtocolsAreSensitive(IAnalyzerConfiguration analyzerConfiguration) : base(analyzerConfiguration)
+        {
+        }
+
+        static ClearTextProtocolsAreSensitive()
         {
             const string allSubdomainsPattern = @"([^/?#]+\.)?";
 
@@ -108,11 +112,11 @@ namespace SonarAnalyzer.Rules.CSharp
 
             var validServerPattern = domainsList.JoinStr("|");
 
-            httpRegex = CompileRegex(@$"^http:\/\/(?!{validServerPattern}).");
-            ftpRegex = CompileRegex(@$"^ftp:\/\/.*@(?!{validServerPattern})");
-            telnetRegex = CompileRegex(@$"^telnet:\/\/.*@(?!{validServerPattern})");
-            telnetRegexForIdentifier = CompileRegex(@"Telnet(?![a-z])", false);
-            validServerRegex = CompileRegex($"^({validServerPattern})$");
+            HttpRegex = CompileRegex(@$"^http:\/\/(?!{validServerPattern}).");
+            FtpRegex = CompileRegex(@$"^ftp:\/\/.*@(?!{validServerPattern})");
+            TelnetRegex = CompileRegex(@$"^telnet:\/\/.*@(?!{validServerPattern})");
+            TelnetRegexForIdentifier = CompileRegex(@"Telnet(?![a-z])", false);
+            ValidServerRegex = CompileRegex($"^({validServerPattern})$");
         }
 
         protected override void Initialize(SonarAnalysisContext context) =>
@@ -142,7 +146,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 context.ReportIssue(Diagnostic.Create(EnableSslRule, objectCreation.Expression.GetLocation()));
             }
-            else if (objectCreation.TypeAsString(context.SemanticModel) is { } typeAsString && telnetRegexForIdentifier.IsMatch(typeAsString))
+            else if (objectCreation.TypeAsString(context.SemanticModel) is { } typeAsString && TelnetRegexForIdentifier.IsMatch(typeAsString))
             {
                 context.ReportIssue(Diagnostic.Create(DefaultRule, objectCreation.Expression.GetLocation(), TelnetKey, RecommendedProtocols[TelnetKey]));
             }
@@ -151,7 +155,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private void VisitInvocationExpression(SonarSyntaxNodeReportingContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
-            if (telnetRegexForIdentifier.IsMatch(invocation.Expression.ToString()))
+            if (TelnetRegexForIdentifier.IsMatch(invocation.Expression.ToString()))
             {
                 context.ReportIssue(Diagnostic.Create(DefaultRule, invocation.GetLocation(), TelnetKey, RecommendedProtocols[TelnetKey]));
             }
@@ -179,20 +183,20 @@ namespace SonarAnalyzer.Rules.CSharp
 
         private bool IsServerSafe(IObjectCreation objectCreation, SemanticModel semanticModel) =>
             objectCreation.ArgumentList?.Arguments.Count > 0
-            && validServerRegex.IsMatch(GetText(objectCreation.ArgumentList.Arguments[0].Expression, semanticModel));
+            && ValidServerRegex.IsMatch(GetText(objectCreation.ArgumentList.Arguments[0].Expression, semanticModel));
 
         private string GetUnsafeProtocol(SyntaxNode node, SemanticModel semanticModel)
         {
             var text = GetText(node, semanticModel);
-            if (httpRegex.IsMatch(text) && !IsNamespace(semanticModel, node.Parent))
+            if (HttpRegex.IsMatch(text) && !IsNamespace(semanticModel, node.Parent))
             {
                 return "http";
             }
-            else if (ftpRegex.IsMatch(text))
+            else if (FtpRegex.IsMatch(text))
             {
                 return "ftp";
             }
-            else if (telnetRegex.IsMatch(text))
+            else if (TelnetRegex.IsMatch(text))
             {
                 return "telnet";
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
@@ -173,7 +173,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
         }
 
-        private void VisitStringExpressions(SonarSyntaxNodeReportingContext c)
+        private static void VisitStringExpressions(SonarSyntaxNodeReportingContext c)
         {
             if (GetUnsafeProtocol(c.Node, c.SemanticModel) is { } unsafeProtocol)
             {


### PR DESCRIPTION
The 5 compiled regex used in  ClearTextProtocolsAreSensitive are not cached between instances and are adding a significant JIT compilation overhead. This PR fixes this:

### Time spend on compiling

akka.net project

Before: 
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/ab77a294-60bb-4f1e-9ebb-bfd312277d86)

After:
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/e4500a37-20fc-4eca-9dec-d670904ab27a)


### Overall

Before: 18th most expensive operation with 14,5 seconds
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/6fb1b792-7c2a-497f-9df8-da7fa4ef47a6)

After: 55 ms
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/063b952c-a1f1-4c71-8c85-5e1350d88b17)
