### PR TITLE
SyntaxNodeExtensions: increase GetBody coverage

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
@@ -204,7 +204,8 @@ namespace SonarAnalyzer.Test.Extensions
         public void GetBody_AccessorDeclaration_BodyBlock()
         {
             var code = "class AClass { int AProperty { set { var x1; var x2; var x3; } } }";
-            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<AccessorDeclarationSyntax>()).Statements.Should().HaveCount(3);
+            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<AccessorDeclarationSyntax>())
+                .Should().BeOfType<BlockSyntax>().Which.Statements.Should().HaveCount(3);
         }
 
         [TestMethod]
@@ -218,7 +219,8 @@ namespace SonarAnalyzer.Test.Extensions
         public void GetBody_LocalFunctionStatement_BodyBlock()
         {
             var code = "class AClass { void AMethod() { int ALocalFunction() { var x1; var x2; var x3; return 42; } } }";
-            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<LocalFunctionStatementSyntax>()).Statements.Should().HaveCount(4);
+            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<LocalFunctionStatementSyntax>())
+                .Should().BeOfType<BlockSyntax>().Which.Statements.Should().HaveCount(4);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
@@ -182,28 +182,28 @@ namespace SonarAnalyzer.Test.Extensions
         [TestMethod]
         public void GetBody_PropertyDeclaration_SingleAccessor()
         {
-            var code = "class AClass { int APropertyWithGetOnly { get => 42; } }";
+            var code = "class AClass { int AProperty { get => 42; } }";
             ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<PropertyDeclarationSyntax>()).Should().BeNull();
         }
 
         [TestMethod]
         public void GetBody_PropertyDeclaration_MultipleAccessors()
         {
-            var code = "class AClass { int APropertyWithGetOnly { get => 42; set { } } }";
+            var code = "class AClass { int AProperty { get => 42; set { } } }";
             ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<PropertyDeclarationSyntax>()).Should().BeNull();
         }
 
         [TestMethod]
         public void GetBody_AccessorDeclaration_ArrowExpression()
         {
-            var code = "class AClass { int APropertyWithGetOnly { get => 42; } }";
+            var code = "class AClass { int AProperty { get => 42; } }";
             ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<AccessorDeclarationSyntax>()).Should().BeNull();
         }
 
         [TestMethod]
         public void GetBody_AccessorDeclaration_BodyBlock()
         {
-            var code = "class AClass { int APropertyWithGetOnly { set { } } }";
+            var code = "class AClass { int AProperty { set { } } }";
             ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<AccessorDeclarationSyntax>()).Should().NotBeNull();
         }
 

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
@@ -23,6 +23,7 @@ extern alias vbnet;
 
 using FluentAssertions.Extensions;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
 using SonarAnalyzer.CFG.Roslyn;
@@ -173,6 +174,40 @@ namespace SonarAnalyzer.Test.Extensions
             ExtensionsCS.GetDeclarationTypeName(SyntaxFactory.StructDeclaration("MyStruct")).Should().Be("struct");
 
         [TestMethod]
