### PR TITLE
Add project with .Net 8 unit tests

### DIFF
--- a/analyzers/SonarAnalyzer.sln
+++ b/analyzers/SonarAnalyzer.sln
@@ -58,6 +58,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AnalysisConfig", "AnalysisC
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SonarAnalyzer.SourceGenerators", "src\SonarAnalyzer.SourceGenerators\SonarAnalyzer.SourceGenerators.csproj", "{76D6EBB8-D2B0-41C1-8880-027EC78CB7FF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SonarAnalyzer.Net8.UnitTest", "tests\SonarAnalyzer.Net8.UnitTest\SonarAnalyzer.Net8.UnitTest.csproj", "{DB0A158B-D003-47ED-8209-E70277EB0693}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -96,6 +98,10 @@ Global
 		{76D6EBB8-D2B0-41C1-8880-027EC78CB7FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76D6EBB8-D2B0-41C1-8880-027EC78CB7FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76D6EBB8-D2B0-41C1-8880-027EC78CB7FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB0A158B-D003-47ED-8209-E70277EB0693}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB0A158B-D003-47ED-8209-E70277EB0693}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB0A158B-D003-47ED-8209-E70277EB0693}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB0A158B-D003-47ED-8209-E70277EB0693}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -108,6 +114,7 @@ Global
 		{28067DB4-C098-4A15-9846-2978711733F3} = {314A0C27-4768-4F15-B7FA-DC3C33C08180}
 		{C086048C-D183-4B4D-9D3C-A6E191F19680} = {0C3E0519-DB5C-47C0-ABB3-9D1FB23DFBAF}
 		{E044950A-098B-4090-B4FB-8D6BD086828B} = {0C3E0519-DB5C-47C0-ABB3-9D1FB23DFBAF}
+		{DB0A158B-D003-47ED-8209-E70277EB0693} = {B7233F78-E142-4882-B084-7C83BE472109}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4259CA71-C565-42DD-8D58-F59819A11065}

--- a/analyzers/tests/SonarAnalyzer.Net8.UnitTest/ReadMe.md
+++ b/analyzers/tests/SonarAnalyzer.Net8.UnitTest/ReadMe.md
@@ -1,0 +1,9 @@
+# Description
+
+This project contains the analyzer unit tests that need the .Net 8 specific runtime.
+
+Due to the following issue we cannot change the main test project to use .Net 8: https://github.com/dotnet/roslyn/issues/69578#issuecomment-1744931047
+
+The current solution uses the main test project as a dependency, in order to have access to the `Verifier` and `VerifierBuilder`. A temporary decision that will allow us to add support on time for .net 8.
+
+The final design is to extract these test utilities in their own project to be able to reuse them where necessary. See: https://github.com/SonarSource/sonar-dotnet/issues/8237

--- a/analyzers/tests/SonarAnalyzer.Net8.UnitTest/Rules/SelfAssignmentTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Net8.UnitTest/Rules/SelfAssignmentTest.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarAnalyzer.UnitTest.TestFramework;
+
+namespace SonarAnalyzer.Net8.UnitTest.Rules;
+
+[TestClass]
+public class SelfAssignmentTest
+{
+    private readonly VerifierBuilder builderCS = new VerifierBuilder<SonarAnalyzer.Rules.CSharp.SelfAssignment>().WithConcurrentAnalysis(false);
+
+    [TestMethod]
+    public void SelfAssignment() =>
+        builderCS.AddPaths("SelfAssignment.cs").WithOptions(ParseOptionsHelper.FromCSharp12).Verify();
+}

--- a/analyzers/tests/SonarAnalyzer.Net8.UnitTest/Rules/SelfAssignmentTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Net8.UnitTest/Rules/SelfAssignmentTest.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.UnitTest.TestFramework;
 
-namespace SonarAnalyzer.UnitTest.Rules;
+namespace SonarAnalyzer.Net8.UnitTest.Rules;
 
 [TestClass]
 public class SelfAssignmentTest

--- a/analyzers/tests/SonarAnalyzer.Net8.UnitTest/Rules/SelfAssignmentTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Net8.UnitTest/Rules/SelfAssignmentTest.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarAnalyzer.UnitTest.TestFramework;
 
-namespace SonarAnalyzer.Net8.UnitTest.Rules;
+namespace SonarAnalyzer.UnitTest.Rules;
 
 [TestClass]
 public class SelfAssignmentTest

--- a/analyzers/tests/SonarAnalyzer.Net8.UnitTest/SonarAnalyzer.Net8.UnitTest.csproj
+++ b/analyzers/tests/SonarAnalyzer.Net8.UnitTest/SonarAnalyzer.Net8.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- `-windows` is required in order to be able to reference SonarAnalyzer.UnitTests -->
+        <!-- `-windows` is required in order to be able to reference SonarAnalyzer.UnitTests to resolve e.g. WinForms references -->
         <TargetFramework>net8.0-windows</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/analyzers/tests/SonarAnalyzer.Net8.UnitTest/SonarAnalyzer.Net8.UnitTest.csproj
