### PR TITLE
Deprecate rule S3884

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/SecurityPInvokeMethodShouldNotBeCalledBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SecurityPInvokeMethodShouldNotBeCalledBase.cs
@@ -20,6 +20,7 @@
 
 namespace SonarAnalyzer.Rules
 {
+    [Obsolete("This rule has been deprecated since 9.18")]
     public abstract class SecurityPInvokeMethodShouldNotBeCalledBase<TSyntaxKind, TInvocationExpressionSyntax> : SonarDiagnosticAnalyzer<TSyntaxKind>
         where TSyntaxKind : struct
         where TInvocationExpressionSyntax : SyntaxNode


### PR DESCRIPTION
Fixes #7960 

RSPEC update has already been done in #8018, so it is basically only adding the `[Obsolete]` attribute.

Internal documentation about [deprecation](https://xtranet-sonarsource.atlassian.net/wiki/spaces/LANG/pages/2907832321/How+to+deprecate+then+delete+a+rule+in+sonar-dotnet.).