### PR TITLE
SyntaxNodeExtensions.GetIdentifier and ISymbolExtensions.NodeIdentifier are duplicates

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/ISymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/ISymbolExtensions.cs
@@ -89,28 +89,8 @@ namespace SonarAnalyzer.Extensions
 
         public static ImmutableArray<SyntaxToken> DeclaringReferenceIdentifiers(this ISymbol symbol) =>
             symbol.DeclaringSyntaxReferences
-               .Select(x => x.GetSyntax().NodeIdentifier())
+               .Select(x => x.GetSyntax().GetIdentifier())
                .WhereNotNull()
                .ToImmutableArray();
-
-        public static SyntaxToken? NodeIdentifier(this SyntaxNode node) =>
-            node.RemoveParentheses() switch
-            {
-                AttributeArgumentSyntax x => x.NameColon?.Name.Identifier,
-                BaseTypeDeclarationSyntax x => x.Identifier,
-                ConstructorDeclarationSyntax x => x.Identifier,
-                DelegateDeclarationSyntax x => x.Identifier,
-                EnumMemberDeclarationSyntax x => x.Identifier,
-                EventDeclarationSyntax x => x.Identifier,
-                InvocationExpressionSyntax x => NodeIdentifier(x.Expression),
-                MemberAccessExpressionSyntax x => x.Name.Identifier,
-                MemberBindingExpressionSyntax x => x.Name.Identifier,
-                MethodDeclarationSyntax x => x.Identifier,
-                ParameterSyntax x => x.Identifier,
-                PropertyDeclarationSyntax x => x.Identifier,
-                SimpleNameSyntax x => x.Identifier,
-                VariableDeclaratorSyntax x => x.Identifier,
-                _ => null,
-            };
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -139,7 +139,10 @@ namespace SonarAnalyzer.Extensions
             node switch
             {
                 AliasQualifiedNameSyntax { Alias.Identifier: var identifier } => identifier,
+                ArgumentSyntax { NameColon.Name.Identifier: var identifier } => identifier,
                 ArrayTypeSyntax { ElementType: { } elementType } => GetIdentifier(elementType),
+                AttributeArgumentSyntax { NameColon.Name.Identifier: var identifier } => identifier,
+                AttributeArgumentSyntax { NameEquals.Name.Identifier: var identifier } => identifier,
                 AttributeSyntax { Name: { } name } => GetIdentifier(name),
                 BaseTypeDeclarationSyntax { Identifier: var identifier } => identifier,
                 ConstructorDeclarationSyntax { Identifier: var identifier } => identifier,
@@ -147,15 +150,16 @@ namespace SonarAnalyzer.Extensions
                 DelegateDeclarationSyntax { Identifier: var identifier } => identifier,
                 DestructorDeclarationSyntax { Identifier: var identifier } => identifier,
                 EnumMemberDeclarationSyntax { Identifier: var identifier } => identifier,
+                EventDeclarationSyntax { Identifier: var identifier } => identifier,
                 IdentifierNameSyntax { Identifier: var identifier } => identifier,
                 IndexerDeclarationSyntax { ThisKeyword: var thisKeyword } => thisKeyword,
                 InvocationExpressionSyntax
                 {
                     Expression: not InvocationExpressionSyntax // We don't want to recurse into nested invocations like: fun()()
                 } invocation => GetIdentifier(invocation.Expression),
-                MethodDeclarationSyntax { Identifier: var identifier } => identifier,
-                MemberBindingExpressionSyntax { Name.Identifier: var identifier } => identifier,
                 MemberAccessExpressionSyntax { Name.Identifier: var identifier } => identifier,
+                MemberBindingExpressionSyntax { Name.Identifier: var identifier } => identifier,
+                MethodDeclarationSyntax { Identifier: var identifier } => identifier,
                 NamespaceDeclarationSyntax { Name: { } name } => GetIdentifier(name),
                 NullableTypeSyntax { ElementType: { } elementType } => GetIdentifier(elementType),
                 OperatorDeclarationSyntax { OperatorToken: var operatorToken } => operatorToken,

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Linq.Expressions;
 using SonarAnalyzer.CFG.Roslyn;
 
 namespace SonarAnalyzer.Extensions

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Linq.Expressions;
 using SonarAnalyzer.CFG.Roslyn;
 
 namespace SonarAnalyzer.Extensions
@@ -162,8 +163,10 @@ namespace SonarAnalyzer.Extensions
                 MethodDeclarationSyntax { Identifier: var identifier } => identifier,
                 NamespaceDeclarationSyntax { Name: { } name } => GetIdentifier(name),
                 NullableTypeSyntax { ElementType: { } elementType } => GetIdentifier(elementType),
+                ObjectCreationExpressionSyntax { Type: var type } => GetIdentifier(type),
                 OperatorDeclarationSyntax { OperatorToken: var operatorToken } => operatorToken,
                 ParameterSyntax { Identifier: var identifier } => identifier,
+                ParenthesizedExpressionSyntax { Expression: { } expression } => GetIdentifier(expression),
                 PropertyDeclarationSyntax { Identifier: var identifier } => identifier,
                 PointerTypeSyntax { ElementType: { } elementType } => GetIdentifier(elementType),
                 PredefinedTypeSyntax { Keyword: var keyword } => keyword,
@@ -171,8 +174,12 @@ namespace SonarAnalyzer.Extensions
                 SimpleNameSyntax { Identifier: var identifier } => identifier,
                 TypeParameterConstraintClauseSyntax { Name.Identifier: var identifier } => identifier,
                 TypeParameterSyntax { Identifier: var identifier } => identifier,
+                PrefixUnaryExpressionSyntax { Operand: { } operand } => GetIdentifier(operand),
+                PostfixUnaryExpressionSyntax { Operand: { } operand } => GetIdentifier(operand),
                 UsingDirectiveSyntax { Alias.Name: { } name } => GetIdentifier(name),
                 VariableDeclaratorSyntax { Identifier: var identifier } => identifier,
+                { } fileScoped when FileScopedNamespaceDeclarationSyntaxWrapper.IsInstance(fileScoped)
+                    && ((FileScopedNamespaceDeclarationSyntaxWrapper)fileScoped).Name is { } name => GetIdentifier(name),
                 { } refType when RefTypeSyntaxWrapper.IsInstance(refType) => GetIdentifier(((RefTypeSyntaxWrapper)refType).Type),
                 _ => null
             };

