### PR TITLE
Cache RegisterNodeAction checks result per SyntaxTree

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
@@ -39,7 +39,7 @@ public sealed class SonarCompilationStartAnalysisContext : SonarAnalysisContextB
     public void RegisterSemanticModelAction(Action<SonarSemanticModelReportingContext> action) =>
         Context.RegisterSemanticModelAction(x => action(new(AnalysisContext, x)));
 
-#pragma warning disable HAA0303, HAA0302, HAA0301
+#pragma warning disable HAA0303, HAA0302, HAA0301, HAA0502
 
     [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/8406", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
     public void RegisterNodeAction<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeReportingContext> action, params TSyntaxKind[] syntaxKinds)
@@ -50,7 +50,7 @@ public sealed class SonarCompilationStartAnalysisContext : SonarAnalysisContextB
             ConcurrentDictionary<SyntaxTree, bool> shouldAnalyzeCache = new();
             Context.RegisterSyntaxNodeAction(x =>
 // The hot path starts in the lambda below.
-#pragma warning restore HAA0303, HAA0302, HAA0301
+#pragma warning restore HAA0303, HAA0302, HAA0301, HAA0502
                 {
                     if (!shouldAnalyzeCache.TryGetValue(x.Node.SyntaxTree, out var canProceedWithAnalysis))
                     {
@@ -59,7 +59,10 @@ public sealed class SonarCompilationStartAnalysisContext : SonarAnalysisContextB
 
                     if (canProceedWithAnalysis)
                     {
+#pragma warning disable HAA0502
+                        // https://github.com/SonarSource/sonar-dotnet/issues/8425
                         action(new(AnalysisContext, x));
+#pragma warning enable HAA0502
                     }
                 },
                 syntaxKinds);

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
@@ -39,15 +39,18 @@ public sealed class SonarCompilationStartAnalysisContext : SonarAnalysisContextB
     public void RegisterSemanticModelAction(Action<SonarSemanticModelReportingContext> action) =>
         Context.RegisterSemanticModelAction(x => action(new(AnalysisContext, x)));
 
+#pragma warning disable HAA0303, HAA0302, HAA0301
+
+    [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/8406", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
     public void RegisterNodeAction<TSyntaxKind>(GeneratedCodeRecognizer generatedCodeRecognizer, Action<SonarSyntaxNodeReportingContext> action, params TSyntaxKind[] syntaxKinds)
         where TSyntaxKind : struct
     {
         if (HasMatchingScope(AnalysisContext.SupportedDiagnostics))
         {
             ConcurrentDictionary<SyntaxTree, bool> shouldAnalyzeCache = new();
-            Context.RegisterSyntaxNodeAction(
-                [PerformanceSensitive("https://github.com/SonarSource/sonar-dotnet/issues/8406", AllowCaptures = false, AllowGenericEnumeration = false, AllowImplicitBoxing = false)]
-                (x) =>
+            Context.RegisterSyntaxNodeAction(x =>
+// The hot path starts in the lambda below.
+#pragma warning restore HAA0303, HAA0302, HAA0301
                 {
                     if (!shouldAnalyzeCache.TryGetValue(x.Node.SyntaxTree, out var canProceedWithAnalysis))
                     {

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarCompilationStartAnalysisContext.cs
@@ -62,7 +62,7 @@ public sealed class SonarCompilationStartAnalysisContext : SonarAnalysisContextB
 #pragma warning disable HAA0502
                         // https://github.com/SonarSource/sonar-dotnet/issues/8425
                         action(new(AnalysisContext, x));
-#pragma warning enable HAA0502
+#pragma warning restore HAA0502
                     }
                 },
                 syntaxKinds);


### PR DESCRIPTION
Fixes #8406

Cache the result of ShouldAnalyzeTree and other checks per SyntaxTree in a dictionary.

### Time spent in `RegisterNodeAction`

Before:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/b541a47c-f4d7-412d-8bbf-55019135ba45)

After:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/5e89467c-e00c-4e56-8a3a-1bbccf5360c8)

### Allocations

Allocation is going down from 13'633 MB to 11'838 MB overall.
Most of it is saved in `RegisterNodeAction`:

Before:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/5cc98de7-5cb6-43c1-8ad1-9e5fd66f0973)

After:
![image](https://github.com/SonarSource/sonar-dotnet/assets/126669183/56e4edca-4ed7-416b-a720-12501501503c)

