### PR TITLE
Fix S2234 FN: primary constructors for records, classes and structs

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -342,6 +342,7 @@ namespace SonarAnalyzer.Extensions
             return false;
         }
 
+        // based on Type="ArgumentListSyntax" in https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
         public static IReadOnlyList<ArgumentSyntax> ArgumentList(this SyntaxNode node) =>
             (node switch
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -342,6 +342,18 @@ namespace SonarAnalyzer.Extensions
             return false;
         }
 
+        public static IReadOnlyList<ArgumentSyntax> ArgumentList(this SyntaxNode node) =>
+            (node switch
+            {
+                ObjectCreationExpressionSyntax creation => creation.ArgumentList,
+                InvocationExpressionSyntax invocation => invocation.ArgumentList,
+                ConstructorInitializerSyntax constructorInitializer => constructorInitializer.ArgumentList,
+                null => null,
+                _ when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(node) => ((PrimaryConstructorBaseTypeSyntaxWrapper)node).ArgumentList,
+                _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(node) => ((ImplicitObjectCreationExpressionSyntaxWrapper)node).ArgumentList,
+                _ => throw new InvalidOperationException($"The {nameof(node)} of kind {node.Kind()} does not have an {nameof(ArgumentList)}."),
+            })?.Arguments ?? (IReadOnlyList<ArgumentSyntax>)Array.Empty<ArgumentSyntax>();
+
         public static ParameterListSyntax ParameterList(this SyntaxNode node) =>
             node switch
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -146,6 +146,7 @@ namespace SonarAnalyzer.Extensions
                 AttributeSyntax { Name: { } name } => GetIdentifier(name),
                 BaseTypeDeclarationSyntax { Identifier: var identifier } => identifier,
                 ConstructorDeclarationSyntax { Identifier: var identifier } => identifier,
+                ConstructorInitializerSyntax { ThisOrBaseKeyword: var keyword } => keyword,
                 ConversionOperatorDeclarationSyntax { Type: { } type } => GetIdentifier(type),
                 DelegateDeclarationSyntax { Identifier: var identifier } => identifier,
                 DestructorDeclarationSyntax { Identifier: var identifier } => identifier,
@@ -177,8 +178,11 @@ namespace SonarAnalyzer.Extensions
                 PostfixUnaryExpressionSyntax { Operand: { } operand } => GetIdentifier(operand),
                 UsingDirectiveSyntax { Alias.Name: { } name } => GetIdentifier(name),
                 VariableDeclaratorSyntax { Identifier: var identifier } => identifier,
+                { } implicitNew when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(implicitNew) => ((ImplicitObjectCreationExpressionSyntaxWrapper)implicitNew).NewKeyword,
                 { } fileScoped when FileScopedNamespaceDeclarationSyntaxWrapper.IsInstance(fileScoped)
                     && ((FileScopedNamespaceDeclarationSyntaxWrapper)fileScoped).Name is { } name => GetIdentifier(name),
+                { } primary when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(primary)
+                    && ((PrimaryConstructorBaseTypeSyntaxWrapper)primary).Type is { } type => GetIdentifier(type),
                 { } refType when RefTypeSyntaxWrapper.IsInstance(refType) => GetIdentifier(((RefTypeSyntaxWrapper)refType).Type),
                 _ => null
             };

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -343,8 +343,8 @@ namespace SonarAnalyzer.Extensions
         }
 
         // based on Type="ArgumentListSyntax" in https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
-        public static IReadOnlyList<ArgumentSyntax> ArgumentList(this SyntaxNode node) =>
-            (node switch
+        public static ArgumentListSyntax ArgumentList(this SyntaxNode node) =>
+            node switch
             {
                 ObjectCreationExpressionSyntax creation => creation.ArgumentList,
                 InvocationExpressionSyntax invocation => invocation.ArgumentList,
@@ -353,7 +353,7 @@ namespace SonarAnalyzer.Extensions
                 _ when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(node) => ((PrimaryConstructorBaseTypeSyntaxWrapper)node).ArgumentList,
                 _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(node) => ((ImplicitObjectCreationExpressionSyntaxWrapper)node).ArgumentList,
                 _ => throw new InvalidOperationException($"The {nameof(node)} of kind {node.Kind()} does not have an {nameof(ArgumentList)}."),
-            })?.Arguments ?? (IReadOnlyList<ArgumentSyntax>)Array.Empty<ArgumentSyntax>();
+            };
 
         public static ParameterListSyntax ParameterList(this SyntaxNode node) =>
             node switch

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
@@ -68,9 +68,9 @@ internal sealed class CSharpFacade : ILanguageFacade<SyntaxKind>
             ArgumentListSyntax x => x,
             ObjectCreationExpressionSyntax x => x.ArgumentList,
             InvocationExpressionSyntax x => x.ArgumentList,
-            _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(invocation) =>
-                ((ImplicitObjectCreationExpressionSyntaxWrapper)invocation).ArgumentList,
             ConstructorInitializerSyntax x => x.ArgumentList,
+            _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(invocation) => ((ImplicitObjectCreationExpressionSyntaxWrapper)invocation).ArgumentList,
+            _ when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(invocation) => ((PrimaryConstructorBaseTypeSyntaxWrapper)invocation).ArgumentList,
             _ => throw new ArgumentException($"{invocation.GetType()} does not contain an ArgumentList.", nameof(invocation)),
         };
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
@@ -60,7 +60,9 @@ internal sealed class CSharpFacade : ILanguageFacade<SyntaxKind>
         };
 
     public IMethodParameterLookup MethodParameterLookup(SyntaxNode invocation, SemanticModel semanticModel) =>
-        invocation != null ? new CSharpMethodParameterLookup(invocation.ArgumentList(), semanticModel) : null;
+        invocation?.ArgumentList() is { } argumentList
+            ? new CSharpMethodParameterLookup(argumentList, semanticModel)
+            : null;
 
     public string GetName(SyntaxNode expression) =>
         expression.GetName();

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpFacade.cs
@@ -56,23 +56,11 @@ internal sealed class CSharpFacade : ILanguageFacade<SyntaxKind>
         {
             null => null,
             AttributeSyntax x => new CSharpAttributeParameterLookup(x, methodSymbol),
-            _ => new CSharpMethodParameterLookup(GetArgumentList(invocation), methodSymbol),
+            _ => new CSharpMethodParameterLookup(invocation.ArgumentList(), methodSymbol),
         };
 
     public IMethodParameterLookup MethodParameterLookup(SyntaxNode invocation, SemanticModel semanticModel) =>
-        invocation != null ? new CSharpMethodParameterLookup(GetArgumentList(invocation), semanticModel) : null;
-
-    private static ArgumentListSyntax GetArgumentList(SyntaxNode invocation) =>
-        invocation switch
-        {
-            ArgumentListSyntax x => x,
-            ObjectCreationExpressionSyntax x => x.ArgumentList,
-            InvocationExpressionSyntax x => x.ArgumentList,
-            ConstructorInitializerSyntax x => x.ArgumentList,
-            _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(invocation) => ((ImplicitObjectCreationExpressionSyntaxWrapper)invocation).ArgumentList,
-            _ when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(invocation) => ((PrimaryConstructorBaseTypeSyntaxWrapper)invocation).ArgumentList,
-            _ => throw new ArgumentException($"{invocation.GetType()} does not contain an ArgumentList.", nameof(invocation)),
-        };
+        invocation != null ? new CSharpMethodParameterLookup(invocation.ArgumentList(), semanticModel) : null;
 
     public string GetName(SyntaxNode expression) =>
         expression.GetName();

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -29,16 +29,8 @@ internal sealed class CSharpSyntaxFacade : SyntaxFacade<SyntaxKind>
         ArgumentList(node)?.OfType<ArgumentSyntax>().Select(x => x.Expression) ?? Enumerable.Empty<SyntaxNode>();
 
     public override IReadOnlyList<SyntaxNode> ArgumentList(SyntaxNode node) =>
-        (node switch
-        {
-            ObjectCreationExpressionSyntax creation => creation.ArgumentList,
-            InvocationExpressionSyntax invocation => invocation.ArgumentList,
-            ConstructorInitializerSyntax constructorInitializer => constructorInitializer.ArgumentList,
-            null => null,
-            _ when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(node) => ((PrimaryConstructorBaseTypeSyntaxWrapper)node).ArgumentList,
-            _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(node) => ((ImplicitObjectCreationExpressionSyntaxWrapper)node).ArgumentList,
-            _ => throw InvalidOperation(node, nameof(ArgumentExpressions))
-        })?.Arguments ?? (IReadOnlyList<SyntaxNode>)Array.Empty<SyntaxNode>();
+        node.ArgumentList();
+
     public override SyntaxToken? ArgumentNameColon(SyntaxNode argument) =>
         (argument as ArgumentSyntax)?.NameColon?.Name?.Identifier;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -29,16 +29,16 @@ internal sealed class CSharpSyntaxFacade : SyntaxFacade<SyntaxKind>
         ArgumentList(node)?.OfType<ArgumentSyntax>().Select(x => x.Expression) ?? Enumerable.Empty<SyntaxNode>();
 
     public override IReadOnlyList<SyntaxNode> ArgumentList(SyntaxNode node) =>
-        node switch
+        (node switch
         {
-            ObjectCreationExpressionSyntax creation => creation.ArgumentList.Arguments,
-            InvocationExpressionSyntax invocation => invocation.ArgumentList.Arguments,
-            ConstructorInitializerSyntax constructorInitializer => constructorInitializer.ArgumentList.Arguments,
-            null => ImmutableArray<SyntaxNode>.Empty,
-            _ when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(node) => ((PrimaryConstructorBaseTypeSyntaxWrapper)node).ArgumentList.Arguments,
-            _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(node) => ((ImplicitObjectCreationExpressionSyntaxWrapper)node).ArgumentList.Arguments,
+            ObjectCreationExpressionSyntax creation => creation.ArgumentList,
+            InvocationExpressionSyntax invocation => invocation.ArgumentList,
+            ConstructorInitializerSyntax constructorInitializer => constructorInitializer.ArgumentList,
+            null => null,
+            _ when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(node) => ((PrimaryConstructorBaseTypeSyntaxWrapper)node).ArgumentList,
+            _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(node) => ((ImplicitObjectCreationExpressionSyntaxWrapper)node).ArgumentList,
             _ => throw InvalidOperation(node, nameof(ArgumentExpressions))
-        };
+        })?.Arguments ?? (IReadOnlyList<SyntaxNode>)Array.Empty<SyntaxNode>();
     public override SyntaxToken? ArgumentNameColon(SyntaxNode argument) =>
         (argument as ArgumentSyntax)?.NameColon?.Name?.Identifier;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -36,8 +36,7 @@ internal sealed class CSharpSyntaxFacade : SyntaxFacade<SyntaxKind>
             ConstructorInitializerSyntax constructorInitializer => constructorInitializer.ArgumentList.Arguments,
             null => ImmutableArray<SyntaxNode>.Empty,
             _ when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(node) => ((PrimaryConstructorBaseTypeSyntaxWrapper)node).ArgumentList.Arguments,
