### PR TITLE
Remove HasMatchingScope from Execute for SyntaxNode

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
@@ -125,15 +125,15 @@ namespace SonarAnalyzer.Rules.CSharp
                     return;
                 }
 
-                context.RegisterNodeAction(
+                c.RegisterNodeAction(
                     VisitStringExpressions,
                     SyntaxKind.StringLiteralExpression,
                     SyntaxKind.InterpolatedStringExpression,
                     SyntaxKindEx.Utf8StringLiteralExpression);
 
-                context.RegisterNodeAction(VisitObjectCreation, SyntaxKind.ObjectCreationExpression, SyntaxKindEx.ImplicitObjectCreationExpression);
-                context.RegisterNodeAction(VisitInvocationExpression, SyntaxKind.InvocationExpression);
-                context.RegisterNodeAction(VisitAssignments, SyntaxKind.SimpleAssignmentExpression);
+                c.RegisterNodeAction(VisitObjectCreation, SyntaxKind.ObjectCreationExpression, SyntaxKindEx.ImplicitObjectCreationExpression);
+                c.RegisterNodeAction(VisitInvocationExpression, SyntaxKind.InvocationExpression);
+                c.RegisterNodeAction(VisitAssignments, SyntaxKind.SimpleAssignmentExpression);
             });
 
         private static void VisitObjectCreation(SonarSyntaxNodeReportingContext context)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    context.RegisterNodeAction(
+                    ccc.RegisterNodeAction(
                         CheckIgnoreAntiforgeryTokenAttribute,
                         SyntaxKind.Attribute,
                         SyntaxKind.ObjectCreationExpression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
@@ -37,14 +37,14 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override void Initialize(SonarAnalysisContext context) =>
              context.RegisterCompilationStartAction(
-                ccc =>
+                c =>
                 {
-                    if (!IsEnabled(ccc.Options))
+                    if (!IsEnabled(c.Options))
                     {
                         return;
                     }
 
-                    ccc.RegisterNodeAction(
+                    c.RegisterNodeAction(
                         CheckIgnoreAntiforgeryTokenAttribute,
                         SyntaxKind.Attribute,
                         SyntaxKind.ObjectCreationExpression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/PermissiveCors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/PermissiveCors.cs
@@ -41,11 +41,11 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             base.Initialize(context);
 
-            context.RegisterCompilationStartAction(compilationContext =>
+            context.RegisterCompilationStartAction(c =>
             {
-                if (IsEnabled(compilationContext.Options))
+                if (IsEnabled(c.Options))
                 {
-                    context.RegisterNodeAction(VisitAttribute, SyntaxKind.Attribute);
+                    c.RegisterNodeAction(VisitAttribute, SyntaxKind.Attribute);
                 }
             });
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/JSInvokableMethodsShouldBePublic.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/JSInvokableMethodsShouldBePublic.cs
@@ -35,7 +35,7 @@ public sealed class JSInvokableMethodsShouldBePublic : SonarDiagnosticAnalyzer
         {
             if (c.Compilation.GetTypeByMetadataName(KnownType.Microsoft_JSInterop_JSInvokable) is not null)
             {
-                context.RegisterNodeAction(CheckMethod, SyntaxKind.MethodDeclaration);
+                c.RegisterNodeAction(CheckMethod, SyntaxKind.MethodDeclaration);
             }
         });
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringCreate.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringCreate.cs
@@ -35,14 +35,14 @@ public sealed class UseStringCreate : SonarDiagnosticAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
     protected override void Initialize(SonarAnalysisContext context) =>
-        context.RegisterCompilationStartAction(start =>
+        context.RegisterCompilationStartAction(c =>
         {
-            if (!CompilationTargetsValidNetVersion(start.Compilation))
+            if (!CompilationTargetsValidNetVersion(c.Compilation))
             {
                 return;
             }
 
-            context.RegisterNodeAction(c =>
+            c.RegisterNodeAction(c =>
             {
                 var node = (InvocationExpressionSyntax)c.Node;
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContext.cs
@@ -107,7 +107,7 @@ public class SonarAnalysisContext
                 var context = new SonarCompilationStartAnalysisContext(this, c);
                 if (context.HasMatchingScope(supportedDiagnostics))
                 {
-                    ExecuteWithoutHasMatchingScope<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(new(this, c), action, null);
+                    ExecuteWithoutHasMatchingScope<SonarCompilationStartAnalysisContext, CompilationStartAnalysisContext>(context, action, null);
                 }
             });
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
@@ -39,5 +39,5 @@ public sealed class SonarCompilationStartAnalysisContext : SonarAnalysisContextB
 
     public void RegisterNodeAction<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeReportingContext> action, params TSyntaxKind[] syntaxKinds)
         where TSyntaxKind : struct =>
-        AnalysisContext.RegisterNodeAction(generatedCodeRecognizer, action, syntaxKinds);
+        AnalysisContext.RegisterNodeActionImpl(generatedCodeRecognizer, action, syntaxKinds);
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
@@ -39,5 +39,5 @@ public sealed class SonarCompilationStartAnalysisContext : SonarAnalysisContextB
 
     public void RegisterNodeAction<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeReportingContext> action, params TSyntaxKind[] syntaxKinds)
         where TSyntaxKind : struct =>
-        AnalysisContext.RegisterNodeActionImpl(generatedCodeRecognizer, action, syntaxKinds);
+        AnalysisContext.RegisterNodeActionScopeValid(generatedCodeRecognizer, action, syntaxKinds);
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
@@ -49,7 +49,7 @@ public sealed class SonarCompilationStartAnalysisContext : SonarAnalysisContextB
         }
     }
 
-    /// <param name="sourceTree">Tree that is definitely known to be analyzed. Pass 'null' if the context doesn't know a specific tree to be analyzed, like a CompilationContext.</param>
+    /// <inheritdoc cref="SonarAnalysisContext.Execute" />
     private void Execute<TSonarContext, TRoslynContext>(TSonarContext context, Action<TSonarContext> action, SyntaxTree sourceTree, GeneratedCodeRecognizer generatedCodeRecognizer = null)
         where TSonarContext : SonarAnalysisContextBase<TRoslynContext>
     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DateAndTimeShouldNotBeUsedasTypeForPrimaryKeyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DateAndTimeShouldNotBeUsedasTypeForPrimaryKeyBase.cs
@@ -42,15 +42,15 @@ public abstract class DateAndTimeShouldNotBeUsedasTypeForPrimaryKeyBase<TSyntaxK
     protected DateAndTimeShouldNotBeUsedasTypeForPrimaryKeyBase() : base(DiagnosticId) { }
 
     protected override void Initialize(SonarAnalysisContext context) =>
-        context.RegisterCompilationStartAction(c =>
+        context.RegisterCompilationStartAction(startContext =>
         {
-            if (ShouldRegisterAction(c.Compilation))
+            if (ShouldRegisterAction(startContext.Compilation))
             {
-                c.RegisterNodeAction(Language.GeneratedCodeRecognizer, cc =>
+                startContext.RegisterNodeAction(Language.GeneratedCodeRecognizer, nodeContext =>
                 {
-                    foreach (var propertyType in TypeNodesOfTemporalKeyProperties(cc))
+                    foreach (var propertyType in TypeNodesOfTemporalKeyProperties(nodeContext))
                     {
-                        cc.ReportIssue(Diagnostic.Create(Rule, propertyType.GetLocation(), Language.Syntax.NodeIdentifier(propertyType)));
+                        nodeContext.ReportIssue(Diagnostic.Create(Rule, propertyType.GetLocation(), Language.Syntax.NodeIdentifier(propertyType)));
                     }
                 }, Language.SyntaxKind.ClassDeclaration);
             }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DateAndTimeShouldNotBeUsedasTypeForPrimaryKeyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DateAndTimeShouldNotBeUsedasTypeForPrimaryKeyBase.cs
@@ -46,11 +46,11 @@ public abstract class DateAndTimeShouldNotBeUsedasTypeForPrimaryKeyBase<TSyntaxK
         {
             if (ShouldRegisterAction(c.Compilation))
             {
-                context.RegisterNodeAction(Language.GeneratedCodeRecognizer, context =>
+                c.RegisterNodeAction(Language.GeneratedCodeRecognizer, cc =>
                 {
-                    foreach (var propertyType in TypeNodesOfTemporalKeyProperties(context))
+                    foreach (var propertyType in TypeNodesOfTemporalKeyProperties(cc))
                     {
-                        context.ReportIssue(Diagnostic.Create(Rule, propertyType.GetLocation(), Language.Syntax.NodeIdentifier(propertyType)));
+                        cc.ReportIssue(Diagnostic.Create(Rule, propertyType.GetLocation(), Language.Syntax.NodeIdentifier(propertyType)));
                     }
                 }, Language.SyntaxKind.ClassDeclaration);
             }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallMethodsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallMethodsBase.cs
@@ -35,13 +35,13 @@ namespace SonarAnalyzer.Rules
         protected DoNotCallMethodsBase(string diagnosticId) : base(diagnosticId) { }
 
         protected override void Initialize(SonarAnalysisContext context) =>
-             context.RegisterCompilationStartAction(start =>
+             context.RegisterCompilationStartAction(c =>
              {
-                 if (!ShouldRegisterAction(start.Compilation))
+                 if (!ShouldRegisterAction(c.Compilation))
                  {
                      return;
                  }
-                 context.RegisterNodeAction(Language.GeneratedCodeRecognizer, AnalyzeInvocation, Language.SyntaxKind.InvocationExpression);
+                 c.RegisterNodeAction(Language.GeneratedCodeRecognizer, AnalyzeInvocation, Language.SyntaxKind.InvocationExpression);
              });
 
         private void AnalyzeInvocation(SonarSyntaxNodeReportingContext analysisContext)

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseUnixEpochBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseUnixEpochBase.cs
@@ -47,33 +47,33 @@ public abstract class UseUnixEpochBase<TSyntaxKind, TLiteralExpression, TMemberA
     protected abstract bool IsZeroTimeOffset(SyntaxNode node);
 
     protected sealed override void Initialize(SonarAnalysisContext context) =>
-        context.RegisterCompilationStartAction(start =>
+        context.RegisterCompilationStartAction(c =>
         {
-            if (!IsUnixEpochSupported(start.Compilation))
+            if (!IsUnixEpochSupported(c.Compilation))
             {
                 return;
             }
 
-            context.RegisterNodeAction(
+            c.RegisterNodeAction(
                 Language.GeneratedCodeRecognizer,
-                c =>
+                cc =>
                 {
-                    var arguments = Language.Syntax.ArgumentExpressions(c.Node);
+                    var arguments = Language.Syntax.ArgumentExpressions(cc.Node);
                     var literalsArguments = arguments.OfType<TLiteralExpression>();
 
                     if (literalsArguments.Any(x => IsValueEqualTo(x, EpochYear)
                         && literalsArguments.Count(x => IsValueEqualTo(x, EpochMonth)) == 2)
-                        && CheckAndGetTypeName(c.Node, c.SemanticModel) is { } name
-                        && IsEpochCtor(c.Node, c.SemanticModel))
+                        && CheckAndGetTypeName(cc.Node, cc.SemanticModel) is { } name
+                        && IsEpochCtor(cc.Node, cc.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation(), name));
+                        cc.ReportIssue(Diagnostic.Create(Rule, cc.Node.GetLocation(), name));
                     }
                     else if (arguments.Count() == 1
                         && ((literalsArguments.Count() == 1  && IsValueEqualTo(literalsArguments.First(), EpochTicks))
-                            || (Language.FindConstantValue(c.SemanticModel, arguments.First()) is long ticks && ticks == EpochTicks))
-                        && CheckAndGetTypeName(c.Node, c.SemanticModel) is { } typeName)
+                            || (Language.FindConstantValue(cc.SemanticModel, arguments.First()) is long ticks && ticks == EpochTicks))
+                        && CheckAndGetTypeName(cc.Node, cc.SemanticModel) is { } typeName)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation(), typeName));
+                        cc.ReportIssue(Diagnostic.Create(Rule, cc.Node.GetLocation(), typeName));
                     }
                 },
                 Language.SyntaxKind.ObjectCreationExpressions);

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.Register.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.Register.cs
@@ -55,8 +55,10 @@ public partial class SonarAnalysisContextTest
     public void RegisterNodeAction_UnchangedFiles_SonarParametrizedAnalysisContext(string unchangedFileName, bool expected)
     {
         var context = new DummyAnalysisContext(TestContext, unchangedFileName);
-        var sut = new SonarParametrizedAnalysisContext(new(context, DummyMainDescriptor));
+        var sonarContext = new SonarAnalysisContext(context, DummyMainDescriptor);
+        var sut = new SonarParametrizedAnalysisContext(sonarContext);
         sut.RegisterNodeAction<SyntaxKind>(CSharpGeneratedCodeRecognizer.Instance, context.DelegateAction);
+        sonarContext.RegisterCompilationStartAction(c => sut.ExecutePostponedActions(c));
 
         context.AssertDelegateInvoked(expected);
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.Register.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.Register.cs
@@ -239,7 +239,7 @@ public partial class SonarAnalysisContextTest
         var sut = new SonarCompilationStartAnalysisContext(new(context, DummyMainDescriptor), startContext);
         sut.RegisterNodeAction<SyntaxKind>(CSharpGeneratedCodeRecognizer.Instance, _ => { });
 
-        startContext.AssertExpectedInvocationCounts(expectedNodeCount: 0); // RegisterNodeAction doesn't use DummyCompilationStartAnalysisContext to register but a newly created context
+        startContext.AssertExpectedInvocationCounts(expectedNodeCount: 1);
     }
 
     [TestMethod]


### PR DESCRIPTION
Fix #8399

Before the changes (for oqtane.framework):
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/5e54f53f-13e5-4eef-983a-a3908f454d73)
After the changes:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/bc705196-345c-4e65-af94-b3d92f5e1e36)


