### PR TITLE
TestFramework: Rework Razor verification

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextBaseTest.ShouldAnalyzeTree.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextBaseTest.ShouldAnalyzeTree.cs
@@ -198,8 +198,7 @@ public partial class SonarAnalysisContextBaseTest
            .AddProject(AnalyzerLanguage.CSharp, createExtraEmptyFile: false)
            .AddSnippet(content, "Foo.cs")
            .GetCompilation();
-
-        DiagnosticVerifier.Verify(compilation, new CS.EmptyStatement(), CompilationErrorBehavior.FailTest, compilation.SyntaxTrees.First());
+        DiagnosticVerifier.Verify(compilation, new CS.EmptyStatement(), CompilationErrorBehavior.FailTest);
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/Metrics/CSharpExecutableLinesMetricTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Metrics/CSharpExecutableLinesMetricTest.cs
@@ -1044,8 +1044,8 @@ class Program
                 .Compile(false)
                 .Single();
 
-            var syntaxTree = compilation.SyntaxTrees.Single(x => x.ToString().Contains(fileName));
-            var semanticModel = compilation.GetSemanticModel(syntaxTree);
+            var syntaxTree = compilation.Compilation.SyntaxTrees.Single(x => x.ToString().Contains(fileName));
+            var semanticModel = compilation.Compilation.GetSemanticModel(syntaxTree);
 
             var lineNumbers = Metrics.CSharp.CSharpExecutableLinesMetric.GetLineNumbers(syntaxTree, semanticModel);
             lineNumbers.Should().BeEquivalentTo(expectedExecutableLines);

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/MethodParameterUnusedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/MethodParameterUnusedTest.cs
@@ -70,7 +70,7 @@ public class Sample
     private void Method(int arg) =>
         arg.ToString();
 }";
-            var compilation1 = roslynCS.AddSnippet(code).WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7).Build().Compile(false).Single();
+            var compilation1 = roslynCS.AddSnippet(code).WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7).Build().Compile(false).Single().Compilation;
             var compilation2 = compilation1.WithAssemblyName("Different-Compilation-Reusing-Same-Nodes");
             // Modified compilation should not reuse cached CFG, because symbols from method would not be equal to symbols from the other CFG.
             Analyze(compilation1).Should().BeEmpty();

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierBuilderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierBuilderTest.cs
@@ -62,38 +62,61 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
         public void AddPaths_SetsIsRazorWithRazorFile()
         {
             Empty.IsRazor.Should().BeFalse();
+            Empty.ParseOptions.Should().BeEmpty();
             var one = Empty.AddPaths("Source1.cs");
             one.IsRazor.Should().BeFalse();
+            one.ParseOptions.Should().BeEmpty();
             var two = one.AddPaths("Source1.razor");
             two.IsRazor.Should().BeTrue();
+            two.ParseOptions.Should().BeEquivalentTo(ParseOptionsHelper.FromCSharp10);
             var three = two.AddPaths("Source2.cs");
             three.IsRazor.Should().BeTrue();
+            three.ParseOptions.Should().BeEquivalentTo(ParseOptionsHelper.FromCSharp10);
             var four = three.AddPaths("Source2.razor");
             four.IsRazor.Should().BeTrue();
+            four.ParseOptions.Should().BeEquivalentTo(ParseOptionsHelper.FromCSharp10);
         }
 
         [TestMethod]
         public void AddPaths_SetsIsRazorWithCshtmlFile()
         {
             Empty.IsRazor.Should().BeFalse();
+            Empty.ParseOptions.Should().BeEmpty();
             var one = Empty.AddPaths("Source1.cs");
             one.IsRazor.Should().BeFalse();
+            one.ParseOptions.Should().BeEmpty();
             var two = one.AddPaths("Source1.cshtml");
             two.IsRazor.Should().BeTrue();
+            two.ParseOptions.Should().BeEquivalentTo(ParseOptionsHelper.FromCSharp10);
             var three = two.AddPaths("Source2.cs");
             three.IsRazor.Should().BeTrue();
+            three.ParseOptions.Should().BeEquivalentTo(ParseOptionsHelper.FromCSharp10);
             var four = three.AddPaths("Source2.cshtml");
             four.IsRazor.Should().BeTrue();
+            four.ParseOptions.Should().BeEquivalentTo(ParseOptionsHelper.FromCSharp10);
         }
 
         [TestMethod]
         public void AddPaths_SetsIsRazorWithRazorAndCshtmlFiles()
         {
             Empty.IsRazor.Should().BeFalse();
+            Empty.ParseOptions.Should().BeEmpty();
             var one = Empty.AddPaths("Source1.razor");
             one.IsRazor.Should().BeTrue();
+            one.ParseOptions.Should().BeEquivalentTo(ParseOptionsHelper.FromCSharp10);
             var two = one.AddPaths("Source1.cshtml");
             two.IsRazor.Should().BeTrue();
+            two.ParseOptions.Should().BeEquivalentTo(ParseOptionsHelper.FromCSharp10);
+        }
+
+        [TestMethod]
+        public void AddPaths_SetsIsRazorWithRazorFile_PreservesOptions()
+        {
+            Empty.IsRazor.Should().BeFalse();
+            Empty.ParseOptions.Should().BeEmpty();
+            var one = Empty.WithOptions(ParseOptionsHelper.FromCSharp12).AddPaths("Source1.razor");
+            one.IsRazor.Should().BeTrue();
+            one.ParseOptions.Should().BeEquivalentTo(ParseOptionsHelper.FromCSharp12, "it should not regress to automatically set version 10");
         }
 
         [TestMethod]
