### PR TITLE
TestFramework: Implement CompilationIssues class

### DIFF
--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/CompilationIssuesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/CompilationIssuesTest.cs
@@ -1,0 +1,104 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.TestFramework.Verification.IssueValidation;
+
+namespace SonarAnalyzer.TestFramework.Test.Verification.IssueValidation;
+
+[TestClass]
+public class CompilationIssuesTest
+{
+    [TestMethod]
+    public void UniqueKeys() =>
+        CreateSut().UniqueKeys().Should().BeEquivalentTo(new IssueLocationKey[]
+        {
+            new("First.cs", 11, true),
+            new("First.cs", 11, false),
+            new("First.cs", 99, true),
+            new("Second.cs", 11, true),
+            new("Third.cs", 1, false)
+        });
+
+    [TestMethod]
+    public void Remove_NoMatch()
+    {
+        var sut = CreateSut();
+        sut.Should().HaveCount(13);
+        sut.Remove(new("ThisKeyIsNotPresent.cs", 11, true)).Should().BeEmpty();
+        sut.Should().HaveCount(13);
+    }
+
+    [TestMethod]
+    public void Remove_WhenPresent()
+    {
+        var sut = CreateSut();
+        sut.Should().HaveCount(13);
+        sut.Remove(new("Second.cs", 11, true)).Should().HaveCount(5);
+        sut.Should().HaveCount(8);
+    }
+
+    [TestMethod]
+    public void Remove_WhenPresent_ReturnsAllOccurances()
+    {
+        var sut = CreateSut();
+        sut.Should().HaveCount(13);
+        sut.Remove(new("Third.cs", 1, false)).Should().HaveCount(3);
+        sut.Should().HaveCount(10);
+    }
+
+    [TestMethod]
+    public void Dump()
+    {
+        using var log = new LogTester();
+        CreateSut().Dump();
+        log.AssertContain("""
+            Actual C# 99 diagnostics First.cs:
+                S1111, Line: 11, [1, 10] Lorem ipsum
+                S1111, Line: 11, [9, 10] Lorem ipsum
+                S2222, Line: 11, [1, 10] Lorem 2222 ipsum
+                S2222, Line: 11, [1, 10] Lorem 2222 ipsum
+                S2222, Line: 99, [1, 10] Lorem 2222 ipsum
+            Actual C# 99 diagnostics Second.cs:
+                S2222, Line: 11, [1, 11] Lorem 2222 ipsum
+                S2222, Line: 11, [2, 12] Lorem 2222 ipsum
+                S2222, Line: 11, [3, 13] Lorem 2222 ipsum
+                S2222, Line: 11, [4, 14] Lorem 2222 ipsum
+                S2222, Line: 11, [5, 15] Lorem 2222 ipsum
+            """);
+    }
+
+    private static CompilationIssues CreateSut() =>
+        new("C# 99", new IssueLocation[]
+        {
+            new() { RuleId = "S1111", FilePath = "First.cs", LineNumber = 11, IsPrimary = true, Start = 1, Length = 10, Message = "Lorem ipsum" },
+            new() { RuleId = "S1111", FilePath = "First.cs", LineNumber = 11, IsPrimary = true, Start = 9, Length = 10, Message = "Lorem ipsum" },
+            new() { RuleId = "S2222", FilePath = "First.cs", LineNumber = 99, IsPrimary = true, Start = 1, Length = 10, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "First.cs", LineNumber = 11, IsPrimary = true, Start = 1, Length = 10, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "First.cs", LineNumber = 11, IsPrimary = false, Start = 1, Length = 10, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, IsPrimary = true, Start = 1, Length = 11, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, IsPrimary = true, Start = 2, Length = 12, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, IsPrimary = true, Start = 3, Length = 13, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, IsPrimary = true, Start = 4, Length = 14, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, IsPrimary = true, Start = 5, Length = 15, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S3333", FilePath = "Third.cs", LineNumber = 1, IsPrimary = false, Start = 1, Length = 10, Message = "Multiple identical secondaries" },
+            new() { RuleId = "S3333", FilePath = "Third.cs", LineNumber = 1, IsPrimary = false, Start = 1, Length = 10, Message = "Multiple identical secondaries" },
+            new() { RuleId = "S3333", FilePath = "Third.cs", LineNumber = 1, IsPrimary = false, Start = 1, Length = 10, Message = "Multiple identical secondaries" }
+        });
+}

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationTest.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.TestFramework.Verification.IssueValidation;
+
+namespace SonarAnalyzer.TestFramework.Test.Verification.IssueValidation;
+
+[TestClass]
+public class IssueLocationTest
+{
+    private static readonly IssueLocation Issue = new() { RuleId = "S1234", FilePath = "File.cs", LineNumber = 42, IsPrimary = true, Message = "Lorem ipsum", Start = 42, Length = 10 };
+
+    [TestMethod]
+    public void IssueLocationKey_CreatedFromIssue()
+    {
+        var sut = new IssueLocationKey(Issue);
+        sut.FilePath.Should().Be("File.cs");
+        sut.LineNumber.Should().Be(42);
+        sut.IsPrimary.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void IssueLocationKey_IsMatch_MatchesSameKey() =>
+        new IssueLocationKey("File.cs", 42, true).IsMatch(Issue).Should().BeTrue();
+
+    [TestMethod]
+    public void IssueLocationKey_IsMatch_DifferentFilePath() =>
+        new IssueLocationKey("Another.cs", 42, true).IsMatch(Issue).Should().BeFalse();
+
+    [TestMethod]
+    public void IssueLocationKey_IsMatch_DifferentLineNumber() =>
+        new IssueLocationKey("File.cs", 1024, true).IsMatch(Issue).Should().BeFalse();
+
+    [TestMethod]
+    public void IssueLocationKey_IsMatch_DifferentIsPrimary() =>
+        new IssueLocationKey("File.cs", 42, false).IsMatch(Issue).Should().BeFalse();
+}

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/LogTester.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/LogTester.cs
@@ -19,6 +19,7 @@
  */
 
 using System.IO;
+using SonarAnalyzer.Test.Helpers;
 
 namespace SonarAnalyzer.Test.TestFramework
 {
@@ -38,10 +39,10 @@ namespace SonarAnalyzer.Test.TestFramework
         }
 
         public void AssertContain(string value) =>
-            outWriter.ToString().Should().Contain(value);
+            outWriter.ToString().Should().ContainIgnoringLineEndings(value);
 
         public void AssertContainError(string value) =>
-            errorWriter.ToString().Should().Contain(value);
+            errorWriter.ToString().Should().ContainIgnoringLineEndings(value);
 
         public void Dispose()
         {

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Extensions/StringAssertionsExtensions.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Extensions/StringAssertionsExtensions.cs
@@ -26,5 +26,8 @@ namespace SonarAnalyzer.Test.Helpers
     {
         public static void BeIgnoringLineEndings(this StringAssertions stringAssertions, string expected) =>
             stringAssertions.Subject.ToUnixLineEndings().Should().Be(expected.ToUnixLineEndings());
+
+        public static void ContainIgnoringLineEndings(this StringAssertions stringAssertions, string expected) =>
+            stringAssertions.Subject.ToUnixLineEndings().Should().Contain(expected.ToUnixLineEndings());
     }
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/IssueLocation.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/IssueLocation.cs
@@ -56,4 +56,9 @@ internal sealed class IssueLocation // ToDo: Refactor the relation between this 
 internal record IssueLocationKey(string FilePath, int LineNumber, bool IsPrimary)
 {
     public IssueLocationKey(IssueLocation issue) : this(issue.FilePath, issue.LineNumber, issue.IsPrimary) { }
+
+    public bool IsMatch(IssueLocation issue) =>
+        issue.FilePath == FilePath
+        && issue.LineNumber == LineNumber
+        && issue.IsPrimary == IsPrimary;
 }


### PR DESCRIPTION
Part of #8543 

This is a prerequisite needed to properly implement issue matching. 

The algorithm will be roughly like:
```
For Each Key In Actual.UniqueKeys
   BuildPairs(Actual.Remove(Key), Expected.Remove(Key))
Next
```
where `Remove` will give us what was removed for the key and considered "done done".

`BuildPairs` will find best matches between these two groups.