### PR TITLE
[DON'T MERGE] Maven ITs failing investigation

### DIFF
--- a/its/src/test/java/com/sonar/it/shared/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/shared/TestUtils.java
@@ -31,6 +31,7 @@ import com.sonar.orchestrator.locator.Location;
 import com.sonar.orchestrator.locator.MavenLocation;
 import com.sonar.orchestrator.util.Command;
 import com.sonar.orchestrator.util.CommandExecutor;
+import com.sonar.orchestrator.util.StreamConsumer;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -178,7 +179,18 @@ public class TestUtils {
 
     LOG.info(String.format("Running `dotnet build` in working directory '%s'", command.getDirectory()));
 
-    int r = CommandExecutor.create().execute(command, 2 * 60 * 1000);
+    final StringBuilder stdOutBuilder = new StringBuilder();
+    StreamConsumer streamConsumer = new StreamConsumer() {
+      @Override
+      public void consumeLine(String line) {
+        stdOutBuilder.append(line).append("\n");
+      }
+    };
+
+    int r = CommandExecutor.create().execute(command, streamConsumer, 2 * 60 * 1000);
+
+    String stdOut = stdOutBuilder.toString();
+    LOG.info(String.format("`dotnet build` stdOut: %s", stdOut));
     assertThat(r).isZero();
   }
 


### PR DESCRIPTION
Temporary PR to investigate flaky issues with Java ITs (CSharp and Others).

All the `expected: 0 but was: 1` reportings in Java `its` come from `TestUtils.runBuild` that runs the `dotnet build /warnaserror:AD0001;CS8032;BC42376 /nr:false command`

```java
int r = CommandExecutor.create().execute(command, 2 * 60 * 1000);
assertThat(r).isZero();
```

All Java `its` work locally (when running `maven clean test` on the `its` dir) so it may be a problem of nuget preventing dotnet build.