@@ -114,6 +137,19 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             Empty.Snippets.Should().BeEmpty();
             one.Snippets.Should().Equal(new Snippet("First", null));
             two.Snippets.Should().Equal(new Snippet("First", null), new Snippet("Second", "WithFileName.cs"));
+        }
+
+        [TestMethod]
+        public void AddSnippet_SetsIsRazorWithRazorFile()
+        {
+            Empty.IsRazor.Should().BeFalse();
+            Empty.ParseOptions.Should().BeEmpty();
+            var one = Empty.AddSnippet("// Nothing to see here", "Source1.cs");
+            one.IsRazor.Should().BeFalse();
+            one.ParseOptions.Should().BeEmpty();
+            var two = one.AddPaths("<div></div>", "Source1.razor");
+            two.IsRazor.Should().BeTrue();
+            two.ParseOptions.Should().BeEquivalentTo(ParseOptionsHelper.FromCSharp10);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierTest.cs
@@ -23,7 +23,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using SonarAnalyzer.Protobuf;
 using SonarAnalyzer.Rules.CSharp;
 using SonarAnalyzer.SymbolicExecution.Sonar.Analyzers;
-using SonarAnalyzer.Test.Helpers;
 
 namespace SonarAnalyzer.Test.TestFramework.Tests
 {
@@ -125,6 +124,16 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             DummyCS.AddSnippet("//Empty").WithProtobufPath("Proto.pb")
                 .Invoking(x => x.Build()).Should().Throw<ArgumentException>().WithMessage("DummyAnalyzerCS does not inherit from UtilityAnalyzerBase.");
 
+        [TestMethod]
+        public void Constructor_IsRazor_NoOptions_Throws() =>
+            DummyCS.AddSnippet("//Empty", "File.razor").WithOptions(ImmutableArray<ParseOptions>.Empty)
+                .Invoking(x => x.Build()).Should().Throw<ArgumentException>().WithMessage("IsRazor was set. ParseOptions must be specified.");
+
+        [TestMethod]
+        public void Constructor_IsRazor_VB_Throws() =>
+            DummyVB.AddSnippet("//Empty", "File.razor")
+                .Invoking(x => x.Build()).Should().Throw<ArgumentException>().WithMessage("IsRazor was set for Visual Basic analyzer. Only C# is supported.");
+
 #if NET
 
         [TestMethod]
@@ -191,25 +200,25 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
         [DataTestMethod]
         [DataRow("net6.0")]
         [DataRow("net7.0")]
-        public void Verify_Razor_WithFramework(string framework)
+        public void Compile_Razor_WithFramework(string framework)
         {
             var compilations = DummyWithLocation.AddPaths("Dummy.razor")
                 .WithFramework(framework)
                 .Build()
                 .Compile(false);
 
-            var reference = compilations.Single().ExternalReferences.First().Display;
+            var reference = compilations.Single().Compilation.ExternalReferences.First().Display;
             reference.Contains(framework).Should().BeTrue();
         }
 
         [TestMethod]
-        public void Verify_Razor_DefaultFramework()
+        public void Compile_Razor_DefaultFramework()
         {
             var compilations = DummyWithLocation.AddPaths("Dummy.razor")
                 .Build()
                 .Compile(false);
 
-            var reference = compilations.Single().ExternalReferences.First().Display;
+            var reference = compilations.Single().Compilation.ExternalReferences.First().Display;
             reference.Contains("net7.0").Should().BeTrue();
         }
 
@@ -228,56 +237,51 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
         }
 
         [TestMethod]
-        public void Verify_Razor_ParseOptions()
+        public void Compile_Razor_ParseOptions_OldVersion() =>
+            DummyWithLocation.AddPaths("Dummy.razor").WithOptions(ImmutableArray.Create<ParseOptions>(new CSharpParseOptions(LanguageVersion.CSharp6))).Build().Compile(false)
+                .Invoking(x => x.ToArray()) // Force evaluation of the collection
+                .Should()
+                .Throw<NotSupportedException>();
+
+        [TestMethod]
+        public void Compile_Razor_ParseOptions_DefaultLanguageVersion()
         {
-            var compilations = DummyWithLocation.AddPaths("Dummy.razor")
-                .WithOptions(ParseOptionsHelper.BeforeCSharp10)
-                .Build()
-                .Compile(false);
+            // Version below C# 10 are not compatible with our EmptyProject scaffolding due to nullable context and global using statements.
+            var expectedLanguageVersions = ParseOptionsHelper.FromCSharp10.Cast<CSharpParseOptions>().Select(x => x.LanguageVersion.ToString());
+            var compilations = DummyWithLocation.AddPaths("Dummy.razor").Build().Compile(false);
+            compilations.Select(c => c.Compilation.LanguageVersionString()).Should().BeEquivalentTo(expectedLanguageVersions);
+        }
 
-            if (!TestContextHelper.IsAzureDevOpsContext || TestContextHelper.IsPullRequestBuild)
+        [TestMethod]
+        public void Compile_Razor_ParseOptions_WithSpecificVersion()
+        {
+            var builder = DummyWithLocation.AddPaths("Dummy.razor");
+            // Version below C# 10 are not compatible with our EmptyProject scaffolding due to nullable context and global using statements.
+            foreach (var options in ParseOptionsHelper.FromCSharp10)
             {
-                compilations.Should().ContainSingle();
-
-                compilations.Single().LanguageVersionString().Should().BeEquivalentTo(LanguageVersion.CSharp5.ToString());
-            }
-            else
-            {
-                compilations.Should().HaveCount(8);
-                var languages = compilations.Select(c => c.LanguageVersionString()).ToList();
-
-                languages.Should().BeEquivalentTo(new List<string>()
-                    {
-                        LanguageVersion.CSharp9.ToString(),
-                        LanguageVersion.CSharp8.ToString(),
-                        LanguageVersion.CSharp7_3.ToString(),
-                        LanguageVersion.CSharp7_2.ToString(),
-                        LanguageVersion.CSharp7_1.ToString(),
-                        LanguageVersion.CSharp7.ToString(),
-                        LanguageVersion.CSharp6.ToString(),
-                        LanguageVersion.CSharp5.ToString()
-                    });
+                // Update Verifier.LanguageVersionReference() in case this breaks
+                builder.WithOptions(ImmutableArray.Create(options)).Build().Compile(false).Should().ContainSingle();
             }
         }
 
         [TestMethod]
-        public void Verify_Razor_AddReferences()
+        public void Compile_Razor_AddReferences()
         {
             var compilations = DummyWithLocation.AddPaths("Dummy.razor")
                 .AddReferences(NuGetMetadataReference.MicrosoftAzureDocumentDB())
                 .Build()
                 .Compile(false);
-            var references = compilations.Single().References;
+            var references = compilations.Single().Compilation.References;
             references.Should().Contain(x => x.Display.Contains("Microsoft.Azure.DocumentDB"));
         }
 
         [TestMethod]
-        public void Verify_Razor_NoReferences()
+        public void Compile_Razor_NoReferences()
         {
             var compilations = DummyWithLocation.AddPaths("Dummy.razor")
                 .Build()
                 .Compile(false);
-            var references = compilations.Single().References;
+            var references = compilations.Single().Compilation.References;
             references.Should().NotContain(x => x.Display.Contains("Microsoft.Azure.DocumentDB"));
         }
 

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/Verifier.cs
@@ -89,6 +89,17 @@ namespace SonarAnalyzer.Test.TestFramework
                 codeFix = builder.CodeFix();
                 ValidateCodeFix();
             }
