### PR TITLE
Add Primary Constructor syntax to the ShimLayer

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/Syntax.xml
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/Syntax.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 
-<!-- 
+<!--
  To re-generate source from this file, run eng/generate-compiler-code.cmd
 -->
 
@@ -3080,7 +3080,7 @@
         </Field>
         <Choice Optional="true">
             <Field Name="StaticKeyword" Type="SyntaxToken"/>
-                <Field Name="Alias" Type="NameEqualsSyntax"/>
+            <Field Name="Alias" Type="NameEqualsSyntax"/>
         </Choice>
         <Field Name="Name" Type="NameSyntax"/>
         <Field Name="SemicolonToken" Type="SyntaxToken">

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/Syntax.xml
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/Syntax.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 
-<!--
+<!-- 
  To re-generate source from this file, run eng/generate-compiler-code.cmd
 -->
 
@@ -3080,7 +3080,7 @@
         </Field>
         <Choice Optional="true">
             <Field Name="StaticKeyword" Type="SyntaxToken"/>
-            <Field Name="Alias" Type="NameEqualsSyntax"/>
+                <Field Name="Alias" Type="NameEqualsSyntax"/>
         </Choice>
         <Field Name="Name" Type="NameSyntax"/>
         <Field Name="SemicolonToken" Type="SyntaxToken">
@@ -3348,6 +3348,7 @@
             </PropertyComment>
         </Field>
         <Field Name="TypeParameterList" Type="TypeParameterListSyntax" Optional="true"/>
+        <Field Name="ParameterList" Type="ParameterListSyntax" Optional="true"/>
         <Field Name="ConstraintClauses" Type="SyntaxList&lt;TypeParameterConstraintClauseSyntax&gt;">
             <PropertyComment>
                 <summary>Gets the type constraint list.</summary>
@@ -3359,7 +3360,7 @@
             </PropertyComment>
         </Field>
     </AbstractNode>
-    <Node Name="ClassDeclarationSyntax" Base="TypeDeclarationSyntax">
+    <Node Name="ClassDeclarationSyntax" Base="TypeDeclarationSyntax" SkipConvenienceFactories="true">
         <TypeComment>
             <summary>Class type declaration syntax.</summary>
         </TypeComment>
@@ -3376,20 +3377,21 @@
             <Kind Name="IdentifierToken"/>
         </Field>
         <Field Name="TypeParameterList" Type="TypeParameterListSyntax" Optional="true" Override="true"/>
+        <Field Name="ParameterList" Type="ParameterListSyntax" Optional="true" Override="true" />
         <Field Name="BaseList" Type="BaseListSyntax" Optional="true" Override="true"/>
         <Field Name="ConstraintClauses" Type="SyntaxList&lt;TypeParameterConstraintClauseSyntax&gt;" Override="true"/>
-        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="OpenBraceToken"/>
         </Field>
         <Field Name="Members" Type="SyntaxList&lt;MemberDeclarationSyntax&gt;" Override="true"/>
-        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="CloseBraceToken"/>
         </Field>
         <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">
             <Kind Name="SemicolonToken"/>
         </Field>
     </Node>
-    <Node Name="StructDeclarationSyntax" Base="TypeDeclarationSyntax">
+    <Node Name="StructDeclarationSyntax" Base="TypeDeclarationSyntax" SkipConvenienceFactories="true">
         <TypeComment>
             <summary>Struct type declaration syntax.</summary>
         </TypeComment>
@@ -3406,20 +3408,21 @@
             <Kind Name="IdentifierToken"/>
         </Field>
         <Field Name="TypeParameterList" Type="TypeParameterListSyntax" Optional="true" Override="true"/>
+        <Field Name="ParameterList" Type="ParameterListSyntax" Optional="true" Override="true" />
         <Field Name="BaseList" Type="BaseListSyntax" Optional="true" Override="true"/>
         <Field Name="ConstraintClauses" Type="SyntaxList&lt;TypeParameterConstraintClauseSyntax&gt;" Override="true"/>
-        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="OpenBraceToken"/>
         </Field>
         <Field Name="Members" Type="SyntaxList&lt;MemberDeclarationSyntax&gt;" Override="true"/>
-        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="CloseBraceToken"/>
         </Field>
         <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">
             <Kind Name="SemicolonToken"/>
         </Field>
     </Node>
-    <Node Name="InterfaceDeclarationSyntax" Base="TypeDeclarationSyntax">
+    <Node Name="InterfaceDeclarationSyntax" Base="TypeDeclarationSyntax" SkipConvenienceFactories="true">
         <TypeComment>
             <summary>Interface type declaration syntax.</summary>
         </TypeComment>
@@ -3436,13 +3439,14 @@
             <Kind Name="IdentifierToken"/>
         </Field>
         <Field Name="TypeParameterList" Type="TypeParameterListSyntax" Optional="true" Override="true"/>
+        <Field Name="ParameterList" Type="ParameterListSyntax" Optional="true" Override="true" />
         <Field Name="BaseList" Type="BaseListSyntax" Optional="true" Override="true"/>
         <Field Name="ConstraintClauses" Type="SyntaxList&lt;TypeParameterConstraintClauseSyntax&gt;" Override="true"/>
-        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="OpenBraceToken"/>
         </Field>
         <Field Name="Members" Type="SyntaxList&lt;MemberDeclarationSyntax&gt;" Override="true"/>
-        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="CloseBraceToken"/>
         </Field>
         <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">
@@ -3479,7 +3483,7 @@
             <Kind Name="SemicolonToken"/>
         </Field>
     </Node>
-    <Node Name="EnumDeclarationSyntax" Base="BaseTypeDeclarationSyntax">
+    <Node Name="EnumDeclarationSyntax" Base="BaseTypeDeclarationSyntax" SkipConvenienceFactories="true">
         <TypeComment>
             <summary>Enum type declaration syntax.</summary>
         </TypeComment>
@@ -3497,7 +3501,7 @@
         </Field>
         <Field Name="BaseList" Type="BaseListSyntax" Optional="true" Override="true">
         </Field>
-        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="OpenBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="OpenBraceToken"/>
         </Field>
         <Field Name="Members" Type="SeparatedSyntaxList&lt;EnumMemberDeclarationSyntax&gt;" AllowTrailingSeparator="true">
@@ -3505,7 +3509,7 @@
                 <summary>Gets the members declaration list.</summary>
             </PropertyComment>
         </Field>
-        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true">
+        <Field Name="CloseBraceToken" Type="SyntaxToken" Override="true" Optional="true">
             <Kind Name="CloseBraceToken"/>
         </Field>
         <Field Name="SemicolonToken" Type="SyntaxToken" Optional="true" Override="true">


### PR DESCRIPTION
Part of #8176.

This PR adds support for the new C#12 syntax introduced by [Primary Constructor](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/primary-constructors) feature:

- `ParameterList` field to `TypeDeclarationSyntax
`
- `ParameterList`, `OpenBraceToken` and `CloseBraceToken` fields to `ClassDeclarationSyntax`
- `ParameterList`, `OpenBraceToken` and `CloseBraceToken` fields to `StructDeclarationSyntax`
- `ParameterList`, `OpenBraceToken` and `CloseBraceToken` fields to `InterfaceDeclarationSyntax`
- optional `OpenBraceToken` and `CloseBraceToken` fields to `EnumDeclarationSyntax`

For now, we miss the `Override="true"` attribute on `ParameterList` of `RecordDeclarationSyntax` since this introduces a breaking change and requires a Microsoft.CodeAnalysis.CSharp version greater than 1.3.1.0.