### PR TITLE
Temporarily disable code signing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,6 +98,7 @@ stages:
         inputs:
           secureFile: 'SonarSource-2021-2023.pfx'
 
+      # Code signing is temporarily disabled until new certificate is properly set up
       - task: VSBuild@1
         displayName: "Build and sign SonarAnalyzer solution"
         env:
@@ -108,7 +109,7 @@ stages:
           solution: '$(solution)'
           platform: '$(buildPlatform)'
           configuration: '$(buildConfiguration)'
-          msbuildArgs: '/p:SignAssembly=$(isReleaseBranch) /p:AssemblyOriginatorKeyFile="$(snk.secureFilePath)" /p:Sha1=$(Build.SourceVersion) /p:BuildNumber=$(Build.BuildId) /p:WarningLevel=0'
+          msbuildArgs: '/p:SignAssembly=false /p:AssemblyOriginatorKeyFile="$(snk.secureFilePath)" /p:Sha1=$(Build.SourceVersion) /p:BuildNumber=$(Build.BuildId) /p:WarningLevel=0'
           vsVersion: $(vsVersion)
 
       - task: NuGetCommand@2
@@ -121,7 +122,9 @@ stages:
           verbosityPack: 'Detailed'
           publishPackageMetadata: true
 
+      # Code signing is temporarily disabled until new certificate is properly set up
       - task: NuGetCommand@2
+        enabled: false
         displayName: "Sign NuGet packages"
         condition: eq(variables.isReleaseBranch, 'True')
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ stages:
         name: pfx
         inputs:
           secureFile: 'SonarSource-2021-2023.pfx'
-      
+
       - task: VSBuild@1
         displayName: "Build and sign SonarAnalyzer solution"
         env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,8 +97,7 @@ stages:
         name: pfx
         inputs:
           secureFile: 'SonarSource-2021-2023.pfx'
-
-      # Code signing is temporarily disabled until new certificate is properly set up
+      
       - task: VSBuild@1
         displayName: "Build and sign SonarAnalyzer solution"
         env:
@@ -109,6 +108,8 @@ stages:
           solution: '$(solution)'
           platform: '$(buildPlatform)'
           configuration: '$(buildConfiguration)'
+          # Code signing is temporarily disabled until new certificate is properly set up
+          # https://github.com/SonarSource/sonar-dotnet/issues/8230
           msbuildArgs: '/p:SignAssembly=false /p:AssemblyOriginatorKeyFile="$(snk.secureFilePath)" /p:Sha1=$(Build.SourceVersion) /p:BuildNumber=$(Build.BuildId) /p:WarningLevel=0'
           vsVersion: $(vsVersion)
 
@@ -122,7 +123,8 @@ stages:
           verbosityPack: 'Detailed'
           publishPackageMetadata: true
 
-      # Code signing is temporarily disabled until new certificate is properly set up
+      # Code signing is temporarily disabled until new certificate is properly set up.
+      # https://github.com/SonarSource/sonar-dotnet/issues/8230
       - task: NuGetCommand@2
         enabled: false
         displayName: "Sign NuGet packages"


### PR DESCRIPTION
Part of #8230 
The current code signing certificate has expired. Until the new one is set up this PR will disable code signing to keep the builds green.