+            if (builder.IsRazor)
+            {
+                if (builder.ParseOptions.IsEmpty)
+                {
+                    throw new ArgumentException($"{nameof(builder.IsRazor)} was set. {nameof(ParseOptions)} must be specified.");
+                }
+                else if (language != AnalyzerLanguage.CSharp)
+                {
+                    throw new ArgumentException($"{nameof(builder.IsRazor)} was set for {language} analyzer. Only C# is supported.");
+                }
+            }
         }
 
         public void Verify()    // This should never have any arguments
@@ -99,21 +110,7 @@ namespace SonarAnalyzer.Test.TestFramework
             }
             foreach (var compilation in Compile(builder.ConcurrentAnalysis))
             {
-                if (builder.IsRazor)
-                {
-                    DiagnosticVerifier.VerifyRazor(
-                        compilation,
-                        analyzers,
-                        builder.ErrorBehavior,
-                        builder.AdditionalFilePath,
-                        onlyDiagnosticIds,
-                        builder.Paths.Where(builder.IsRazorOrCshtmlFile).Select(TestCasePath),
-                        builder.Snippets.Where(x => builder.IsRazorOrCshtmlFile(x.FileName)));
-                }
-                else
-                {
-                    DiagnosticVerifier.Verify(compilation, analyzers, builder.ErrorBehavior, builder.AdditionalFilePath, onlyDiagnosticIds);
-                }
+                DiagnosticVerifier.Verify(compilation.Compilation, analyzers, builder.ErrorBehavior, builder.AdditionalFilePath, onlyDiagnosticIds, compilation.AdditionalSourceFiles);
             }
         }
 
