### PR TITLE
Specify the java location

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -408,6 +408,7 @@ stages:
         displayName: "Mend scan"
         condition: eq(variables.isReleaseBranch, 'True')
         env:
+          JAVA: 'C:\Program Files\JDK Temurin\17'
           WS_PRODUCTNAME: '$(MEND_PRODUCTNAME)'
           WS_APIKEY: '$(MEND_APIKEY)'
           BUILD_NUMBER: '$(Build.BuildId)'


### PR DESCRIPTION
- to fix the CI

Buil error:
```
Running the Mend unified agent for SonarSource/sonar-dotnet 9.16...
& : The term '\bin\java.exe' is not recognized as the name of a cmdlet, function, script file, or operable program. 
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\sonar-ci\_work\1\s\scripts\Mend\Mend-Scan.ps1:14 char:3
```

