### PR TITLE
S4261: Simplify name comparrission

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodShouldBeNamedAccordingToSynchronicity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodShouldBeNamedAccordingToSynchronicity.cs
@@ -91,7 +91,7 @@ namespace SonarAnalyzer.Rules.CSharp
             || typeSymbol.ImplementsAny(AsyncReturnInterfaces);
 
         private static bool HasAsyncSuffix(MethodDeclarationSyntax methodDeclaration) =>
-            methodDeclaration.Identifier.ValueText.ToUpper().EndsWith("ASYNC");
+            methodDeclaration.Identifier.ValueText.EndsWith("async", StringComparison.OrdinalIgnoreCase);
 
         private static bool IsSignalRHubMethod(ISymbol methodSymbol) =>
             methodSymbol.GetEffectiveAccessibility() == Accessibility.Public


### PR DESCRIPTION
May fix https://community.sonarsource.com/t/false-negative-async-suffix-reported-when-the-character-a-or-a-is-in-front-of-the-async-suffix/107390

The issue is not reproducible on my side but the pattern used is not recommended by Microsoft:
> The [ToUpper](https://learn.microsoft.com/en-us/dotnet/api/system.string.toupper?view=net-8.0) method is often used to convert a string to uppercase so that it can be used in a case-insensitive comparison. A better method to perform case-insensitive comparison is to call a string comparison method that has a [StringComparison](https://learn.microsoft.com/en-us/dotnet/api/system.stringcomparison?view=net-8.0) parameter whose value you set to [StringComparison.CurrentCultureIgnoreCase](https://learn.microsoft.com/en-us/dotnet/api/system.stringcomparison?view=net-8.0#system-stringcomparison-currentcultureignorecase) for a culture-sensitive, case-insensitive comparison.

[Source](https://learn.microsoft.com/en-us/dotnet/api/system.string.toupper?view=net-8.0#system-string-toupper(system-globalization-cultureinfo))

 This may also fix the issue reported by community even though it does not reproduce (I tried "ToUpper" with all installed cultures and all of them do return something that correctly ends with "asnyc").