@@ -123,7 +120,7 @@ namespace SonarAnalyzer.Test.TestFramework
             {
                 foreach (var analyzer in analyzers)
                 {
-                    DiagnosticVerifier.VerifyNoIssueReported(compilation, analyzer, builder.ErrorBehavior, builder.AdditionalFilePath, onlyDiagnosticIds);
+                    DiagnosticVerifier.VerifyNoIssueReported(compilation.Compilation, analyzer, builder.ErrorBehavior, builder.AdditionalFilePath, onlyDiagnosticIds);
                 }
             }
         }
@@ -148,7 +145,7 @@ namespace SonarAnalyzer.Test.TestFramework
         {
             foreach (var compilation in Compile(false))
             {
-                DiagnosticVerifier.Verify(compilation, analyzers.Single(), CompilationErrorBehavior.Default, builder.AdditionalFilePath);
+                DiagnosticVerifier.Verify(compilation.Compilation, analyzers.Single(), CompilationErrorBehavior.Default, builder.AdditionalFilePath);
                 new FileInfo(builder.ProtobufPath).Length.Should().Be(0, "protobuf file should be empty");
             }
         }
@@ -158,7 +155,7 @@ namespace SonarAnalyzer.Test.TestFramework
         {
             foreach (var compilation in Compile(false))
             {
-                DiagnosticVerifier.Verify(compilation, analyzers.Single(), builder.ErrorBehavior, builder.AdditionalFilePath);
+                DiagnosticVerifier.Verify(compilation.Compilation, analyzers.Single(), builder.ErrorBehavior, builder.AdditionalFilePath);
                 verifyProtobuf(ReadProtobuf().ToList());
             }
 
@@ -173,105 +170,106 @@ namespace SonarAnalyzer.Test.TestFramework
             }
         }
 
