### PR TITLE
Remove unneeded CSharpSyntaxNode casts

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.RoslynCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.RoslynCfg.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             }
 
-            public void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, CSharpSyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol)
+            public void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, SyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol)
             {
                 if (body.CreateCfg(c.SemanticModel, c.Cancel) is { } cfg)
                 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.SonarCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.SonarCfg.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
             }
 
-            public void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, CSharpSyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol)
+            public void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, SyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol)
             {
                 if (CSharpControlFlowGraph.TryGet(body, c.SemanticModel, out var cfg))
                 {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             if (c.SemanticModel.GetDeclaredSymbol(c.Node) is IMethodSymbol symbol)
             {
-                checker.CheckForNoExitMethod(c, (CSharpSyntaxNode)c.Node, identifier, symbol);
+                checker.CheckForNoExitMethod(c, c.Node, identifier, symbol);
             }
         }
 
@@ -124,7 +124,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private interface IChecker
         {
             void CheckForNoExitProperty(SonarSyntaxNodeReportingContext c, PropertyDeclarationSyntax property, IPropertySymbol propertySymbol);
-            void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, CSharpSyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol);
+            void CheckForNoExitMethod(SonarSyntaxNodeReportingContext c, SyntaxNode body, SyntaxToken identifier, IMethodSymbol symbol);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -110,7 +110,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
                                        .Cast<ISymbolicExecutionAnalyzer>() // ISymbolicExecutionAnalyzer should be passed as TSonarFallback to CreateFactory. Have you passed a Roslyn rule instead?
                                        .Where(x => x.SupportedDiagnostics.Any(descriptor => IsEnabled(context, descriptor)))
                                        .ToList();
-        if (enabledAnalyzers.Any() && CSharpControlFlowGraph.TryGet((CSharpSyntaxNode)context.Node, context.SemanticModel, out var cfg))
+        if (enabledAnalyzers.Any() && CSharpControlFlowGraph.TryGet(context.Node, context.SemanticModel, out var cfg))
         {
             var lva = new SonarCSharpLiveVariableAnalysis(cfg, symbol, context.SemanticModel, context.Cancel);
             try


### PR DESCRIPTION
Legacy Sonar CFG creating used to depend on `CSharpSyntaxNode`. This was removed quite some time ago, while working on Roslyn-based CFG and SE.

This PR removes the last leftovers from that process.