### PR TITLE
TestFramework: Create CompilationIssues class

### DIFF
--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/DiagnosticsComparerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/DiagnosticsComparerTest.cs
@@ -27,6 +27,7 @@ namespace SonarAnalyzer.Test.Helpers
     public class DiagnosticsComparerTest
     {
         [TestMethod]
+        [Ignore]    // ToDo: Rework
         public void CompareShouldListAllDifferences_CS()
         {
             const string expected =
@@ -58,6 +59,7 @@ Line 12: Expected Secondary issue was not raised! ID: flow-2
         }
 
         [TestMethod]
+        [Ignore]    // ToDo: Rework
         public void CompareShouldListAllDifferences_VB()
         {
             const string expected =

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticsComparer.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticsComparer.cs
@@ -26,29 +26,31 @@ namespace SonarAnalyzer.Test.TestFramework
     {
         public static StringBuilder Compare(Diagnostic[] diagnostics, Dictionary<string, IList<IIssueLocation>> expectedIssuesPerFile, string languageVersion)
         {
-            var summary = new StringBuilder($"Comparing actual issues with expected:\nLanguage version: {languageVersion}.\n");
-            var actualIssuesPerFile = diagnostics.ToIssueLocationsPerFile();
+            throw new NotImplementedException();
 
-            foreach (var fileName in actualIssuesPerFile.Keys.OrderBy(x => x))
-            {
-                summary.Append('\n').Append(fileName).Append('\n');
+            //var summary = new StringBuilder($"Comparing actual issues with expected:\nLanguage version: {languageVersion}.\n");
+            //var actualIssuesPerFile = diagnostics.ToIssueLocationsPerFile();
 
-                var expectedIssues = expectedIssuesPerFile[fileName];
-                foreach (var actualIssue in actualIssuesPerFile[fileName].OrderBy(x => x.LineNumber))
-                {
-                    var expectedIssue = expectedIssues.FirstOrDefault(x => x.IsPrimary == actualIssue.IsPrimary && x.LineNumber == actualIssue.LineNumber);
-                    summary.AppendComparison(actualIssue, expectedIssue);
-                    expectedIssues.Remove(expectedIssue);
-                }
+            //foreach (var fileName in actualIssuesPerFile.Keys.OrderBy(x => x))
+            //{
+            //    summary.Append('\n').Append(fileName).Append('\n');
 
-                foreach (var expectedIssue in expectedIssues.OrderBy(x => x.LineNumber))
-                {
-                    var issueId = expectedIssue.IssueId is { } id ? $" ID: {id}" : string.Empty;
-                    summary.Append($"Line {expectedIssue.LineNumber}: Expected {IssueType(expectedIssue.IsPrimary)} issue was not raised!{issueId}\n");
-                }
-            }
+            //    var expectedIssues = expectedIssuesPerFile[fileName];
+            //    foreach (var actualIssue in actualIssuesPerFile[fileName].OrderBy(x => x.LineNumber))
+            //    {
+            //        var expectedIssue = expectedIssues.FirstOrDefault(x => x.IsPrimary == actualIssue.IsPrimary && x.LineNumber == actualIssue.LineNumber);
+            //        summary.AppendComparison(actualIssue, expectedIssue);
+            //        expectedIssues.Remove(expectedIssue);
+            //    }
 
-            return summary;
+            //    foreach (var expectedIssue in expectedIssues.OrderBy(x => x.LineNumber))
+            //    {
+            //        var issueId = expectedIssue.IssueId is { } id ? $" ID: {id}" : string.Empty;
+            //        summary.Append($"Line {expectedIssue.LineNumber}: Expected {IssueType(expectedIssue.IsPrimary)} issue was not raised!{issueId}\n");
+            //    }
+            //}
+
+            //return summary;
         }
 
         private static void AppendComparison(this StringBuilder summary, IIssueLocation actual, IIssueLocation expected)
@@ -73,28 +75,6 @@ namespace SonarAnalyzer.Test.TestFramework
             {
                 summary.Append($"{prefix}: {issueType} issue should have a length of {expected.Length} but got a length of {actual.Length}!{issueId}\n");
             }
-        }
-
-        private static Dictionary<string, IList<IIssueLocation>> ToIssueLocationsPerFile(this IEnumerable<Diagnostic> diagnostics)
-        {
-            var issuesPerFile = new Dictionary<string, IList<IIssueLocation>>();
-
-            foreach (var diagnostic in diagnostics)
-            {
-                var path = diagnostic.Location.SourceTree?.FilePath ?? string.Empty;
-                if (!issuesPerFile.ContainsKey(path))
-                {
-                    issuesPerFile.Add(path, new List<IIssueLocation>());
-                }
-                issuesPerFile[path].Add(new IssueLocationCollector.IssueLocation(diagnostic));
-
-                for (var i = 0; i < diagnostic.AdditionalLocations.Count; i++)
-                {
-                    issuesPerFile[path].Add(new IssueLocationCollector.IssueLocation(diagnostic.GetSecondaryLocation(i)));
-                }
-            }
-
-            return issuesPerFile;
         }
 
         private static string IssueType(bool isPrimary) =>

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueLocationCollector.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueLocationCollector.cs
@@ -253,6 +253,7 @@ internal class MyClass : IInterface1 // there should be no Noncompliant comment
         [DebuggerDisplay("ID:{IssueId} @{LineNumber} Primary:{IsPrimary} Start:{Start} Length:{Length} '{Message}'")]
         internal class IssueLocation : IIssueLocation
         {
+            public string FilePath { get; init; }
             public bool IsPrimary { get; init; }
             public int LineNumber { get; init; }
             public string Message { get; init; }
@@ -276,6 +277,7 @@ internal class MyClass : IInterface1 // there should be no Noncompliant comment
                 LineNumber = location.GetLineNumberToReport();
                 Start = location.GetLineSpan().StartLinePosition.Character;
                 Length = location.SourceSpan.Length;
+                FilePath = location.SourceTree?.FilePath;
             }
         }
     }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/CompilationIssues.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/CompilationIssues.cs
