### PR TITLE
Utility analyzer: Enable concurrent analysis and use producer/consumer pattern for file writes

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -92,7 +92,7 @@ namespace SonarAnalyzer.Rules
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterCompilationStartAction(startContext =>
             {
-                var parameters = base.ReadParameters(startContext);
+                var parameters = ReadParameters(startContext);
                 if (!parameters.IsAnalyzerEnabled)
                 {
                     return;

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -102,7 +102,7 @@ namespace SonarAnalyzer.Rules
                 {
                     Directory.CreateDirectory(parameters.OutPath);
                     using var stream = File.Create(Path.Combine(parameters.OutPath, FileName));
-                    while (treeMessages.TryTake(out var message))
+                    foreach (var message in treeMessages.GetConsumingEnumerable())
                     {
                         message.WriteDelimitedTo(stream);
                     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -133,7 +133,7 @@ namespace SonarAnalyzer.Rules
                     treeMessages.CompleteAdding();
                     try
                     {
-                        consumerTask.Wait(cancel); // Throws, if the task failed.
+                        consumerTask.Wait(cancel); // Wait until all messages are written to disk. Throws, if the task failed.
                     }
                     finally
                     {

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -124,6 +124,7 @@ namespace SonarAnalyzer.Rules
                     }
                     treeMessages.CompleteAdding();
                     consumerTask.Wait();
+                    treeMessages.Dispose();
                 });
             });
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -35,7 +35,6 @@ namespace SonarAnalyzer.Rules
     {
         protected static readonly ISet<string> FileExtensionWhitelist = new HashSet<string> { ".cs", ".csx", ".vb" };
         private readonly DiagnosticDescriptor rule;
-        protected override bool EnableConcurrentExecution => false;
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(rule);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Utilities/UtilityAnalyzerBase.cs
@@ -103,7 +103,7 @@ namespace SonarAnalyzer.Rules
                 {
                     Directory.CreateDirectory(parameters.OutPath);
                     using var stream = File.Create(Path.Combine(parameters.OutPath, FileName));
-                    foreach (var message in treeMessages.GetConsumingEnumerable(cancel))
+                    foreach (var message in treeMessages.GetConsumingEnumerable(cancel).WhereNotNull())
                     {
                         message.WriteDelimitedTo(stream);
                     }


### PR DESCRIPTION
Fixes #6674
Fixes #8460

Akka test (dotnet build in Sonar context):

Run  | Master (b36349a9bbef58e114f47446a57878fe10c74969) | After (c6d7e8daf305e35a80115a1ea39af569c74c1402) |  Diff
-- | -- | -- | --
Run 1 | 0:01:13 | 0:01:12 | 1.62%
Run 2 | 0:01:11 | 0:01:14 | -3.83%
Run 3 | 0:01:16 | 0:01:08 | 10.76%
Run 4 | 0:01:14 | 0:01:09 | 6.99%
Average | 0:01:14 | 0:01:11 | 4.02%

The Utility Analyzers in Akka create 936 protobuf files with a total size of 35.195.405 bytes/35MB (ucfgs excluded). 75% of the 35MB are contributed by the CopyPasteTokenAnalyzer (token-cpd.pb).

AnalyzerRunner (Akka)
`C:\Projects\OpenSource\roslyn\artifacts\bin\AnalyzerRunner\Release\net7.0\AnalyzerRunner.exe C:\Projects\sonar-dotnet\analyzers\packaging\binaries "C:\Projects\Sprints\UtilityAnalyzerPerf\Benchmark\Projects\akka.net\src\Akka.sln" /a CopyPasteTokenAnalyzer /a FileMetadataAnalyzer /a LogAnalyzer /a MetricsAnalyzer /a SymbolReferenceAnalyzer /a TokenTypeAnalyzer`

|                          | Master  | After   |        |
|--------------------------|---------|---------|--------|
|                          | Average | Average | Diff   |
| CopyPasteTokenAnalyzer:  | 2515.50 | 1948.00 | 22.56% |
| FileMetadataAnalyzer:    | 617.25  | 584.75  | 5.27%  |
| LogAnalyzer:             | 244.50  | 200.25  | 18.10% |
| MetricsAnalyzer:         | 5132.00 | 5046.50 | 1.67%  |
| SymbolReferenceAnalyzer: | 3892.75 | 3963.00 | -1.80% |
| TokenTypeAnalyzer:       | 2392.00 | 2305.25 | 3.63%  |

AWS SDK

file | MB
-- | --
file-metadata.pb | 65.63
log.pb | 0.70
metrics.pb | 118.76
symrefs.pb | 219.60
token-cpd.pb | 1951.50
token-type.pb | 499.95

Run | Master | PR | Diff
-- | -- | -- | --
AWS | 0:50:13 | 0:47:45 | 4.92%
AWS | 0:49:25 | 0:50:46 | -2.72%
AWS | 0:49:40 | 0:48:55 | 1.52%
Average | 0:49:46 | 0:49:09 | 1.26%



[Measurement details](https://docs.google.com/spreadsheets/d/1So6qSOwELpnxVEpXnnEd_KUm5bcvHrTpnKd59rNx2kk/edit#gid=826944333)

TODO:

* [x] Measure on a large-scale project (AWS?) without ucfg generation (SQ community edition):
