### PR TITLE
Fix S2583/S2589 FP: Tuple deconstruction assignment

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
@@ -51,6 +51,9 @@ internal static class IOperationExtensions
     internal static IConversionOperationWrapper? AsConversion(this IOperation operation) =>
         operation.As(OperationKindEx.Conversion, IConversionOperationWrapper.FromOperation);
 
+    internal static IDeclarationExpressionOperationWrapper? AsDeclarationExpression(this IOperation operation) =>
+        operation.As(OperationKindEx.DeclarationExpression, IDeclarationExpressionOperationWrapper.FromOperation);
+
     internal static IDeclarationPatternOperationWrapper? AsDeclarationPattern(this IOperation operation) =>
         operation.As(OperationKindEx.DeclarationPattern, IDeclarationPatternOperationWrapper.FromOperation);
 
@@ -68,6 +71,9 @@ internal static class IOperationExtensions
 
     internal static IPropertyReferenceOperationWrapper? AsPropertyReference(this IOperation operation) =>
         operation.As(OperationKindEx.PropertyReference, IPropertyReferenceOperationWrapper.FromOperation);
+
+    internal static ITupleOperationWrapper? AsTuple(this IOperation operation) =>
+        operation.As(OperationKindEx.Tuple, ITupleOperationWrapper.FromOperation);
 
     internal static IAwaitOperationWrapper ToAwait(this IOperation operation) =>
         IAwaitOperationWrapper.FromOperation(operation);
@@ -122,6 +128,9 @@ internal static class IOperationExtensions
 
     internal static IEventReferenceOperationWrapper ToEventReference(this IOperation operation) =>
         IEventReferenceOperationWrapper.FromOperation(operation);
+
+    internal static ITupleOperationWrapper ToTuple(this IOperation operation) =>
+        ITupleOperationWrapper.FromOperation(operation);
 
     internal static IUnaryOperationWrapper ToUnary(this IOperation operation) =>
         IUnaryOperationWrapper.FromOperation(operation);

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationDispatcher.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationDispatcher.cs
@@ -45,6 +45,7 @@ internal static class OperationDispatcher
         { OperationKindEx.CompoundAssignment, new CompoundAssignment() },
         { OperationKindEx.Conversion, new Conversion() },
         { OperationKindEx.DeclarationPattern, new DeclarationPattern() },