-        public IEnumerable<Compilation> Compile(bool concurrentAnalysis) =>
-            builder.IsRazor ? CompileRazor() : CreateProject(concurrentAnalysis).Solution.Compile(builder.ParseOptions.ToArray());
+        public IEnumerable<CompilationData> Compile(bool concurrentAnalysis)
+        {
+            using var scope = new EnvironmentVariableScope { EnableConcurrentAnalysis = concurrentAnalysis };
+            return builder.IsRazor
+                ? CompileRazor()
+                : CreateProject(concurrentAnalysis).Solution.Compile(builder.ParseOptions.ToArray()).Select(x => new CompilationData(x, null));
+        }
 
-        private IEnumerable<Compilation> CompileRazor()
+        private IEnumerable<CompilationData> CompileRazor()
         {
             if (!MSBuildLocator.IsRegistered)
             {
                 MSBuildLocator.RegisterDefaults();
             }
-
             if (!razorSupportedFrameworks.Contains(builder.RazorFramework))
             {
                 throw new InvalidOperationException("Razor compilation is supported only for .NET 6 and .NET 7 frameworks.");
             }
-
             using var workspace = MSBuildWorkspace.Create();
             workspace.WorkspaceFailed += (_, failure) => Console.WriteLine(failure.Diagnostic);
 
             // Copy razor project directory and test case files to a temporary build location
             var tempPath = Path.Combine(Path.GetTempPath(), $"ut-razor-{Guid.NewGuid()}");
+            Directory.CreateDirectory(tempPath);
             try
             {
-                Directory.CreateDirectory(tempPath);
-
-                List<string> languages = new();
-                if (builder.ParseOptions != null && builder.ParseOptions.Any())
+                foreach (var langVersion in builder.ParseOptions.Cast<CSharpParseOptions>().Select(LanguageVersionReference).ToArray())
                 {
-                    foreach (var parseOption in builder.ParseOptions)
-                    {
-                        if (parseOption is CSharpParseOptions csharpParseOptions)
-                        {
-                            languages.Add(GetLanguageVersionReference(csharpParseOptions));
-                        }
-                    }
-                }
-                else
-                {
-                    languages.Add("latest");
-                }
-
-                foreach (var lang in languages)
-                {
-                    Directory.CreateDirectory(Path.Combine(tempPath, lang));
-                    // Copy all the files
-                    // To improve: Paths are currently relative to entry assembly => needs to be duplicated in different projects for now.
-                    foreach (var file in Directory.GetFiles(@"TestCases\Razor\EmptyProject").Concat(builder.Paths.Select(TestCasePath)))
-                    {
-                        File.Copy(file, Path.Combine(tempPath, lang, Path.GetFileName(file)));
-                    }
-                    foreach (var snippet in builder.Snippets)
-                    {
-                        File.WriteAllText(Path.Combine(tempPath, lang, snippet.FileName), snippet.Content);
-                    }
-                    var csprojPath = Path.Combine(tempPath, lang, "EmptyProject.csproj");
-                    var destinationXml = XElement.Load(csprojPath);
-
-                    // Set TargetFramework
-                    destinationXml.Descendants("TargetFramework").Single().Value = builder.RazorFramework;
-                    // Add References
-                    var itemGroup = destinationXml.Descendants("ItemGroup").Single();
-                    foreach (var reference in builder.References)
-                    {
-                        itemGroup.Add(new XElement("Reference", new XAttribute("Include", reference.Display)));
-                    }
-                    // Set LangVersion
-                    destinationXml.Descendants("LangVersion").Single().Value = lang;
-                    destinationXml.Save(csprojPath);
-
-                    yield return workspace.OpenProjectAsync(csprojPath).Result.GetCompilationAsync().Result;
+                    var projectRoot = Path.Combine(tempPath, langVersion);
+                    Directory.CreateDirectory(projectRoot);
+                    var csProjPath = PrepareRazorProject(projectRoot, langVersion);
+                    var razorFiles = PrepareRazorFiles(projectRoot);
+                    yield return new(workspace.OpenProjectAsync(csProjPath).Result.GetCompilationAsync().Result, razorFiles.ToArray());
                 }
             }
             finally
             {
-                if (Directory.Exists(tempPath))
-                {
-                    Directory.Delete(tempPath, true);
-                }
+                Directory.Delete(tempPath, true);
             }
         }
 
