### PR TITLE
Use correct NuGet api and specify protocol version

### DIFF
--- a/analyzers/NuGet.Config
+++ b/analyzers/NuGet.Config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Repox" value="https://repox.jfrog.io/artifactory/api/nuget/nuget" />
+    <add key="Repox" value="https://repox.jfrog.io/artifactory/api/nuget/v3/nuget/index.json" protocolVersion="3" />
   </packageSources>
   <packageSourceCredentials>
     <Repox>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -253,6 +253,9 @@ stages:
           cd analyzers
           & dotnet test $(ProjectFilePath) -f $(FrameworkMoniker) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter="Moq|Humanizer|AltCover|Microsoft.VisualStudio.TestPlatform.*|\.Test^",AltCoverPathFilter="SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration",AltCoverAttributeFilter="ExcludeFromCodeCoverage",AltCoverReport="$(CoveragePath)/coverage.$(CoverageArtifactName).xml"
         displayName: '.Net UTs'
+        env:
+          ARTIFACTORY_USER: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
+          ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)
 
       - task: PublishPipelineArtifact@1
         displayName: 'Save coverage files'


### PR DESCRIPTION
In order to avoid problems with repox integration (server errors, HTTP response code 500) we have to specify an URL that contains the protocol version and also to specify the protocol version in the NuGet.config file.