+        { OperationKindEx.DeconstructionAssignment, new DeconstructionAssignment() },
         { OperationKindEx.Decrement, new IncrementOrDecrement() },
         { OperationKindEx.DefaultValue, new DefaultValue() },
         { OperationKindEx.DelegateCreation, new NotNullOperation() },

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/DeconstructionAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/DeconstructionAssignment.cs
@@ -1,0 +1,90 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using OperationValueList = System.Collections.Generic.List<(Microsoft.CodeAnalysis.IOperation TupleMember, SonarAnalyzer.SymbolicExecution.Roslyn.SymbolicValue Value)>;
+
+namespace SonarAnalyzer.SymbolicExecution.Roslyn.OperationProcessors;
+
+internal sealed class DeconstructionAssignment : SimpleProcessor<IDeconstructionAssignmentOperationWrapper>
+{
+    protected override IDeconstructionAssignmentOperationWrapper Convert(IOperation operation) =>
+        IDeconstructionAssignmentOperationWrapper.FromOperation(operation);
+
+    protected override ProgramState Process(SymbolicContext context, IDeconstructionAssignmentOperationWrapper assignment)
+    {
+        var list = new OperationValueList();
+        CollectOperationValues(context.State, assignment.Target, assignment.Value, list);
+        var newState = context.State;
+        foreach (var (tupleMember, value) in list)
+        {
+            newState = newState.SetOperationAndSymbolValue(tupleMember, value);
+        }
+        return newState;
+    }
+
+    private static void CollectOperationValues(ProgramState state, IOperation target, IOperation value, OperationValueList operationValues)
+    {
+        var leftTupleElements = TupleElements(target);
+        // If the right side is a tuple, then every symbol/constraint is copied to the left side.
+        if (Unwrap(value).AsTuple() is { } rightSideTuple)
+        {
+            var rightTupleElements = TupleElements(rightSideTuple.WrappedOperation);
+            for (var i = 0; i < leftTupleElements.Length; i++)
+            {
+                var leftTupleMember = leftTupleElements[i];
+                var rightTupleMember = rightTupleElements[i];
+                if (leftTupleMember.Kind == OperationKindEx.Discard)
+                {
+                    continue;
+                }
+                if (leftTupleMember.AsTuple() is { } nestedTuple)
+                {
+                    var rightSideMember = rightTupleMember.AsTuple()?.WrappedOperation ?? rightTupleMember;
+                    CollectOperationValues(state, nestedTuple.WrappedOperation, rightSideMember, operationValues);
+                }
+                else
+                {
+                    operationValues.Add((leftTupleMember, state[rightTupleMember]));
+                }
+            }
+        }
+        // If the right side is not a tuple, then every member of the left side tuple is set to empty.
+        else
+        {
+            foreach (var tupleMember in leftTupleElements.Where(x => x.Kind != OperationKindEx.Discard))
+            {
+                operationValues.Add((tupleMember, SymbolicValue.Empty));
+            }
+        }
+    }
+
+    private static IOperation[] TupleElements(IOperation operation) =>
+        Unwrap(operation)
+            .ToTuple()
+            .Elements
+            .Select(Unwrap)
+            .ToArray();
+
+    private static IOperation Unwrap(IOperation operation)
+    {
+        var unwrapped = operation.UnwrapConversion();
+        return unwrapped.AsDeclarationExpression()?.Expression ?? unwrapped;
+    }
+}

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/ProgramState.cs
@@ -63,6 +63,16 @@ public sealed record ProgramState : IEquatable<ProgramState>
         Exceptions = original.Exceptions;
     }
 
+    public ProgramState SetOperationAndSymbolValue(IOperation operation, SymbolicValue value)
+    {
+        var newState = SetOperationValue(operation, value);
+        if (operation.TrackedSymbol(this) is { } symbol)
+        {
+            newState = newState.SetSymbolValue(symbol, value);
+        }
+        return newState;
+    }
+
     public ProgramState SetOperationValue(IOperationWrapper operation, SymbolicValue value) =>
         operation is null
             ? throw new ArgumentNullException(nameof(operation))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.OperationAndSymbolValue.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/SymbolicExecution/Roslyn/ProgramStateTest.OperationAndSymbolValue.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2023 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.SymbolicExecution.Roslyn;
+using SonarAnalyzer.UnitTest.TestFramework.SymbolicExecution;
+
+namespace SonarAnalyzer.UnitTest.SymbolicExecution.Roslyn;
+
+public partial class ProgramStateTest
+{
+    [TestMethod]
+    public void SetOperationAndSymbolValue_TrackedSymbol()
+    {
+        var operations = TestHelper.CompileCfgBodyCS("bool b = true;").Blocks[1].Operations;
+        var localReference = operations[0].ChildOperations.First().ToLocalReference();
+        var symbol = localReference.Local;
+        var sut = ProgramState.Empty;
+
+        sut[localReference].Should().BeNull();
+        sut[symbol].Should().BeNull();
+
+        sut = sut.SetOperationAndSymbolValue(localReference.WrappedOperation, SymbolicValue.True);
+
+        sut[localReference].Should().Be(SymbolicValue.True);
+        sut[symbol].Should().Be(SymbolicValue.True);
+    }
+
+    [TestMethod]
+    public void SetOperationAndSymbolValue_NotTrackedSymbol()
+    {
+        var operations = TestHelper.CompileCfgBodyCS("""var texts = new string[] { }; texts[42] = string.Empty;""").Blocks[1].Operations;
+        var arrayElementReference = operations[1].ChildOperations.First().ChildOperations.First().ToArrayElementReference();
+        var sut = ProgramState.Empty;
+
+        sut[arrayElementReference].Should().BeNull();
+
+        sut = sut.SetOperationAndSymbolValue(arrayElementReference.WrappedOperation, SymbolicValue.NotNull);
+
+        sut[arrayElementReference].Should().Be(SymbolicValue.NotNull);
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp10.cs
@@ -26,3 +26,35 @@ class AClass
         else if (myStruct.y) { } // FN
     }
 }
