### PR TITLE
Remove MSBuild 14 related logic

### DIFF
--- a/analyzers/its/regression-test.ps1
+++ b/analyzers/its/regression-test.ps1
@@ -1,8 +1,8 @@
 [CmdletBinding(PositionalBinding = $false)]
 param
 (
-    [Parameter(HelpMessage = "Version of MS Build: 14.0, 15.0, 16.0 or Current")]
-    [ValidateSet("14.0", "15.0", "16.0", "Current")]
+    [Parameter(HelpMessage = "Version of MS Build: 15.0, 16.0 or Current")]
+    [ValidateSet("15.0", "16.0", "Current")]
     [string]
     $msbuildVersion = "Current",
 
@@ -70,7 +70,6 @@ function Build-Project-MSBuild([string]$ProjectName, [string]$SolutionRelativePa
     $Env:PROJECT = $ProjectName
 
     Restore-Packages $msbuildVersion $solutionPath
-    # Note: Summary doesn't work for MSBuild 14
     Invoke-MSBuild $msbuildVersion $solutionPath `
         /m:$CpuCount `
         /t:rebuild `

--- a/analyzers/its/regression-test.ps1
+++ b/analyzers/its/regression-test.ps1
@@ -1,11 +1,6 @@
 [CmdletBinding(PositionalBinding = $false)]
 param
 (
-    [Parameter(HelpMessage = "Version of MS Build: 15.0, 16.0 or Current")]
-    [ValidateSet("15.0", "16.0", "Current")]
-    [string]
-    $msbuildVersion = "Current",
-
     [Parameter(HelpMessage = "The key of the rule to test, e.g. S1234. If omitted, all rules will be tested.")]
     [ValidatePattern("^S[0-9]+")]
     [string]
@@ -69,8 +64,8 @@ function Build-Project-MSBuild([string]$ProjectName, [string]$SolutionRelativePa
     Write-Debug "Setting PROJECT environment variable to '${ProjectName}'"
     $Env:PROJECT = $ProjectName
 
-    Restore-Packages $msbuildVersion $solutionPath
-    Invoke-MSBuild $msbuildVersion $solutionPath `
+    Restore-Packages $solutionPath
+    Invoke-MSBuild $solutionPath `
         /m:$CpuCount `
         /t:rebuild `
         /p:Configuration=Debug `

--- a/scripts/build/build-utils.ps1
+++ b/scripts/build/build-utils.ps1
@@ -12,11 +12,7 @@ function Get-VsWherePath {
     return Get-ExecutablePath -name "vswhere.exe" -envVar "VSWHERE_PATH"
 }
 
-function Get-MsBuildPath([ValidateSet("14.0", "15.0", "16.0", "17.0", "Current")][string]$msbuildVersion) {
-    if ($msbuildVersion -eq "14.0") {
-        return Get-ExecutablePath -name "msbuild.exe" -envVar "MSBUILD_PATH"
-    }
-
+function Get-MsBuildPath([ValidateSet("15.0", "16.0", "17.0", "Current")][string]$msbuildVersion) {
     #If MSBUILD_PATH environment variable is found, the version is not checked and the value of input parameter is ignored.
     Write-Host "Trying to find 'msbuild.exe' using 'MSBUILD_PATH' environment variable"
     $msbuildPathEnvVar = "MSBUILD_PATH"
@@ -53,11 +49,11 @@ function Get-CodeCoveragePath {
     return Get-ExecutablePath -name "CodeCoverage.exe" -directory $codeCoverageDirectory -envVar "CODE_COVERAGE_PATH"
 }
 
-function Get-MSBuildImportBeforePath([ValidateSet("14.0", "15.0", "16.0", "17.0", "Current")][string]$msbuildVersion) {
+function Get-MSBuildImportBeforePath([ValidateSet("15.0", "16.0", "17.0", "Current")][string]$msbuildVersion) {
     return "$env:USERPROFILE\AppData\Local\Microsoft\MSBuild\${msbuildVersion}\Microsoft.Common.targets\ImportBefore"
 }
 
-function Get-MSBuildImportBeforePath-SystemX64([ValidateSet("14.0", "15.0", "16.0", "17.0", "Current")][string]$msbuildVersion) {
+function Get-MSBuildImportBeforePath-SystemX64([ValidateSet("15.0", "16.0", "17.0", "Current")][string]$msbuildVersion) {
     return "C:\Windows\SysWOW64\config\systemprofile\AppData\Local\Microsoft\MSBuild\${msbuildVersion}\Microsoft.Common.targets\ImportBefore"
 }
 
@@ -91,7 +87,7 @@ function New-NuGetPackages([string]$binPath) {
 
 # Used by the integration tests in analyzers\its\regression-test.ps1
 function Restore-Packages (
-    [Parameter(Mandatory = $true, Position = 0)][ValidateSet("14.0", "15.0", "16.0", "17.0", "Current")][string]$msbuildVersion,
+    [Parameter(Mandatory = $true, Position = 0)][ValidateSet("15.0", "16.0", "17.0", "Current")][string]$msbuildVersion,
     [Parameter(Mandatory = $true, Position = 1)][string]$solutionPath) {
 
     $solutionName = Split-Path $solutionPath -Leaf
@@ -111,7 +107,7 @@ function Restore-Packages (
 
 # Build
 function Invoke-MSBuild (
-    [Parameter(Mandatory = $true, Position = 0)][ValidateSet("14.0", "15.0", "16.0", "17.0", "Current")][string]$msbuildVersion,
+    [Parameter(Mandatory = $true, Position = 0)][ValidateSet("15.0", "16.0", "17.0", "Current")][string]$msbuildVersion,
     [Parameter(Mandatory = $true, Position = 1)][string]$solutionPath,
     [parameter(ValueFromRemainingArguments = $true)][array]$remainingArgs) {
 
@@ -160,7 +156,7 @@ function Invoke-UnitTests([string]$binPath, [string]$buildConfiguration) {
     Test-ExitCode "ERROR: Unit tests for .NET 6 FAILED."
 }
 
-function Invoke-IntegrationTests([ValidateSet("14.0", "15.0", "16.0", "17.0", "Current")][string] $msbuildVersion) {
+function Invoke-IntegrationTests([ValidateSet("15.0", "16.0", "17.0", "Current")][string] $msbuildVersion) {
     Write-Header "Running integration tests"
 
     Invoke-InLocation "its" {

--- a/scripts/build/build-utils.ps1
+++ b/scripts/build/build-utils.ps1
@@ -158,7 +158,7 @@ function Invoke-IntegrationTests() {
     Invoke-InLocation "its" {
         Exec { & git submodule update --init --recursive --depth 1 }
 
-        Exec { & .\regression-test.ps1
+        Exec { & .\regression-test.ps1 `
         } -errorMessage "ERROR: Integration tests FAILED."
     }
 }

--- a/scripts/build/dev-build.ps1
+++ b/scripts/build/dev-build.ps1
@@ -53,12 +53,10 @@ try {
     $buildConfiguration = if ($release) { "Release" } else { "Debug" }
     $binPath = "bin\${buildConfiguration}"
     $solutionName = "SonarAnalyzer.sln"
-    $msbuildVersion = "15.0"
 
     Write-Host "Solution to build: $solutionName"
     Write-Host "Build configuration: $buildConfiguration"
     Write-Host "Bin folder to use: $binPath"
-    Write-Host "MSBuild: ${msbuildVersion}"
 
     $StartDate=(Get-Date)
 
@@ -69,7 +67,7 @@ try {
         Get-ChildItem tests\*\bin\Debug | Remove-Item -Recurse
         Get-ChildItem tests\*\bin\Release | Remove-Item -Recurse
 
-        Invoke-MSBuild $msbuildVersion $solutionName /t:"Restore,Rebuild" `
+        Invoke-MSBuild $solutionName /t:"Restore,Rebuild" `
             /consoleloggerparameters:Summary `
             /m `
             /p:configuration=$buildConfiguration `
@@ -85,7 +83,7 @@ try {
     }
 
     if ($its) {
-        Invoke-IntegrationTests $msbuildVersion
+        Invoke-IntegrationTests
     }
 
     if ($coverage) {


### PR DESCRIPTION
As part of [MMF-3594](https://sonarsource.atlassian.net/browse/MMF-3594), we are dropping support for MSBuild 14.
The goal of this PR is to remove all the MSBuild 14 test infrastructure from the analyzer.

[MMF-3594]: https://sonarsource.atlassian.net/browse/MMF-3594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