### PR TITLE
Improve S5443 performance: Reuse compiled Regex

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
@@ -28,16 +28,26 @@ namespace SonarAnalyzer.Rules
     {
         private const RegexOptions WindowsAndUnixOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
 
-        protected static string[] InsecureEnvironmentVariables { get; } = { "tmp", "temp", "tmpdir" };
+        protected static string[] InsecureEnvironmentVariables { get; }
 
-        private static readonly Regex UserProfile = new("""^%USERPROFILE%[\\\/]AppData[\\\/]Local[\\\/]Temp""", WindowsAndUnixOptions);
-        private static readonly Regex LinuxDirectories = new($@"^({LinuxDirs().JoinStr("|", Regex.Escape)})(\/|$)", RegexOptions.Compiled);
-        private static readonly Regex MacDirectories = new($@"^({MacDirs().JoinStr("|", Regex.Escape)})(\/|$)", WindowsAndUnixOptions);
-        private static readonly Regex WindowsDirectories = new("""^([a-z]:[\\\/]?|[\\\/][\\\/][^\\\/]+[\\\/]|[\\\/])(windows[\\\/])?te?mp([\\\/]|$)""", WindowsAndUnixOptions);
-        private static readonly Regex EnvironmentVariables = new($@"^%({InsecureEnvironmentVariables.JoinStr("|")})%([\\\/]|$)", WindowsAndUnixOptions);
+        private static readonly Regex UserProfile;
+        private static readonly Regex LinuxDirectories;
+        private static readonly Regex MacDirectories;
+        private static readonly Regex WindowsDirectories;
+        private static readonly Regex EnvironmentVariables;
 
         protected PubliclyWritableDirectoriesBase(IAnalyzerConfiguration configuration) : base(configuration)
         {
+        }
+
+        static PubliclyWritableDirectoriesBase()
+        {
+            InsecureEnvironmentVariables = new[] { "tmp", "temp", "tmpdir" };
+            UserProfile = new("""^%USERPROFILE%[\\\/]AppData[\\\/]Local[\\\/]Temp""", WindowsAndUnixOptions);
+            LinuxDirectories = new($@"^({LinuxDirs().JoinStr("|", Regex.Escape)})(\/|$)", RegexOptions.Compiled);
+            MacDirectories = new($@"^({MacDirs().JoinStr("|", Regex.Escape)})(\/|$)", WindowsAndUnixOptions);
+            WindowsDirectories = new("""^([a-z]:[\\\/]?|[\\\/][\\\/][^\\\/]+[\\\/]|[\\\/])(windows[\\\/])?te?mp([\\\/]|$)""", WindowsAndUnixOptions);
+            EnvironmentVariables = new($@"^%({InsecureEnvironmentVariables.JoinStr("|")})%([\\\/]|$)", WindowsAndUnixOptions);
         }
 
         protected static bool IsSensitiveDirectoryUsage(string directory) =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
@@ -18,9 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Data;
 using System.Text.RegularExpressions;
-using Microsoft.CodeAnalysis;
 
 namespace SonarAnalyzer.Rules
 {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
@@ -40,12 +40,13 @@ namespace SonarAnalyzer.Rules
 
         static PubliclyWritableDirectoriesBase()
         {
-            InsecureEnvironmentVariables = new[] { "tmp", "temp", "tmpdir" };
+            var insecureEnvironmentVariables = new[] { "tmp", "temp", "tmpdir" };
+            InsecureEnvironmentVariables = insecureEnvironmentVariables;
             UserProfile = new("""^%USERPROFILE%[\\\/]AppData[\\\/]Local[\\\/]Temp""", WindowsAndUnixOptions);
             LinuxDirectories = new($@"^({LinuxDirs().JoinStr("|", Regex.Escape)})(\/|$)", RegexOptions.Compiled);
             MacDirectories = new($@"^({MacDirs().JoinStr("|", Regex.Escape)})(\/|$)", WindowsAndUnixOptions);
             WindowsDirectories = new("""^([a-z]:[\\\/]?|[\\\/][\\\/][^\\\/]+[\\\/]|[\\\/])(windows[\\\/])?te?mp([\\\/]|$)""", WindowsAndUnixOptions);
-            EnvironmentVariables = new($@"^%({InsecureEnvironmentVariables.JoinStr("|")})%([\\\/]|$)", WindowsAndUnixOptions);
+            EnvironmentVariables = new($@"^%({insecureEnvironmentVariables.JoinStr("|")})%([\\\/]|$)", WindowsAndUnixOptions);
         }
 
         private readonly DiagnosticDescriptor rule;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
@@ -29,22 +29,15 @@ namespace SonarAnalyzer.Rules
         private const RegexOptions WindowsAndUnixOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
 
         private static readonly Regex UserProfile = new("""^%USERPROFILE%[\\\/]AppData[\\\/]Local[\\\/]Temp""", WindowsAndUnixOptions);
-        private static readonly Regex LinuxDirectories;
-        private static readonly Regex MacDirectories;
+        private static readonly Regex LinuxDirectories = new($@"^({LinuxDirs().JoinStr("|", Regex.Escape)})(\/|$)", RegexOptions.Compiled);
+        private static readonly Regex MacDirectories = new($@"^({MacDirs().JoinStr("|", Regex.Escape)})(\/|$)", WindowsAndUnixOptions);
         private static readonly Regex WindowsDirectories = new("""^([a-z]:[\\\/]?|[\\\/][\\\/][^\\\/]+[\\\/]|[\\\/])(windows[\\\/])?te?mp([\\\/]|$)""", WindowsAndUnixOptions);
-        private static readonly Regex EnvironmentVariables;
+        private static readonly Regex EnvironmentVariables = new($@"^%({InsecureEnvironmentVariables.JoinStr("|")})%([\\\/]|$)", WindowsAndUnixOptions);
 
         protected static string[] InsecureEnvironmentVariables { get; } = { "tmp", "temp", "tmpdir" };
 
         protected PubliclyWritableDirectoriesBase(IAnalyzerConfiguration configuration) : base(configuration)
         {
-        }
-
-        static PubliclyWritableDirectoriesBase()
-        {
-            LinuxDirectories = new Regex($@"^({LinuxDirs().JoinStr("|", Regex.Escape)})(\/|$)", RegexOptions.Compiled);
-            MacDirectories = new Regex($@"^({MacDirs().JoinStr("|", Regex.Escape)})(\/|$)", WindowsAndUnixOptions);
-            EnvironmentVariables = new Regex($@"^%({InsecureEnvironmentVariables.JoinStr("|")})%([\\\/]|$)", WindowsAndUnixOptions);
         }
 
         protected static bool IsSensitiveDirectoryUsage(string directory) =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
@@ -28,13 +28,13 @@ namespace SonarAnalyzer.Rules
     {
         private const RegexOptions WindowsAndUnixOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
 
+        protected static string[] InsecureEnvironmentVariables { get; } = { "tmp", "temp", "tmpdir" };
+
         private static readonly Regex UserProfile = new("""^%USERPROFILE%[\\\/]AppData[\\\/]Local[\\\/]Temp""", WindowsAndUnixOptions);
         private static readonly Regex LinuxDirectories = new($@"^({LinuxDirs().JoinStr("|", Regex.Escape)})(\/|$)", RegexOptions.Compiled);
         private static readonly Regex MacDirectories = new($@"^({MacDirs().JoinStr("|", Regex.Escape)})(\/|$)", WindowsAndUnixOptions);
         private static readonly Regex WindowsDirectories = new("""^([a-z]:[\\\/]?|[\\\/][\\\/][^\\\/]+[\\\/]|[\\\/])(windows[\\\/])?te?mp([\\\/]|$)""", WindowsAndUnixOptions);
         private static readonly Regex EnvironmentVariables = new($@"^%({InsecureEnvironmentVariables.JoinStr("|")})%([\\\/]|$)", WindowsAndUnixOptions);
-
-        protected static string[] InsecureEnvironmentVariables { get; } = { "tmp", "temp", "tmpdir" };
 
         protected PubliclyWritableDirectoriesBase(IAnalyzerConfiguration configuration) : base(configuration)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
@@ -54,8 +54,8 @@ namespace SonarAnalyzer.Rules
 
         static PubliclyWritableDirectoriesBase()
         {
-            LinuxDirectories = new Regex($@"^({LinuxDirs().JoinStr("|", x => Regex.Escape(x))})(\/|$)", RegexOptions.Compiled);
-            MacDirectories = new Regex($@"^({MacDirs().JoinStr("|", x => Regex.Escape(x))})(\/|$)", WindowsAndUnixOptions);
+            LinuxDirectories = new Regex($@"^({LinuxDirs().JoinStr("|", Regex.Escape)})(\/|$)", RegexOptions.Compiled);
+            MacDirectories = new Regex($@"^({MacDirs().JoinStr("|", Regex.Escape)})(\/|$)", WindowsAndUnixOptions);
             EnvironmentVariables = new Regex($@"^%({InsecureEnvironmentVariables.JoinStr("|")})%([\\\/]|$)", WindowsAndUnixOptions);
         }
 


### PR DESCRIPTION
see also #8181
Strips of another 4,5 seconds (or 0,08%) by caching the JITed regex in `IsSensitiveDirectoryUsage`:

### JIT

Before:
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/64422d3c-199f-4a9d-b630-1e6ffa99d20d)

After:
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/d8915822-04b2-4811-8dd1-557d43e1baa1)

### Overall

Before
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/3bb05e8e-af6b-4d79-9751-be060055807d)

After
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/95b17493-c740-4a20-af0b-22a8e4431a64)