+
+// https://github.com/SonarSource/sonar-dotnet/issues/7057
+public class Repro_7057
+{
+    private (string, int) SomeTuple() => ("hello", 1);
+    private string SomeString() => "hello";
+
+    public void WithTuple()
+    {
+        string text1 = null;
+        (text1, var (text2, _)) = (SomeString(), SomeTuple());
+        if (text1 == null) // Compliant
+        {
+            Console.WriteLine();
+        }
+        if (text2 == null) // Compliant
+        {
+            Console.WriteLine();
+        }
+
+        string text3 = null;
+        ((text3, _), var (text4, _)) = ((null, 42), ("hello", 42));
+        if (text3 == null)          // Noncompliant
+        {
+            Console.WriteLine();
+        }
+        if (text4 == null)          // Noncompliant
+        {
+            Console.WriteLine();    // Secondary
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp7.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp7.cs
@@ -294,7 +294,7 @@ namespace Tests.Diagnostics
         {
             var tmp = 0;
             var flag = true;
-            while (flag)            // Noncompliant
+            while (flag)            // Compliant
             {
                 (flag, tmp) = (false, 5);
             }
@@ -329,7 +329,7 @@ namespace Tests.Diagnostics
         {
             var tmp = 0;
             var flag = "x";
-            while (flag != null)            // Noncompliant
+            while (flag != null)            // Compliant
             {
                 (flag, tmp) = (null, 5);
             }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp8.cs
@@ -133,8 +133,8 @@ namespace Tests.Diagnostics
         public void NestedDeconstructionAssignment()
         {
             var (a, (b, _)) = (true, (true, true));
-            if (a) { }  // FN
-            if (b) { }  // FN
+            if (a) { }  // Noncompliant
+            if (b) { }  // Noncompliant
         }
 
         int UsingDeclaration_Null()
@@ -330,7 +330,7 @@ namespace Tests.Diagnostics
             {
             }
 
-            if (b)  // FN
+            if (b)  // Noncompliant
             {
             }
         }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp9.cs
@@ -121,11 +121,11 @@ namespace Tests.Diagnostics
             {
                 var tmp = 0;
                 var flag = true;
-                while (flag)        // Noncompliant
+                while (flag)        // Compliant
                 {
                     (flag, tmp) = (false, 5);
                 }
-                o = value;          // Secondary
+                o = value;
             }
         }
     }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -3125,7 +3125,7 @@ public class Tuples
 
         (memoryStream, str) = GetData();
 
-        if (memoryStream != null) // Noncompliant FP: memoryStream was reassigned as a tuple
+        if (memoryStream != null) // Compliant: memoryStream was reassigned as a tuple
         {
             // some code
         }
@@ -3142,27 +3142,90 @@ public class Repro_7057
 
     public void WithTuple()
     {
-        string current = null;
-        string last;
-        do
+        string text1 = null;
+        (text1, _) = SomeTuple();
+        if (text1 == null) // Compliant
         {
-            last = current;
-            (current, _) = SomeTuple();
+            Console.WriteLine();
         }
-        while (last == null);   // Noncompliant FP
+
+        string text2 = "";
+        (text2, _) = (null, 42);
+        if (text2 == null) // Noncompliant
+        {
+            Console.WriteLine();
+        }
+
+        string text3 = null;
+        ((text3, _), _) = (SomeTuple(), 42);
+        if (text3 == null) // Compliant
+        {
+            Console.WriteLine();
+        }
+
+        var (text4, _) = SomeTuple();
+        if (text4 == null) // Compliant
+        {
+            Console.WriteLine();
+        }
+
+        var (text5, _) = (null as string, 42);
+        if (text5 == null) // Noncompliant
+        {
+            Console.WriteLine();
+        }
+
+        string text6 = null;
+        (_, (text6, _)) = (42, SomeTuple());
+        if (text6 == null) // Compliant
+        {
+            Console.WriteLine();
+        }
+
+        string text7 = "";
+        (_, (text7, _)) = (SomeTuple(), (null, 42));
+        if (text7 == null) // Noncompliant
+        {
+            Console.WriteLine();
+        }
+
+        string text8, text9, text10;
+        text8 = text9 = text10 = SomeString();
+        (text8, (text9, text10)) = ("", ("", ""));
+        if (text8 == null           // Noncompliant
+            || text9 == null        // Noncompliant
+            || text10 == null)      // Noncompliant
+        {
+            Console.WriteLine();    // Secondary
+        }
+
+        var tuple = ("hello", 42);
+        if (tuple.Item1 == null)    // FN
+        {
+            Console.WriteLine();
+        }
+
+        string text11 = SomeString();
+        string text12 = null;
+        (text11, text12) = (text12, text11);
+        if (text11 == null)         // Noncompliant
+        {
+            Console.WriteLine();
+        }
+        if (text12 == null)         // Compliant
+        {
+            Console.WriteLine();
+        }
     }
 
     public void WithString()
     {
         string current = null;
-        string last;
-
-        do
+        current = SomeString();
+        if (current == null) // Compliant
         {
-            last = current;
-            current = SomeString();
+            Console.WriteLine();
         }
-        while (last == null);
     }
 }
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -3216,6 +3216,13 @@ public class Repro_7057
         {
             Console.WriteLine();
         }
+
+        string text13;
+        (text13, text13) = (SomeString(), null);
+        if (text11 == null)         // Noncompliant
+        {
+            Console.WriteLine();
+        }
     }
 
     public void WithString()

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyCollectionsShouldNotBeEnumerated.CSharp10.cs
@@ -8,12 +8,12 @@ public class Sample
         List<int> list;
 
         (list, var a) = (new List<int>(), 42);
