### PR TITLE
Cache ShouldAnalyzeTree results for better performance

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarAnalysisContextBase.cs
@@ -47,6 +47,9 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
     public SonarAnalysisContext AnalysisContext { get; }
     public TContext Context { get; }
 
+    private readonly ConcurrentDictionary<SyntaxTree, bool> shouldAnalyzeTreeCache = new();
+    private bool? shouldAnalyzeNullTreeCache = null;
+
     protected SonarAnalysisContextBase(SonarAnalysisContext analysisContext, TContext context)
     {
         AnalysisContext = analysisContext ?? throw new ArgumentNullException(nameof(analysisContext));
@@ -55,12 +58,25 @@ public abstract class SonarAnalysisContextBase<TContext> : SonarAnalysisContextB
 
     /// <param name="tree">Tree to decide on. Can be null for Symbol-based and Compilation-based scenarios. And we want to analyze those too.</param>
     /// <param name="generatedCodeRecognizer">When set, generated trees are analyzed only when language-specific 'analyzeGeneratedCode' configuration property is also set.</param>
-    public bool ShouldAnalyzeTree(SyntaxTree tree, GeneratedCodeRecognizer generatedCodeRecognizer) =>
-        SonarLintXml() is var sonarLintXml
-        && (generatedCodeRecognizer is null
-            || sonarLintXml.AnalyzeGeneratedCode(Compilation.Language)
-            || !tree.IsConsideredGenerated(generatedCodeRecognizer, Compilation, IsRazorAnalysisEnabled()))
-        && (tree is null || (!IsUnchanged(tree) && !IsExcluded(sonarLintXml, tree.FilePath)));
+    public bool ShouldAnalyzeTree(SyntaxTree tree, GeneratedCodeRecognizer generatedCodeRecognizer)
+    {
+        if (tree is null)
+        {
+            return shouldAnalyzeNullTreeCache ??= AnalyzeTree(null);
+        }
+        else
+        {
+            return shouldAnalyzeTreeCache.GetOrAdd(tree, AnalyzeTree);
+        }
+
+        bool AnalyzeTree(SyntaxTree syntaxTree) =>
+            SonarLintXml() is var sonarLintXml
+            && (generatedCodeRecognizer is null
+                || sonarLintXml.AnalyzeGeneratedCode(Compilation.Language)
+                || !syntaxTree.IsConsideredGenerated(generatedCodeRecognizer, Compilation, IsRazorAnalysisEnabled()))
+            && (syntaxTree is null || (!IsUnchanged(syntaxTree) && !IsExcluded(sonarLintXml, syntaxTree.FilePath)));
+    }
+
 
     /// <summary>
     /// Reads configuration from SonarProjectConfig.xml file and caches the result for scope of this analysis.


### PR DESCRIPTION
Fixes #8406

Solution using `ConcurrentDirctionary` within the `AnalysisContext`.

On oqtane framework, before changes:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/89ea7f54-e19a-49a5-8568-499b6ed1cef5)

After changes:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/ed5237a8-f577-474f-b21d-7bd239f9baec)

From RegisterNodeAction point of view:
Before:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/5891b6ee-dd51-4f3e-a26f-67ebfd500327)
After:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/d48e7c3e-9d38-4621-9736-5c16b581cd2e)
