### PR TITLE
Cache ShouldAnalyzeTree results for better performance

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -47,6 +47,9 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
     public SonarAnalysisContext AnalysisContext { get; }
     public TContext Context { get; }
 
+    private readonly ConcurrentDictionary<SyntaxTree, bool> shouldAnalyzeTreeCache = new();
+    private bool? shouldAnalyzeNullTreeCache = null;
+
     protected SonarAnalysisContextBase(SonarAnalysisContext analysisContext, TContext context)
     {
         AnalysisContext = analysisContext ?? throw new ArgumentNullException(nameof(analysisContext));
@@ -55,12 +58,25 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
 
     /// <param name="tree">Tree to decide on. Can be null for Symbol-based and Compilation-based scenarios. And we want to analyze those too.</param>
     /// <param name="generatedCodeRecognizer">When set, generated trees are analyzed only when language-specific 'analyzeGeneratedCode' configuration property is also set.</param>
-    public bool ShouldAnalyzeTree(SyntaxTree tree, GeneratedCodeRecognizer generatedCodeRecognizer) =>
-        SonarLintXml() is var sonarLintXml
-        && (generatedCodeRecognizer is null
-            || sonarLintXml.AnalyzeGeneratedCode(Compilation.Language)
-            || !tree.IsConsideredGenerated(generatedCodeRecognizer, Compilation, IsRazorAnalysisEnabled()))
-        && (tree is null || (!IsUnchanged(tree) && !IsExcluded(sonarLintXml, tree.FilePath)));
+    public bool ShouldAnalyzeTree(SyntaxTree tree, GeneratedCodeRecognizer generatedCodeRecognizer)
+    {
+        if (tree is null)
+        {
+            return shouldAnalyzeNullTreeCache ??= AnalyzeTree(null);
+        }
+        else
+        {
+            return shouldAnalyzeTreeCache.GetOrAdd(tree, AnalyzeTree);
+        }
+
+        bool AnalyzeTree(SyntaxTree syntaxTree) =>
+            SonarLintXml() is var sonarLintXml
+            && (generatedCodeRecognizer is null
+                || sonarLintXml.AnalyzeGeneratedCode(Compilation.Language)
+                || !syntaxTree.IsConsideredGenerated(generatedCodeRecognizer, Compilation, IsRazorAnalysisEnabled()))
+            && (syntaxTree is null || (!IsUnchanged(syntaxTree) && !IsExcluded(sonarLintXml, syntaxTree.FilePath)));
+    }
+
 
     /// <summary>
     /// Reads configuration from SonarProjectConfig.xml file and caches the result for scope of this analysis.


### PR DESCRIPTION
Fixes #8406

Solution using Tuple to store the latest SyntaxTree within the `RegisterNodeAction` of `CompilationStartActionContext`.

On oqtane framework, before changes:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/a4cb19ef-31e8-4d60-a914-a10c93211529)

After changes:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/bdbc77a9-798a-431d-8991-0f798a02dc46)

From `RegisterNodeAction` point of view:
Before:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/b6ef4f19-8acd-4a1e-83b5-0056884e588f)
After:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/020cbcb6-fdde-4a5f-bac0-333b2c9a0a1a)