+++ b/analyzers/tests/SonarAnalyzer.Net8.UnitTest/SonarAnalyzer.Net8.UnitTest.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <!-- `-windows` is required in order to be able to reference SonarAnalyzer.UnitTests -->
+        <TargetFramework>net8.0-windows</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="altcover" Version="8.6.68" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+      <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+      <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Remove="TestCases\**\*" />
+      <None Include="TestCases\**\*">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/analyzers/tests/SonarAnalyzer.Net8.UnitTest/TestCases/SelfAssignment.cs
+++ b/analyzers/tests/SonarAnalyzer.Net8.UnitTest/TestCases/SelfAssignment.cs
@@ -1,4 +1,4 @@
-﻿namespace SonarAnalyzer.UnitTest.TestCases;
+﻿namespace SonarAnalyzer.Net8.UnitTest.TestCases;
 
 class WithInlineArrays
 {

--- a/analyzers/tests/SonarAnalyzer.Net8.UnitTest/TestCases/SelfAssignment.cs
+++ b/analyzers/tests/SonarAnalyzer.Net8.UnitTest/TestCases/SelfAssignment.cs
@@ -1,0 +1,16 @@
+﻿namespace SonarAnalyzer.Net8.UnitTest.TestCases;
+
+class WithInlineArrays
+{
+    void Test(Buffer b)
+    {
+        b = b; // Noncompliant: local to local assignment
+               // Secondary@-1
+    }
+
+    [System.Runtime.CompilerServices.InlineArray(10)]
+    struct Buffer
+    {
+        int arrayItem;
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.Net8.UnitTest/TestCases/SelfAssignment.cs
+++ b/analyzers/tests/SonarAnalyzer.Net8.UnitTest/TestCases/SelfAssignment.cs
@@ -1,4 +1,4 @@
-﻿namespace SonarAnalyzer.Net8.UnitTest.TestCases;
+﻿namespace SonarAnalyzer.UnitTest.TestCases;
 
 class WithInlineArrays
 {

--- a/analyzers/tests/SonarAnalyzer.Net8.UnitTest/packages.lock.json
+++ b/analyzers/tests/SonarAnalyzer.Net8.UnitTest/packages.lock.json
@@ -1,0 +1,495 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0-windows7.0": {
+      "altcover": {
+        "type": "Direct",
+        "requested": "[8.6.68, )",
+        "resolved": "8.6.68",
+        "contentHash": "Q/9iaREaVi2RakQLiCVUYGVKuuvqog0YPsHwpkOjEG8RiCbnqp1ujmH0lQEyQGZP0v3Y2mqYvdZEaH9BjFGuFA=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.6.3, )",
+        "resolved": "17.6.3",
+        "contentHash": "MglaNTl646dC2xpHKotSk1xscmHO5uV3x3NK057IUA9BM3Wgl16WMEb9ptGczk518JfLd1+Th5OAYwnoWgHQQQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.6.3",
+          "Microsoft.TestPlatform.TestHost": "17.6.3"
+        }
+      },
+      "MSTest.TestAdapter": {
+        "type": "Direct",
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "kMvdO5dhrUR3o1qk0fzS0St0prlKyMQAfz1ChVAUdGGobTU5ehR60szOFto0+Q7rFG5iXMvTlVIthXM9EcNYnw=="
+      },
+      "MSTest.TestFramework": {
+        "type": "Direct",
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "3rjkGxciNHHmPW8cl1/QVIYjOpfptjmAH5JrLBw+dnMTYDoweg3I579N7OIbar3Zd3q9dfWFrCy2LEV/AmPn3A=="
+      },
+      "StyleCop.Analyzers": {
+        "type": "Direct",
+        "requested": "[1.2.0-beta.435, )",
+        "resolved": "1.2.0-beta.435",
+        "contentHash": "TADk7vdGXtfTnYCV7GyleaaRTQjfoSfZXprQrVMm7cSJtJbFc1QIbWPyLvrgrfGdfHbGmUPvaN4ODKNxg2jgPQ==",
+        "dependencies": {
+          "StyleCop.Analyzers.Unstable": "1.2.0.435"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "FluentAssertions": {
+        "type": "Transitive",
+        "resolved": "6.12.0",
+        "contentHash": "ZXhHT2YwP9lajrwSKbLlFqsmCCvFJMoRSK9t7sImfnCyd0OB3MhgxdoMcVqxbq1iyxD6mD2fiackWmBb7ayiXQ==",
+        "dependencies": {
+          "System.Configuration.ConfigurationManager": "4.4.0"
+        }
+      },
+      "Google.Protobuf": {
+        "type": "Transitive",
+        "resolved": "3.6.1",
+        "contentHash": "741fGeDQjixBJaU2j+0CbrmZXsNJkTn/hWbOh4fLVXndHsCclJmWznCPWrJmPoZKvajBvAz3e8ECJOUvRtwjNQ==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1"
+        }
+      },
+      "Google.Protobuf.Tools": {
+        "type": "Transitive",
+        "resolved": "3.6.1",
+        "contentHash": "mNgfZ1A7UtbZUOIA8+UcKOouKnbd2tu9CKctCvGXFunZGrViWk6QbNwSBc268Sle9Gwl+WQB+u6qQezp5f9y3w=="
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "3aeMZ1N0lJoSyzqiP03hqemtb1BijhsJADdobn/4nsMJ8V1H+CrpuduUe4hlRdx+ikBQju1VGjMD1GJ3Sk05Eg=="
+      },
+      "Microsoft.Build.Framework": {
+        "type": "Transitive",
+        "resolved": "16.10.0",
+        "contentHash": "uD2GUw3AYlFSpU42c/80DouuJL6w1Kb06q4FEjQhW/9wjhBwukgx13T5MPIpSvQ8ssahKINanHfMUL89EVQHgQ==",
+        "dependencies": {
+          "System.Security.Permissions": "4.7.0"
+        }
+      },
+      "Microsoft.Build.Locator": {
+        "type": "Transitive",
+        "resolved": "1.5.5",
+        "contentHash": "ZuXb72Shd0kiNyVx+R9x8b51cvIdtZRt6V5O5jbtl7+p6j+q9wNgU69qGp1Rmtq9/yPyqvd39tW4xQJvb/LLSA=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.3.4",
+        "contentHash": "AxkxcPR+rheX0SmvpLVIGLhOUXAKG56a64kV9VQZ4y9gR9ZmPXnqZvHJnmwLSwzrEP6junUF11vuc+aqo5r68g=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.8.0-2.final",
+        "contentHash": "sH+5d3H18D8W13Kgusib4usJRWnDcZoJ3nU7MiIlytg7uiLA8DlAQKWEk+x8h8SJOD7CSeqqL9/D6c6ShqidLg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.4",
+          "System.Collections.Immutable": "7.0.0",
+          "System.Reflection.Metadata": "7.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.8.0-2.final",
+        "contentHash": "2HS51hRSY7NbyiQAOW/0WQArfqkUhVWqmN+Z/KEeqnm+6fk46HmYesvN/BS5RKa1KswcjYYK92xdne+WdhebiQ==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "[4.8.0-2.final]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "4.8.0-2.final",
+        "contentHash": "6VTrdbD8uJ01Y0U5YCHhp5PJxnStW9gdn5Qu9UFaHU6J1TyXmBxv5k257ZYrLi2LXHCQ8xNiSdaQW1UL9sUSrA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.CSharp": "[4.8.0-2.final]",
+          "Microsoft.CodeAnalysis.Common": "[4.8.0-2.final]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[4.8.0-2.final]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic": {
+        "type": "Transitive",
+        "resolved": "4.8.0-2.final",
+        "contentHash": "jZxZWXtUYKg8Pz6AvvbKXleCbBnBt1civwOZhj21edZxAH9pNLDoosK+pg/fVXKuISOzCRpbw3KfOTxXTO3VHQ==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "[4.8.0-2.final]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
+        "type": "Transitive",
+        "resolved": "4.8.0-2.final",
+        "contentHash": "tkKcZD/hVrPHoDXJl4ru8NYH88pdMXBstuzv6BGmYpGOiXeevT8eqvJRO2EpCAlMeHElsr/uZwW+bni/wITZ9g==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "[4.8.0-2.final]",
+          "Microsoft.CodeAnalysis.VisualBasic": "[4.8.0-2.final]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[4.8.0-2.final]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "4.8.0-2.final",
+        "contentHash": "1ptN6/nDnlYK+jvXTkyb0OSkPQYSMnbTbGAe2+HKqFU6/TdgR2Nu3yMVnn2uSo6EIhS1mElz+8weI6G00VUmQQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "7.0.0",
+          "Microsoft.CodeAnalysis.Common": "[4.8.0-2.final]",
+          "System.Composition": "7.0.0",
+          "System.IO.Pipelines": "7.0.0",
+          "System.Threading.Channels": "7.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.MSBuild": {
+        "type": "Transitive",
+        "resolved": "4.8.0-2.final",
+        "contentHash": "AhFFM7BCa4Y75IEXTW8wXP4GX+9hXzV20yDqR1KuNTsvsJGSM47OwZmQWZBcIrVDLUSVhmpdj7A/tOdkFu9R+g==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "16.10.0",
+          "Microsoft.CodeAnalysis.Common": "[4.8.0-2.final]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[4.8.0-2.final]",
+          "System.Text.Json": "7.0.3"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.6.3",
+        "contentHash": "Gorg6F1dOxlI28yHYKhbQ3pOOfHeW6sUfsmwFQFaIV+xttUAZ+l8KarHIfsR+rBAnjY9VH71BXvPXBuObCkXsw=="
+      },
+      "Microsoft.Composition": {
+        "type": "Transitive",
+        "resolved": "1.0.27",
+        "contentHash": "pwu80Ohe7SBzZ6i69LVdzowp6V+LaVRzd5F7A6QlD42vQkX0oT7KXKWWPlM/S00w1gnMQMRnEdbtOV12z6rXdQ=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "z7aeg8oHln2CuNulfhiLYxCVMPEwBl3rzicjvIX+4sUuCwvXw5oXQEtbiU2c0z4qYL5L3Kmx0mMA/+t/SbY67w=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.6.3",
+        "contentHash": "gSqtX3RvcFisaLPs6sKXdZkSwUix83NQ9nOU/w6pYrHTl+d8GsVHSL9rvDNxMgoV5BNOdyU7zK7JOfbSaVMDWQ==",
+        "dependencies": {
+          "NuGet.Frameworks": "6.5.0",
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.6.3",
+        "contentHash": "lrgRXKFfIZSPlhuoQGLtciO/osL+4oADYEYb0d5or7n7YyJATIWespq3lRgz2IQpRh6N7cm0DnCOWeZiCRGzxA==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.6.3",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "mtVirZr++rq+XCDITMUdnETD59XoeMxSpLRIII7JRI6Yj0LEDiO1pPn0ktlnIj12Ix8bfvQqQDMMIF9wC98oCA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0"
+        }
+      },
+      "Moq": {
+        "type": "Transitive",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "6.7.0",
+        "contentHash": "o3hdvub38qN4UuPWISIvdhM36liEno2o58LRnIrSucZ6+SNv4jc+Cqh/y7BfmQ+UvpqLY19yEc4123rMpp6Edg==",
+        "dependencies": {
+          "NuGet.Frameworks": "6.7.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "6.7.0",
+        "contentHash": "M1ttuwgjCNIEcgjFj3Fh/SZ/CaZY11SpxDOEOgPFUxB24K9JMGnB5BGBMOV8joleNcbwzEEY6WCVwHPYg3bb9A==",
+        "dependencies": {
+          "NuGet.Common": "6.7.0",
+          "System.Security.Cryptography.ProtectedData": "4.4.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "6.7.0",
+        "contentHash": "mTKaTSINpCjMHTNdaPMD/0nfHvWGetG67KzWtDJklnAp9nNwqA+t65G0v8XA/Ve35ipmPRdklxFIl3O55iTgnQ=="
+      },
+      "NuGet.Packaging": {
+        "type": "Transitive",
+        "resolved": "6.7.0",
+        "contentHash": "uDhdZXzW8MLXhloPla/7j8jBWduNhDvY5UC1Dg1z8zJEvkGSj+WAcXKvymDf9UpbyiklWmonlb2hkX02ToJ1yQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "NuGet.Configuration": "6.7.0",
+          "NuGet.Versioning": "6.7.0",
+          "System.Security.Cryptography.Pkcs": "6.0.4"
+        }
+      },
+      "NuGet.Protocol": {
+        "type": "Transitive",
+        "resolved": "6.7.0",
+        "contentHash": "CZvnf3n0A1wtGNHAViLtZbtqZ5KXnI/fDe0CE+rphoIYJP91D8ImYQG2eM/Y4aQ1n4pcqebg/XVnSr37qjXoeQ==",
+        "dependencies": {
+          "NuGet.Packaging": "6.7.0"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Transitive",
+        "resolved": "6.7.0",
+        "contentHash": "3sKMpt6btwpv6TKbbpUisT7a9qZoqoAGvHC0lUiqMl9V1oArqXP0DRhlNq7alFynA1HqKOFeRje5kPYkbqFJ/Q=="
+      },
+      "StyleCop.Analyzers.Unstable": {
+        "type": "Transitive",
+        "resolved": "1.2.0.435",
+        "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "dQPcs0U1IKnBdRDBkrCTi1FoajSTBzLcVTpjO4MBCMC7f4pDOIPzgBoX8JjG7X6uZRJ8EBxsi8+DR1JuwjnzOQ=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "tRwgcAkDd85O8Aq6zHDANzQaq380cek9lbMg5Qma46u5BZXq/G+XvIYmu+UI+BIIZ9zssXLYrkTykEqxxvhcmg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "7.0.0",
+          "System.Composition.Convention": "7.0.0",
+          "System.Composition.Hosting": "7.0.0",
+          "System.Composition.Runtime": "7.0.0",
+          "System.Composition.TypedParts": "7.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "2QzClqjElKxgI1jK1Jztnq44/8DmSuTSGGahXqQ4TdEV0h9s2KikQZIgcEqVzR7OuWDFPGLHIprBJGQEPr8fAQ=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "IMhTlpCs4HmlD8B+J8/kWfwX7vrBBOs6xyjSTzBlYSs7W4OET4tlkR/Sg9NG8jkdJH9Mymq0qGdYS1VPqRTBnQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "7.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "eB6gwN9S+54jCTBJ5bpwMOVerKeUfGGTYCzz3QgDr1P55Gg/Wb27ShfPIhLMjmZ3MoAKu8uUSv6fcCdYJTN7Bg==",
+        "dependencies": {
+          "System.Composition.Runtime": "7.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "aZJ1Zr5Txe925rbo4742XifEyW0MIni1eiUebmcrP3HwLXZ3IbXUj4MFMUH/RmnJOAQiS401leg/2Sz1MkApDw=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "ZK0KNPfbtxVceTwh+oHNGUOYV2WNOHReX2AXipuvkURC7s/jPwoWfsu3SnDBDgofqbiWr96geofdQ2erm/KTHg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "7.0.0",
+          "System.Composition.Hosting": "7.0.0",
+          "System.Composition.Runtime": "7.0.0"
+        }
+      },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gWwQv/Ug1qWJmHCmN17nAbxJYmQBM/E94QxKLksvUiiKB1Ld3Sc/eK1lgmbSjDFxkQhVuayI/cGFZhpBSodLrg==",
+        "dependencies": {
+          "System.Security.Cryptography.ProtectedData": "4.4.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "v+XbyYHaZjDfn0ENmJEV1VYLgGgCTx1gnfOBcppowbpOAriglYgGCvFCPr2EEZyBvXlpxbEsTwkOlInl107ahA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "Microsoft.Win32.SystemEvents": "4.7.0"
+        }
+      },
+      "System.Formats.Asn1": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "T6fD00dQ3NTbPDy31m4eQUwKW84s03z0N2C8HpOklyeaDgaJPa/TexP4/SkORMSOwc7WhKifnA6Ya33AkzmafA=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "jRn6JYnNPW6xgQazROBLSfpdoczRw694vO5kKvMcNnpXuolEixUyw6IBuBs2Y2mlSX/LdLvyyWmfXhaI3ND1Yg=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "dependencies": {
+          "System.Collections.Immutable": "7.0.0"
+        }
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Security.AccessControl": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "JECvTt5aFF3WT3gHpfofL2MNNP6v84sxtXxpqhLBCcDRzqsPBmHhQ6shv4DwwN2tRlzsUxtb3G9M3763rbXKDg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "System.Security.Principal.Windows": "4.7.0"
+        }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "6.0.4",
+        "contentHash": "LGbXi1oUJ9QgCNGXRO9ndzBL/GZgANcsURpMhNR8uO+rca47SZmciS3RSQUvlQRwK3QHZSHNOXzoMUASKA+Anw==",
+        "dependencies": {
+          "System.Formats.Asn1": "6.0.0"
+        }
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "cJV7ScGW7EhatRsjehfvvYVBvtiSMKgN8bOVI0bQhnF5bU7vnHVIsH49Kva7i7GWaWYvmEzkYVk1TC+gZYBEog=="
+      },
+      "System.Security.Permissions": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "dkOV6YYVBnYRa15/yv004eCGRBVADXw8qRbbNiCn/XpdJSUXkkUeIvdvFHkvnko4CdKMqG8yRHC4ox83LSlMsQ==",
+        "dependencies": {
+          "System.Security.AccessControl": "4.7.0",
+          "System.Windows.Extensions": "4.7.0"
+        }
+      },
+      "System.Security.Principal.Windows": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "ojD0PX0XhneCsUbAZVKdb7h/70vyYMDYs85lwEI+LngEONe/17A0cFaRFqZU+sOEidcVswYWikYOQ9PPfjlbtQ=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "OP6umVGxc0Z0MvZQBVigj4/U31Pw72ITihDWP9WiWDm+q5aoe0GaJivsfYGq53o6dxH7DcXWiCTl7+0o2CGdmg=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "7.0.3",
+        "contentHash": "AyjhwXN1zTFeIibHimfJn6eAsZ7rTBib79JQpzg8WAuR/HKDu9JGNHTuu3nbbXQ/bgI+U4z6HtZmCHNXB1QXrQ==",
+        "dependencies": {
+          "System.Text.Encodings.Web": "7.0.0"
+        }
+      },
+      "System.Threading.Channels": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "qmeeYNROMsONF6ndEZcIQ+VxR4Q/TX/7uIVLJqtwIWL7dDWeh0l1UIqgo4wYyjG//5lUNhwkLDSFl+pAWO6oiA=="
+      },
+      "System.Windows.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "CeWTdRNfRaSh0pm2gDTJFwVaXfTq6Xwv/sA887iwPTneW7oMtMlpvDIO+U60+3GWTB7Aom6oQwv5VZVUhQRdPQ==",
+        "dependencies": {
+          "System.Drawing.Common": "4.7.0"
+        }
+      },
+      "SonarAnalyzer": {
+        "type": "Project",
+        "dependencies": {
+          "Google.Protobuf": "[3.6.1, )",
+          "Google.Protobuf.Tools": "[3.6.1, )",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[1.3.2, )",
+          "Microsoft.Composition": "[1.0.27, )",
+          "SonarAnalyzer.CFG": "[1.0.0, )",
+          "System.Collections.Immutable": "[1.1.37, )"
+        }
+      },
+      "sonaranalyzer.cfg": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "Microsoft.Composition": "[1.0.27, )",
+          "System.Collections.Immutable": "[1.1.37, )"
+        }
+      },
+      "sonaranalyzer.csharp": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "SonarAnalyzer": "[1.0.0, )",
+          "System.Collections.Immutable": "[1.1.37, )"
+        }
+      },
+      "sonaranalyzer.unittest": {
+        "type": "Project",
+        "dependencies": {
+          "FluentAssertions": "[6.12.0, )",
+          "MSTest.TestAdapter": "[3.1.1, )",
+          "MSTest.TestFramework": "[3.1.1, )",
+          "Microsoft.Build.Locator": "[1.5.5, )",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[4.8.0-2.final, )",
+          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "[4.8.0-2.final, )",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[4.8.0-2.final, )",
+          "Microsoft.CodeAnalysis.Workspaces.MSBuild": "[4.8.0-2.final, )",
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.NET.Test.Sdk": "[17.6.3, )",
+          "Moq": "[4.18.4, )",
+          "NuGet.Protocol": "[6.7.0, )",
+          "SonarAnalyzer": "[1.0.0, )",
+          "SonarAnalyzer.CFG": "[1.0.0, )",
+          "SonarAnalyzer.CSharp": "[1.0.0, )",
+          "SonarAnalyzer.VisualBasic": "[1.0.0, )",
+          "altcover": "[8.6.68, )"
+        }
+      },
+      "sonaranalyzer.visualbasic": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "[1.3.2, )",
+          "SonarAnalyzer": "[1.0.0, )",
+          "System.Collections.Immutable": "[1.1.37, )"
+        }
+      }
+    }
+  }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/ParseOptionsHelper.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/ParseOptionsHelper.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
     /// Local run: Only the latest language version is used to simplify debugging.
     /// CI run: All configured versions are returned.
     /// </summary>
