### PR TITLE
Fix S2372 FP: Add support for method invocations

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertyGetterWithThrowBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertyGetterWithThrowBase.cs
@@ -68,7 +68,8 @@ namespace SonarAnalyzer.Rules
 
                             var symbol = c.SemanticModel.GetSymbolInfo(throwExpression).Symbol;
                             if (symbol == null ||
-                                symbol.ContainingType.DerivesFromAny(AllowedExceptionBaseTypes))
+                                symbol.ContainingType.DerivesFromAny(AllowedExceptionBaseTypes) ||
+                                (symbol.Kind == SymbolKind.Method && ((IMethodSymbol)symbol).ReturnType?.DerivesFromAny(AllowedExceptionBaseTypes) == true))
                             {
                                 return;
                             }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertyGetterWithThrowBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertyGetterWithThrowBase.cs
@@ -69,7 +69,7 @@ namespace SonarAnalyzer.Rules
                             var symbol = c.SemanticModel.GetSymbolInfo(throwExpression).Symbol;
                             if (symbol == null ||
                                 symbol.ContainingType.DerivesFromAny(AllowedExceptionBaseTypes) ||
-                                (symbol.Kind == SymbolKind.Method && ((IMethodSymbol)symbol).ReturnType?.DerivesFromAny(AllowedExceptionBaseTypes) == true))
+                                (symbol as IMethodSymbol)?.ReturnType?.DerivesFromAny(AllowedExceptionBaseTypes) == true)
                             {
                                 return;
                             }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertyGetterWithThrowBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertyGetterWithThrowBase.cs
@@ -66,10 +66,8 @@ namespace SonarAnalyzer.Rules
                                 return;
                             }
 
-                            var symbol = c.SemanticModel.GetSymbolInfo(throwExpression).Symbol;
-                            if (symbol == null ||
-                                symbol.ContainingType.DerivesFromAny(AllowedExceptionBaseTypes) ||
-                                (symbol as IMethodSymbol)?.ReturnType?.DerivesFromAny(AllowedExceptionBaseTypes) == true)
+                            var type = c.SemanticModel.GetTypeInfo(throwExpression).Type;
+                            if (type == null || type.DerivesFromAny(AllowedExceptionBaseTypes))
                             {
                                 return;
                             }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/PropertyGetterWithThrow.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/PropertyGetterWithThrow.cs
@@ -84,5 +84,16 @@
             {
             }
         }
+        public int MyProperty9
+        {
+            get
+            {
+                throw FactoryMethod(); // Compliant
+            }
+        }
+        private NotSupportedException FactoryMethod()
+        {
+            return new NotSupportedException();
+        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/PropertyGetterWithThrow.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/PropertyGetterWithThrow.cs
@@ -95,5 +95,17 @@
         {
             return new NotSupportedException();
         }
+        public int MyProperty10
+        {
+            get
+            {
+                throw FactoryMethod2(); // Noncompliant {{Remove the exception throwing from this property getter, or refactor the property into a method.}}
+//              ^^^^^^^^^^^^^^^^^^^^^^^
+            }
+        }
+        private Exception FactoryMethod2()
+        {
+            return new Exception();
+        }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/PropertyGetterWithThrow.vb
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/PropertyGetterWithThrow.vb
@@ -57,5 +57,13 @@ Namespace Tests.Diagnostics
 
             End Set
         End Property
+        Public ReadOnly Property Foo9() As Integer
+            Get
+                Throw FactoryMethod() ' Compliant
+            End Get
+        End Property
+        private Function FactoryMethod() as NotSupportedException
+            return new NotSupportedException()
+        End Function
     End Class
 End Namespace

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/PropertyGetterWithThrow.vb
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/PropertyGetterWithThrow.vb
@@ -65,5 +65,14 @@ Namespace Tests.Diagnostics
         private Function FactoryMethod() as NotSupportedException
             return new NotSupportedException()
         End Function
+        Public ReadOnly Property Foo10() As Integer
+            Get
+                Throw FactoryMethod2() ' Noncompliant
+'               ^^^^^^^^^^^^^^^^^^^^^^
+            End Get
+        End Property
+        private Function FactoryMethod2() as Exception
+            return new Exception()
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #8611

…to ignore the issue, if the returned exception type is derived from one of the AllowedExceptionBaseTypes.
New test cases failed before and worked after fix.