### PR TITLE
NullPointerDereference.SyntaxKindWalker reduce allocations and evaluations in the hot path

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+
 namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.CSharp;
 
 public class NullPointerDereference : NullPointerDereferenceBase
@@ -38,20 +39,37 @@ public class NullPointerDereference : NullPointerDereferenceBase
         return walker.Result;
     }
 
-    private sealed class SyntaxKindWalker : SafeCSharpSyntaxWalker
+    internal sealed class SyntaxKindWalker : SafeCSharpSyntaxWalker
     {
         public bool Result { get; private set; }
 
         public override void Visit(SyntaxNode node)
         {
+            Result |= node.Kind() is SyntaxKindEx.ForEachVariableStatement;
             if (!Result)
             {
-                Result = node.IsAnyKind(
-                    SyntaxKind.AwaitExpression,
-                    SyntaxKind.ElementAccessExpression,
-                    SyntaxKind.ForEachStatement,
-                    SyntaxKind.SimpleMemberAccessExpression);
                 base.Visit(node);
+            }
+        }
+
+        public override void VisitAwaitExpression(AwaitExpressionSyntax node) =>
+            Result = true;
+
+        public override void VisitElementAccessExpression(ElementAccessExpressionSyntax node) =>
+            Result = true;
+
+        public override void VisitForEachStatement(ForEachStatementSyntax node) =>
+            Result = true;
+
+        public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+        {
+            if (node.Kind() is SyntaxKind.SimpleMemberAccessExpression)
+            {
+                Result = true;
+            }
+            else
+            {
+                base.VisitMemberAccessExpression(node);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-
 namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.CSharp;
 
 public class NullPointerDereference : NullPointerDereferenceBase

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-
 namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.VisualBasic;
 
 public class NullPointerDereference : NullPointerDereferenceBase

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+
 namespace SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.VisualBasic;
 
 public class NullPointerDereference : NullPointerDereferenceBase
@@ -35,21 +36,20 @@ public class NullPointerDereference : NullPointerDereferenceBase
         return walker.Result;
     }
 
-    private sealed class SyntaxKindWalker : SafeVisualBasicSyntaxWalker
+    internal sealed class SyntaxKindWalker : SafeVisualBasicSyntaxWalker
     {
         public bool Result { get; private set; }
 
-        public override void Visit(SyntaxNode node)
-        {
-            if (!Result)
-            {
-                Result = node.IsAnyKind(
-                    SyntaxKind.AwaitExpression,
-                    SyntaxKind.ForEachStatement,
-                    SyntaxKind.InvocationExpression,    // For array access arr(42)
-                    SyntaxKind.SimpleMemberAccessExpression);
-                base.Visit(node);
-            }
-        }
+        public override void VisitAwaitExpression(AwaitExpressionSyntax node) =>
+            Result = true;
+
+        public override void VisitForEachBlock(ForEachBlockSyntax node) =>
+            Result = true;
+
+        public override void VisitInvocationExpression(InvocationExpressionSyntax node) =>
+            Result = true; // For array access arr(42)
+
+        public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node) =>
+            Result = true; // SimpleMemberAccess and DictionaryAccess
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/NullPointerDereferenceSyntaxKindWalkerTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/NullPointerDereferenceSyntaxKindWalkerTests.cs
@@ -33,13 +33,9 @@ public class NullPointerDereferenceSyntaxKindWalkerTests
     [DataRow("""this.ToString();""")]
     [DataRow("""_ = Int32.MaxValue;""")]
     [DataRow("""_ = (new int[0])[0];""")]
-
 #if NET
-
     [DataRow("""foreach(var (i, j) in new(int, int)[0]) { }""")]
-
 #endif
-
     public void SyntaxKindChecks_CS_True(string statement)
     {
         var root = TestHelper.CompileCS(WrapInMethod_CS(statement)).Tree.GetRoot();
@@ -51,8 +47,7 @@ public class NullPointerDereferenceSyntaxKindWalkerTests
     [TestMethod]
     public void SyntaxKindChecks_CS_PointerMemberAccess()
     {
-        var root = TestHelper.CompileCS(
-            """
+        var root = TestHelper.CompileCS("""
             public class Test
             {
                 public unsafe void M(int i)
@@ -81,7 +76,7 @@ public class NullPointerDereferenceSyntaxKindWalkerTests
     [DataTestMethod]
     [DataRow("""Await Task.Yield()""")]
     [DataRow("""Dim t As Task : Await t""")]
-    [DataRow("""For Each i In New Integer(-1) { } : Next""")]
+    [DataRow("""For Each i In New Integer() { } : Next""")]
     [DataRow("""ToString()""")]
     [DataRow("""call ToString""")]
     [DataRow("""Dim arr(0) As Integer : Dim i = arr(0)""")]
@@ -97,6 +92,7 @@ public class NullPointerDereferenceSyntaxKindWalkerTests
 
     [DataTestMethod]
     [DataRow("""Dim i As System.Int32""")]
+    [DataRow("""Dim i = 1 + 1""")]
     public void SyntaxKindChecks_VB_False(string statement)
     {
         var root = TestHelper.CompileVB(WrapInMethod_VB(statement)).Tree.GetRoot();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/NullPointerDereferenceSyntaxKindWalkerTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/NullPointerDereferenceSyntaxKindWalkerTests.cs
@@ -58,7 +58,7 @@ public class NullPointerDereferenceSyntaxKindWalkerTests
                 public unsafe void M(int i)
                 {
                     int* iPtr = &i;
-                    iPtr -> ToString();
+                    iPtr->ToString();
                 }
             }
             """).Tree.GetRoot();

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/NullPointerDereferenceSyntaxKindWalkerTests.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/SymbolicExecution/NullPointerDereferenceSyntaxKindWalkerTests.cs
@@ -1,0 +1,130 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using CS = SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.CSharp;
+using VB = SonarAnalyzer.SymbolicExecution.Roslyn.RuleChecks.VisualBasic;
+
+namespace SonarAnalyzer.UnitTest.Rules.SymbolicExecution;
+
+[TestClass]
+public class NullPointerDereferenceSyntaxKindWalkerTests
+{
+    [DataTestMethod]
+    [DataRow("""await Task.Yield();""")]
+    [DataRow("""await (Task)null;""")]
+    [DataRow("""foreach(var i in new int[0]) { }""")]
+    [DataRow("""this.ToString();""")]
+    [DataRow("""_ = Int32.MaxValue;""")]
+    [DataRow("""_ = (new int[0])[0];""")]
+
+#if NET
+
+    [DataRow("""foreach(var (i, j) in new(int, int)[0]) { }""")]
+
+#endif
+
+    public void SyntaxKindChecks_CS_True(string statement)
+    {
+        var root = TestHelper.CompileCS(WrapInMethod_CS(statement)).Tree.GetRoot();
+        var sut = new CS.NullPointerDereference.SyntaxKindWalker();
+        sut.SafeVisit(root);
+        sut.Result.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void SyntaxKindChecks_CS_PointerMemberAccess()
+    {
+        var root = TestHelper.CompileCS(
+            """
+            public class Test
+            {
+                public unsafe void M(int i)
+                {
+                    int* iPtr = &i;
+                    iPtr -> ToString();
+                }
+            }
+            """).Tree.GetRoot();
+        var sut = new CS.NullPointerDereference.SyntaxKindWalker();
+        sut.SafeVisit(root);
+        sut.Result.Should().BeFalse();
+    }
+
+    [DataTestMethod]
+    [DataRow("""ToString();""")]
+    [DataRow("""(ToString()?.Length)?.ToString();""")]
+    public void SyntaxKindChecks_CS_False(string statement)
+    {
+        var root = TestHelper.CompileCS(WrapInMethod_CS(statement)).Tree.GetRoot();
+        var sut = new CS.NullPointerDereference.SyntaxKindWalker();
+        sut.SafeVisit(root);
+        sut.Result.Should().BeFalse();
+    }
+
+    [DataTestMethod]
+    [DataRow("""Await Task.Yield()""")]
+    [DataRow("""Dim t As Task : Await t""")]
+    [DataRow("""For Each i In New Integer(-1) { } : Next""")]
+    [DataRow("""ToString()""")]
+    [DataRow("""call ToString""")]
+    [DataRow("""Dim arr(0) As Integer : Dim i = arr(0)""")]
+    [DataRow("""Dim i = Int32.MaxValue""")]
+    [DataRow("""Dim dict = New Dictionary(Of String, Integer) : Dim i = dict!Test""")]
+    public void SyntaxKindChecks_VB_True(string statement)
+    {
+        var root = TestHelper.CompileVB(WrapInMethod_VB(statement)).Tree.GetRoot();
+        var sut = new VB.NullPointerDereference.SyntaxKindWalker();
+        sut.SafeVisit(root);
+        sut.Result.Should().BeTrue();
+    }
+
+    [DataTestMethod]
+    [DataRow("""Dim i As System.Int32""")]
+    public void SyntaxKindChecks_VB_False(string statement)
+    {
+        var root = TestHelper.CompileVB(WrapInMethod_VB(statement)).Tree.GetRoot();
+        var sut = new VB.NullPointerDereference.SyntaxKindWalker();
+        sut.SafeVisit(root);
+        sut.Result.Should().BeFalse();
+    }
+
+    private static string WrapInMethod_VB(string statements) =>
+        $$"""
+        Imports System.Threading.Tasks
+        Public Class Test
+            Public Async Function M() As Task
+                {{statements}}
+            End Function
+        End Class
+        """;
+
+    private static string WrapInMethod_CS(string statements) =>
+        $$"""
+        using System;
+        using System.Threading.Tasks;
+        public class Test
+        {
+            public async Task M()
+            {
+                {{statements}}
+            }
+        }
+        """;
+}


### PR DESCRIPTION
See also #8103

This PR fixes the params array allocation caused by IsAnyKind and reactors the SyntaxWalker to do the SyntaxKind checks in the dedicated Visit... methods. That way the number of comparisons is reduced.