### PR TITLE
Fix S2743 FP: Arrow properties do not have static fields

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInGenericClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInGenericClass.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         CheckMember(c, variable, variable.Identifier.GetLocation(), typeParameterNames);
                     }
-                    foreach (var property in typeDeclaration.Members.OfType<PropertyDeclarationSyntax>().Where(x => x.Modifiers.Any(SyntaxKind.StaticKeyword)))
+                    foreach (var property in typeDeclaration.Members.OfType<PropertyDeclarationSyntax>().Where(x => x.Modifiers.Any(SyntaxKind.StaticKeyword) && x.ExpressionBody is null))
                     {
                         CheckMember(c, property, property.Identifier.GetLocation(), typeParameterNames);
                     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/StaticFieldInGenericClass.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/StaticFieldInGenericClass.cs
@@ -21,6 +21,8 @@ namespace Tests.TestCases
 //                           ^^^^^^
         public /*comment */ static string sProp2 { get; set; } // Noncompliant {{A static field in a generic type is not shared among instances of different close constructed types.}}
 
+        public static int ArrowProperty => 42; // Noncompliant FP, doesn't have a static backing field
+
         public string sProp3 { get; set; }
 
         public static T tProp { get; set; }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/StaticFieldInGenericClass.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/StaticFieldInGenericClass.cs
@@ -21,7 +21,7 @@ namespace Tests.TestCases
 //                           ^^^^^^
         public /*comment */ static string sProp2 { get; set; } // Noncompliant {{A static field in a generic type is not shared among instances of different close constructed types.}}
 
-        public static int ArrowProperty => 42; // Noncompliant FP, doesn't have a static backing field
+        public static int ArrowProperty => 42; // Compliant, doesn't have a static backing field
 
         public string sProp3 { get; set; }
 
@@ -41,9 +41,9 @@ namespace Tests.TestCases
 
         public static List<int> Numbers { get; } = new List<int>(); // Noncompliant
 
-        public static string State => nameof(State); // Noncompliant - FP
+        public static string State => nameof(State); // Compliant
 
-        public static object New => new object(); // Noncompliant - FP, always a new instance
+        public static object New => new object(); // Compliant always a new instance
 
         public static object Y { get { return new object(); } } // Noncompliant - FP, always a new instance
 


### PR DESCRIPTION
Fixes #8358
