### PR TITLE
Documentation: Remove re-ci-infrastructure links to dead documentation/code

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,6 @@ Then, update the projects to include this additional file:
 
 ### Build configuration
 
-* [CI Infrastructure](https://github.com/SonarSource/re-ci-infrastructure)
-* [CI Infrastructure docs](https://github.com/SonarSource/re-ci-infrastructure/blob/master/languages-dotnet/README.md)
 * [VM Images repository](https://github.com/SonarSource/re-ci-images)
 * [Provisioning repository](https://github.com/SonarSource/dotnet-infra/blob/main/src/dotnet_infra/constructs/asg.py)
 * [Azure Pipelines](https://sonarsource.visualstudio.com/DotNetTeam%20Project/_build?definitionId=77&_a=summary)


### PR DESCRIPTION
Follow-up of #8516

Resolving [this comment](https://github.com/SonarSource/sonar-dotnet/pull/8516#discussion_r1442655426)

About re-ci-infrastructure, according to Mate:

_You are absolutely right. 
re-ci-infrastructure was used to provision the GCP infrastructure, but it's now deprecated following the switch to AWS. I'll take care of archiving the code at the end of January. 
Thanks for updating the README. Please let me know if clarification is needed in the documentation of dotnet-infra or re-ci-images._
