### PR TITLE
Add Alias any Type syntax to the ShimLayer

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/Syntax.xml
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/Syntax.xml
@@ -3079,10 +3079,17 @@
             <Kind Name="UsingKeyword"/>
         </Field>
         <Choice Optional="true">
-            <Field Name="StaticKeyword" Type="SyntaxToken"/>
+            <Field Name="StaticKeyword" Type="SyntaxToken">
+                <Kind Name="StaticKeyword"/>
+            </Field>
+            <Sequence>
+                <Field Name="UnsafeKeyword" Type="SyntaxToken" Optional="true">
+                    <Kind Name="UnsafeKeyword"/>
+                </Field>
             <Field Name="Alias" Type="NameEqualsSyntax"/>
+            </Sequence>
         </Choice>
-        <Field Name="Name" Type="NameSyntax"/>
+        <Field Name="NamespaceOrType" Type="TypeSyntax"/>
         <Field Name="SemicolonToken" Type="SyntaxToken">
             <Kind Name="SemicolonToken"/>
         </Field>


### PR DESCRIPTION
Part of #8176.

This PR adds support for the new C#12 syntax introduced by [Alias any Type](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/using-alias-types) feature:
- `UsingDirectiveSyntax`, `StaticKeyword` field
- `UsingDirectiveSyntax`, optional sequence of `UnsafeKeywords` of type `SyntaxToken`
