### PR TITLE
FileMetadataAnalyzer: Use tree.IsGenerated extension method

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/FileMetadataAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/FileMetadataAnalyzerBase.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules
             new()
             {
                 FilePath = tree.FilePath,
-                IsGenerated = Language.GeneratedCodeRecognizer.IsGenerated(tree),
+                IsGenerated = tree.IsGenerated(Language.GeneratedCodeRecognizer, model.Compilation),
                 Encoding = tree.Encoding?.WebName.ToLowerInvariant() ?? string.Empty
             };
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/FileMetadataAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/Utilities/FileMetadataAnalyzerTest.cs
@@ -98,9 +98,10 @@ namespace SonarAnalyzer.UnitTest.Rules
             var tree = new Mock<SyntaxTree>();
             tree.SetupGet(x => x.FilePath).Returns("File.Generated.cs");    // Generated to simplify mocking for GeneratedCodeRecognizer
             tree.SetupGet(x => x.Encoding).Returns(() => null);
+            var model = TestHelper.CompileCS(string.Empty).Model;
             var sut = new TestFileMetadataAnalyzer(null, isTestProject);
 
-            sut.TestCreateMessage(UtilityAnalyzerParameters.Default, tree.Object, null).Encoding.Should().BeEmpty();
+            sut.TestCreateMessage(UtilityAnalyzerParameters.Default, tree.Object, model).Encoding.Should().BeEmpty();
         }
 
         [DataTestMethod]


### PR DESCRIPTION
Fixes #7858
Fairly simple change to use the cached value for `IsGenerated`. This seemed to be the only remaining code that didn't use the extension method.

According to the issue, `UtilityAnalyzerBase` was also affected but it seemed it was fixed in the meantime already.