-        list.Clear();   // FN
+        list.Clear();   // Noncompliant
         list.Add(42);
         list.Clear();
 
         (var list2, var b) = (new List<int>(), 42);
-        list2.Clear();   // FN
+        list2.Clear();   // Noncompliant
         list2.Add(42);
         list2.Clear();
 

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.CSharp10.cs
@@ -7,7 +7,7 @@ public class Sample
         int? nullable;
 
         (nullable, _) = (null, 42);
-        var v = nullable.Value; // FN
+        var v = nullable.Value; // Noncompliant
 
         nullable = null;
         v = nullable.Value;     // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/EmptyNullableValueAccess.cs
@@ -148,13 +148,13 @@ class AssignmentAndDeconstruction
     void TypeInference()
     {
         (int? discard, int? b) = (null, null);
-        _ = b.Value;        // FN: b is empty
+        _ = b.Value;        // Noncompliant
     }
 
     void FirstLevel()
     {
         var (b, _) = (null as bool?, null as bool?);
-        _ = b.Value;        // FN: b is empty
+        _ = b.Value;        // Noncompliant
     }
 
     void SecondLevel()
@@ -162,7 +162,7 @@ class AssignmentAndDeconstruction
         (int? i1, (int? i2, int? i3)) = (42, (42, null));
         _ = i1.Value;       // Compliant
         _ = i2.Value;       // Compliant
-        _ = i3.Value;       // FN
+        _ = i3.Value;       // Noncompliant
     }
 
     void ThirdLevel()
@@ -171,7 +171,7 @@ class AssignmentAndDeconstruction
         _ = i1.Value;       // Compliant
         _ = i2.Value;       // Compliant
         _ = i3.Value;       // Compliant
-        _ = i4.Value;       // FN
+        _ = i4.Value;       // Noncompliant
         _ = i5.Value;       // Compliant
     }
 