+        public void GetBody_FieldDeclaration()
+        {
+            ExtensionsCS.GetBody(SyntaxFactory.FieldDeclaration(SyntaxFactory.VariableDeclaration(SyntaxFactory.ParseTypeName("int")))).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void GetBody_PropertyDeclaration_SingleAccessor()
+        {
+            var code = "class AClass { int APropertyWithGetOnly { get => 42; } }";
+            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<PropertyDeclarationSyntax>()).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void GetBody_PropertyDeclaration_MultipleAccessors()
+        {
+            var code = "class AClass { int APropertyWithGetOnly { get => 42; set { } } }";
+            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<PropertyDeclarationSyntax>()).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void GetBody_AccessorDeclaration_ArrowExpression()
+        {
+            var code = "class AClass { int APropertyWithGetOnly { get => 42; } }";
+            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<AccessorDeclarationSyntax>()).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void GetBody_AccessorDeclaration_BodyBlock()
+        {
+            var code = "class AClass { int APropertyWithGetOnly { set { } } }";
+            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<AccessorDeclarationSyntax>()).Should().NotBeNull();
+        }
+
+        [TestMethod]
         public void CreateCfg_MethodDeclaration_ReturnsCfg_CS()
         {
             const string code = """
@@ -230,7 +265,7 @@ namespace SonarAnalyzer.Test.Extensions
             const string code = """
                 public class Sample
                 {
-                    private string field = null!;   // null! itself doens't have operation, and we can still generate CFG for it from the equals clause
+                    private string field = null!;   // null! itself doesn't have operation, and we can still generate CFG for it from the equals clause
                 }
                 """;
             CreateCfgCS<SyntaxCS.EqualsValueClauseSyntax>(code).Should().NotBeNull();

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
@@ -203,8 +203,8 @@ namespace SonarAnalyzer.Test.Extensions
         [TestMethod]
         public void GetBody_AccessorDeclaration_BodyBlock()
         {
-            var code = "class AClass { int AProperty { set { } } }";
-            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<AccessorDeclarationSyntax>()).Should().NotBeNull();
+            var code = "class AClass { int AProperty { set { var x1; var x2; var x3; } } }";
+            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<AccessorDeclarationSyntax>()).Statements.Should().HaveCount(3);
         }
 
         [TestMethod]
@@ -217,8 +217,8 @@ namespace SonarAnalyzer.Test.Extensions
         [TestMethod]
         public void GetBody_LocalFunctionStatement_BodyBlock()
         {
-            var code = "class AClass { void AMethod() { int ALocalFunction() { return 42; } } }";
-            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<LocalFunctionStatementSyntax>()).Should().NotBeNull();
+            var code = "class AClass { void AMethod() { int ALocalFunction() { var x1; var x2; var x3; return 42; } } }";
+            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<LocalFunctionStatementSyntax>()).Statements.Should().HaveCount(4);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
@@ -208,6 +208,20 @@ namespace SonarAnalyzer.Test.Extensions
         }
 
         [TestMethod]
+        public void GetBody_LocalFunctionStatement_ArrowExpression()
+        {
+            var code = "class AClass { void AMethod() { int ALocalFunction() => 42; } }";
+            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<LocalFunctionStatementSyntax>()).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void GetBody_LocalFunctionStatement_BodyBlock()
+        {
+            var code = "class AClass { void AMethod() { int ALocalFunction() { return 42; } } }";
+            ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<LocalFunctionStatementSyntax>()).Should().NotBeNull();
+        }
+
+        [TestMethod]
         public void CreateCfg_MethodDeclaration_ReturnsCfg_CS()
         {
             const string code = """

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
@@ -203,7 +203,7 @@ namespace SonarAnalyzer.Test.Extensions
         [TestMethod]
         public void GetBody_AccessorDeclaration_BodyBlock()
         {
-            var code = "class AClass { int AProperty { set { var x1; var x2; var x3; } } }";
+            var code = "class AClass { int AProperty { set { int i = 1; i++; i++; } } }";
             ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<AccessorDeclarationSyntax>())
                 .Should().BeOfType<BlockSyntax>().Which.Statements.Should().HaveCount(3);
         }
@@ -218,7 +218,7 @@ namespace SonarAnalyzer.Test.Extensions
         [TestMethod]
         public void GetBody_LocalFunctionStatement_BodyBlock()
         {
-            var code = "class AClass { void AMethod() { int ALocalFunction() { var x1; var x2; var x3; return 42; } } }";
+            var code = "class AClass { void AMethod() { int ALocalFunction(int i) { i++; i++; i++; return i; } } }";
             ExtensionsCS.GetBody(CSharpSyntaxTree.ParseText(code).Single<LocalFunctionStatementSyntax>())
                 .Should().BeOfType<BlockSyntax>().Which.Statements.Should().HaveCount(4);
         }


### PR DESCRIPTION
Cover `SyntaxNodeExtensions.GetBody`, introduced in https://github.com/SonarSource/sonar-dotnet/pull/8584 but not covered.
