### PR TITLE
Fix S2583/S2589 FP: Not tracked collection types can learn `CollectionConstraint` from `BinaryOperation`

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.Collections.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Binary.Collections.cs
@@ -18,7 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis;
 using SonarAnalyzer.SymbolicExecution.Constraints;
+using SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks;
 
 namespace SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors;
 
@@ -47,6 +49,7 @@ internal sealed partial class Binary
 
         ISymbol InstanceOfCountProperty(IOperation operation) =>
             operation.AsPropertyReference() is { Instance: { } instance, Property.Name: nameof(Array.Length) or nameof(List<int>.Count) }
+            && instance.Type.DerivesOrImplementsAny(EmptyCollectionsShouldNotBeEnumeratedBase.TrackedCollectionTypes)
             && instance.TrackedSymbol(state) is { } symbol
                 ? symbol
                 : null;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
@@ -29,7 +29,7 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
     protected const string DiagnosticId = "S4158";
     protected const string MessageFormat = "Remove this call, the collection is known to be empty here.";
 
-    private static readonly KnownType[] TrackedCollectionTypes = new[]
+    internal static readonly ImmutableArray<KnownType> TrackedCollectionTypes = new[]
     {
         KnownType.System_Collections_Generic_List_T,
         KnownType.System_Collections_Generic_IList_T,
@@ -42,7 +42,7 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
         KnownType.System_Array,
         KnownType.System_Collections_Generic_Dictionary_TKey_TValue,
         KnownType.System_Collections_Generic_IDictionary_TKey_TValue,
-    };
+    }.ToImmutableArray();
 
     protected static readonly HashSet<string> RaisingMethods = new()
     {
@@ -199,7 +199,7 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
                     nonEmptyAccess.Add(context.Operation.Instance);
                 }
             }
-            if (instance.Type.IsAny(TrackedCollectionTypes))
+            if (instance.Type.DerivesOrImplementsAny(TrackedCollectionTypes))
             {
                 return ProcessAddMethod(context.State, targetMethod, instance)
                     ?? ProcessRemoveMethod(context.State, targetMethod, instance)
@@ -264,7 +264,7 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
                 return NumberConstraint.From(1, null);
             }
         }
-        return instance.Type.IsAny(TrackedCollectionTypes) ? NumberConstraint.From(0, null) : null;
+        return instance.Type.DerivesOrImplementsAny(TrackedCollectionTypes) ? NumberConstraint.From(0, null) : null;
     }
 
     private static ProgramState ProcessIndexerAccess(ProgramState state, IPropertyReferenceOperationWrapper propertyReference)

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
@@ -33,15 +33,21 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
     {
         KnownType.System_Collections_Generic_List_T,
         KnownType.System_Collections_Generic_IList_T,
+        KnownType.System_Collections_Immutable_IImmutableList_T,
         KnownType.System_Collections_Generic_ICollection_T,
         KnownType.System_Collections_Generic_HashSet_T,
         KnownType.System_Collections_Generic_ISet_T,
+        KnownType.System_Collections_Immutable_IImmutableSet_T,
         KnownType.System_Collections_Generic_Queue_T,
+        KnownType.System_Collections_Immutable_IImmutableQueue_T,
         KnownType.System_Collections_Generic_Stack_T,
+        KnownType.System_Collections_Immutable_IImmutableStack_T,
         KnownType.System_Collections_ObjectModel_ObservableCollection_T,
         KnownType.System_Array,
+        KnownType.System_Collections_Immutable_IImmutableArray_T,
         KnownType.System_Collections_Generic_Dictionary_TKey_TValue,
         KnownType.System_Collections_Generic_IDictionary_TKey_TValue,
+        KnownType.System_Collections_Immutable_IImmutableDictionary_TKey_TValue,
     }.ToImmutableArray();
 
     protected static readonly HashSet<string> RaisingMethods = new()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/CollectionConstraintTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/CollectionConstraintTests.cs
@@ -115,7 +115,7 @@ public class CollectionConstraintTests
                     if (notACollection.Count > 0)
                     {
                         notACollection.Remove(5);
-                        if (notACollection.Count > 0)   // Noncompliant FP
+                        if (notACollection.Count > 0)   // Compliant
                         {
                             Console.WriteLine();
                         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/CollectionConstraintTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/CollectionConstraintTests.cs
@@ -79,7 +79,7 @@ public class CollectionConstraintTests
 
     [TestMethod]
     public void CollectionConstraint_ShouldNotLearnConstraintForNonCollectionProperties() =>
-    builder.AddSnippet($$$"""
+        builder.AddSnippet($$$"""
             ﻿using System.Collections.Generic;
 
             class Tests
@@ -93,6 +93,33 @@ public class CollectionConstraintTests
                     // This FP used to trigger due to S4158, when checking for the Length property.
                     if (this.Length < 0) // Compliant
                     { }
+                }
+            }
+            """)
+        .Verify();
+
+    [TestMethod]
+    public void CollectionConstraint_ShouldNotLearnConstraintFromBinariesForNonTrackedTypes() =>
+        builder.AddSnippet("""
+            using System;
+            ﻿using System.Collections.Generic;
+            class NotACollection
+            {
+                List<int> items;
+                int Count => items.Count;
+            
+                void Remove(int i) => items.Remove(i);
+            
+                void Foo(NotACollection notACollection)
+                {
+                    if (notACollection.Count > 0)
+                    {
+                        notACollection.Remove(5);
+                        if (notACollection.Count > 0)   // Noncompliant FP
+                        {
+                            Console.WriteLine();
+                        }
+                    }
                 }
             }
             """)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -463,10 +463,10 @@ class AdvancedTests
         sb.Clear();
         sb.Clear();                                         // Compliant
 
-        var custom = new CustomCollection();
-        custom.Clear();
-        custom.AddMethodWithDifferentName(5);
-        custom.Clear();                                     // Compliant
+        var collectionLookALike = new CollectionLookALike();
+        collectionLookALike.Clear();
+        collectionLookALike.AddMethodWithDifferentName(5);
+        collectionLookALike.Clear();                        // Compliant
     }
 
     public void AssignmentToInterface()
@@ -502,6 +502,15 @@ class AdvancedTests
         readOnly.GetEnumerator();                           // Noncompliant
         readOnly = new List<int> { 5 };
         readOnly.GetEnumerator();                           // Compliant
+    }
+
+    public void DeriveFromTrackedCollection()
+    {
+        var custom = new CustomCollection<int>();
+        custom.Clear();                                     // Compliant, state is unknown
+        custom.Clear();                                     // Noncompliant
+        custom.Add(5);
+        custom.Clear();                                     // Compliant
     }
 
     public void UnknownExtensionMethods()
@@ -735,11 +744,13 @@ class AdvancedTests
 
     void Foo(List<int> items) { }
 
-    class CustomCollection
+    class CollectionLookALike
     {
         public void Clear() { }
         public void AddMethodWithDifferentName(int item) { }
     }
+
+    class CustomCollection<T> : Collection<T> { }
 
     class CustomIList : IList<int>
     {


### PR DESCRIPTION
Fixes and issue introduced in #7877 
```
class NotACollection
{
    List<int> items;
    int Count => items.Count;

    void Remove(int i) => items.Remove(i);

    void Foo(NotACollection notACollection)
    {
        if (notACollection.Count > 0)
        {
            notACollection.Remove(5);
            if (notACollection.Count > 0)   // Noncompliant FP
            {
                Console.WriteLine();
            }
        }
    }
}
```