### PR TITLE
Annotate S4212 as obsolete

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
@@ -20,6 +20,7 @@
 
 namespace SonarAnalyzer.Rules.CSharp
 {
+    [Obsolete("This rule has been deprecated since 9.14")]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class SerializationConstructorsShouldBeSecured : SonarDiagnosticAnalyzer
     {


### PR DESCRIPTION
Fixes #8228
Added also in the list of obsolete rules: https://docs.google.com/spreadsheets/d/1-30aNgv2Ust0RjiCi-gtAmyRDPrB9IhwA2Mor5LBYlE/edit#gid=0


In previously deleted rules none (from the ones I deleted), except one, was annotated as obsolete ([example](https://github.com/SonarSource/sonar-dotnet/pull/8049/files) ) but I think it's good to do so.