### PR TITLE
Fix S4027 FP: BinaryFormatter. Serialization constructors are obsolete and should not be required

### DIFF
--- a/analyzers/its/expected/Automapper/AutoMapper--net461-S4027.json
+++ b/analyzers/its/expected/Automapper/AutoMapper--net461-S4027.json
@@ -4,19 +4,6 @@
 "id":  "S4027",
 "message":  "Implement the missing constructors for this exception.",
 "location":  {
-"uri":  "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/sources/AutoMapper/src/AutoMapper/AutoMapperMappingException.cs#L11",
-"region":  {
-"startLine":  11,
-"startColumn":  18,
-"endLine":  11,
-"endColumn":  44
-}
-}
-},
-{
-"id":  "S4027",
-"message":  "Implement the missing constructors for this exception.",
-"location":  {
 "uri":  "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/sources/AutoMapper/src/AutoMapper/AutoMapperMappingException.cs#L79",
 "region":  {
 "startLine":  79,

--- a/analyzers/its/expected/Automapper/AutoMapper--netstandard2.0-S4027.json
+++ b/analyzers/its/expected/Automapper/AutoMapper--netstandard2.0-S4027.json
@@ -4,19 +4,6 @@
 "id":  "S4027",
 "message":  "Implement the missing constructors for this exception.",
 "location":  {
-"uri":  "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/sources/AutoMapper/src/AutoMapper/AutoMapperMappingException.cs#L11",
-"region":  {
-"startLine":  11,
-"startColumn":  18,
-"endLine":  11,
-"endColumn":  44
-}
-}
-},
-{
-"id":  "S4027",
-"message":  "Implement the missing constructors for this exception.",
-"location":  {
 "uri":  "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/sources/AutoMapper/src/AutoMapper/AutoMapperMappingException.cs#L79",
 "region":  {
 "startLine":  79,

--- a/analyzers/its/expected/Nancy/Nancy--net452-S4027.json
+++ b/analyzers/its/expected/Nancy/Nancy--net452-S4027.json
@@ -173,19 +173,6 @@
 "id":  "S4027",
 "message":  "Implement the missing constructors for this exception.",
 "location":  {
-"uri":  "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/sources/Nancy/src/Nancy/Validation/ModelValidationException.cs#L8",
-"region":  {
-"startLine":  8,
-"startColumn":  18,
-"endLine":  8,
-"endColumn":  42
-}
-}
-},
-{
-"id":  "S4027",
-"message":  "Implement the missing constructors for this exception.",
-"location":  {
 "uri":  "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/sources/Nancy/src/Nancy/ViewEngines/AmbiguousViewsException.cs#L8",
 "region":  {
 "startLine":  8,

--- a/analyzers/its/expected/Nancy/Nancy--netstandard2.0-S4027.json
+++ b/analyzers/its/expected/Nancy/Nancy--netstandard2.0-S4027.json
@@ -173,19 +173,6 @@
 "id":  "S4027",
 "message":  "Implement the missing constructors for this exception.",
 "location":  {
-"uri":  "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/sources/Nancy/src/Nancy/Validation/ModelValidationException.cs#L8",
-"region":  {
-"startLine":  8,
-"startColumn":  18,
-"endLine":  8,
-"endColumn":  42
-}
-}
-},
-{
-"id":  "S4027",
-"message":  "Implement the missing constructors for this exception.",
-"location":  {
 "uri":  "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/sources/Nancy/src/Nancy/ViewEngines/AmbiguousViewsException.cs#L8",
 "region":  {
 "startLine":  8,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsNeedStandardConstructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsNeedStandardConstructors.cs
@@ -53,11 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             return HasConstructor(ctors, Accessibility.Public) &&
                    HasConstructor(ctors, Accessibility.Public, KnownType.System_String) &&
-                   HasConstructor(ctors, Accessibility.Public, KnownType.System_String, KnownType.System_Exception) &&
-                   HasConstructor(ctors,
-                       classSymbol.IsSealed ? Accessibility.Private : Accessibility.Protected,
-                       KnownType.System_Runtime_Serialization_SerializationInfo,
-                       KnownType.System_Runtime_Serialization_StreamingContext);
+                   HasConstructor(ctors, Accessibility.Public, KnownType.System_String, KnownType.System_Exception);
         }
 
         private static bool HasConstructor(ImmutableArray<IMethodSymbol> constructors,

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ExceptionsNeedStandardConstructors.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ExceptionsNeedStandardConstructors.cs
@@ -22,7 +22,7 @@ namespace MyLibrary
         My_01_Exception(SerializationInfo info, StreamingContext context) {}
     }
 
-    public class My_02_Exception : Exception // Noncompliant
+    public class My_02_Exception : Exception // Compliant
     {
         public My_02_Exception() { }
 
@@ -30,10 +30,10 @@ namespace MyLibrary
 
         public My_02_Exception(string message, Exception innerException) { }
 
-        public My_02_Exception(SerializationInfo info, StreamingContext context) { }
+        public My_02_Exception(SerializationInfo info, StreamingContext context) { } // optional serialization constructor (should be protected)
     }
 
-    public class My_03_Exception : Exception // Noncompliant
+    public class My_03_Exception : Exception // Compliant
     {
         public My_03_Exception() { }
 
@@ -41,10 +41,10 @@ namespace MyLibrary
 
         public My_03_Exception(string message, Exception innerException) { }
 
-        private My_03_Exception(SerializationInfo info, StreamingContext context) { }
+        private My_03_Exception(SerializationInfo info, StreamingContext context) { }  // optional serialization constructor (should be protected)
     }
 
-    public sealed class My_04_Exception : Exception // Noncompliant
+    public sealed class My_04_Exception : Exception // Compliant
     {
         public My_04_Exception() { }
 
@@ -52,7 +52,7 @@ namespace MyLibrary
 
         public My_04_Exception(string message, Exception innerException) { }
 
-        protected My_04_Exception(SerializationInfo info, StreamingContext context) { }
+        protected My_04_Exception(SerializationInfo info, StreamingContext context) { }  // optional serialization constructor (should be private)
     }
 
     public sealed class My_05_Exception : Exception
@@ -66,7 +66,7 @@ namespace MyLibrary
         private My_05_Exception(SerializationInfo info, StreamingContext context) { }
     }
 
-    public sealed class My_06_Exception : Exception // Noncompliant
+    public sealed class My_06_Exception : Exception // Compliant
     {
         public My_06_Exception() { }
 
@@ -74,6 +74,6 @@ namespace MyLibrary
 
         public My_06_Exception(string message, Exception innerException) { }
 
-        public My_06_Exception(SerializationInfo info, StreamingContext context) { }
+        public My_06_Exception(SerializationInfo info, StreamingContext context) { } // optional serialization constructor (should be protected)
     }
 }


### PR DESCRIPTION
Fixes #8560