### PR TITLE
JSON Lexical Analyzer: Fix locale on decimal parsing

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Json/Parsing/LexicalAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Json/Parsing/LexicalAnalyzer.cs
@@ -306,7 +306,7 @@ namespace SonarAnalyzer.Json.Parsing
             {
                 var baseValue = @decimal == null
                     ? (object)double.Parse(integral.ToString(), CultureInfo.InvariantCulture)
-                    : decimal.Parse(integral + CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator + @decimal, CultureInfo.InvariantCulture);
+                    : decimal.Parse(integral + CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator + @decimal, CultureInfo.InvariantCulture);
 
                 if (exponent == null)   // Integer or Decimal
                 {


### PR DESCRIPTION
Fixes issue introduced [here](https://github.com/SonarSource/sonar-dotnet/pull/8312#discussion_r1388294151).
To reproduce the issue you need to switch to a Windows locale that uses a decimal separator different than `.`: for example french.  