### PR TITLE
Fix S1172 FP: VB names should not be case sensitive

### DIFF
--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodParameterUnused.cs
@@ -107,7 +107,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     .Cast<IdentifierNameSyntax>()
                     .Select(x => x.Identifier.ValueText)
                     .WhereNotNull()
-                    .ToHashSet();
+                    .ToHashSet(StringComparer.InvariantCultureIgnoreCase);
 
             return methodBlock.BlockStatement.ParameterList.Parameters
                 .Where(p => !usedIdentifiers.Contains(p.Identifier.Identifier.ValueText))

--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodParameterUnused.vb
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/MethodParameterUnused.vb
@@ -91,6 +91,10 @@ Namespace Tests.TestCases
             Return a
         End Function
 
+        Private Function Casing(DifferentCasing As Integer) As Integer
+            Return differentCASING
+        End Function
+
         Sub DoSomething3(ByVal a As Integer) ' Default accessibility is public
             Console.WriteLine("foo")
         End Sub


### PR DESCRIPTION
Fixes #8489
