### PR TITLE
Revert BUILD-3696 Use agent pool on AWS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ schedules:
 trigger:
 - master
 
-pool: .net-bubble-aws-re-team-prod
+pool: '.Net Bubble - GCP'
 
 variables:
   - group: sonar-dotnet-variables
@@ -101,7 +101,7 @@ stages:
         name: SM_CLIENT_CERT
         inputs:
           secureFile: digicert_authentication_certificate.p12
-
+ 
       - task: DownloadSecureFile@1
         # This file contains the signing certificate without the private key. The private key will be downloaded later, during the signing process.
         displayName: 'Download crt file'
@@ -112,8 +112,8 @@ stages:
       - task: PowerShell@2
         displayName: "Signing certificate setup"
         # Initialize the DigiCert Private Key Provider.
-        # What we think it does: The smctl tool authenticates with a client certificate (SM_CLIENT_CERT_FILE) and a client password (SM_CLIENT_CERT_PASSWORD).
-        # It uses an API Key (SM_API_KEY) and the ID of the certificate (SM_CERT) to check if the authenticated client is authorized to use the
+        # What we think it does: The smctl tool authenticates with a client certificate (SM_CLIENT_CERT_FILE) and a client password (SM_CLIENT_CERT_PASSWORD). 
+        # It uses an API Key (SM_API_KEY) and the ID of the certificate (SM_CERT) to check if the authenticated client is authorized to use the 
         # certificate specified and synchronize (potentially private) information about the certificate.
         condition: eq(variables.isReleaseBranch, 'True')
         env:


### PR DESCRIPTION
Temporary revert until the assembly signing is fixed.

```
smctl sync:
smctl : The term 'smctl' is not recognized as the name of a cmdlet, function, script file, or operable program. Check
the spelling of the name, or if a path was included, verify that the path is correct and try again.
```