### PR TITLE
Add 'failIfNoTests' in the Maven ITs

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -62,6 +62,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.2.5</version>
+          <configuration>
+            <failIfNoTests>true</failIfNoTests>
+            <!-- Display logs in AzureDevOps pipeline output -->
+            <redirectTestOutputToFile>false</redirectTestOutputToFile>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Similar to [this scanner PR](https://github.com/SonarSource/sonar-scanner-msbuild/pull/1845), we want to fail if for some reason no tests are discovered.