### PR TITLE
Fix S2589 FP: Custom Equals(null) is wrongly assumed to always return false

### DIFF
--- a/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.UnitTest/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.CSharp8.cs
@@ -563,6 +563,6 @@ public struct Repro_8382
 {
     public bool Equals(string? other) => true;
     public bool Repro(object? obj, bool condition) =>
-        Equals((string?)null) // Noncompliant FP this is a local method, it does not need to follow the Equals contract.
+        Equals((string?)null) // Compliant. This is a local method, it does not need to follow the Equals contract.
         || condition;
 }


### PR DESCRIPTION
Fixes #8382