### PR TITLE
Bump Scanner for .NET to 6.0.0.81631 for ITs

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -28,14 +28,14 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator-junit5</artifactId>
-      <version>4.4.0.1640</version>
+      <version>4.6.0.1748</version>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.scanner.msbuild</groupId>
-      <artifactId>sonar-scanner-msbuild</artifactId>
+      <artifactId>sonar-scanner</artifactId>
       <version>${scannerMsbuild.version}</version>
       <type>zip</type>
-      <classifier>net46</classifier>
+      <classifier>net-framework</classifier>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -20,7 +20,7 @@
   </organization>
 
   <properties>
-    <scannerMsbuild.version>5.15.0.80890</scannerMsbuild.version>
+    <scannerMsbuild.version>6.0.0.81631</scannerMsbuild.version>
     <surefire.argLine>-server</surefire.argLine>
   </properties>
 

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -20,7 +20,6 @@
   </organization>
 
   <properties>
-    <scannerMsbuild.version>6.0.0.81631</scannerMsbuild.version>
     <surefire.argLine>-server</surefire.argLine>
   </properties>
 
@@ -29,13 +28,6 @@
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator-junit5</artifactId>
       <version>4.6.0.1748</version>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.scanner.msbuild</groupId>
-      <artifactId>sonar-scanner</artifactId>
-      <version>${scannerMsbuild.version}</version>
-      <type>zip</type>
-      <classifier>net-framework</classifier>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
@@ -70,36 +62,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.2.2</version>
-          <configuration>
-            <systemProperties>
-              <scannerMsbuild.version>${scannerMsbuild.version}</scannerMsbuild.version>
-            </systemProperties>
-          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.6.1</version>
-        <executions>
-          <execution>
-            <id>get-scanner-2.1</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>get</goal>
-            </goals>
-            <configuration>
-              <artifactId>sonar-scanner-msbuild</artifactId>
-              <groupId>org.sonarsource.scanner.msbuild</groupId>
-              <packaging>zip</packaging>
-              <version>2.1.0.0</version>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
 
 </project>

--- a/its/src/test/java/com/sonar/it/shared/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/shared/TestUtils.java
@@ -156,7 +156,7 @@ public class TestUtils {
   private static Build<ScannerForMSBuild> newScanner(Path projectDir) {
     // We need to set the fallback version to run from inside the IDE when the property isn't set
     return ScannerForMSBuild.create(projectDir.toFile())
-      .setScannerVersion(System.getProperty("scannerMsbuild.version", "5.15.0.80890"))
+      .setScannerVersion(System.getProperty("scannerMsbuild.version", "6.0.0.81631"))
 
       // In order to be able to run tests on Azure pipelines, the AGENT_BUILDDIRECTORY environment variable
       // needs to be set to the analyzed project directory.

--- a/its/src/test/java/com/sonar/it/shared/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/shared/TestUtils.java
@@ -156,7 +156,7 @@ public class TestUtils {
   private static Build<ScannerForMSBuild> newScanner(Path projectDir) {
     // We need to set the fallback version to run from inside the IDE when the property isn't set
     return ScannerForMSBuild.create(projectDir.toFile())
-      .setScannerVersion(System.getProperty("scannerMsbuild.version", "LATEST_RELEASE"))
+      .setScannerVersion(ScannerForMSBuild.LATEST_RELEASE)
 
       // In order to be able to run tests on Azure pipelines, the AGENT_BUILDDIRECTORY environment variable
       // needs to be set to the analyzed project directory.

--- a/its/src/test/java/com/sonar/it/shared/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/shared/TestUtils.java
@@ -156,7 +156,7 @@ public class TestUtils {
   private static Build<ScannerForMSBuild> newScanner(Path projectDir) {
     // We need to set the fallback version to run from inside the IDE when the property isn't set
     return ScannerForMSBuild.create(projectDir.toFile())
-      .setScannerVersion(System.getProperty("scannerMsbuild.version", "6.0.0.81631"))
+      .setScannerVersion(System.getProperty("scannerMsbuild.version", "LATEST_RELEASE"))
 
       // In order to be able to run tests on Azure pipelines, the AGENT_BUILDDIRECTORY environment variable
       // needs to be set to the analyzed project directory.


### PR DESCRIPTION
Bump S4NET to [latest (6.0.0.81631)](https://github.com/SonarSource/sonar-scanner-msbuild/releases/tag/6.0.0.81631)

The 6.0.0.81631 release of the S4NET is a major version release, introducing several breaking changes that need to be tested with `sonar-dotnet` ITs.

The PR stays in draft for the time being, since we may not need this if we successfully run on the latest S4NET.

The work to run on the latest S4NET, instead of a fixed version, will be done in the context of https://github.com/SonarSource/sonar-scanner-msbuild/issues/1774