-            _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(node)
-                => ((ImplicitObjectCreationExpressionSyntaxWrapper)node).ArgumentList.Arguments,
+            _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(node) => ((ImplicitObjectCreationExpressionSyntaxWrapper)node).ArgumentList.Arguments,
             _ => throw InvalidOperation(node, nameof(ArgumentExpressions))
         };
     public override SyntaxToken? ArgumentNameColon(SyntaxNode argument) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -125,7 +125,7 @@ internal sealed class CSharpSyntaxFacade : SyntaxFacade<SyntaxKind>
         node switch
         {
             ArrowExpressionClauseSyntax x => x.Expression,
-            ArgumentSyntax argument => argument.Expression,
+            ArgumentSyntax x => x.Expression,
             AttributeArgumentSyntax x => x.Expression,
             InterpolationSyntax x => x.Expression,
             InvocationExpressionSyntax x => x.Expression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -35,7 +35,7 @@ internal sealed class CSharpSyntaxFacade : SyntaxFacade<SyntaxKind>
         Cast<ArgumentSyntax>(argument).GetArgumentIndex();
 
     public override SyntaxToken? ArgumentNameColon(SyntaxNode argument) =>
-        (argument as ArgumentSyntax)?.NameColon?.Name?.Identifier;
+        (argument as ArgumentSyntax)?.NameColon?.Name.Identifier;
 
     public override SyntaxNode AssignmentLeft(SyntaxNode assignment) =>
         Cast<AssignmentExpressionSyntax>(assignment).Left;

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -31,11 +31,11 @@ internal sealed class CSharpSyntaxFacade : SyntaxFacade<SyntaxKind>
     public override IReadOnlyList<SyntaxNode> ArgumentList(SyntaxNode node) =>
         node.ArgumentList();
 
-    public override SyntaxToken? ArgumentNameColon(SyntaxNode argument) =>
-        (argument as ArgumentSyntax)?.NameColon?.Name?.Identifier;
-
     public override int? ArgumentIndex(SyntaxNode argument) =>
         Cast<ArgumentSyntax>(argument).GetArgumentIndex();
+
+    public override SyntaxToken? ArgumentNameColon(SyntaxNode argument) =>
+        (argument as ArgumentSyntax)?.NameColon?.Name?.Identifier;
 
     public override SyntaxNode AssignmentLeft(SyntaxNode assignment) =>
         Cast<AssignmentExpressionSyntax>(assignment).Left;

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -29,7 +29,7 @@ internal sealed class CSharpSyntaxFacade : SyntaxFacade<SyntaxKind>
         ArgumentList(node)?.OfType<ArgumentSyntax>().Select(x => x.Expression) ?? Enumerable.Empty<SyntaxNode>();
 
     public override IReadOnlyList<SyntaxNode> ArgumentList(SyntaxNode node) =>
-        node.ArgumentList();
+        node.ArgumentList()?.Arguments;
 
     public override int? ArgumentIndex(SyntaxNode argument) =>
         Cast<ArgumentSyntax>(argument).GetArgumentIndex();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AssertionArgsShouldBePassedInCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AssertionArgsShouldBePassedInCorrectOrder.cs
@@ -32,7 +32,7 @@ public sealed class AssertionArgsShouldBePassedInCorrectOrder : SonarDiagnosticA
     protected override void Initialize(SonarAnalysisContext context) =>
         context.RegisterNodeAction(c =>
         {
-            if (c.Node is InvocationExpressionSyntax { ArgumentList: { Arguments.Count: >= 2 } argumentList } invocation
+            if (c.Node is InvocationExpressionSyntax { ArgumentList.Arguments.Count: >= 2 } invocation
                 && GetParameters(invocation.GetName()) is { } knownAssertParameters
                 && c.SemanticModel.GetSymbolInfo(invocation).AllSymbols()
                     .SelectMany(symbol =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AssertionArgsShouldBePassedInCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AssertionArgsShouldBePassedInCorrectOrder.cs
@@ -37,7 +37,7 @@ public sealed class AssertionArgsShouldBePassedInCorrectOrder : SonarDiagnosticA
                 && c.SemanticModel.GetSymbolInfo(invocation).AllSymbols()
                     .SelectMany(symbol =>
                         symbol is IMethodSymbol { IsStatic: true, ContainingSymbol: INamedTypeSymbol container } methodSymbol
-                            ? knownAssertParameters.Select(knownParameters => FindWrongArguments(c.SemanticModel, container, methodSymbol, argumentList, knownParameters))
+                            ? knownAssertParameters.Select(knownParameters => FindWrongArguments(c.SemanticModel, container, methodSymbol, invocation, knownParameters))
                             : Enumerable.Empty<WrongArguments?>())
                     .FirstOrDefault(x => x is not null) is (Expected: var expected, Actual: var actual))
             {
@@ -79,10 +79,10 @@ public sealed class AssertionArgsShouldBePassedInCorrectOrder : SonarDiagnosticA
     private static WrongArguments? FindWrongArguments(SemanticModel semanticModel,
                                                       INamedTypeSymbol container,
                                                       IMethodSymbol symbol,
-                                                      ArgumentListSyntax argumentList,
+                                                      InvocationExpressionSyntax invocation,
                                                       KnownAssertParameters knownParameters) =>
         container.Is(knownParameters.AssertClass)
-        && CSharpFacade.Instance.MethodParameterLookup(argumentList, symbol) is var parameterLookup
+        && CSharpFacade.Instance.MethodParameterLookup(invocation, symbol) is var parameterLookup
         && parameterLookup.TryGetSyntax(knownParameters.ExpectedParameterName, out var expectedArguments)
         && expectedArguments.FirstOrDefault() is { } expected
         && semanticModel.GetConstantValue(expected).HasValue is false

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
@@ -39,10 +39,12 @@ namespace SonarAnalyzer.Rules.CSharp
             node switch
             {
                 InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax { Name: { } name } } => name.GetLocation(), // A.B.C() -> C
-                InvocationExpressionSyntax {  Expression: { } expression } => expression.GetLocation(),                           // A() -> A
+                InvocationExpressionSyntax { Expression: { } expression } => expression.GetLocation(),                            // A() -> A
                 ObjectCreationExpressionSyntax { Type: QualifiedNameSyntax { Right: { } right } } => right.GetLocation(),         // new A.B.C() -> C
                 ObjectCreationExpressionSyntax { Type: { } type } => type.GetLocation(),                                          // new A() -> A
                 ConstructorInitializerSyntax { ThisOrBaseKeyword: { } keyword } => keyword.GetLocation(),                         // this() -> this
+                _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(node) =>
+                    ((ImplicitObjectCreationExpressionSyntaxWrapper)node).NewKeyword.GetLocation(),                               // new() -> new
                 _ when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(node) && ((PrimaryConstructorBaseTypeSyntaxWrapper)node).Type is { } type =>
                     type is QualifiedNameSyntax { Right: { } right }
                         ? right.GetLocation()                                                                                     // class A: B.C() -> C

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
@@ -34,22 +34,5 @@ namespace SonarAnalyzer.Rules.CSharp
             };
 
         protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
-
-        protected override Location PrimaryLocation(SyntaxNode node) =>
-            node switch
-            {
-                InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax { Name: { } name } } => name.GetLocation(), // A.B.C() -> C
-                InvocationExpressionSyntax { Expression: { } expression } => expression.GetLocation(),                            // A() -> A
-                ObjectCreationExpressionSyntax { Type: QualifiedNameSyntax { Right: { } right } } => right.GetLocation(),         // new A.B.C() -> C
-                ObjectCreationExpressionSyntax { Type: { } type } => type.GetLocation(),                                          // new A() -> A
-                ConstructorInitializerSyntax { ThisOrBaseKeyword: { } keyword } => keyword.GetLocation(),                         // this() -> this
-                _ when ImplicitObjectCreationExpressionSyntaxWrapper.IsInstance(node) =>
-                    ((ImplicitObjectCreationExpressionSyntaxWrapper)node).NewKeyword.GetLocation(),                               // new() -> new
-                _ when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(node) && ((PrimaryConstructorBaseTypeSyntaxWrapper)node).Type is { } type =>
-                    type is QualifiedNameSyntax { Right: { } right }
-                        ? right.GetLocation()                                                                                     // class A: B.C() -> C
-                        : type.GetLocation(),                                                                                     // class A: B() -> B
-                _ => base.PrimaryLocation(node),
-            };
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
@@ -28,10 +28,22 @@ namespace SonarAnalyzer.Rules.CSharp
                 SyntaxKind.InvocationExpression,
                 SyntaxKind.ObjectCreationExpression,
                 SyntaxKind.ThisConstructorInitializer,
+                SyntaxKind.BaseConstructorInitializer,
                 SyntaxKindEx.PrimaryConstructorBaseType,
                 SyntaxKindEx.ImplicitObjectCreationExpression,
             };
 
         protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
+
+        protected override Location PrimaryLocation(SyntaxNode node) =>
+            node switch
+            {
+                InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax { Name: { } name } } => name.GetLocation(),
+                InvocationExpressionSyntax {  Expression: { } expression } => expression.GetLocation(),
+                ObjectCreationExpressionSyntax { Type: QualifiedNameSyntax { Right: { } right } } => right.GetLocation(),
+                ObjectCreationExpressionSyntax { Type: { } type } => type.GetLocation(),
+                ConstructorInitializerSyntax { ThisOrBaseKeyword: { } keyword } => keyword.GetLocation(),
+                _ => base.PrimaryLocation(node),
+            };
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
@@ -38,13 +38,15 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override Location PrimaryLocation(SyntaxNode node) =>
             node switch
             {
-                InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax { Name: { } name } } => name.GetLocation(),
-                InvocationExpressionSyntax {  Expression: { } expression } => expression.GetLocation(),
-                ObjectCreationExpressionSyntax { Type: QualifiedNameSyntax { Right: { } right } } => right.GetLocation(),
-                ObjectCreationExpressionSyntax { Type: { } type } => type.GetLocation(),
-                ConstructorInitializerSyntax { ThisOrBaseKeyword: { } keyword } => keyword.GetLocation(),
+                InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax { Name: { } name } } => name.GetLocation(), // A.B.C() -> C
+                InvocationExpressionSyntax {  Expression: { } expression } => expression.GetLocation(),                           // A() -> A
+                ObjectCreationExpressionSyntax { Type: QualifiedNameSyntax { Right: { } right } } => right.GetLocation(),         // new A.B.C() -> C
+                ObjectCreationExpressionSyntax { Type: { } type } => type.GetLocation(),                                          // new A() -> A
+                ConstructorInitializerSyntax { ThisOrBaseKeyword: { } keyword } => keyword.GetLocation(),                         // this() -> this
                 _ when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(node) && ((PrimaryConstructorBaseTypeSyntaxWrapper)node).Type is { } type =>
-                    type is QualifiedNameSyntax { Right: { } right } ? right.GetLocation() : type.GetLocation(),
+                    type is QualifiedNameSyntax { Right: { } right }
+                        ? right.GetLocation()                                                                                     // class A: B.C() -> C
+                        : type.GetLocation(),                                                                                     // class A: B() -> B
                 _ => base.PrimaryLocation(node),
             };
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParametersCorrectOrder.cs
@@ -43,6 +43,8 @@ namespace SonarAnalyzer.Rules.CSharp
                 ObjectCreationExpressionSyntax { Type: QualifiedNameSyntax { Right: { } right } } => right.GetLocation(),
                 ObjectCreationExpressionSyntax { Type: { } type } => type.GetLocation(),
                 ConstructorInitializerSyntax { ThisOrBaseKeyword: { } keyword } => keyword.GetLocation(),