-    internal static class ParseOptionsHelper
+    public static class ParseOptionsHelper
     {
         public static ImmutableArray<ParseOptions> BeforeCSharp7 { get; }
         public static ImmutableArray<ParseOptions> BeforeCSharp8 { get; }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Verifier.cs
@@ -33,7 +33,7 @@ using SonarAnalyzer.UnitTest.Helpers;
 
 namespace SonarAnalyzer.UnitTest.TestFramework
 {
-    internal class Verifier
+    public class Verifier
     {
         private const string TestCases = "TestCases";
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/VerifierBuilder.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.UnitTest.TestFramework
     /// <summary>
     /// Immutable builder that holds all parameters for rule verification.
     /// </summary>
-    internal record VerifierBuilder
+    public record VerifierBuilder
     {
         // All properties are (and should be) immutable.
         public ImmutableArray<Func<DiagnosticAnalyzer>> Analyzers { get; init; } = ImmutableArray<Func<DiagnosticAnalyzer>>.Empty;
@@ -158,14 +158,14 @@ namespace SonarAnalyzer.UnitTest.TestFramework
             !string.IsNullOrEmpty(fileName) && (fileName.EndsWith(".razor", StringComparison.OrdinalIgnoreCase) || fileName.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase));
     }
 
-    internal record VerifierBuilder<TAnalyzer> : VerifierBuilder
+    public record VerifierBuilder<TAnalyzer> : VerifierBuilder
         where TAnalyzer : DiagnosticAnalyzer, new()
     {
         public VerifierBuilder() =>
             Analyzers = new Func<DiagnosticAnalyzer>[] { () => new TAnalyzer() }.ToImmutableArray();
     }
 
-    internal static class VerifierBuilderExtensions
+    public static class VerifierBuilderExtensions
     {
         public static void Verify(this VerifierBuilder builder) =>
             builder.Build().Verify();

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -216,7 +216,11 @@ stages:
             $testProjectPaths += @{ path = "tests\SonarAnalyzer.Net8.UnitTest\SonarAnalyzer.Net8.UnitTest.csproj"; name = "net8" }
           }
 
+          Write-Output $testProjectPaths
+
           foreach ($testProject in $testProjectPaths) {
+            Write-Host "======="
+            Write-Output $testProject
             & dotnet test $($testProject.path) -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=$(CoveragePath)/coverage.$($testProject.name).xml
           }
         displayName: '.Net UTs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -191,14 +191,17 @@ stages:
             FrameworkMoniker: 'net48'
             CoverageArtifactName: 'DotnetCoverageNet48'
             TestResultsArtifactName: 'DotnetTestResultsNet48'
+            ProjectFilePath: 'tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj'
           Net70:
             FrameworkMoniker: 'net7.0'
             CoverageArtifactName: 'DotnetCoverageNet7'
             TestResultsArtifactName: 'DotnetTestResultsNet7'
+            ProjectFilePath: 'tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj'
           Net80:
             FrameworkMoniker: 'net8.0-windows'
             CoverageArtifactName: 'DotnetCoverageNet8'
             TestResultsArtifactName: 'DotnetTestResultsNet8'
+            ProjectFilePath: 'tests\SonarAnalyzer.Net8.UnitTest\SonarAnalyzer.Net8.UnitTest.csproj'
 
       steps:
       - task: DownloadPipelineArtifact@2
@@ -209,20 +212,7 @@ stages:
 
       - powershell: |
           cd analyzers
-
-          $testProjectPaths = @(@{ path = "tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj"; name = "common" })
-
-          if ("$(FrameworkMoniker)" -eq "net8.0-windows") {
-            $testProjectPaths += @{ path = "tests\SonarAnalyzer.Net8.UnitTest\SonarAnalyzer.Net8.UnitTest.csproj"; name = "net8" }
-          }
-
-          Write-Output $testProjectPaths
-
-          foreach ($testProject in $testProjectPaths) {
-            Write-Host "======="
-            Write-Output $testProject
-            dotnet test $($testProject.path) -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=$(CoveragePath)/coverage.$($testProject.name).xml
-          }
+          & dotnet test $(ProjectFilePath) -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=$(CoveragePath)/coverage.$(FrameworkMoniker).xml
         displayName: '.Net UTs'
 
       - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -221,7 +221,7 @@ stages:
           foreach ($testProject in $testProjectPaths) {
             Write-Host "======="
             Write-Output $testProject
-            & dotnet test $($testProject.path) -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=$(CoveragePath)/coverage.$($testProject.name).xml
+            dotnet test $($testProject.path) -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=$(CoveragePath)/coverage.$($testProject.name).xml
           }
         displayName: '.Net UTs'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,9 @@ variables:
   - name: UnitTestProjectPath
     value: 'analyzers\tests\SonarAnalyzer.UnitTest\'
   - name: UnitTestResultsPath
-    value: '$(UnitTestProjectPath)\TestResults'
+    value: '$(Agent.TempDirectory)\TestResults'
+  - name: CoveragePath
+    value: '$(Agent.TempDirectory)\coverage'
   - name: UnitTestExclusionsPattern
     value: 'analyzers/tests/SonarAnalyzer.UnitTest/TestCases/**/*'
   - name: isReleaseBranch
@@ -193,6 +195,10 @@ stages:
             FrameworkMoniker: 'net7.0'
             CoverageArtifactName: 'DotnetCoverageNet7'
             TestResultsArtifactName: 'DotnetTestResultsNet7'
+          Net80:
+              FrameworkMoniker: 'net8.0-windows'
+              CoverageArtifactName: 'DotnetCoverageNet8'
+              TestResultsArtifactName: 'DotnetTestResultsNet8'
 
       steps:
       - task: DownloadPipelineArtifact@2
@@ -203,13 +209,19 @@ stages:
 
       - powershell: |
           cd analyzers
-          & dotnet test -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=coverage/coverage.xml
+          if ("$(FrameworkMoniker)" -eq "net8.0-windows") {
+            & dotnet test "tests\SonarAnalyzer.Net8.UnitTest\SonarAnalyzer.Net8.UnitTest.csproj" -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=$(CoveragePath)/coverage.$(FrameworkMoniker).xml
+          }
+          else
+          {
+            & dotnet test "tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj" -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=$(CoveragePath)/coverage.xml
+          }
         displayName: '.Net UTs'
 
       - task: PublishPipelineArtifact@1
         displayName: 'Save coverage files'
         inputs:
-          path: '$(UnitTestProjectPath)\coverage'
+          path: '$(CoveragePath)'
           artifact: $(CoverageArtifactName)
 
       - task: PublishPipelineArtifact@1
@@ -313,6 +325,12 @@ stages:
         inputs:
           artifact: DotnetCoverageNet7
           targetPath: 'coverage'
+          
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download coverage reports'
+        inputs:
+          artifact: DotnetCoverageNet8
+          targetPath: 'coverage'
 
       - task: DownloadPipelineArtifact@2
         displayName: 'Download test results'
@@ -324,6 +342,12 @@ stages:
         displayName: 'Download test results'
         inputs:
           artifact: DotnetTestResultsNet7
+          targetPath: 'TestResults'
+          
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download test results'
+        inputs:
+          artifact: DotnetTestResultsNet8
           targetPath: 'TestResults'
 
       - powershell: |
@@ -340,9 +364,8 @@ stages:
             $pattern = 'C:\\ProgramData\\vsts-agent\\\d+\\s'
             (Get-Content -path $path -Raw) -replace $pattern,$localPath | Set-Content $path
           }
-
-          Update-Coverage-BasePaths 'coverage\coverage.net48.xml'
-          Update-Coverage-BasePaths 'coverage\coverage.net7.0.xml'
+  
+          dir coverage\*.xml | % { Update-Coverage-BasePaths $_.FullName }
         displayName: Fix coverage paths
 
       - task: SonarCloudAnalyze@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -191,14 +191,25 @@ stages:
             FrameworkMoniker: 'net48'
             CoverageArtifactName: 'DotnetCoverageNet48'
             TestResultsArtifactName: 'DotnetTestResultsNet48'
+            TestProjectPaths:
+              - path: 'tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj'
+                name: 'common'
           Net70:
             FrameworkMoniker: 'net7.0'
             CoverageArtifactName: 'DotnetCoverageNet7'
             TestResultsArtifactName: 'DotnetTestResultsNet7'
+            TestProjectPaths:
+              - path: 'tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj'
+                name: 'common'
           Net80:
-              FrameworkMoniker: 'net8.0-windows'
-              CoverageArtifactName: 'DotnetCoverageNet8'
-              TestResultsArtifactName: 'DotnetTestResultsNet8'
+            FrameworkMoniker: 'net8.0-windows'
+            CoverageArtifactName: 'DotnetCoverageNet8'
+            TestResultsArtifactName: 'DotnetTestResultsNet8'
+            TestProjectPaths:
+              - path: 'tests\SonarAnalyzer.Net8.UnitTest\SonarAnalyzer.Net8.UnitTest.csproj'
+                name: 'net8'
+              - path: 'tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj'
+                name: 'common'
 
       steps:
       - task: DownloadPipelineArtifact@2
@@ -209,12 +220,8 @@ stages:
 
       - powershell: |
           cd analyzers
-          if ("$(FrameworkMoniker)" -eq "net8.0-windows") {
-            & dotnet test "tests\SonarAnalyzer.Net8.UnitTest\SonarAnalyzer.Net8.UnitTest.csproj" -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=$(CoveragePath)/coverage.$(FrameworkMoniker).xml
-          }
-          else
-          {
-            & dotnet test "tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj" -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=$(CoveragePath)/coverage.xml
+          foreach ($testProject in $TestProjectPaths) {
+            & dotnet test $($testProject.path) -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=$(CoveragePath)/coverage.$($testProject.name).xml
           }
         displayName: '.Net UTs'
 
@@ -325,7 +332,7 @@ stages:
         inputs:
           artifact: DotnetCoverageNet7
           targetPath: 'coverage'
-          
+
       - task: DownloadPipelineArtifact@2
         displayName: 'Download coverage reports'
         inputs:
@@ -343,7 +350,7 @@ stages:
         inputs:
           artifact: DotnetTestResultsNet7
           targetPath: 'TestResults'
-          
+
       - task: DownloadPipelineArtifact@2
         displayName: 'Download test results'
         inputs:
@@ -364,7 +371,7 @@ stages:
             $pattern = 'C:\\ProgramData\\vsts-agent\\\d+\\s'
             (Get-Content -path $path -Raw) -replace $pattern,$localPath | Set-Content $path
           }
-  
+
           dir coverage\*.xml | % { Update-Coverage-BasePaths $_.FullName }
         displayName: Fix coverage paths
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -191,25 +191,14 @@ stages:
             FrameworkMoniker: 'net48'
             CoverageArtifactName: 'DotnetCoverageNet48'
             TestResultsArtifactName: 'DotnetTestResultsNet48'
-            TestProjectPaths:
-              - path: 'tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj'
-                name: 'common'
           Net70:
             FrameworkMoniker: 'net7.0'
             CoverageArtifactName: 'DotnetCoverageNet7'
             TestResultsArtifactName: 'DotnetTestResultsNet7'
-            TestProjectPaths:
-              - path: 'tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj'
-                name: 'common'
           Net80:
             FrameworkMoniker: 'net8.0-windows'
             CoverageArtifactName: 'DotnetCoverageNet8'
             TestResultsArtifactName: 'DotnetTestResultsNet8'
-            TestProjectPaths:
-              - path: 'tests\SonarAnalyzer.Net8.UnitTest\SonarAnalyzer.Net8.UnitTest.csproj'
-                name: 'net8'
-              - path: 'tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj'
-                name: 'common'
 
       steps:
       - task: DownloadPipelineArtifact@2
@@ -220,7 +209,14 @@ stages:
 
       - powershell: |
           cd analyzers
-          foreach ($testProject in $TestProjectPaths) {
+
+          $testProjectPaths = @(@{ path = "tests\SonarAnalyzer.UnitTest\SonarAnalyzer.UnitTest.csproj"; name = "common" })
+
+          if ("$(FrameworkMoniker)" -eq "net8.0-windows") {
+            $testProjectPaths += @{ path = "tests\SonarAnalyzer.Net8.UnitTest\SonarAnalyzer.Net8.UnitTest.csproj"; name = "net8" }
+          }
+
+          foreach ($testProject in $testProjectPaths) {
             & dotnet test $($testProject.path) -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter='Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|.*Test',AltCoverPathFilter='SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration',AltCoverAttributeFilter='ExcludeFromCodeCoverage',AltCoverReport=$(CoveragePath)/coverage.$($testProject.name).xml
           }
         displayName: '.Net UTs'


### PR DESCRIPTION
Fixes #8171 

I've tested the coverage import with a separate PR that I had to remove. Here is how it looks on sonarcloud:
![image](https://github.com/SonarSource/sonar-dotnet/assets/56015273/032eff8b-a383-4535-b51d-818afad630b3)
and this is the build: https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=79428
