### PR TITLE
Coverage: Quick fix pattern after migration to AWS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -412,7 +412,7 @@ stages:
               $path
             )
             $localPath = (Get-Location).Path
-            $pattern = 'C:\\ProgramData\\vsts-agent\\\d+\\s'
+            $pattern = 'C:\\sonar-ci\\_work\\\d+\\s'
             (Get-Content -path $path -Raw) -replace $pattern,$localPath | Set-Content $path
           }
 


### PR DESCRIPTION
This is a quick quick-fix for coverage issue. A proper fix will coverage

We have problem with agent working directories again. File was imported like this - note `1` in the path
```
"C:\\sonar-ci\\_work\\1\\s\\analyzers\\tests\\SonarAnalyzer.TestFramework\\Analyzers\\DummyAnalyzerWithLocation.cs",\
```

and coverage was computed on an agent with a different working directory, note `2` in the path.
```
16:17:30.748 DEBUG: Did not find deterministic source path in 'C:\sonar-ci\_work\2\s\analyzers\tests\SonarAnalyzer.TestFramework\Analyzers\DummyAnalyzerWithLocation.cs'. Will skip this coverage entry. Verify sonar.sources in .sonarqube\out\sonar-project.properties.
16:17:30.748 DEBUG: CoveredFile created: (ID '968', path 'C:\sonar-ci\_work\2\s\analyzers\tests\SonarAnalyzer.TestFramework\Analyzers\DummyAnalyzerWithLocation.cs', NO INDEXED PATH).
```

We have a fix for this, but the fix was replacing 
```
C:\\ProgramData\\vsts-agent\\\d+\\s
```
and currently, the path is
```
C:\\sonar-ci\\_work\\1\\s\\
```