--- a/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Facade/CSharpSyntaxFacade.cs
@@ -137,7 +137,7 @@ internal sealed class CSharpSyntaxFacade : SyntaxFacade<SyntaxKind>
         };
 
     public override SyntaxToken? NodeIdentifier(SyntaxNode node) =>
-        node.NodeIdentifier();
+        node.GetIdentifier();
 
     public override SyntaxToken? ObjectCreationTypeIdentifier(SyntaxNode objectCreation) =>
         objectCreation == null ? null : Cast<ObjectCreationExpressionSyntax>(objectCreation).GetObjectCreationTypeIdentifier();

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
             context.RegisterNodeAction(c =>
             {
                 if (!c.IsRedundantPositionalRecordContext()
-                    && c.Node.NodeIdentifier() is { } identifier
+                    && c.Node.GetIdentifier() is { } identifier
                     && FrameworkNamespaces.Contains(identifier.ValueText)
                     && c.SemanticModel.GetDeclaredSymbol(c.Node)?.DeclaredAccessibility == Accessibility.Public)
                 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringCreate.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringCreate.cs
@@ -53,7 +53,7 @@ public sealed class UseStringCreate : SonarDiagnosticAnalyzer
                     && node.ArgumentList.Arguments[0].Expression is InterpolatedStringExpressionSyntax
                     && c.SemanticModel.GetTypeInfo(left).Type.Is(KnownType.System_FormattableString))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, node.NodeIdentifier()?.GetLocation()));