+                _ when PrimaryConstructorBaseTypeSyntaxWrapper.IsInstance(node) && ((PrimaryConstructorBaseTypeSyntaxWrapper)node).Type is { } type =>
+                    type is QualifiedNameSyntax { Right: { } right } ? right.GetLocation() : type.GetLocation(),
                 _ => base.PrimaryLocation(node),
             };
     }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxNodeReportingContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxNodeReportingContext.cs
@@ -48,17 +48,17 @@ public sealed class SonarSyntaxNodeReportingContext : SonarTreeReportingContextB
 
     /// <summary>
     /// Roslyn invokes the analyzer twice for PrimaryConstructorBaseType. The ContainingSymbol is first the type and second the constructor. This check filters can be used to filter
-    /// the first invocation. See also <seealso href="https://github.com/dotnet/roslyn/issues/70488">#roslyn/70488</seealso>
+    /// the first invocation. See also <seealso href="https://github.com/dotnet/roslyn/issues/70488">#Roslyn/70488</seealso>.
     /// </summary>
     /// <returns>
-    /// Returns <see langword="true"/> for the invocation on the class declaration and <see langword="false"/> for the ctor invocation.
+    /// Returns <see langword="true"/> for the invocation with PrimaryConstructorBaseType and ContainingSymbol being the type <see langword="false"/> for everything else.
     /// </returns>
     public bool IsRedundantPrimaryConstructorBaseTypeContext() =>
-        Context.Compilation.Language == LanguageNames.CSharp
-        && Context is
+        Context is
         {
             Node.RawKind: (int)SyntaxKindEx.PrimaryConstructorBaseType,
-            ContainingSymbol.Kind: SymbolKind.Method,
+            Compilation.Language: LanguageNames.CSharp,
+            ContainingSymbol.Kind: SymbolKind.NamedType,
         };
 
     public bool IsAzureFunction() =>

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxNodeReportingContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxNodeReportingContext.cs
@@ -46,6 +46,21 @@ public sealed class SonarSyntaxNodeReportingContext : SonarTreeReportingContextB
     public bool IsRedundantPositionalRecordContext() =>
         Context.ContainingSymbol.Kind == SymbolKind.Method;
 
+    /// <summary>
+    /// Roslyn invokes the analyzer twice for PrimaryConstructorBaseType. The ContainingSymbol is first the type and second the constructor. This check filters can be used to filter
+    /// the first invocation. See also <seealso href="https://github.com/dotnet/roslyn/issues/70488">#roslyn/70488</seealso>
+    /// </summary>
+    /// <returns>
+    /// Returns <see langword="true"/> for the invocation on the class declaration and <see langword="false"/> for the ctor invocation.
+    /// </returns>
+    public bool IsRedundantPrimaryConstructorBaseTypeContext() =>
+        Context.Compilation.Language == LanguageNames.CSharp
+        && Context is
+        {
+            Node.RawKind: (int)SyntaxKindEx.PrimaryConstructorBaseType,
+            ContainingSymbol.Kind: SymbolKind.Method,
+        };
+
     public bool IsAzureFunction() =>
         AzureFunctionMethod() is not null;
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxNodeReportingContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarSyntaxNodeReportingContext.cs
@@ -51,7 +51,8 @@ public sealed class SonarSyntaxNodeReportingContext : SonarTreeReportingContextB
     /// the first invocation. See also <seealso href="https://github.com/dotnet/roslyn/issues/70488">#Roslyn/70488</seealso>.
     /// </summary>
     /// <returns>
-    /// Returns <see langword="true"/> for the invocation with PrimaryConstructorBaseType and ContainingSymbol being the type <see langword="false"/> for everything else.
+    /// Returns <see langword="true"/> for the invocation with PrimaryConstructorBaseType and ContainingSymbol being <see cref="SymbolKind.NamedType"/> and
+    /// <see langword="false"/> for everything else.
     /// </returns>
     public bool IsRedundantPrimaryConstructorBaseTypeContext() =>
         Context is

--- a/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
@@ -24,10 +24,10 @@ public abstract class SyntaxFacade<TSyntaxKind>
     where TSyntaxKind : struct
 {
     public abstract bool AreEquivalent(SyntaxNode firstNode, SyntaxNode secondNode);
-    public abstract SyntaxToken? ArgumentNameColon(SyntaxNode argument); 
     public abstract IEnumerable<SyntaxNode> ArgumentExpressions(SyntaxNode node);
     public abstract int? ArgumentIndex(SyntaxNode argument);
     public abstract IReadOnlyList<SyntaxNode> ArgumentList(SyntaxNode node);
+    public abstract SyntaxToken? ArgumentNameColon(SyntaxNode argument);
     public abstract SyntaxNode AssignmentLeft(SyntaxNode assignment);
     public abstract SyntaxNode AssignmentRight(SyntaxNode assignment);
     public abstract ImmutableArray<SyntaxNode> AssignmentTargets(SyntaxNode assignment);
@@ -37,6 +37,8 @@ public abstract class SyntaxFacade<TSyntaxKind>
     public abstract SyntaxNode CastExpression(SyntaxNode cast);
     public abstract ComparisonKind ComparisonKind(SyntaxNode node);
     public abstract IEnumerable<SyntaxNode> EnumMembers(SyntaxNode @enum);
+    public abstract ImmutableArray<SyntaxToken> FieldDeclarationIdentifiers(SyntaxNode node);
+    public abstract bool HasExactlyNArguments(SyntaxNode invocation, int count);
     public abstract SyntaxToken? InvocationIdentifier(SyntaxNode invocation);
     public abstract bool IsAnyKind(SyntaxNode node, ISet<TSyntaxKind> syntaxKinds);
     public abstract bool IsAnyKind(SyntaxNode node, params TSyntaxKind[] syntaxKinds);

--- a/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Facade/SyntaxFacade.cs
@@ -24,8 +24,10 @@ public abstract class SyntaxFacade<TSyntaxKind>
     where TSyntaxKind : struct
 {
     public abstract bool AreEquivalent(SyntaxNode firstNode, SyntaxNode secondNode);
+    public abstract SyntaxToken? ArgumentNameColon(SyntaxNode argument); 
     public abstract IEnumerable<SyntaxNode> ArgumentExpressions(SyntaxNode node);
     public abstract int? ArgumentIndex(SyntaxNode argument);
+    public abstract IReadOnlyList<SyntaxNode> ArgumentList(SyntaxNode node);
     public abstract SyntaxNode AssignmentLeft(SyntaxNode assignment);
     public abstract SyntaxNode AssignmentRight(SyntaxNode assignment);
     public abstract ImmutableArray<SyntaxNode> AssignmentTargets(SyntaxNode assignment);
@@ -35,8 +37,6 @@ public abstract class SyntaxFacade<TSyntaxKind>
     public abstract SyntaxNode CastExpression(SyntaxNode cast);
     public abstract ComparisonKind ComparisonKind(SyntaxNode node);
     public abstract IEnumerable<SyntaxNode> EnumMembers(SyntaxNode @enum);
-    public abstract ImmutableArray<SyntaxToken> FieldDeclarationIdentifiers(SyntaxNode node);
-    public abstract bool HasExactlyNArguments(SyntaxNode invocation, int count);
     public abstract SyntaxToken? InvocationIdentifier(SyntaxNode invocation);
     public abstract bool IsAnyKind(SyntaxNode node, ISet<TSyntaxKind> syntaxKinds);
     public abstract bool IsAnyKind(SyntaxNode node, params TSyntaxKind[] syntaxKinds);

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/MethodParameterLookupBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/MethodParameterLookupBase.cs
@@ -26,6 +26,7 @@ public interface IMethodParameterLookup
     bool TryGetSyntax(IParameterSymbol parameter, out ImmutableArray<SyntaxNode> expressions);
     bool TryGetSyntax(string parameterName, out ImmutableArray<SyntaxNode> expressions);
     bool TryGetNonParamsSyntax(IParameterSymbol parameter, out SyntaxNode expression);
+    IMethodSymbol MethodSymbol { get; }
 }
 
 // This should come from the Roslyn API (https://github.com/dotnet/roslyn/issues/9)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
@@ -27,16 +27,16 @@ namespace SonarAnalyzer.Rules
         protected abstract TSyntaxKind[] InvocationKinds { get; }
         protected override string MessageFormat => "Parameters to '{0}' have the same names but not the same order as the method arguments.";
 
-        protected ParametersCorrectOrderBase() : base(DiagnosticId)
-        {
-        }
+        protected ParametersCorrectOrderBase() : base(DiagnosticId) { }
 
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(Language.GeneratedCodeRecognizer,
                 c =>
                 {
+                    const int MinNumberOfNameableArguments = 2;
                     if (!c.IsRedundantPrimaryConstructorBaseTypeContext()
-                        && Language.Syntax.ArgumentList(c.Node) is { Count: >= 2 } argumentList // there must be at least two arguments to be able to swap
+                        && Language.Syntax.ArgumentList(c.Node) is { Count: >= MinNumberOfNameableArguments } argumentList  // there must be at least two arguments to be able to swap, and further
+                        && argumentList.Select(ArgumentName).WhereNotNull().Take(MinNumberOfNameableArguments).Count() == MinNumberOfNameableArguments // at least two arguments with a "name"
                         && Language.MethodParameterLookup(c.Node, c.SemanticModel) is var methodParameterLookup)
                     {
                         foreach (var argument in argumentList)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
@@ -50,7 +50,8 @@ namespace SonarAnalyzer.Rules
                                 && Language.Syntax.NodeExpression(argument) is { } argumentExpression
                                 && c.Context.SemanticModel.GetTypeInfo(argumentExpression).ConvertedType is { } argumentType
                                 // is there another parameter that seems to be a better fit (name and type match): p_x
-                                && methodParameterLookup.MethodSymbol.Parameters.FirstOrDefault(p => MatchingNames(p, argumentName) && argumentType.DerivesOrImplements(p.Type)) is { IsParams: false }
+                                && methodParameterLookup.MethodSymbol.Parameters.FirstOrDefault(p => MatchingNames(p, argumentName)) is { IsParams: false } otherParameter
+                                && argumentType.DerivesOrImplements(otherParameter.Type)
                                 // is there an argument that matches the parameter p_y by name: a_y
                                 && Language.Syntax.ArgumentList(c.Node).FirstOrDefault(x => MatchingNames(parameterSymbol, ArgumentName(x))) is { })
                             {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
@@ -64,11 +64,11 @@ namespace SonarAnalyzer.Rules
                     }
                 }, InvocationKinds);
 
-        protected virtual Location PrimaryLocation(SyntaxNode node)
-            => node.GetLocation();
+        protected virtual Location PrimaryLocation(SyntaxNode node) =>
+            node.GetLocation();
 
-        private static bool MatchingNames(IParameterSymbol parameter, string argumentName) =>
-            parameter.Name == argumentName;
+        private bool MatchingNames(IParameterSymbol parameter, string argumentName) =>
+            Language.NameComparer.Equals(parameter.Name, argumentName);
 
         private string ArgumentName(SyntaxNode argument) =>
             Language.Syntax.NodeIdentifier(Language.Syntax.NodeExpression(argument))?.ValueText;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Rules
         {
         }
 
-        protected override void Initialize(SonarAnalysisContext context) =>
+        protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(Language.GeneratedCodeRecognizer,
                 c =>
                 {
@@ -57,12 +57,15 @@ namespace SonarAnalyzer.Rules
                                 var secondaryLocations = methodParameterLookup.MethodSymbol.DeclaringSyntaxReferences
                                     .Select(s => Language.Syntax.NodeIdentifier(s.GetSyntax())?.GetLocation())
                                     .WhereNotNull();
-                                c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], c.Node.GetLocation(), secondaryLocations, properties: null, methodParameterLookup.MethodSymbol.Name));
+                                c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], PrimaryLocation(c.Node), secondaryLocations, properties: null, methodParameterLookup.MethodSymbol.Name));
                                 return;
                             }
                         }
                     }
                 }, InvocationKinds);
