### PR TITLE
S3415, S2701, S2699, S2187: Fix failing tests for NUnit 4.0 release

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/AnalysisContext/SonarAnalysisContextTest.cs
@@ -65,7 +65,8 @@ public partial class SonarAnalysisContextTest
             new TestSetup(
                 "TestMethodShouldContainAssertion.NUnit.cs",
                 new TestMethodShouldContainAssertion(),
-                TestMethodShouldContainAssertionTest.WithTestReferences(NuGetMetadataReference.NUnit(Constants.NuGetLatestVersion)).References),    // ToDo: Reuse the entire builder in TestSetup
+                // Breaking changes in NUnit 4.0 would fail the test https://github.com/SonarSource/sonar-dotnet/issues/8409
+                TestMethodShouldContainAssertionTest.WithTestReferences(NuGetMetadataReference.NUnit("3.14.0")).References),    // ToDo: Reuse the entire builder in TestSetup
 
             // SyntaxTreeAnalysisContext
             // S3244 - MAIN and TEST

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
@@ -46,7 +46,7 @@ public class AssertionArgsShouldBePassedInCorrectOrderTest
 
     [DataTestMethod]
     [DataRow("2.5.7.10213")]
-    [DataRow("3.14.0")] // Breaking changes in NUnit 4.0 would fail the test
+    [DataRow("3.14.0")] // Breaking changes in NUnit 4.0 would fail the test https://github.com/SonarSource/sonar-dotnet/issues/8409
     public void AssertionArgsShouldBePassedInCorrectOrder_NUnit(string testFwkVersion) =>
         builder.AddPaths("AssertionArgsShouldBePassedInCorrectOrder.NUnit.cs")
             .AddReferences(NuGetMetadataReference.NUnit(testFwkVersion))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
@@ -54,7 +54,8 @@ public class AssertionArgsShouldBePassedInCorrectOrderTest
 
     [TestMethod]
     public void AssertionArgsShouldBePassedInCorrectOrder_NUnit_Static() =>
