### PR TITLE
Improve S2068 performance: Reuse compiled Regex

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -40,8 +40,8 @@ namespace SonarAnalyzer.Rules
         private const string DefaultCredentialWords = "password, passwd, pwd, passphrase";
 
         private static readonly ConcurrentDictionary<string, Regex> PasswordValuePattern = new();
-        protected static readonly Regex ValidCredentialPattern = new(@"^(\?|:\w+|\{\d+[^}]*\}|""|')$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        protected static readonly Regex UriUserInfoPattern = CreateUriUserInfoPattern();
+        private static readonly Regex ValidCredentialPattern = new(@"^(\?|:\w+|\{\d+[^}]*\}|""|')$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex UriUserInfoPattern = CreateUriUserInfoPattern();
 
         private readonly IAnalyzerConfiguration configuration;
         private readonly DiagnosticDescriptor rule;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -44,13 +44,13 @@ namespace SonarAnalyzer.Rules
             set
             {
                 credentialWords = value;
-                SplitCredentialWords = GetSplitCredentialWords(credentialWords);
+                SplitCredentialWords = SplitCredentialWordsByComma(credentialWords);
             }
         }
 
         protected ImmutableList<string> SplitCredentialWords { get; private set; }
 
-        public DoNotHardcodeCredentialsBase()
+        protected DoNotHardcodeCredentialsBase()
         {
             CredentialWords = DefaultCredentialWords;   // Property will initialize multiple state variables
         }
@@ -58,11 +58,11 @@ namespace SonarAnalyzer.Rules
         protected static Regex PasswordValueRegex(string credentialWords) =>
             PasswordValuePattern.GetOrAdd(credentialWords, static credentialWords =>
             {
-                var splitCredentialWords = string.Join("|", GetSplitCredentialWords(credentialWords).Select(Regex.Escape));
+                var splitCredentialWords = string.Join("|", SplitCredentialWordsByComma(credentialWords).Select(Regex.Escape));
                 return new Regex($@"\b(?<credential>{splitCredentialWords})\s*[:=]\s*(?<suffix>.+)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
             });
 
-        protected static ImmutableList<string> GetSplitCredentialWords(string credentialWords) =>
+        protected static ImmutableList<string> SplitCredentialWordsByComma(string credentialWords) =>
             credentialWords.ToUpperInvariant()
                 .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x.Trim())

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -66,16 +66,18 @@ namespace SonarAnalyzer.Rules
             }
         }
 
-        protected DoNotHardcodeCredentialsBase()
+        protected DoNotHardcodeCredentialsBase(IAnalyzerConfiguration configuration)
         {
+            this.configuration = configuration;
+            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
             CredentialWords = DefaultCredentialWords;   // Property will initialize multiple state variables
         }
 
         private static Regex PasswordValueRegex(string credentialWords) =>
             PasswordValuePattern.GetOrAdd(credentialWords, static credentialWords =>
             {
-                var splitCredentialWords = string.Join("|", SplitCredentialWordsByComma(credentialWords).Select(Regex.Escape));
-                return new Regex($@"\b(?<credential>{splitCredentialWords})\s*[:=]\s*(?<suffix>.+)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                var credentialWordsPattern = string.Join("|", SplitCredentialWordsByComma(credentialWords).Select(Regex.Escape));
+                return new Regex($@"\b(?<credential>{credentialWordsPattern})\s*[:=]\s*(?<suffix>.+)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
             });
 
         private static ImmutableList<string> SplitCredentialWordsByComma(string credentialWords) =>
@@ -98,12 +100,6 @@ namespace SonarAnalyzer.Rules
 
             static string CreateUserInfoGroup(string name, string additionalCharacters = null) =>
                 $@"(?<{name}>[\w\d{Regex.Escape(UriPasswordSpecialCharacters)}{additionalCharacters}]+)";
-        }
-
-        protected DoNotHardcodeCredentialsBase(IAnalyzerConfiguration configuration)
-        {
-            this.configuration = configuration;
-            rule = Language.CreateDescriptor(DiagnosticId, MessageFormat);
         }
 
         protected sealed override void Initialize(SonarParametrizedAnalysisContext context)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -45,8 +45,8 @@ namespace SonarAnalyzer.Rules
         private readonly DiagnosticDescriptor rule;
 
         private string credentialWords;
-        private Regex PasswordValuePattern;
         private ImmutableList<string> splitCredentialWords;
+        private Regex passwordValuePattern;
 
         protected abstract ILanguageFacade<TSyntaxKind> Language { get; }
         protected abstract void InitializeActions(SonarParametrizedAnalysisContext context);
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules
                 var split = SplitCredentialWordsByComma(credentialWords);
                 splitCredentialWords = split;
                 var credentialWordsPattern = string.Join("|", split.Select(Regex.Escape));
-                PasswordValuePattern = new Regex($@"\b(?<credential>{credentialWordsPattern})\s*[:=]\s*(?<suffix>.+)$", RegexOptions.IgnoreCase);
+                passwordValuePattern = new Regex($@"\b(?<credential>{credentialWordsPattern})\s*[:=]\s*(?<suffix>.+)$", RegexOptions.IgnoreCase);
             }
         }
 
@@ -208,7 +208,7 @@ namespace SonarAnalyzer.Rules
                 return Enumerable.Empty<string>();
             }
 
-            var match = PasswordValuePattern.Match(variableValue);
+            var match = passwordValuePattern.Match(variableValue);
             if (match.Success && !IsValidCredential(match.Groups["suffix"].Value))
             {
                 credentialWordsFound.Add(match.Groups["credential"].Value);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules
                 credentialWords = value;
                 var split = SplitCredentialWordsByComma(credentialWords);
                 splitCredentialWords = split;
-                var credentialWordsPattern = string.Join("|", split.Select(Regex.Escape));
+                var credentialWordsPattern = split.Select(Regex.Escape).JoinStr("|");
                 passwordValuePattern = new Regex($@"\b(?<credential>{credentialWordsPattern})\s*[:=]\s*(?<suffix>.+)$", RegexOptions.IgnoreCase);
             }
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -78,7 +78,7 @@ namespace SonarAnalyzer.Rules
         {
             // Make a local copy of the reference to the tuple class to avoid concurrency issues between the access of Item1 and Item2
             var local = PasswordValuePattern;
-            if (local.Item1 == credentialWords)
+            if (local?.Item1 == credentialWords)
             {
                 return local.Item2;
             }


### PR DESCRIPTION
see also #8181 and #8183

Before:
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/28cd0253-1303-4d9c-b614-a130b4ab3a3d)

After:
![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/8254d8fc-e0ec-4d15-95a6-89fbe50c3259)