+
+        protected virtual Location PrimaryLocation(SyntaxNode node)
+            => node.GetLocation();
 
         private static bool MatchingNames(IParameterSymbol parameter, string argumentName) =>
             parameter.Name == argumentName;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules
                 }, InvocationKinds);
 
         protected virtual Location PrimaryLocation(SyntaxNode node) =>
-            node.GetLocation();
+            Language.Syntax.NodeIdentifier(node)?.GetLocation() ?? node.GetLocation();
 
         private bool MatchingNames(IParameterSymbol parameter, string argumentName) =>
             Language.NameComparer.Equals(parameter.Name, argumentName);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules
                                 var secondaryLocations = methodParameterLookup.MethodSymbol.DeclaringSyntaxReferences
                                     .Select(s => Language.Syntax.NodeIdentifier(s.GetSyntax())?.GetLocation())
                                     .WhereNotNull();
-                                c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], PrimaryLocation(c.Node), secondaryLocations, properties: null, methodParameterLookup.MethodSymbol.Name));
+                                c.ReportIssue(Diagnostic.Create(Rule, PrimaryLocation(c.Node), secondaryLocations, properties: null, methodParameterLookup.MethodSymbol.Name));
                                 return;
                             }
                         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeExtensions.cs
@@ -101,8 +101,8 @@ namespace SonarAnalyzer.Extensions
             };
 
         // based on kind="ArgumentList" in https://github.com/dotnet/roslyn/blob/main/src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml
-        public static IReadOnlyList<ArgumentSyntax> ArgumentList(this SyntaxNode node) =>
-            (node switch
+        public static ArgumentListSyntax ArgumentList(this SyntaxNode node) =>
+            node switch
             {
                 ArrayCreationExpressionSyntax arrayCreation => arrayCreation.ArrayBounds,
                 AttributeSyntax attribute => attribute.ArgumentList,
@@ -114,7 +114,7 @@ namespace SonarAnalyzer.Extensions
                 RedimClauseSyntax reDim => reDim.ArrayBounds,
                 null => null,
                 _ => throw new InvalidOperationException($"The {nameof(node)} of kind {node.Kind()} does not have an {nameof(ArgumentList)}."),
-            })?.Arguments ?? (IReadOnlyList<ArgumentSyntax>)Array.Empty<ArgumentSyntax>();
+            };
 
         /// <summary>
         /// Returns the left hand side of a conditional access expression. Returns c in case like a?.b?[0].c?.d.e?.f if d is passed.

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeExtensions.cs
@@ -100,6 +100,7 @@ namespace SonarAnalyzer.Extensions
                 _ => null,
             };
 