-        builder.WithTopLevelStatements().AddReferences(NuGetMetadataReference.NUnit(Constants.NuGetLatestVersion)).AddSnippet("""
+        // Breaking changes in NUnit 4.0 would fail the test https://github.com/SonarSource/sonar-dotnet/issues/8409
+        builder.WithTopLevelStatements().AddReferences(NuGetMetadataReference.NUnit("3.14.0")).AddSnippet("""
             using static NUnit.Framework.Assert;
             var str = "";
             AreEqual(str, ""); // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
@@ -46,7 +46,7 @@ public class AssertionArgsShouldBePassedInCorrectOrderTest
 
     [DataTestMethod]
     [DataRow("2.5.7.10213")]
-    [DataRow("3.14.0")] // Breaking changes in NUnit 4.0 fail the test
+    [DataRow("3.14.0")] // Breaking changes in NUnit 4.0 would fail the test
     public void AssertionArgsShouldBePassedInCorrectOrder_NUnit(string testFwkVersion) =>
         builder.AddPaths("AssertionArgsShouldBePassedInCorrectOrder.NUnit.cs")
             .AddReferences(NuGetMetadataReference.NUnit(testFwkVersion))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/AssertionArgsShouldBePassedInCorrectOrderTest.cs
@@ -46,7 +46,7 @@ public class AssertionArgsShouldBePassedInCorrectOrderTest
 
     [DataTestMethod]
     [DataRow("2.5.7.10213")]
-    [DataRow(Constants.NuGetLatestVersion)]
+    [DataRow("3.14.0")] // Breaking changes in NUnit 4.0 fail the test
     public void AssertionArgsShouldBePassedInCorrectOrder_NUnit(string testFwkVersion) =>
         builder.AddPaths("AssertionArgsShouldBePassedInCorrectOrder.NUnit.cs")
             .AddReferences(NuGetMetadataReference.NUnit(testFwkVersion))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseLiteralBoolInAssertionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseLiteralBoolInAssertionsTest.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [DataTestMethod]
         [DataRow("2.5.7.10213")]
-        [DataRow("3.14.0")] // Breaking changes in NUnit 4.0 would fail the test
+        [DataRow("3.14.0")] // Breaking changes in NUnit 4.0 would fail the test https://github.com/SonarSource/sonar-dotnet/issues/8409
         public void DoNotUseLiteralBoolInAssertions_NUnit(string testFwkVersion) =>
             builder.AddPaths("DoNotUseLiteralBoolInAssertions.NUnit.cs")
                 .AddReferences(NuGetMetadataReference.NUnit(testFwkVersion))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseLiteralBoolInAssertionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/DoNotUseLiteralBoolInAssertionsTest.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [DataTestMethod]
         [DataRow("2.5.7.10213")]
-        [DataRow(Constants.NuGetLatestVersion)]
+        [DataRow("3.14.0")] // Breaking changes in NUnit 4.0 would fail the test
         public void DoNotUseLiteralBoolInAssertions_NUnit(string testFwkVersion) =>
             builder.AddPaths("DoNotUseLiteralBoolInAssertions.NUnit.cs")
                 .AddReferences(NuGetMetadataReference.NUnit(testFwkVersion))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestClassShouldHaveTestMethodTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestClassShouldHaveTestMethodTest.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [DataTestMethod]
         [DataRow("2.5.7.10213")]
-        [DataRow(Constants.NuGetLatestVersion)]
+        [DataRow("3.14.0")] // Breaking changes in NUnit 4.0 would fail the test https://github.com/SonarSource/sonar-dotnet/issues/8409
         public void TestClassShouldHaveTestMethod_NUnit(string testFwkVersion) =>
             builder
                 .AddPaths("TestClassShouldHaveTestMethod.NUnit.cs")

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.UnitTest.Rules
                 .Verify();
 
         [DataTestMethod]
-        [DataRow(NUnitVersions.Ver3, Latest, Latest)] 
+        [DataRow(NUnitVersions.Ver3, Latest, Latest)]
         [DataRow(NUnitVersions.Ver3Latest, FluentAssertionVersions.Ver5, Latest)] // Breaking changes in NUnit 4.0 would fail the test https://github.com/SonarSource/sonar-dotnet/issues/8409
         [DataRow(NUnitVersions.Ver3Latest, Latest, Latest)] // Breaking changes in NUnit 4.0 would fail the test https://github.com/SonarSource/sonar-dotnet/issues/8409
         public void TestMethodShouldContainAssertion_NUnit(string testFwkVersion, string fluentVersion, string nSubstituteVersion) =>

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
@@ -43,6 +43,7 @@ namespace SonarAnalyzer.UnitTest.Rules
         private static class NUnitVersions
         {
             public const string Ver3 = "3.11.0";
+            public const string Ver3Latest = "3.14.0";
             public const string Ver25 = "2.5.7.10213";
             public const string Ver27 = "2.7.0";
         }
@@ -58,9 +59,9 @@ namespace SonarAnalyzer.UnitTest.Rules
                 .Verify();
 
         [DataTestMethod]
-        [DataRow(NUnitVersions.Ver3, Latest, Latest)]
-        [DataRow(Latest, FluentAssertionVersions.Ver5, Latest)]
-        [DataRow(Latest, Latest, Latest)]
+        [DataRow(NUnitVersions.Ver3, Latest, Latest)] 
+        [DataRow(NUnitVersions.Ver3Latest, FluentAssertionVersions.Ver5, Latest)] // Breaking changes in NUnit 4.0 would fail the test
+        [DataRow(NUnitVersions.Ver3Latest, Latest, Latest)] // Breaking changes in NUnit 4.0 would fail the test
         public void TestMethodShouldContainAssertion_NUnit(string testFwkVersion, string fluentVersion, string nSubstituteVersion) =>
             WithTestReferences(NuGetMetadataReference.NUnit(testFwkVersion), fluentVersion, nSubstituteVersion).AddPaths("TestMethodShouldContainAssertion.NUnit.cs").Verify();
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/Rules/TestMethodShouldContainAssertionTest.cs
@@ -60,8 +60,8 @@ namespace SonarAnalyzer.UnitTest.Rules
 
         [DataTestMethod]
         [DataRow(NUnitVersions.Ver3, Latest, Latest)] 
-        [DataRow(NUnitVersions.Ver3Latest, FluentAssertionVersions.Ver5, Latest)] // Breaking changes in NUnit 4.0 would fail the test
-        [DataRow(NUnitVersions.Ver3Latest, Latest, Latest)] // Breaking changes in NUnit 4.0 would fail the test
+        [DataRow(NUnitVersions.Ver3Latest, FluentAssertionVersions.Ver5, Latest)] // Breaking changes in NUnit 4.0 would fail the test https://github.com/SonarSource/sonar-dotnet/issues/8409
+        [DataRow(NUnitVersions.Ver3Latest, Latest, Latest)] // Breaking changes in NUnit 4.0 would fail the test https://github.com/SonarSource/sonar-dotnet/issues/8409
         public void TestMethodShouldContainAssertion_NUnit(string testFwkVersion, string fluentVersion, string nSubstituteVersion) =>
             WithTestReferences(NuGetMetadataReference.NUnit(testFwkVersion), fluentVersion, nSubstituteVersion).AddPaths("TestMethodShouldContainAssertion.NUnit.cs").Verify();
 


### PR DESCRIPTION
NUnit 4.0 release had breaking changes. Some tests with `Constants.NuGetLatestVersion` are failing due to that. To make the test pass `NuGetLatestVersion` is replaced by the fixed version `3.14.0`. 
#8409 was created to follow up on the breaking change, as the assertion methods are moved to another type and namespace and we need to adopt a couple of rules to reflect that.