@@ -179,7 +179,7 @@ class AssignmentAndDeconstruction
     {
         (_, (int? i1, (int?, int?) _, int? i2)) = (42, (42, (42, null), null));
         _ = i1.Value;       // Compliant
-        _ = i2.Value;       // FN
+        _ = i2.Value;       // Noncompliant
     }
 
     void TwoWaySwapping()
@@ -187,8 +187,8 @@ class AssignmentAndDeconstruction
         bool? b1 = null;
         bool? b2 = true;
         (b1, b2) = (b2, b1);
-        _ = b1.Value;       // Noncompliant, FP: after swapping is non-empty
-        _ = b2.Value;       // FN: after swapping is empty
+        _ = b1.Value;       // Compliant: after swapping is non-empty
+        _ = b2.Value;       // Noncompliant
     }
 
     void ThreeWaySwapping()
@@ -197,9 +197,9 @@ class AssignmentAndDeconstruction
         bool? b2 = true;
         bool? b3 = null;
         (b1, b2, b3) = (b2, b3, b2);
-        _ = b1.Value;       // Noncompliant, FP: after swapping is non-empty
-        _ = b2.Value;       // FN: after swapping is empty
-        _ = b3.Value;       // Noncompliant, FP: after swapping is non-empty
+        _ = b1.Value;       // Compliant: after swapping is non-empty
+        _ = b2.Value;       // Noncompliant
+        _ = b3.Value;       // Compliant: after swapping is non-empty
     }
 
     void CustomDeconstruction()
@@ -209,7 +209,7 @@ class AssignmentAndDeconstruction
         _ = i1.Value;       // Compliant
         _ = i2.Value;       // Compliant, unknown
         _ = i3.Value;       // Compliant, unknown
-        _ = i4.Value;       // FN
+        _ = i4.Value;       // Noncompliant
     }
 
     struct DeconstructableStruct

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/HashesShouldHaveUnpredictableSalt.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/HashesShouldHaveUnpredictableSalt.CSharp10.cs
@@ -5,6 +5,6 @@ public class Sample
     public void Examples(byte[] passwordBytes)
     {
         (var shortSalt, int a) = (new byte[15], 42);
-        PasswordDeriveBytes aes = new PasswordDeriveBytes(passwordBytes, shortSalt); // FN
+        PasswordDeriveBytes aes = new PasswordDeriveBytes(passwordBytes, shortSalt); // Noncompliant
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/InitializationVectorShouldBeRandom.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/InitializationVectorShouldBeRandom.CSharp10.cs
@@ -9,6 +9,6 @@ public class Sample
         AesCng aes = new AesCng();
         aes.CreateEncryptor();
         (var rgb, int a) = (new byte[16], 42);
-        aes.CreateEncryptor(aes.Key, rgb); // FN
+        aes.CreateEncryptor(aes.Key, rgb); // Noncompliant
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp10.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.CSharp10.cs
@@ -8,16 +8,15 @@ public class Sample
     public void Examples()
     {
         StringBuilder sb = new();
-
         (sb, int a) = (null, 42);
-        sb.ToString(); // FN
+        sb.ToString();  // Noncompliant
     }
 
     public void Unassigned()
     {
         StringBuilder isNull, hasValue;
         (isNull, hasValue) = (null, new StringBuilder());
-        isNull.ToString();      // FN
+        isNull.ToString();  // Noncompliant
         hasValue.ToString();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ObjectsShouldNotBeDisposedMoreThanOnce.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ObjectsShouldNotBeDisposedMoreThanOnce.cs
@@ -250,7 +250,7 @@ class TestLoops
             disposable.Dispose();       // Compliant
 
         foreach (var (_, disposable) in tuples)
-            disposable.Dispose();       // Noncompliant FP
+            disposable.Dispose();       // Compliant
     }
 }
 


### PR DESCRIPTION
Fixes #7057 

The PR aims to fix FPs related to deconstruction assignments.
It doesn't handle:
- pattern matching involving tuples
- TupleBinaryOperation (e.g. `if ((first, second) == ("abc", "xyz"))`)
These scenarios need to be handled in separate PRs.