+        // based on kind="ArgumentList" in https://github.com/dotnet/roslyn/blob/main/src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml
         public static IReadOnlyList<ArgumentSyntax> ArgumentList(this SyntaxNode node) =>
             (node switch
             {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SyntaxNodeExtensions.cs
@@ -100,6 +100,21 @@ namespace SonarAnalyzer.Extensions
                 _ => null,
             };
 
+        public static IReadOnlyList<ArgumentSyntax> ArgumentList(this SyntaxNode node) =>
+            (node switch
+            {
+                ArrayCreationExpressionSyntax arrayCreation => arrayCreation.ArrayBounds,
+                AttributeSyntax attribute => attribute.ArgumentList,
+                InvocationExpressionSyntax invocation => invocation.ArgumentList,
+                MidExpressionSyntax mid => mid.ArgumentList,
+                ModifiedIdentifierSyntax modified => modified.ArrayBounds,
+                ObjectCreationExpressionSyntax creation => creation.ArgumentList,
+                RaiseEventStatementSyntax raise => raise.ArgumentList,
+                RedimClauseSyntax reDim => reDim.ArrayBounds,
+                null => null,
+                _ => throw new InvalidOperationException($"The {nameof(node)} of kind {node.Kind()} does not have an {nameof(ArgumentList)}."),
+            })?.Arguments ?? (IReadOnlyList<ArgumentSyntax>)Array.Empty<ArgumentSyntax>();
+
         /// <summary>
         /// Returns the left hand side of a conditional access expression. Returns c in case like a?.b?[0].c?.d.e?.f if d is passed.
         /// </summary>

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicFacade.cs
@@ -51,10 +51,14 @@ internal sealed class VisualBasicFacade : ILanguageFacade<SyntaxKind>
         node.FindConstantValue(model);
 
     public IMethodParameterLookup MethodParameterLookup(SyntaxNode invocation, IMethodSymbol methodSymbol) =>
-        invocation != null ? new VisualBasicMethodParameterLookup(invocation.ArgumentList(), methodSymbol) : null;
+        invocation?.ArgumentList() is { } argumentList
+            ? new VisualBasicMethodParameterLookup(argumentList, methodSymbol)
+            : null;
 
     public IMethodParameterLookup MethodParameterLookup(SyntaxNode invocation, SemanticModel semanticModel) =>
-        invocation != null ? new VisualBasicMethodParameterLookup(invocation.ArgumentList(), semanticModel) : null;
+        invocation?.ArgumentList() is { } argumentList
+            ? new VisualBasicMethodParameterLookup(argumentList, semanticModel)
+            : null;
 
     public string GetName(SyntaxNode expression) =>
         expression.GetName();

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicFacade.cs
@@ -51,20 +51,10 @@ internal sealed class VisualBasicFacade : ILanguageFacade<SyntaxKind>
         node.FindConstantValue(model);
 
     public IMethodParameterLookup MethodParameterLookup(SyntaxNode invocation, IMethodSymbol methodSymbol) =>
-        invocation != null ? new VisualBasicMethodParameterLookup(GetArgumentList(invocation), methodSymbol) : null;
+        invocation != null ? new VisualBasicMethodParameterLookup(invocation.ArgumentList(), methodSymbol) : null;
 
     public IMethodParameterLookup MethodParameterLookup(SyntaxNode invocation, SemanticModel semanticModel) =>
-        invocation != null ? new VisualBasicMethodParameterLookup(GetArgumentList(invocation), semanticModel) : null;
-
-    private static ArgumentListSyntax GetArgumentList(SyntaxNode invocation) =>
-        invocation switch
-        {
-            ArgumentListSyntax x => x,
-            AttributeSyntax x => x.ArgumentList,
-            ObjectCreationExpressionSyntax x => x.ArgumentList,
-            InvocationExpressionSyntax x => x.ArgumentList,
-            _ => throw new ArgumentException($"{invocation.GetType()} does not contain an ArgumentList.", nameof(invocation)),
-        };
+        invocation != null ? new VisualBasicMethodParameterLookup(invocation.ArgumentList(), semanticModel) : null;
 
     public string GetName(SyntaxNode expression) =>
         expression.GetName();

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Collections.Generic;
-
 namespace SonarAnalyzer.Helpers.Facade;
 
 internal sealed class VisualBasicSyntaxFacade : SyntaxFacade<SyntaxKind>
@@ -31,7 +29,7 @@ internal sealed class VisualBasicSyntaxFacade : SyntaxFacade<SyntaxKind>
         ArgumentList(node).OfType<ArgumentSyntax>().Select(x => x.GetExpression()).WhereNotNull();
 
     public override IReadOnlyList<SyntaxNode> ArgumentList(SyntaxNode node) =>
-        node.ArgumentList();
+        node.ArgumentList()?.Arguments;
 
     public override int? ArgumentIndex(SyntaxNode argument) =>
         Cast<ArgumentSyntax>(argument).GetArgumentIndex();

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
@@ -26,7 +26,7 @@ internal sealed class VisualBasicSyntaxFacade : SyntaxFacade<SyntaxKind>
         SyntaxFactory.AreEquivalent(firstNode, secondNode);
 
     public override IEnumerable<SyntaxNode> ArgumentExpressions(SyntaxNode node) =>
-        ArgumentList(node).OfType<ArgumentSyntax>().Select(x => x.GetExpression()).WhereNotNull();
+        ArgumentList(node)?.OfType<ArgumentSyntax>().Select(x => x.GetExpression()).WhereNotNull() ?? Enumerable.Empty<SyntaxNode>();
 
     public override IReadOnlyList<SyntaxNode> ArgumentList(SyntaxNode node) =>
         node.ArgumentList()?.Arguments;

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Facade/VisualBasicSyntaxFacade.cs
@@ -31,13 +31,7 @@ internal sealed class VisualBasicSyntaxFacade : SyntaxFacade<SyntaxKind>
         ArgumentList(node).OfType<ArgumentSyntax>().Select(x => x.GetExpression()).WhereNotNull();
 
     public override IReadOnlyList<SyntaxNode> ArgumentList(SyntaxNode node) =>
-        (node switch
-        {
-            ObjectCreationExpressionSyntax creation => creation.ArgumentList,
-            InvocationExpressionSyntax invocation => invocation.ArgumentList,
-            null => null,
-            _ => throw InvalidOperation(node, nameof(ArgumentExpressions))
-        })?.Arguments ?? (IReadOnlyList<SyntaxNode>)Array.Empty<SyntaxNode>();
+        node.ArgumentList();
 
     public override int? ArgumentIndex(SyntaxNode argument) =>
         Cast<ArgumentSyntax>(argument).GetArgumentIndex();

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
@@ -209,21 +209,6 @@ internal static class VisualBasicSyntaxHelper
             ? argumentList.Arguments[index].GetExpression().RemoveParentheses()
             : null;
 
-    public static IReadOnlyList<ArgumentSyntax> ArgumentList(this SyntaxNode node) =>
-        (node switch
-        {
-            ObjectCreationExpressionSyntax creation => creation.ArgumentList,
-            InvocationExpressionSyntax invocation => invocation.ArgumentList,
-            ModifiedIdentifierSyntax modified => modified.ArrayBounds,
-            AttributeSyntax attribute => attribute.ArgumentList,
-            MidExpressionSyntax mid => mid.ArgumentList,
-            RaiseEventStatementSyntax raise => raise.ArgumentList,
-            RedimClauseSyntax reDim => reDim.ArrayBounds,
-            ArrayCreationExpressionSyntax arrayCreation => arrayCreation.ArrayBounds,
-            null => null,
-            _ => throw new InvalidOperationException($"The {nameof(node)} of kind {node.Kind()} does not have an {nameof(ArgumentList)}."),
-        })?.Arguments ?? (IReadOnlyList<ArgumentSyntax>)Array.Empty<ArgumentSyntax>();
-
     /// <summary>
     /// Returns argument expressions for given parameter.
     ///

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Helpers/VisualBasicSyntaxHelper.cs
@@ -209,6 +209,21 @@ internal static class VisualBasicSyntaxHelper
             ? argumentList.Arguments[index].GetExpression().RemoveParentheses()
             : null;
 
+    public static IReadOnlyList<ArgumentSyntax> ArgumentList(this SyntaxNode node) =>
+        (node switch
+        {
+            ObjectCreationExpressionSyntax creation => creation.ArgumentList,
+            InvocationExpressionSyntax invocation => invocation.ArgumentList,
+            ModifiedIdentifierSyntax modified => modified.ArrayBounds,
+            AttributeSyntax attribute => attribute.ArgumentList,
+            MidExpressionSyntax mid => mid.ArgumentList,
+            RaiseEventStatementSyntax raise => raise.ArgumentList,
+            RedimClauseSyntax reDim => reDim.ArrayBounds,
+            ArrayCreationExpressionSyntax arrayCreation => arrayCreation.ArrayBounds,
+            null => null,
+            _ => throw new InvalidOperationException($"The {nameof(node)} of kind {node.Kind()} does not have an {nameof(ArgumentList)}."),
+        })?.Arguments ?? (IReadOnlyList<ArgumentSyntax>)Array.Empty<ArgumentSyntax>();
+
     /// <summary>
     /// Returns argument expressions for given parameter.
     ///

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
@@ -21,67 +21,14 @@
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-    public sealed class ParametersCorrectOrder : ParametersCorrectOrderBase<ArgumentSyntax>
+    public sealed class ParametersCorrectOrder : ParametersCorrectOrderBase<SyntaxKind>
     {
-        private static readonly DiagnosticDescriptor rule =
-            DescriptorFactory.Create(DiagnosticId, MessageFormat);
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
-
-        protected override void Initialize(SonarAnalysisContext context)
+        protected override SyntaxKind[] InvocationKinds => new[]
         {
-            context.RegisterNodeAction(
-                c =>
-                {
-                    var methodCall = (InvocationExpressionSyntax)c.Node;
+            SyntaxKind.ObjectCreationExpression,
+            SyntaxKind.InvocationExpression
+        };
 
-                    var memberAccess = methodCall.Expression as MemberAccessExpressionSyntax;
-                    Location getLocation() =>
-                        memberAccess == null
-                        ? methodCall.Expression.GetLocation()
-                        : memberAccess.Name.GetLocation();
-
-                    AnalyzeArguments(c, methodCall.ArgumentList, getLocation);
-                }, SyntaxKind.InvocationExpression);
-
-            context.RegisterNodeAction(
-                c =>
-                {
-                    var objectCreationCall = (ObjectCreationExpressionSyntax)c.Node;
-
-                    var qualifiedAccess = objectCreationCall.Type as QualifiedNameSyntax;
-                    Location getLocation() =>
-                        qualifiedAccess == null
-                        ? objectCreationCall.Type.GetLocation()
-                        : qualifiedAccess.Right.GetLocation();
-
-                    AnalyzeArguments(c, objectCreationCall.ArgumentList, getLocation);
-                }, SyntaxKind.ObjectCreationExpression);
-        }
-
-        private void AnalyzeArguments(SonarSyntaxNodeReportingContext analysisContext, ArgumentListSyntax argumentList,
-            Func<Location> getLocation)
-        {
-            if (argumentList == null)
-            {
-                return;
-            }
-
-            var methodParameterLookup = new VisualBasicMethodParameterLookup(argumentList, analysisContext.SemanticModel);
-
-            ReportIncorrectlyOrderedParameters(analysisContext, methodParameterLookup, argumentList.Arguments, getLocation);
-        }
-
-        protected override TypeInfo GetArgumentTypeSymbolInfo(ArgumentSyntax argument, SemanticModel semanticModel) =>
-            semanticModel.GetTypeInfo(argument.GetExpression());
-
-        protected override Location GetMethodDeclarationIdentifierLocation(SyntaxNode syntaxNode) =>
-            (syntaxNode as MethodBlockBaseSyntax)?.FindIdentifierLocation();
-
-        protected override SyntaxToken? GetArgumentIdentifier(ArgumentSyntax argument) =>
-            (argument.GetExpression() as IdentifierNameSyntax)?.Identifier;
-
-        protected override SyntaxToken? GetNameColonArgumentIdentifier(ArgumentSyntax argument) =>
-            (argument as SimpleArgumentSyntax)?.NameColonEquals?.Name.Identifier;
+        protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
     }
 }
-

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
@@ -30,5 +30,14 @@ namespace SonarAnalyzer.Rules.VisualBasic
         };
 
         protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
+        protected override Location PrimaryLocation(SyntaxNode node) =>
+            node switch
+            {
+                InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax { Name: { } name } } => name.GetLocation(),
+                InvocationExpressionSyntax { Expression: { } expression } => expression.GetLocation(),
+                ObjectCreationExpressionSyntax { Type: QualifiedNameSyntax { Right: { } right } } => right.GetLocation(),
+                ObjectCreationExpressionSyntax { Type: { } type } => type.GetLocation(),
+                _ => base.PrimaryLocation(node),
+            };
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ParametersCorrectOrder.cs
@@ -30,13 +30,14 @@ namespace SonarAnalyzer.Rules.VisualBasic
         };
 
         protected override ILanguageFacade<SyntaxKind> Language => VisualBasicFacade.Instance;
+
         protected override Location PrimaryLocation(SyntaxNode node) =>
             node switch
             {
-                InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax { Name: { } name } } => name.GetLocation(),
-                InvocationExpressionSyntax { Expression: { } expression } => expression.GetLocation(),
-                ObjectCreationExpressionSyntax { Type: QualifiedNameSyntax { Right: { } right } } => right.GetLocation(),
-                ObjectCreationExpressionSyntax { Type: { } type } => type.GetLocation(),
+                InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax { Name: { } name } } => name.GetLocation(), // A.B.C() -> C
+                InvocationExpressionSyntax { Expression: { } expression } => expression.GetLocation(),                            // A() -> A
+                ObjectCreationExpressionSyntax { Type: QualifiedNameSyntax { Right: { } right } } => right.GetLocation(),         // New A.B.C() -> C
+                ObjectCreationExpressionSyntax { Type: { } type } => type.GetLocation(),                                          // New A() -> A
                 _ => base.PrimaryLocation(node),
             };
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -802,6 +802,10 @@ public class X
             argumentList.Should().BeEmpty();
         }
 
+        [TestMethod]
+        public void ArgumentList_CS_Null() =>
+            ExtensionsCS.ArgumentList(null).Should().BeEmpty();
+
         [DataTestMethod]
         [DataRow("_ = $$new int[] { 1 }$$;")]
         [DataRow("_ = $$new { A = 1 }$$;")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -747,7 +747,7 @@ public class X
                 }
                 """;
             var node = NodeBetweenMarkers(code, LanguageNames.CSharp);
-            var argumentList = ExtensionsCS.ArgumentList(node);
+            var argumentList = ExtensionsCS.ArgumentList(node).Arguments;
             var argument = argumentList.Should().ContainSingle().Which;
             (argument is { Expression: SyntaxCS.LiteralExpressionSyntax { Token.ValueText: "1" } }).Should().BeTrue();
         }
@@ -768,7 +768,7 @@ public class X
                 
                 """;
             var node = NodeBetweenMarkers(code, LanguageNames.CSharp);
