### PR TITLE
Update .Net ITs order to run the internal projects first

### DIFF
--- a/analyzers/its/regression-test.ps1
+++ b/analyzers/its/regression-test.ps1
@@ -459,11 +459,13 @@ try {
     # redirects the outputs of the different configurations in separate folders.
 
     # Do not forget to update ValidateSet of -project parameter when new project is added.
+    Build-Project-MSBuild "ManuallyAddedNoncompliantIssues.CS" "ManuallyAddedNoncompliantIssues.CS.sln"
+    Build-Project-MSBuild "ManuallyAddedNoncompliantIssues.VB" "ManuallyAddedNoncompliantIssues.VB.sln"
+    CheckInternalProjectsDifferences
+
     Build-Project-MSBuild "AnalyzeGenerated.CS" "AnalyzeGenerated.CS.sln"
     Build-Project-MSBuild "AnalyzeGenerated.VB" "AnalyzeGenerated.VB.sln"
     Build-Project-MSBuild "Ember-MM" "Ember Media Manager.sln"
-    Build-Project-MSBuild "ManuallyAddedNoncompliantIssues.CS" "ManuallyAddedNoncompliantIssues.CS.sln"
-    Build-Project-MSBuild "ManuallyAddedNoncompliantIssues.VB" "ManuallyAddedNoncompliantIssues.VB.sln"
     Build-Project-MSBuild "Nancy" "Nancy.sln"
     Build-Project-MSBuild "Roslyn.1.3.1" "Roslyn.1.3.1.sln"
     Build-Project-MSBuild "SkipGenerated.CS" "SkipGenerated.CS.sln"
@@ -483,8 +485,6 @@ try {
     Build-Project-DotnetTool "BlazorSample" "BlazorSample.sln"
 
     Write-Header "Processing analyzer results"
-
-    CheckInternalProjectsDifferences
 
     # Not needed when $project is internal
     if ($project -eq "" -or -not $InternalProjects.Contains($project)) {


### PR DESCRIPTION
Internal projects are verified differently and we don't need to wait for the other projects to run to validate them.