### PR TITLE
Java ITs: Use LATEST_RELEASE SQ version

### DIFF
--- a/its/src/test/java/com/sonar/it/shared/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/shared/TestUtils.java
@@ -71,7 +71,7 @@ public class TestUtils {
     return OrchestratorExtension.builderEnv()
       .useDefaultAdminCredentialsForBuilds(true)
       // See https://github.com/SonarSource/orchestrator#version-aliases
-      .setSonarVersion(System.getProperty("sonar.runtimeVersion", "DEV"))
+      .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE"))
       .setEdition(Edition.DEVELOPER)
       .activateLicense();
   }


### PR DESCRIPTION
This should be reverted as soon as SQ is stable again.