-            var argumentList = ExtensionsCS.ArgumentList(node);
+            var argumentList = ExtensionsCS.ArgumentList(node).Arguments;
             var argument = argumentList.Should().ContainSingle().Which;
             (argument is { Expression: SyntaxCS.LiteralExpressionSyntax { Token.ValueText: "1" } }).Should().BeTrue();
         }
@@ -781,7 +781,7 @@ public class X
                 public class Derived(int p): $$Base(1)$$;
                 """;
             var node = NodeBetweenMarkers(code, LanguageNames.CSharp);
-            var argumentList = ExtensionsCS.ArgumentList(node);
+            var argumentList = ExtensionsCS.ArgumentList(node).Arguments;
             var argument = argumentList.Should().ContainSingle().Which;
             (argument is { Expression: SyntaxCS.LiteralExpressionSyntax { Token.ValueText: "1" } }).Should().BeTrue();
         }
@@ -798,13 +798,12 @@ public class X
                 }
                 """;
             var node = NodeBetweenMarkers(code, LanguageNames.CSharp);
-            var argumentList = ExtensionsCS.ArgumentList(node);
-            argumentList.Should().BeEmpty();
+            ExtensionsCS.ArgumentList(node).Should().BeNull();
         }
 
         [TestMethod]
         public void ArgumentList_CS_Null() =>
-            ExtensionsCS.ArgumentList(null).Should().BeEmpty();
+            ExtensionsCS.ArgumentList(null).Should().BeNull();
 
         [DataTestMethod]
         [DataRow("_ = $$new int[] { 1 }$$;")]
@@ -847,7 +846,7 @@ public class X
                 """;
             var node = NodeBetweenMarkers(code, LanguageNames.VisualBasic, getInnermostNodeForTie: true);
             var argumentList = ExtensionsVB.ArgumentList(node);
-            var argument = argumentList.Should().ContainSingle().Which;
+            var argument = argumentList.Arguments.Should().ContainSingle().Which;
             (argument.GetExpression() is SyntaxVB.LiteralExpressionSyntax { Token.ValueText: "1" }).Should().BeTrue();
         }
 
@@ -864,7 +863,7 @@ public class X
                 """;
             var node = NodeBetweenMarkers(code, LanguageNames.VisualBasic, getInnermostNodeForTie: true);
             var argumentList = ExtensionsVB.ArgumentList(node);
-            argumentList.Should().SatisfyRespectively(
+            argumentList.Arguments.Should().SatisfyRespectively(
                 a => (a.GetExpression() is SyntaxVB.IdentifierNameSyntax { Identifier.ValueText: "s" }).Should().BeTrue(),
                 a => (a.GetExpression() is SyntaxVB.LiteralExpressionSyntax { Token.ValueText: "1" }).Should().BeTrue());
         }
@@ -879,7 +878,7 @@ public class X
                 """;
             var node = NodeBetweenMarkers(code, LanguageNames.VisualBasic, getInnermostNodeForTie: true);
             var argumentList = ExtensionsVB.ArgumentList(node);
-            var argument = argumentList.Should().ContainSingle().Which;
+            var argument = argumentList.Arguments.Should().ContainSingle().Which;
             (argument.GetExpression() is SyntaxVB.LiteralExpressionSyntax { Token.ValueText: "1" }).Should().BeTrue();
         }
 
@@ -899,7 +898,7 @@ public class X
                 """;
             var node = NodeBetweenMarkers(code, LanguageNames.VisualBasic, getInnermostNodeForTie: true);
             var argumentList = ExtensionsVB.ArgumentList(node);
-            var argument = argumentList.Should().ContainSingle().Which;
+            var argument = argumentList.Arguments.Should().ContainSingle().Which;
             (argument.GetExpression() is SyntaxVB.LiteralExpressionSyntax { Token.ValueText: "1" }).Should().BeTrue();
         }
 
@@ -914,13 +913,12 @@ public class X
                 End Class
                 """;
             var node = NodeBetweenMarkers(code, LanguageNames.VisualBasic, getInnermostNodeForTie: false);
-            var argumentList = ExtensionsVB.ArgumentList(node);
-            argumentList.Should().BeEmpty();
+            ExtensionsVB.ArgumentList(node).Should().BeNull();
         }
 
         [TestMethod]
         public void ArgumentList_VB_Null() =>
-            ExtensionsVB.ArgumentList(null).Should().BeEmpty();
+            ExtensionsVB.ArgumentList(null).Should().BeNull();
 
         [DataTestMethod]
         [DataRow("$$Dim a = 1$$")]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Facade/CSharpFacadeTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Facade/CSharpFacadeTests.cs
@@ -116,10 +116,10 @@ public class CSharpFacadeTests
             """;
         var (tree, model) = TestHelper.CompileCS(code);
         var root = tree.GetRoot();
-        var invocation = root.DescendantNodes().OfType<ArgumentListSyntax>().First();
+        var argumentList = root.DescendantNodes().OfType<ArgumentListSyntax>().First();
         var method = model.GetDeclaredSymbol(root.DescendantNodes().OfType<MethodDeclarationSyntax>().First());
-        var actual = sut.MethodParameterLookup(invocation, method);
-        actual.Should().NotBeNull().And.BeOfType<CSharpMethodParameterLookup>();
+        var actual = () => sut.MethodParameterLookup(argumentList, method);
+        actual.Should().Throw<InvalidOperationException>();
     }
 
     [TestMethod]
@@ -138,7 +138,7 @@ public class CSharpFacadeTests
         var methodDeclaration = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
         var method = model.GetDeclaredSymbol(methodDeclaration);
         var actual = () => sut.MethodParameterLookup(methodDeclaration, method); // MethodDeclarationSyntax passed instead of invocation
-        actual.Should().Throw<ArgumentException>().Which.Message.Should().StartWith("Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax does not contain an ArgumentList.");
+        actual.Should().Throw<InvalidOperationException>().Which.Message.Should().StartWith("The node of kind MethodDeclaration does not have an ArgumentList.");
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Facade/SyntaxFacadeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Facade/SyntaxFacadeTest.cs
@@ -131,4 +131,57 @@ public class SyntaxFacadeTest
     [DataRow("A.B?.C?.D", ".D")]
     public void RemoveConditionalAccess_SimpleInvocation_CS(string invocation, string expected) =>
         cs.RemoveConditionalAccess(CS.SyntaxFactory.ParseExpression(invocation)).ToString().Should().Be(expected);
+
+    [TestMethod]
+    public void ArgumentNameColon_VB_SimpleNameWithNameColonEquals()
+    {
+        var expression = VB.SyntaxFactory.LiteralExpression(VB.SyntaxKind.TrueLiteralExpression, VB.SyntaxFactory.Token(VB.SyntaxKind.TrueKeyword));
+        var argument = VB.SyntaxFactory.SimpleArgument(VB.SyntaxFactory.NameColonEquals(VB.SyntaxFactory.IdentifierName("a")), expression);
+        vb.ArgumentNameColon(argument).Should().BeOfType<SyntaxToken>().Subject.ValueText.Should().Be("a");
+    }
+
+    [TestMethod]
+    public void ArgumentNameColon_VB_SimpleNameWithoutNameColonEquals()
+    {
+        var expression = VB.SyntaxFactory.LiteralExpression(VB.SyntaxKind.TrueLiteralExpression, VB.SyntaxFactory.Token(VB.SyntaxKind.TrueKeyword));
+        var argument = VB.SyntaxFactory.SimpleArgument(expression);
+        vb.ArgumentNameColon(argument).Should().BeNull();
+    }
+
+    [TestMethod]
+    public void ArgumentNameColon_VB_OmittedArgument()
+    {
+        var argument = VB.SyntaxFactory.OmittedArgument();
+        vb.ArgumentNameColon(argument).Should().BeNull();
+    }
+
+    [TestMethod]
+    public void ArgumentNameColon_VB_UnsupportedSyntaxKind()
+    {
+        var expression = VB.SyntaxFactory.LiteralExpression(VB.SyntaxKind.TrueLiteralExpression, VB.SyntaxFactory.Token(VB.SyntaxKind.TrueKeyword));
+        vb.ArgumentNameColon(expression).Should().BeNull();
+    }
+
+    [TestMethod]
+    public void ArgumentNameColon_CS_WithNameColon()
+    {
+        var expression = CS.SyntaxFactory.LiteralExpression(CS.SyntaxKind.TrueLiteralExpression, CS.SyntaxFactory.Token(CS.SyntaxKind.TrueKeyword));
+        var argument = CS.SyntaxFactory.Argument(CS.SyntaxFactory.NameColon(CS.SyntaxFactory.IdentifierName("a")), CS.SyntaxFactory.Token(CS.SyntaxKind.None), expression);
+        cs.ArgumentNameColon(argument).Should().BeOfType<SyntaxToken>().Subject.ValueText.Should().Be("a");
+    }
+
+    [TestMethod]
+    public void ArgumentNameColon_CS_WithoutNameColon()
+    {
+        var expression = CS.SyntaxFactory.LiteralExpression(CS.SyntaxKind.TrueLiteralExpression, CS.SyntaxFactory.Token(CS.SyntaxKind.TrueKeyword));
+        var argument = CS.SyntaxFactory.Argument(expression);
+        cs.ArgumentNameColon(argument).Should().BeNull();
+    }
+
+    [TestMethod]
+    public void ArgumentNameColon_CS_UnsupportedSyntaxKind()
+    {
+        var expression = CS.SyntaxFactory.LiteralExpression(CS.SyntaxKind.TrueLiteralExpression, CS.SyntaxFactory.Token(CS.SyntaxKind.TrueKeyword));
+        cs.ArgumentNameColon(expression).Should().BeNull();
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Facade/SyntaxFacadeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Facade/SyntaxFacadeTest.cs
@@ -156,6 +156,15 @@ public class SyntaxFacadeTest
     }
 
     [TestMethod]
