### PR TITLE
ShimLayer: Add SyntaxKindEx.FunctionPointerCallingConvention

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/SyntaxKindEx.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/SyntaxKindEx.cs
@@ -79,6 +79,7 @@ namespace StyleCop.Analyzers.Lightup
         public const SyntaxKind FunctionPointerType = (SyntaxKind)9056;
         public const SyntaxKind FunctionPointerParameter = (SyntaxKind)9057;
         public const SyntaxKind FunctionPointerParameterList = (SyntaxKind)9058;
+        public const SyntaxKind FunctionPointerCallingConvention = (SyntaxKind)9059;
         public const SyntaxKind InitAccessorDeclaration = (SyntaxKind)9060;
         public const SyntaxKind WithExpression = (SyntaxKind)9061;
         public const SyntaxKind WithInitializerExpression = (SyntaxKind)9062;


### PR DESCRIPTION
We've missed this one:
https://github.com/dotnet/roslyn/blob/b3e63468749b56e9b30334bbd5312a723b5cc3ab/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs#L886