+                    c.ReportIssue(Diagnostic.Create(Rule, node.GetIdentifier()?.GetLocation()));
                 }
             },
             SyntaxKind.InvocationExpression);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -836,43 +836,87 @@ public class X
         }
 
         [DataTestMethod]
-        [DataRow("""$$global::System$$.Int32 i;""", "global")]              // AliasQualifiedNameSyntax
-        [DataRow("""int i = Math.Abs($$1$$);""", null)]                     // ArgumentSyntax
-        [DataRow("""int i = Math.Abs($$value: 1$$);""", "value")]           // ArgumentSyntax
-        [DataRow("""$$int[]$$ i;""", "int")]                                // ArrayTypeSyntax
-        [DataRow("""$$int[][]$$ i;""", "int")]                              // ArrayTypeSyntax
-        [DataRow("""[DebuggerDisplay($$""$$)]int i;""", null)]              // AttributeArgumentSyntax
-        [DataRow("""[DebuggerDisplay($$value: ""$$)]int i;""", "value")]    // AttributeArgumentSyntax
-        [DataRow("""[DebuggerDisplay("", $$Name = ""$$)]int i;""", "Name")] // AttributeArgumentSyntax
-        [DataRow("""[$$DebuggerDisplay("")$$]int i;""", "DebuggerDisplay")] // AttributeSyntax
-        [DataRow("""class $$T$$ { }""", "T")]                               // BaseTypeDeclarationSyntax
-        [DataRow("""struct $$T$$ { }""", "T")]                              // BaseTypeDeclarationSyntax
-        [DataRow("""interface $$T$$ { }""", "T")]                           // BaseTypeDeclarationSyntax
-        [DataRow("""record $$T$$ { }""", "T")]                              // BaseTypeDeclarationSyntax
-        [DataRow("""record class $$T$$ { }""", "T")]                        // BaseTypeDeclarationSyntax
-        [DataRow("""record struct $$T$$ { }""", "T")]                       // BaseTypeDeclarationSyntax
-        [DataRow("""enum $$T$$ { }""", "T")]                                // BaseTypeDeclarationSyntax
-        [DataRow("""$$Test() { }$$""", "Test")]                             // ConstructorDeclarationSyntax
+        [DataRow("""$$global::System$$.Int32 i;""", "global")]                        // AliasQualifiedNameSyntax
+        [DataRow("""int i = Math.Abs($$1$$);""", null)]                               // ArgumentSyntax
+        [DataRow("""int i = Math.Abs($$value: 1$$);""", "value")]                     // ArgumentSyntax
+        [DataRow("""$$int[]$$ i;""", "int")]                                          // ArrayTypeSyntax
+        [DataRow("""$$int[][]$$ i;""", "int")]                                        // ArrayTypeSyntax
+        [DataRow("""[DebuggerDisplay($$""$$)]int i;""", null)]                        // AttributeArgumentSyntax
+        [DataRow("""[DebuggerDisplay($$value: ""$$)]int i;""", "value")]              // AttributeArgumentSyntax
+        [DataRow("""[DebuggerDisplay("", $$Name = ""$$)]int i;""", "Name")]           // AttributeArgumentSyntax
+        [DataRow("""[$$DebuggerDisplay("")$$]int i;""", "DebuggerDisplay")]           // AttributeSyntax
+        [DataRow("""class $$T$$ { }""", "T")]                                         // BaseTypeDeclarationSyntax
+        [DataRow("""struct $$T$$ { }""", "T")]                                        // BaseTypeDeclarationSyntax
+        [DataRow("""interface $$T$$ { }""", "T")]                                     // BaseTypeDeclarationSyntax
+        [DataRow("""record $$T$$ { }""", "T")]                                        // BaseTypeDeclarationSyntax
+        [DataRow("""record class $$T$$ { }""", "T")]                                  // BaseTypeDeclarationSyntax
+        [DataRow("""record struct $$T$$ { }""", "T")]                                 // BaseTypeDeclarationSyntax
+        [DataRow("""enum $$T$$ { }""", "T")]                                          // BaseTypeDeclarationSyntax
+        [DataRow("""$$Test() { }$$""", "Test")]                                       // ConstructorDeclarationSyntax
         [DataRow("""$$public static implicit operator int(Test t) => 1;$$""", "int")] // ConversionOperatorDeclarationSyntax
