### PR TITLE
IsRedundantPrimaryConstructorBaseTypeContext: Add tests

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarSyntaxNodeReportingContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarSyntaxNodeReportingContextTest.cs
@@ -85,49 +85,62 @@ public class SonarSyntaxNodeReportingContextTest
     }
 #endif
 
-    [TestMethod]
-    public void IsRedundantPrimaryConstructorBaseTypeContext_ReturnsTrueForTypeDeclaration()
+    [DataTestMethod]
+    [DataRow("class")]
+
+#if NET
+
+    [DataRow("record")]
+
+#endif
+
+    public void IsRedundantPrimaryConstructorBaseTypeContext_ReturnsTrueForTypeDeclaration(string type)
     {
         var compilerVersion = typeof(DiagnosticAnalyzer).Assembly.GetName().Version;
+        // Depending on the version of the compiler, the node action is called either twice with different ContainingSymbol or just once
         var assertion = compilerVersion < new Version(5, 0) // Fix the compiler version once https://github.com/dotnet/roslyn/pull/70655 is released
             ? """
-              //                            ^^^^^^^    {{IsRedundantPrimaryConstructorBaseTypeContext is True, ContainingSymbol is NamedType Derived}}
-              //                            ^^^^^^^@-1 {{IsRedundantPrimaryConstructorBaseTypeContext is False, ContainingSymbol is Method Derived.Derived(int)}}
+              //  ^^^^^^^    {{IsRedundantPrimaryConstructorBaseTypeContext is True, ContainingSymbol is NamedType Derived}}
+              //  ^^^^^^^@-1 {{IsRedundantPrimaryConstructorBaseTypeContext is False, ContainingSymbol is Method Derived.Derived(int)}}
               """
             : """
-              //                            ^^^^^^^    {{IsRedundantPrimaryConstructorBaseTypeContext is False, ContainingSymbol is Method Derived.Derived(int)}}
+              //  ^^^^^^^    {{IsRedundantPrimaryConstructorBaseTypeContext is False, ContainingSymbol is Method Derived.Derived(int)}}
               """;
         var snippet = $$"""
-            public class Base(int i);
-            public class Derived(int i) : Base(i);
+            public {{type}} Base(int i);
+            public {{type}} Derived(int i) :
+                Base(i); // This is the node that is asserted
             {{assertion}}
             """;
         new VerifierBuilder()
-            .AddAnalyzer(() => new TestAnalyzer(new[] { SyntaxKindEx.PrimaryConstructorBaseType }))
+            .AddAnalyzer(() => new TestAnalyzer(new[] { SyntaxKindEx.PrimaryConstructorBaseType }, c =>
+                $"IsRedundantPrimaryConstructorBaseTypeContext is {c.IsRedundantPrimaryConstructorBaseTypeContext()}, ContainingSymbol is {c.ContainingSymbol.Kind} {c.ContainingSymbol.ToDisplayString()}"))
             .WithOptions(ParseOptionsHelper.FromCSharp12)
             .AddSnippet(snippet)
             .Verify();
     }
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
+#pragma warning disable RS1036 // Specify analyzer banned API enforcement setting
     private sealed class TestAnalyzer : SonarDiagnosticAnalyzer
+#pragma warning restore RS1036 // Specify analyzer banned API enforcement setting
     {
         private readonly SyntaxKind[] syntaxKinds;
+        private readonly Func<SonarSyntaxNodeReportingContext, string> message;
+
         public DiagnosticDescriptor Rule { get; } = DiagnosticDescriptorFactory.Create(AnalyzerLanguage.CSharp,
             new RuleDescriptor("Test", "Test", "BUG", "BLOCKER", "READY", SourceScope.All, true, "Test"), "{0}", true, false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        public TestAnalyzer(SyntaxKind[] syntaxKinds)
+        public TestAnalyzer(SyntaxKind[] syntaxKinds, Func<SonarSyntaxNodeReportingContext, string> message)
         {
             this.syntaxKinds = syntaxKinds;
+            this.message = message;
         }
 
         protected override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(CSharpGeneratedCodeRecognizer.Instance, c =>
-            {
-                var message = $"IsRedundantPrimaryConstructorBaseTypeContext is {c.IsRedundantPrimaryConstructorBaseTypeContext()}, ContainingSymbol is {c.ContainingSymbol.Kind} {c.ContainingSymbol.ToDisplayString()}";
-                c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation(), message));
-            }, syntaxKinds);
+                c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation(), message(c))), syntaxKinds);
     }
 }


### PR DESCRIPTION
`IsRedundantPrimaryConstructorBaseTypeContext` wasn't under test properly. Now that https://github.com/dotnet/roslyn/pull/70655 has fixed the double invocation, we need to make sure that `IsRedundantPrimaryConstructorBaseTypeContext` returns `true` on the invocation that will be suppressed in the future. The test will fail once https://github.com/dotnet/roslyn/pull/70655 is released, and therefore, a compiler version check was already included and only needs to be updated once we know the correct version number.