@@ -1,0 +1,68 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.IO;
+
+namespace SonarAnalyzer.TestFramework.Verification.IssueValidation;
+
+internal sealed class CompilationIssues
+{
+    public string LanguageVersion { get; }
+    private readonly DiagnosticVerifier.FileIssueLocations[] fileIssues;
+
+    public CompilationIssues(string languageVersion, IEnumerable<DiagnosticVerifier.File> files)
+    {
+        LanguageVersion = languageVersion;
+        fileIssues = files.Select(x => new DiagnosticVerifier.FileIssueLocations(x.FileName, IssueLocationCollector.GetExpectedIssueLocations(x.Content.Lines))).ToArray();
+    }
+
+    public CompilationIssues(string languageVersion, Diagnostic[] diagnostics)
+    {
+        var map = new Dictionary<string, List<IIssueLocation>>();
+        foreach (var diagnostic in diagnostics)
+        {
+            Add(new IssueLocationCollector.IssueLocation(diagnostic));
+            for (var i = 0; i < diagnostic.AdditionalLocations.Count; i++)
+            {
+                Add(new IssueLocationCollector.IssueLocation(diagnostic.GetSecondaryLocation(i)));
+            }
+        }
+        LanguageVersion = languageVersion;
+        fileIssues = map.Select(x => new DiagnosticVerifier.FileIssueLocations(x.Key, x.Value)).ToArray();
+
+        void Add(IssueLocationCollector.IssueLocation issue)
+        {
+            var list = map.GetOrAdd(issue.FilePath ?? string.Empty, _ => new List<IIssueLocation>());
+            list.Add(issue);
+        }
+    }
+
+    public void Dump()
+    {
+        foreach (var file in fileIssues)
+        {
+            Console.WriteLine($"Actual {LanguageVersion} diagnostics {Path.GetFileName(file.FileName)}:");
+            foreach (var issue in file.IssueLocations.OrderBy(x => x.LineNumber))
+            {
+                Console.WriteLine($"  ID: {issue.IssueId}, Line: {issue.LineNumber}, [{issue.Start}, {issue.Length}] {issue.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part of #8543 

This PR:
* Creates `CompilationIssues` class that holds issues from all files from a compilation. It will be heavily used later for way more logic.
* Comments out unused `DiagnosticComparer` for now. That will be reworked/partially reused later.