-        private static string GetLanguageVersionReference(CSharpParseOptions parseOption) =>
-            parseOption.LanguageVersion switch
+        private static string LanguageVersionReference(CSharpParseOptions options) =>
+            options.LanguageVersion switch
             {
-                LanguageVersion.CSharp5 => "5.0",
-                LanguageVersion.CSharp6 => "6.0",
-                LanguageVersion.CSharp7 => "7.0",
-                LanguageVersion.CSharp7_1 => "7.1",
-                LanguageVersion.CSharp7_2 => "7.2",
-                LanguageVersion.CSharp7_3 => "7.3",
-                LanguageVersion.CSharp8 => "8.0",
-                LanguageVersion.CSharp9 => "9.0",
+                // 5 and 6 should not be needed here
+                // 7 also does not support with Nullable context
+                // 8 and 9 do not support global using directives
                 LanguageVersion.CSharp10 => "10.0",
                 LanguageVersion.CSharp11 => "11.0",
-                _ => "latest"
+                LanguageVersion.CSharp12 => "12.0",
+                _ => throw new NotSupportedException($"Unexpected language version {options.LanguageVersion}. Update this switch to add the new version.")
             };
+
+        private string PrepareRazorProject(string projectRoot, string langVersion)
+        {
+            // To improve: Paths are currently relative to entry assembly => needs to be duplicated in different projects for now.
+            foreach (var file in Directory.GetFiles(@"TestCases\Razor\EmptyProject"))
+            {
+                File.Copy(file, Path.Combine(projectRoot, Path.GetFileName(file)));
+            }
+            var csProjPath = Path.Combine(projectRoot, "EmptyProject.csproj");
+            var xml = XElement.Load(csProjPath);
+            xml.Descendants("TargetFramework").Single().Value = builder.RazorFramework;
+            xml.Descendants("LangVersion").Single().Value = langVersion;
+            var references = xml.Descendants("ItemGroup").Single();
+            foreach (var reference in builder.References)
+            {
+                references.Add(new XElement("Reference", new XAttribute("Include", reference.Display)));
+            }
+            xml.Save(csProjPath);
+            return csProjPath;
+        }
+
+        private List<string> PrepareRazorFiles(string projectRoot)
+        {
+            var razorFiles = new List<string>();
+            // To improve: Paths are currently relative to entry assembly => needs to be duplicated in different projects for now.
+            foreach (var file in builder.Paths.Select(TestCasePath))
+            {
+                var filePath = Path.Combine(projectRoot, Path.GetFileName(file));
+                File.Copy(file, filePath);
+                if (IsRazorOrCshtml(filePath))
+                {
+                    razorFiles.Add(filePath);
+                }
+            }
+            foreach (var snippet in builder.Snippets.Where(x => IsRazorOrCshtml(x.FileName)))
+            {
+                var filePath = Path.Combine(projectRoot, snippet.FileName);
+                File.WriteAllText(filePath, snippet.Content);
+                if (IsRazorOrCshtml(filePath))
+                {
+                    razorFiles.Add(filePath);
+                }
+            }
+            return razorFiles;
+        }
 
         private ProjectBuilder CreateProject(bool concurrentAnalysis)
         {
-            using var scope = new EnvironmentVariableScope { EnableConcurrentAnalysis = concurrentAnalysis };
             var paths = builder.Paths.Select(TestCasePath).ToArray();
             return SolutionBuilder.Create()
                 .AddProject(language, true, builder.OutputKind)
@@ -318,14 +316,15 @@ namespace SonarAnalyzer.Test.TestFramework
 
         private void ValidateExtension(string path)
         {
-            var extension = Path.GetExtension(path);
-            if (!extension.Equals(language.FileExtension, StringComparison.OrdinalIgnoreCase)
-                && !extension.Equals(".razor", StringComparison.OrdinalIgnoreCase)
-                && !extension.Equals(".cshtml", StringComparison.OrdinalIgnoreCase))
+            if (!Path.GetExtension(path).Equals(language.FileExtension, StringComparison.OrdinalIgnoreCase) && !IsRazorOrCshtml(path))
             {
                 throw new ArgumentException($"Path '{path}' doesn't match {language.LanguageName} file extension '{language.FileExtension}'.");
             }
         }
+
+        private static bool IsRazorOrCshtml(string path) =>
+            Path.GetExtension(path) is var extension
+            && (extension.Equals(".razor", StringComparison.OrdinalIgnoreCase) || extension.Equals(".cshtml", StringComparison.OrdinalIgnoreCase));
 
         private void ValidateCodeFix()
         {
@@ -360,5 +359,7 @@ namespace SonarAnalyzer.Test.TestFramework
                 throw new ArgumentException($"{analyzers.Single().GetType().Name} does not support diagnostics fixable by the {codeFix.GetType().Name}.");
             }
         }
