### PR TITLE
GitHub workflow: Improve author_association to NONE only

### DIFF
--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     # PRs from forks don't have required token authorization
     if: github.event.pull_request.head.repo.full_name == github.repository
-        && (github.event.review.author_association == 'COLLABORATOR' || github.event.review.author_association == 'MEMBER')
+        && github.event.review.author_association != 'NONE'
     steps:
       - uses: sonarsource/gh-action-lt-backlog/MoveCardToReview@v1
         with:

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -12,7 +12,7 @@ jobs:
     # PRs from forks don't have required token authorization
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
-        && (github.event.review.author_association == 'COLLABORATOR' || github.event.review.author_association == 'MEMBER')
+        && github.event.review.author_association != 'NONE'
         && github.event.review.state == 'changes_requested'
     steps:
       - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReview@v1
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
-        && (github.event.review.author_association == 'COLLABORATOR' || github.event.review.author_association == 'MEMBER')
+        && github.event.review.author_association != 'NONE'
         && github.event.review.state == 'approved'
     steps:
       - uses: sonarsource/gh-action-lt-backlog/MoveCardAfterReview@v1


### PR DESCRIPTION
#8505 didn't work as expected, as COLLABORATOR gets promoted to CONTRIBUTOR and cannot distinguish internal/external