### PR TITLE
GitHub workflow: cc Denis from new milestone

### DIFF
--- a/.github/workflows/CreateMilestone.yml
+++ b/.github/workflows/CreateMilestone.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           column-id: 4971951  # Kanban "To Do" column
-          body: "cc @tom-howlett-sonarsource"
+          body: "cc @denis-troller"


### PR DESCRIPTION
When we create a new milestone, a new issue is created like this: #8443

It CC's PM to see if rules needs update after our release. The CC makes you get email notifications from the card.

This updates it from Tom to Denis.