+
+        public sealed record CompilationData(Compilation Compilation, string[] AdditionalSourceFiles);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/Verifier.cs
@@ -196,7 +196,7 @@ namespace SonarAnalyzer.Test.TestFramework
             Directory.CreateDirectory(tempPath);
             try
             {
-                foreach (var langVersion in builder.ParseOptions.Cast<CSharpParseOptions>().Select(LanguageVersionReference).ToArray())
+                foreach (var langVersion in builder.ParseOptions.Cast<CSharpParseOptions>().Select(LangVersion))
                 {
                     var projectRoot = Path.Combine(tempPath, langVersion);
                     Directory.CreateDirectory(projectRoot);
@@ -209,19 +209,19 @@ namespace SonarAnalyzer.Test.TestFramework
             {
                 Directory.Delete(tempPath, true);
             }
-        }
 
-        private static string LanguageVersionReference(CSharpParseOptions options) =>
-            options.LanguageVersion switch
-            {
-                // 5 and 6 should not be needed here
-                // 7 also does not support with Nullable context
-                // 8 and 9 do not support global using directives
-                LanguageVersion.CSharp10 => "10.0",
-                LanguageVersion.CSharp11 => "11.0",
-                LanguageVersion.CSharp12 => "12.0",
-                _ => throw new NotSupportedException($"Unexpected language version {options.LanguageVersion}. Update this switch to add the new version.")
-            };
+            static string LangVersion(CSharpParseOptions options) =>
+                options.LanguageVersion switch
+                {
+                    // 5 and 6 should not be needed here
+                    // 7 also does not support with Nullable context
+                    // 8 and 9 do not support global using directives
+                    LanguageVersion.CSharp10 => "10.0",
+                    LanguageVersion.CSharp11 => "11.0",
+                    LanguageVersion.CSharp12 => "12.0",
+                    _ => throw new NotSupportedException($"Unexpected language version {options.LanguageVersion}. Update this switch to add the new version.")
+                };
+        }
 
         private string PrepareRazorProject(string projectRoot, string langVersion)
         {
@@ -322,10 +322,6 @@ namespace SonarAnalyzer.Test.TestFramework
             }
         }
 
-        private static bool IsRazorOrCshtml(string path) =>
-            Path.GetExtension(path) is var extension
-            && (extension.Equals(".razor", StringComparison.OrdinalIgnoreCase) || extension.Equals(".cshtml", StringComparison.OrdinalIgnoreCase));
-
         private void ValidateCodeFix()
         {
             _ = builder.CodeFixedPath ?? throw new ArgumentException($"{nameof(builder.CodeFixedPath)} was not set.");
@@ -359,6 +355,10 @@ namespace SonarAnalyzer.Test.TestFramework
                 throw new ArgumentException($"{analyzers.Single().GetType().Name} does not support diagnostics fixable by the {codeFix.GetType().Name}.");
             }
         }
+
+        private static bool IsRazorOrCshtml(string path) =>
+            Path.GetExtension(path) is var extension
+            && (extension.Equals(".razor", StringComparison.OrdinalIgnoreCase) || extension.Equals(".cshtml", StringComparison.OrdinalIgnoreCase));
 
         public sealed record CompilationData(Compilation Compilation, string[] AdditionalSourceFiles);
     }


### PR DESCRIPTION
Part of #8543 

The previous Razor validation in `Verifier` class is unfortunate, as it compiles files from temp directory, but uses files from TestCases directory to compute expected issues. Those files do not match on their paths, causing issues not being paired properly.
