### PR TITLE
Ignore Verify_Razor_WithFramework test

### DIFF
--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierTest.cs
@@ -188,6 +188,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 .WithAdditionalFilePath(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, ProjectType.Unknown))
                 .VerifyNoIssueReported();
 
+        [Ignore("REVERT AFTER 9.20 RELEASE")]
         [DataTestMethod]
         [DataRow("net6.0")]
         [DataRow("net7.0")]

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierTest.cs
@@ -188,7 +188,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 .WithAdditionalFilePath(AnalysisScaffolding.CreateSonarProjectConfig(TestContext, ProjectType.Unknown))
                 .VerifyNoIssueReported();
 
-        [Ignore("REVERT AFTER 9.20 RELEASE")]
+        [Ignore("Revert after 9.19 release")]
         [DataTestMethod]
         [DataRow("net6.0")]
         [DataRow("net7.0")]


### PR DESCRIPTION
To be reverted after 9.19 release

For context (internal link): https://sonarsource.slack.com/archives/C012KBFFYD6/p1706698914234329