-        [DataRow("""$$delegate void D();$$""", "D")] // DelegateDeclarationSyntax
-        [DataRow("""$$~Test() { }$$""", "Test")] // DestructorDeclarationSyntax
-        [DataRow("""enum E { $$M$$ }""", "M")] // EnumMemberDeclarationSyntax
-        [DataRow("""enum E { $$M = 1$$, }""", "M")] // EnumMemberDeclarationSyntax
-        [DataRow("""$$event Action E {add { } remove { } }$$""", "E")] // EventDeclarationSyntax
-        [DataRow("""$$event Action E;$$""", null)] // EventFieldDeclarationSyntax
-        [DataRow("""$$event Action E1, E2;$$""", null)] // EventFieldDeclarationSyntax
-        [DataRow("""$$Int32$$ i;""", "Int32")] // IdentifierNameSyntax
-        [DataRow("""$$int this[int i] { get => 1; set { } }""", "this")] // IndexerDeclarationSyntax
-
-        public void GetIdentifier(string member, string expected)
+        [DataRow("""$$delegate void D();$$""", "D")]                                  // DelegateDeclarationSyntax
+        [DataRow("""$$~Test() { }$$""", "Test")]                                      // DestructorDeclarationSyntax
+        [DataRow("""enum E { $$M$$ }""", "M")]                                        // EnumMemberDeclarationSyntax
+        [DataRow("""enum E { $$M = 1$$, }""", "M")]                                   // EnumMemberDeclarationSyntax
+        [DataRow("""$$event Action E {add { } remove { } }$$""", "E")]                // EventDeclarationSyntax
+        [DataRow("""$$event Action E;$$""", null)]                                    // EventFieldDeclarationSyntax
+        [DataRow("""$$event Action E1, E2;$$""", null)]                               // EventFieldDeclarationSyntax
+        [DataRow("""$$Int32$$ i;""", "Int32")]                                        // IdentifierNameSyntax
+        [DataRow("""$$int this[int i] { get => 1; set { } }$$""", "this")]            // IndexerDeclarationSyntax
+        [DataRow("""int i = $$Math.Abs(1)$$;""", "Abs")]                              // InvocationExpressionSyntax
+        [DataRow("""int i = $$Fun()()$$;""", null)]                                   // InvocationExpressionSyntax
+        [DataRow("""int i = $$int.MaxValue$$;""", "MaxValue")]                        // MemberAccessExpressionSyntax
+        [DataRow("""string s = (new object())?$$.ToString$$();""", "ToString")]       // MemberBindingExpressionSyntax
+        [DataRow("""string s = (new object())?$$.ToString()$$;""", "ToString")]       // MemberBindingExpressionSyntax
+        [DataRow("""$$void M() { }$$""", "M")]                                        // MethodDeclarationSyntax
+        [DataRow("""$$int?$$ i;""", "int")]                                           // NullableTypeSyntax
+        [DataRow("""object o = $$new object()$$;""", "object")]                       // ObjectCreationExpressionSyntax
+        [DataRow("""$$public static Test operator +(Test t) => default;$$""", "+")]   // OperatorDeclarationSyntax
+        [DataRow("""void M($$int i$$) { }""", "i")]                                   // ParameterSyntax
+        [DataRow("""int i = $$(int.MaxValue)$$;""", "MaxValue")]                      // ParenthesizedExpressionSyntax
+        [DataRow("""$$int P { get; }$$""", "P")]                                      // PropertyDeclarationSyntax
+        [DataRow("""int i = $$-int.MaxValue$$;""", "MaxValue")]                       // PrefixUnaryExpressionSyntax
+        [DataRow("""object o = $$new object()!$$;""", "object")]                      // PostfixUnaryExpressionSyntax
+        [DataRow("""$$int*$$ i;""", "int")]                                           // PointerTypeSyntax
+        [DataRow("""$$System.Collections.ArrayList$$ l;""", "ArrayList")]             // QualifiedNameSyntax
+        [DataRow("""$$List<int>$$ l;""", "List")]                                     // SimpleNameSyntax
+        [DataRow("""void M<T>() where $$T : class$$ { }""", "T")]                     // TypeParameterConstraintClauseSyntax
+        [DataRow("""void M<$$T$$>() { }""", "T")]                                     // TypeParameterSyntax
+        [DataRow("""int $$i$$;""", "i")]                                              // VariableDeclaratorSyntax
+        [DataRow("""void M(int p) { $$ref int$$ i = ref p; }""", "int")]              // RefTypeSyntax
+        public void GetIdentifier_Members(string member, string expected)
         {
             var node = NodeBetweenMarkers($$"""
                 using System;
+                using System.Collections.Generic;
                 using System.Diagnostics;
-                class Test
+                unsafe class Test
                 {
+                    static Func<int> Fun() => default;
                     {{member}}
                 }
+                """, LanguageNames.CSharp);
+            var actual = ExtensionsCS.GetIdentifier(node);
+            if (expected is null)
+            {
+                actual.Should().BeNull();
+            }
+            else
+            {
+                actual.Should().NotBeNull();
+                actual.Value.ValueText.Should().Be(expected);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow("""$$namespace A.B.C { }$$""", "C")]           // NamespaceDeclarationSyntax
+        [DataRow("""$$namespace A.B.C;$$""", "C")]              // FileScopedNamespaceDeclarationSyntax
+        [DataRow("""$$using A = System.Collections;$$""", "A")] // UsingDirectiveSyntax
+        [DataRow("""$$using System.Collections;$$""", null)]    // UsingDirectiveSyntax
+        public void GetIdentifier_CompilationUnit(string member, string expected)
+        {
+            var node = NodeBetweenMarkers($$"""
+                {{member}}
                 """, LanguageNames.CSharp);
             var actual = ExtensionsCS.GetIdentifier(node);
             if (expected is null)

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Extensions/SyntaxNodeExtensionsTest.cs
@@ -835,6 +835,57 @@ public class X
             actual.Should().BeNull();
         }
 
+        [DataTestMethod]
+        [DataRow("""$$global::System$$.Int32 i;""", "global")]              // AliasQualifiedNameSyntax
+        [DataRow("""int i = Math.Abs($$1$$);""", null)]                     // ArgumentSyntax
+        [DataRow("""int i = Math.Abs($$value: 1$$);""", "value")]           // ArgumentSyntax
+        [DataRow("""$$int[]$$ i;""", "int")]                                // ArrayTypeSyntax
+        [DataRow("""$$int[][]$$ i;""", "int")]                              // ArrayTypeSyntax
+        [DataRow("""[DebuggerDisplay($$""$$)]int i;""", null)]              // AttributeArgumentSyntax
+        [DataRow("""[DebuggerDisplay($$value: ""$$)]int i;""", "value")]    // AttributeArgumentSyntax
+        [DataRow("""[DebuggerDisplay("", $$Name = ""$$)]int i;""", "Name")] // AttributeArgumentSyntax
+        [DataRow("""[$$DebuggerDisplay("")$$]int i;""", "DebuggerDisplay")] // AttributeSyntax
+        [DataRow("""class $$T$$ { }""", "T")]                               // BaseTypeDeclarationSyntax
+        [DataRow("""struct $$T$$ { }""", "T")]                              // BaseTypeDeclarationSyntax
+        [DataRow("""interface $$T$$ { }""", "T")]                           // BaseTypeDeclarationSyntax
+        [DataRow("""record $$T$$ { }""", "T")]                              // BaseTypeDeclarationSyntax
+        [DataRow("""record class $$T$$ { }""", "T")]                        // BaseTypeDeclarationSyntax
+        [DataRow("""record struct $$T$$ { }""", "T")]                       // BaseTypeDeclarationSyntax
+        [DataRow("""enum $$T$$ { }""", "T")]                                // BaseTypeDeclarationSyntax
+        [DataRow("""$$Test() { }$$""", "Test")]                             // ConstructorDeclarationSyntax
+        [DataRow("""$$public static implicit operator int(Test t) => 1;$$""", "int")] // ConversionOperatorDeclarationSyntax
+        [DataRow("""$$delegate void D();$$""", "D")] // DelegateDeclarationSyntax
+        [DataRow("""$$~Test() { }$$""", "Test")] // DestructorDeclarationSyntax
+        [DataRow("""enum E { $$M$$ }""", "M")] // EnumMemberDeclarationSyntax
+        [DataRow("""enum E { $$M = 1$$, }""", "M")] // EnumMemberDeclarationSyntax
+        [DataRow("""$$event Action E {add { } remove { } }$$""", "E")] // EventDeclarationSyntax
+        [DataRow("""$$event Action E;$$""", null)] // EventFieldDeclarationSyntax
+        [DataRow("""$$event Action E1, E2;$$""", null)] // EventFieldDeclarationSyntax
+        [DataRow("""$$Int32$$ i;""", "Int32")] // IdentifierNameSyntax
+        [DataRow("""$$int this[int i] { get => 1; set { } }""", "this")] // IndexerDeclarationSyntax
+
+        public void GetIdentifier(string member, string expected)
+        {
+            var node = NodeBetweenMarkers($$"""
+                using System;
+                using System.Diagnostics;
+                class Test
+                {
+                    {{member}}
+                }
+                """, LanguageNames.CSharp);
+            var actual = ExtensionsCS.GetIdentifier(node);
+            if (expected is null)
+            {
+                actual.Should().BeNull();
+            }
+            else
+            {
+                actual.Should().NotBeNull();
+                actual.Value.ValueText.Should().Be(expected);
+            }
+        }
+
         private static SyntaxNode NodeBetweenMarkers(string code, string language)
         {
             var position = code.IndexOf("$$");

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/DummyAnalyzerWithLocation.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestFramework/Tests/DummyAnalyzerWithLocation.cs
@@ -18,10 +18,12 @@
 * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
+extern alias csharp;
+
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SonarAnalyzer.AnalysisContext;
-using SonarAnalyzer.Extensions;
+using ExtensionsCS = csharp::SonarAnalyzer.Extensions.SyntaxNodeExtensions;
 
 namespace SonarAnalyzer.UnitTest.TestFramework.Tests;
 
@@ -43,7 +45,7 @@ internal class DummyAnalyzerWithLocation : SonarDiagnosticAnalyzer
     private void ReportIssue(SonarSyntaxNodeReportingContext context)
     {
         if (context.Node is InvocationExpressionSyntax invocation
-            && invocation.NodeIdentifier() is { ValueText: "RaiseHere" } identifier)
+            && ExtensionsCS.GetIdentifier(invocation) is { ValueText: "RaiseHere" } identifier)
         {
             context.ReportIssue(Diagnostic.Create(rule, identifier.GetLocation(), invocation.ArgumentList.Arguments.Select(arg => arg.GetLocation())));
         }


### PR DESCRIPTION
Fixes #8241