### PR TITLE
TokenTypeAnalyzer: Use heuristic for lowercase identifier

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -207,7 +207,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     { Expression: not SimpleNameSyntax and not MemberAccessExpressionSyntax and not AliasQualifiedNameSyntax } => true,
                     { Expression: MemberAccessExpressionSyntax left } => AnyMemberAccessLeftIsNotAType(left),
                     // Heuristic: any MemberAccess that starts with a lowercase on the most left hand side, is assumed to start
-                    // as an expression (e.g. i.Length). Rational: It is (almost) granted that Types (including enums) start
+                    // as an expression (e.g. s.Length). Rational: It is (almost) granted that Types (including enums) start
                     // with an uppercase in C#. Any identifier, that starts with a lower case is assumed to refer a local, a parameter,
                     // or a field.
                     { Expression: SimpleNameSyntax { Identifier.ValueText: { Length: >= 1 } mostLeftIdentifier } } => char.IsLower(mostLeftIdentifier[0]),

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Utilities/TokenTypeAnalyzer.cs
@@ -195,17 +195,22 @@ namespace SonarAnalyzer.Rules.CSharp
                     // 'name' can not be a nested type, if there is an expression to the left of the member access,
                     // that can not bind to a type. The only things that can bind to a type are SimpleNames (Identifier or GenericName)
                     // or pre-defined types. None of the pre-defined types have a nested type, so we can exclude these as well.
-                    { Parent: MemberAccessExpressionSyntax x } when AnyMemberAccessLeftIsNotASimpleName(x) => TokenType.UnknownTokentype,
+                    { Parent: MemberAccessExpressionSyntax x } when AnyMemberAccessLeftIsNotAType(x) => TokenType.UnknownTokentype,
                     // The left side of a pointer member access must be a pointer and can not be a type
                     { Parent: MemberAccessExpressionSyntax { RawKind: (int)SyntaxKind.PointerMemberAccessExpression } } => TokenType.UnknownTokentype,
                     _ => ClassifyIdentifierByModel(name),
                 };
 
-            private static bool AnyMemberAccessLeftIsNotASimpleName(MemberAccessExpressionSyntax memberAccess) =>
+            private static bool AnyMemberAccessLeftIsNotAType(MemberAccessExpressionSyntax memberAccess) =>
                 memberAccess switch
                 {
                     { Expression: not SimpleNameSyntax and not MemberAccessExpressionSyntax and not AliasQualifiedNameSyntax } => true,
-                    { Expression: MemberAccessExpressionSyntax left } => AnyMemberAccessLeftIsNotASimpleName(left),
+                    { Expression: MemberAccessExpressionSyntax left } => AnyMemberAccessLeftIsNotAType(left),
+                    // Heuristic: any MemberAccess that starts with a lowercase on the most left hand side, is assumed to start
+                    // as an expression (e.g. i.Length). Rational: It is (almost) granted that Types (including enums) start
+                    // with an uppercase in C#. Any identifier, that starts with a lower case is assumed to refer a local, a parameter,
+                    // or a field.
+                    { Expression: SimpleNameSyntax { Identifier.ValueText: { Length: >= 1 } mostLeftIdentifier } } => char.IsLower(mostLeftIdentifier[0]),
                     _ => false,
                 };
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/TokenTypeAnalyzerTest.Classifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/TokenTypeAnalyzerTest.Classifier.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace SonarAnalyzer.UnitTest.Rules;
 
 public partial class TokenTypeAnalyzerTest
@@ -980,7 +982,8 @@ public partial class TokenTypeAnalyzerTest
     [DataTestMethod]
     [DataRow("_ = [u:i];")]
     [DataRow("[u:i] = [u:i] + [u:i];")]
-    [DataRow("_ = i.[u:ToString]().[u:ToString]();")] // "i" must be queried. It could be a type.
+    [DataRow("_ = [u:i].[u:ToString]().[u:ToString]();")]          // Heuristic: "i" is lower case and identified as "not a type".
+    [DataRow("_ = [u:ex].[u:InnerException].[u:InnerException];")] // Heuristic: "ex" is lower case and identified as "not a type".
     [DataRow("_ = [u:ex]?.[u:ToString]();")]
     [DataRow("_ = ([u:ex] ?? new Exception()).[u:ToString]();")]
     [DataRow("[u:ex] ??= new Exception();")]
@@ -1120,6 +1123,25 @@ public partial class TokenTypeAnalyzerTest
             }
             """, allowSemanticModel);
 
+    [DataTestMethod]
+    [WorkItem(8388)] // https://github.com/SonarSource/sonar-dotnet/pull/8388
+    [DataRow("""_ = [u:iPhone].Latest;""")]              // [u:iPhone] -> False classification because of heuristic. Should be t:
+    [DataRow("""_ = [u:iPhone].[u:Latest];""")]          // [u:iPhone] -> False classification because of heuristic. Should be t:
+    [DataRow("""[u:iPhone].[u:iPhone15Pro].[u:M]();""")] // [u:iPhone] -> False classification because of heuristic. Should be t:
+    [DataRow("""[u:iPhone15Pro].[u:M]();""")]            // Correct
+    public void IdentifierToken_MemberAccess_FalseClassification(string statement) =>
+        ClassifierTestHarness.AssertTokenTypes($$"""
+            public class iPhone
+            {
+                public static iPhone iPhone15Pro;
+                public static iPhone Latest;
+
+                public void M()
+                {
+                    {{statement}}
+                }
+            }
+            """, allowSemanticModel: false);
 #if NET
 
     [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/TokenTypeAnalyzerTest.Classifier.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/TokenTypeAnalyzerTest.Classifier.cs
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 namespace SonarAnalyzer.UnitTest.Rules;
 
 public partial class TokenTypeAnalyzerTest


### PR DESCRIPTION
SemanticModel queries caused by `ClassifyMemberAccess` are the main contributor to the TokenTypeAnalyzer performance by far:

![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/fbed4ef9-d9c7-4895-b034-3cd58c9ef55d)

We can not fully guarantee the correctness of the classification without querying the semantic model:
```cs
_ = A.B.C;
```
Here we already know that `C` can not be a type, but for `A` and `B` it is not decidable. The following definitions of `A` and `B` could be valid:
```cs
// All Properties:
class A { B B { get; } } // the above would be interpreted like this.A.B.C;
class A { static B B { get; } } // B is a static member and `A` refers to a type
class A { class B { static C C { get; } } // B is a nested class in A and C is a static property of B
```
We can use one heuristic to minimize the number of queries: Such accesses often start with locals, or parameters, which are lowercase. So if the most left-hand side is lowercase, we can assume it binds to a parameter or local or field. In such a case, we know that everything right of it must also be some kind of expression and can not be a type.

Note: The opposite is not applicable: If the most left-hand side starts with an uppercase, it not necessarily is bound to a type. It can also bind to a property.

### Performance results with the analyzer runner

CsvHelper:
Before: 4 sec
After: 3,5 sec
Ratio: 87,5%

Akka.Net
Before | 28,424 | 29,356 | 29,166
After | 28,916 | 24,744 | 24,175

Ratio: 25,945 / 28,982 = 89,5%

~12% performance improvement.

### Scanner run for Fluent Assertions

`CreateMessage` of the TokenType analyzer went down from 11th place to 34th place:

![image](https://github.com/SonarSource/sonar-dotnet/assets/103252490/600d626f-1304-4dbe-9514-d1cfd8096d12)

Build times:
Master
01:24.38 | 01:23.56 | 03:08.98
PR
02:54.63 | 1:34.655 | 01:25.34