+    public void ArgumentNameColon_VB_RangeArgument()
+    {
+        var literal1 = VB.SyntaxFactory.LiteralExpression(VB.SyntaxKind.NumericLiteralExpression, VB.SyntaxFactory.Literal(1));
+        var literal2 = literal1.WithToken(VB.SyntaxFactory.Literal(2));
+        var argument = VB.SyntaxFactory.RangeArgument(literal1, literal2);
+        vb.ArgumentNameColon(argument).Should().BeNull();
+    }
+
+    [TestMethod]
     public void ArgumentNameColon_VB_UnsupportedSyntaxKind()
     {
         var expression = VB.SyntaxFactory.LiteralExpression(VB.SyntaxKind.TrueLiteralExpression, VB.SyntaxFactory.Token(VB.SyntaxKind.TrueKeyword));

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Facade/SyntaxFacadeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Facade/SyntaxFacadeTest.cs
@@ -165,7 +165,7 @@ public class SyntaxFacadeTest
     [TestMethod]
     public void ArgumentNameColon_CS_WithNameColon()
     {
-        var expression = CS.SyntaxFactory.LiteralExpression(CS.SyntaxKind.TrueLiteralExpression, CS.SyntaxFactory.Token(CS.SyntaxKind.TrueKeyword));
+        var expression = CS.SyntaxFactory.LiteralExpression(CS.SyntaxKind.TrueLiteralExpression);
         var argument = CS.SyntaxFactory.Argument(CS.SyntaxFactory.NameColon(CS.SyntaxFactory.IdentifierName("a")), CS.SyntaxFactory.Token(CS.SyntaxKind.None), expression);
         cs.ArgumentNameColon(argument).Should().BeOfType<SyntaxToken>().Subject.ValueText.Should().Be("a");
     }
@@ -173,7 +173,7 @@ public class SyntaxFacadeTest
     [TestMethod]
     public void ArgumentNameColon_CS_WithoutNameColon()
     {
-        var expression = CS.SyntaxFactory.LiteralExpression(CS.SyntaxKind.TrueLiteralExpression, CS.SyntaxFactory.Token(CS.SyntaxKind.TrueKeyword));
+        var expression = CS.SyntaxFactory.LiteralExpression(CS.SyntaxKind.TrueLiteralExpression);
         var argument = CS.SyntaxFactory.Argument(expression);
         cs.ArgumentNameColon(argument).Should().BeNull();
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Facade/VisualBasicFacadeTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Facade/VisualBasicFacadeTests.cs
@@ -97,8 +97,8 @@ public class VisualBasicFacadeTests
         var root = tree.GetRoot();
         var argumentList = root.DescendantNodes().OfType<ArgumentListSyntax>().First();
         var method = model.GetDeclaredSymbol(root.DescendantNodes().OfType<MethodStatementSyntax>().First());
-        var actual = sut.MethodParameterLookup(argumentList, method);
-        actual.Should().NotBeNull().And.BeOfType<VisualBasicMethodParameterLookup>();
+        var actual = () => sut.MethodParameterLookup(argumentList, method);
+        actual.Should().Throw<InvalidOperationException>();
     }
 
     [TestMethod]
@@ -117,7 +117,7 @@ public class VisualBasicFacadeTests
         var methodDeclaration = root.DescendantNodes().OfType<MethodStatementSyntax>().First();
         var method = model.GetDeclaredSymbol(methodDeclaration);
         var actual = () => sut.MethodParameterLookup(methodDeclaration, method); // MethodDeclarationSyntax passed instead of invocation
-        actual.Should().Throw<ArgumentException>().Which.Message.Should().StartWith("Microsoft.CodeAnalysis.VisualBasic.Syntax.MethodStatementSyntax does not contain an ArgumentList.");
+        actual.Should().Throw<InvalidOperationException>().Which.Message.Should().StartWith("The node of kind FunctionStatement does not have an ArgumentList.");
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ParametersCorrectOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ParametersCorrectOrderTest.cs
@@ -71,5 +71,23 @@ Public Class Foo
         Dim y = New System. ()
     End Sub
 End Class").WithErrorBehavior(CompilationErrorBehavior.Ignore).Verify();
+
+        [TestMethod]
+        public void ParametersCorrectOrder_InvalidCode_CS1() =>
+            builderCS.AddSnippet("""
+                class BaseConstructor
+                {
+                    class Base(int a, int b) // Secondary [1, 2, 3, 4, 5, 6]
+                    {
+                        Base(int a, int b, string c) : this(b, a) { }  // Noncompliant [1]
+                        Base(string c, int a, int b) : this(b, a) { }  // Noncompliant [2]
+                    }
+
+                    class ParamsFullyInverted(int a, int b) : Base(b, a);                                    // Noncompliant [3]
+                    class ParamsPartiallyInverted(int a, int b, int c) : Base(b, a);                         // Noncompliant [4]
+                    class ParamsFullyInvertedWithAdditionalParamAfter(int a, int b, string s) : Base(b, a);  // Noncompliant [5]
+                    class ParamsFullyInvertedWithAdditionalParamBefore(string s, int a, int b) : Base(b, a); // Noncompliant [6]
+                }
+                """).WithOptions(ParseOptionsHelper.FromCSharp12).WithConcurrentAnalysis(false).Verify();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ParametersCorrectOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/ParametersCorrectOrderTest.cs
@@ -71,23 +71,5 @@ Public Class Foo
         Dim y = New System. ()
     End Sub
 End Class").WithErrorBehavior(CompilationErrorBehavior.Ignore).Verify();
-
-        [TestMethod]
-        public void ParametersCorrectOrder_InvalidCode_CS1() =>
-            builderCS.AddSnippet("""
-                class BaseConstructor
-                {
-                    class Base(int a, int b) // Secondary [1, 2, 3, 4, 5, 6]
-                    {
-                        Base(int a, int b, string c) : this(b, a) { }  // Noncompliant [1]
-                        Base(string c, int a, int b) : this(b, a) { }  // Noncompliant [2]
-                    }
-
-                    class ParamsFullyInverted(int a, int b) : Base(b, a);                                    // Noncompliant [3]
-                    class ParamsPartiallyInverted(int a, int b, int c) : Base(b, a);                         // Noncompliant [4]
-                    class ParamsFullyInvertedWithAdditionalParamAfter(int a, int b, string s) : Base(b, a);  // Noncompliant [5]
-                    class ParamsFullyInvertedWithAdditionalParamBefore(string s, int a, int b) : Base(b, a); // Noncompliant [6]
-                }
-                """).WithOptions(ParseOptionsHelper.FromCSharp12).WithConcurrentAnalysis(false).Verify();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp12.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp12.cs
@@ -29,7 +29,8 @@ namespace Repro_8071
 
         void WithPromotion(short a, short b)
         {
-            _ = new SomeRecord(b, a);           // Noncompliant [SomeRecord2]
+            SomeRecord _ = new(b, a);           // Noncompliant [SomeRecord2]
+            //             ^^^
         }
 
         void WithCasting(long a, long b)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp12.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp12.cs
@@ -8,11 +8,14 @@ namespace Repro_8071
         class Base(int a, int b) // Secondary [Base1, Base2, Base3, Base4, Base5, Base6]
         {
             Base(int a, int b, string c) : this(b, a) { }  // Noncompliant [Base1]
+            //                             ^^^^
             Base(string c, int a, int b) : this(b, a) { }  // Noncompliant [Base2]
         }
 
         class ParamsFullyInverted(int a, int b) : Base(b, a);                                    // Noncompliant [Base3]
-        class ParamsPartiallyInverted(int a, int b, int c) : Base(b, a);                         // Noncompliant [Base4]
+        //                                        ^^^^
+        class ParamsPartiallyInverted(int a, int b, int c) : BaseConstructor.Base(b, a);         // Noncompliant [Base4]
+        //                                                                   ^^^^
         class ParamsFullyInvertedWithAdditionalParamAfter(int a, int b, string s) : Base(b, a);  // Noncompliant [Base5]
         class ParamsFullyInvertedWithAdditionalParamBefore(string s, int a, int b) : Base(b, a); // Noncompliant [Base6]
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp12.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp12.cs
@@ -5,39 +5,39 @@ namespace Repro_8071
 {
     class BaseConstructor
     {
-        class Base(int a, int b)
+        class Base(int a, int b) // Secondary [Base1, Base2, Base3, Base4, Base5, Base6]
         {
-            Base(int a, int b, string c) : this(b, a) { }  // FN: ctor params inverted with additional param after
-            Base(string c, int a, int b) : this(b, a) { }  // FN: ctor params inverted with additional param before
+            Base(int a, int b, string c) : this(b, a) { }  // Noncompliant [Base1]
+            Base(string c, int a, int b) : this(b, a) { }  // Noncompliant [Base2]
         }
 
-        class ParamsFullyInverted(int a, int b) : Base(b, a);                                    // FN
-        class ParamsPartiallyInverted(int a, int b, int c) : Base(b, a);                         // FN
-        class ParamsFullyInvertedWithAdditionalParamAfter(int a, int b, string s) : Base(b, a);  // FN
-        class ParamsFullyInvertedWithAdditionalParamBefore(string s, int a, int b) : Base(b, a); // FN
+        class ParamsFullyInverted(int a, int b) : Base(b, a);                                    // Noncompliant [Base3]
+        class ParamsPartiallyInverted(int a, int b, int c) : Base(b, a);                         // Noncompliant [Base4]
+        class ParamsFullyInvertedWithAdditionalParamAfter(int a, int b, string s) : Base(b, a);  // Noncompliant [Base5]
+        class ParamsFullyInvertedWithAdditionalParamBefore(string s, int a, int b) : Base(b, a); // Noncompliant [Base6]
     }
 
     class WithRecordStructs
     {
         void Basics(int a, int b, int c)
         {
-            _ = new SomeRecord(b, a);           // Noncompliant
+            _ = new SomeRecord(b, a);           // Noncompliant [SomeRecord1]
         }
 
         void WithPromotion(short a, short b)
         {
-            _ = new SomeRecord(b, a);           // Noncompliant
+            _ = new SomeRecord(b, a);           // Noncompliant [SomeRecord2]
         }
 
         void WithCasting(long a, long b)
         {
-            _ = new SomeRecord((int)b, (int)a); // FN
+            _ = new SomeRecord((int)b, (int)a); // FN [SomeRecord3]
         }
 
-        record SomeRecord(int a, int b)
+        record SomeRecord(int a, int b)  // Secondary [SomeRecord1, SomeRecord2, SomeRecord4, SomeRecord5]
         {
-            public SomeRecord(int a, int b, string c) : this(b, a) { } // FN
-            public SomeRecord(string c, int a, int b) : this(b, a) { } // FN
+            public SomeRecord(int a, int b, string c) : this(b, a) { } // Noncompliant [SomeRecord4]
+            public SomeRecord(string c, int a, int b) : this(b, a) { } // Noncompliant [SomeRecord5]
         }
     }
 
@@ -45,23 +45,23 @@ namespace Repro_8071
     {
         void Basics(int a, int b, int c)
         {
-            _ = new SomeRecordStruct(b, a);           // Noncompliant
+            _ = new SomeRecordStruct(b, a);           // Noncompliant [SomeRecordStruct1]
         }
 
         void WithPromotion(short a, short b)
         {
-            _ = new SomeRecordStruct(b, a);           // Noncompliant
+            _ = new SomeRecordStruct(b, a);           // Noncompliant [SomeRecordStruct2]
         }
 
         void WithCasting(long a, long b)
         {
-            _ = new SomeRecordStruct((int)b, (int)a); // FN
+            _ = new SomeRecordStruct((int)b, (int)a); // FN [SomeRecordStruct3]
         }
 
-        record struct SomeRecordStruct(int a, int b)
+        record struct SomeRecordStruct(int a, int b) // Secondary [SomeRecordStruct1, SomeRecordStruct2, SomeRecordStruct4, SomeRecordStruct5]
         {
-            public SomeRecordStruct(int a, int b, string c) : this(b, a) { } // FN
-            public SomeRecordStruct(string c, int a, int b) : this(b, a) { } // FN
+            public SomeRecordStruct(int a, int b, string c) : this(b, a) { } // Noncompliant [SomeRecordStruct4]
+            public SomeRecordStruct(string c, int a, int b) : this(b, a) { } // Noncompliant [SomeRecordStruct5]
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp12.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.CSharp12.cs
@@ -5,19 +5,25 @@ namespace Repro_8071
 {
     class BaseConstructor
     {
-        class Base(int a, int b) // Secondary [Base1, Base2, Base3, Base4, Base5, Base6]
+        class Base(int a, int b) // Secondary [Base1, Base2, Base3, Base4, Base5, Base6, Base7, Base8]
         {
-            Base(int a, int b, string c) : this(b, a) { }  // Noncompliant [Base1]
-            //                             ^^^^
-            Base(string c, int a, int b) : this(b, a) { }  // Noncompliant [Base2]
+            Base(int a, int b, string c) : this(b, a) { }                                            // Noncompliant [Base1]
+            //                             ^^^^                                                      
+            Base(string c, int a, int b) : this(b, a) { }                                            // Noncompliant [Base2]
         }
 
-        class ParamsFullyInverted(int a, int b) : Base(b, a);                                    // Noncompliant [Base3]
+        class ParamsFullyInverted(int a, int b) : Base(b, a);                                        // Noncompliant [Base3]
         //                                        ^^^^
-        class ParamsPartiallyInverted(int a, int b, int c) : BaseConstructor.Base(b, a);         // Noncompliant [Base4]
+        class ParamsPartiallyInverted(int a, int b, int c) : BaseConstructor.Base(b, a);             // Noncompliant [Base4]
         //                                                                   ^^^^
-        class ParamsFullyInvertedWithAdditionalParamAfter(int a, int b, string s) : Base(b, a);  // Noncompliant [Base5]
-        class ParamsFullyInvertedWithAdditionalParamBefore(string s, int a, int b) : Base(b, a); // Noncompliant [Base6]
+        class ParamsPartiallyInvertedWithAdditionalParamAfter(int a, int b, string s) : Base(b, a);  // Noncompliant [Base5]
+        class ParamsPartiallyInvertedWithAdditionalParamBefore(string s, int a, int b) : Base(b, a); // Noncompliant [Base6]
+
+        Base MyMethod(int b, int a)
+        {
+            _ = new Base(b, a);                                                                      // Noncompliant [Base7]
+            return new(b, a);                                                                        // Noncompliant [Base8]
+        }
     }
 
     class WithRecordStructs

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.cs
@@ -30,6 +30,7 @@ namespace Tests.Diagnostics
             var b = "2";
 
             Comparer.Default.Compare(b, a); // Noncompliant
+            //               ^^^^^^^
         }
     }
 
@@ -75,6 +76,7 @@ namespace Tests.Diagnostics
             var some = 6;
 
             divide(dividend, 1 + 1, divisor, other2: 6);  // Noncompliant [1] operation succeeds, but result is unexpected
+//          ^^^^^^
 
             divide(divisor, other2, dividend);
             divide(divisor, other2, dividend, other2: someOther); // Noncompliant [2] {{Parameters to 'divide' have the same names but not the same order as the method arguments.}}
@@ -200,8 +202,10 @@ namespace Repro_8070
     {
         void Test(int a, int b, int c)
         {
-            _ = new SomeClass(b, a);                  // Noncompliant, fully inverted
-            _ = new SomeClass(b, a, c);               // Noncompliant, partially inverted
+            _ = new SomeClass(b, a);                              // Noncompliant, fully inverted
+            //      ^^^^^^^^^
+            _ = new InvokingConstructorViaNew.SomeClass(b, a, c); // Noncompliant, partially inverted
+            //                                ^^^^^^^^^
         }
 
         class SomeClass
@@ -225,28 +229,29 @@ namespace Repro_8070
     {
         class Base
         {
-            public Base(int a, int b) { }
-            public Base(int a, int b, int c) { }
+            public Base(int a, int b) { }        // Secondary [Base1, Base3, Base4]
+            public Base(int a, int b, int c) { } // Secondary [Base2]
         }
 
         class ParamsFullyInverted : Base
         {
-            public ParamsFullyInverted(int a, int b) : base(b, a) { }                                    // FN
+            public ParamsFullyInverted(int a, int b) : base(b, a) { }                                    // Noncompliant [Base1]
+            //                                         ^^^^
         }
 
         class ParamsPartiallyInverted : Base
         {
-            public ParamsPartiallyInverted(int a, int b, int c) : base(b, a, c) { }                      // FN
+            public ParamsPartiallyInverted(int a, int b, int c) : base(b, a, c) { }                      // Noncompliant [Base2]
         }
 
         class ParamsFullyInvertedWithAdditionalParamAfter : Base
         {
-            public ParamsFullyInvertedWithAdditionalParamAfter(int a, int b, string s) : base(b, a) { }  // FN
+            public ParamsFullyInvertedWithAdditionalParamAfter(int a, int b, string s) : base(b, a) { }  // Noncompliant [Base3]
         }
 
         class ParamsFullyInvertedWithAdditionalParamBefore : Base
         {
-            public ParamsFullyInvertedWithAdditionalParamBefore(string s, int a, int b) : base(b, a) { } // FN
+            public ParamsFullyInvertedWithAdditionalParamBefore(string s, int a, int b) : base(b, a) { } // Noncompliant [Base4]
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.cs
@@ -215,9 +215,9 @@ namespace Repro_8070
     {
         class SomeClass
         {
-            public SomeClass(int a, int b) { }
-            public SomeClass(int a, int b, string c) : this(b, a) { } // FN: ctor params fully inverted with additional par after
-            public SomeClass(string c, int a, int b) : this(b, a) { } // FN: ctor params fully inverted with additional par before
+            public SomeClass(int a, int b) { } // Secondary [SomeClass1, SomeClass2]
+            public SomeClass(int a, int b, string c) : this(b, a) { } // Noncompliant [SomeClass1]
+            public SomeClass(string c, int a, int b) : this(b, a) { } // Noncompliant [SomeClass2]
         }
     }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.vb
@@ -19,7 +19,9 @@
             Foo.GlobalDivide(divisor, dividend)
 
             Divide(dividend, divisor) ' Noncompliant [1] {{Parameters to 'Divide' have the same names but not the same order as the method arguments.}}
+'           ^^^^^^
             Foo.GlobalDivide(dividend, divisor) ' Noncompliant [2]
+            '   ^^^^^^^^^^^^
 
             Divide(dividend:=dividend, divisor:= divisor)
 
@@ -41,8 +43,10 @@
             x = New Foo
 
             x = New Foo(right, left) ' Noncompliant
+            '       ^^^
             x = New FooFoo(right, left) ' Noncompliant
             x = New Foo.FooFoo(right, left) ' Noncompliant
+            '           ^^^^^^
 
             x = New Foo(ValProp, Foo.ValProp)
         End Sub

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/ParametersCorrectOrder.vb
@@ -19,7 +19,7 @@
             Foo.GlobalDivide(divisor, dividend)
 
             Divide(dividend, divisor) ' Noncompliant [1] {{Parameters to 'Divide' have the same names but not the same order as the method arguments.}}
-            Foo.GlobalDivide(dividend, divisor) ' Noncompliant
+            Foo.GlobalDivide(dividend, divisor) ' Noncompliant [2]
 
             Divide(dividend:=dividend, divisor:= divisor)
 
@@ -53,11 +53,11 @@
         Sub FooBar(ByVal value As Integer, ByVal ParamArray args() As String)
         End Sub
 
-        Public Function Divide(ByVal divisor As Integer, ByVal dividend As Integer) As Double ' Should be secondary-location for [1], but does not work
+        Public Function Divide(ByVal divisor As Integer, ByVal dividend As Integer) As Double ' Secondary [1]
             Return divisor / dividend
         End Function
 
-        Public Shared Function GlobalDivide(ByVal divisor As Integer, ByVal dividend As Integer) As Double
+        Public Shared Function GlobalDivide(ByVal divisor As Integer, ByVal dividend As Integer) As Double ' Secondary [2]
             Return divisor / dividend
         End Function
 


### PR DESCRIPTION
Fixes #8070
Fixes #8071

The original implementation was rewritten from scratch. The reasons are

* The implementation didn't follow our principals
* The analyzer wasn't derived from `SonarDiagnosticAnalyzer<TSyntaxKind>`
* The registration happened in the derived classes instead of the base class
* `LanguageFacade` wasn't used
* There was a mixture of `abstract` methods (e.g., `GetArgumentTypeSymbolInfo`) and passed delegates (e.g., `getLocationToReport` parameter in `ReportIncorrectlyOrderedParameters`) which are both used as language-specific holes for the language-neutral implementation
* The `ArgumentIdentifier` private class and derived classes are not needed
* The logic was complex to follow

The current implementation follows our standards more closely and moves a lot of logic to the facade.