### PR TITLE
TestFramework: Refactor DiagnosticVerifier.AnalyzerExceptions

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/Rules/CheckFileLicenseTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/CheckFileLicenseTest.cs
@@ -191,9 +191,10 @@ namespace SonarAnalyzer.Test.Rules
         public void CheckFileLicense_WhenProvidingAnInvalidRegex_ShouldThrowException_CS()
         {
             var compilation = SolutionBuilder.CreateSolutionFromPath(@"TestCases\CheckFileLicense_NoLicenseStartWithUsing.cs").Compile(ParseOptionsHelper.CSharpLatest.ToArray()).Single();
-            var diagnostics = DiagnosticVerifier.GetDiagnosticsIgnoreExceptions(compilation, new CS.CheckFileLicense { HeaderFormat = FailingSingleLineRegexHeader, IsRegularExpression = true });
-            diagnostics.Should().ContainSingle(x => x.Id == "AD0001").Which.GetMessage().Should()
-                .StartWith("Analyzer 'SonarAnalyzer.Rules.CSharp.CheckFileLicense' threw an exception of type 'System.InvalidOperationException' with message 'Invalid regular expression:");
+            var errors = DiagnosticVerifier.AnalyzerExceptions(compilation, new CS.CheckFileLicense { HeaderFormat = FailingSingleLineRegexHeader, IsRegularExpression = true });
+            errors.Should().ContainSingle().Which.GetMessage().Should()
+                .Contain("System.InvalidOperationException")
+                .And.Contain("Invalid regular expression: " + FailingSingleLineRegexHeader);
         }
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/MethodsShouldNotHaveTooManyLinesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/MethodsShouldNotHaveTooManyLinesTest.cs
@@ -106,8 +106,8 @@ public class Foo
         {
             var compilation = SolutionBuilder.CreateSolutionFromPath(@"TestCases\MethodsShouldNotHaveTooManyLines_CustomValues.cs")
                 .Compile(ParseOptionsHelper.CSharpLatest.ToArray()).Single();
-            var diagnostics = DiagnosticVerifier.GetDiagnosticsIgnoreExceptions(compilation, new CS.MethodsShouldNotHaveTooManyLines { Max = max });
-            diagnostics.Should().OnlyContain(x => x.Id == "AD0001" && x.GetMessage(null).Contains("Invalid rule parameter: maximum number of lines = ")).And.HaveCount(12);
+            var errors = DiagnosticVerifier.AnalyzerExceptions(compilation, new CS.MethodsShouldNotHaveTooManyLines { Max = max });
+            errors.Should().OnlyContain(x => x.GetMessage(null).Contains("Invalid rule parameter: maximum number of lines = ")).And.HaveCount(12);
         }
 
         [TestMethod]
@@ -134,8 +134,8 @@ public class Foo
         {
             var compilation = SolutionBuilder.CreateSolutionFromPath(@"TestCases\MethodsShouldNotHaveTooManyLines_CustomValues.vb")
                 .Compile(ParseOptionsHelper.VisualBasicLatest.ToArray()).Single();
-            var diagnostics = DiagnosticVerifier.GetDiagnosticsIgnoreExceptions(compilation, new VB.MethodsShouldNotHaveTooManyLines { Max = max });
-            diagnostics.Should().OnlyContain(x => x.Id == "AD0001" && x.GetMessage(null).Contains("Invalid rule parameter: maximum number of lines = ")).And.HaveCount(7);
+            var errors = DiagnosticVerifier.AnalyzerExceptions(compilation, new VB.MethodsShouldNotHaveTooManyLines { Max = max });
+            errors.Should().OnlyContain(x => x.GetMessage(null).Contains("Invalid rule parameter: maximum number of lines = ")).And.HaveCount(7);
         }
 
         private static VerifierBuilder CreateCSBuilder(int maxLines) =>

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/SymbolicExecution/SymbolicExecutionRunnerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/SymbolicExecution/SymbolicExecutionRunnerTest.cs
@@ -460,9 +460,10 @@ public class Sample
         var sut = new ConfigurableSERunnerCS();
         sut.RegisterRule<ThrowAssignmentRuleCheck>(ThrowAssignmentRuleCheck.SThrow);
         var compilation = SolutionBuilder.Create().AddProject(AnalyzerLanguage.CSharp).AddSnippet(code).Solution.Compile(ParseOptionsHelper.CSharpLatest.ToArray()).Single();
-        var diagnostics = DiagnosticVerifier.GetDiagnosticsIgnoreExceptions(compilation, sut);
-        diagnostics.Should().ContainSingle(x => x.Id == "AD0001").Which.GetMessage().Should()
-            .StartWith("Analyzer 'SonarAnalyzer.Test.Rules.SymbolicExecutionRunnerTest+ConfigurableSERunnerCS' threw an exception of type 'SonarAnalyzer.SymbolicExecution.SymbolicExecutionException' with message 'Error processing method: Method ## Method file: snippet1.cs ## Method line: 3,4 ## Inner exception: System.InvalidOperationException: This check is not useful.");
+        var errors = DiagnosticVerifier.AnalyzerExceptions(compilation, sut);
+        errors.Should().ContainSingle().Which.GetMessage().Should()
+            .Contain("SonarAnalyzer.SymbolicExecution.SymbolicExecutionException")
+            .And.Contain("Error processing method: Method ## Method file: snippet1.cs ## Method line: 3,4 ## Inner exception: System.InvalidOperationException: This check is not useful.");
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifier.cs
@@ -26,7 +26,7 @@ namespace SonarAnalyzer.Test.TestFramework
 {
     public static class DiagnosticVerifier
     {
-        private const string AnalyzerFailedDiagnosticId = "AD0001";
+        private const string AD0001 = nameof(AD0001);
 
         private static readonly string[] BuildErrorsToIgnore =
         {
@@ -96,8 +96,8 @@ namespace SonarAnalyzer.Test.TestFramework
             return ret;
         }
 
-        public static IEnumerable<Diagnostic> GetDiagnosticsIgnoreExceptions(Compilation compilation, DiagnosticAnalyzer analyzer) =>
-            GetAnalyzerDiagnostics(compilation, new[] { analyzer }, CompilationErrorBehavior.FailTest);
+        public static IEnumerable<Diagnostic> AnalyzerExceptions(Compilation compilation, DiagnosticAnalyzer analyzer) =>
+            GetAnalyzerDiagnostics(compilation, new[] { analyzer }, CompilationErrorBehavior.FailTest).Where(x => x.Id == AD0001);
 
         public static ImmutableArray<Diagnostic> GetAnalyzerDiagnostics(Compilation compilation,
                                                                         DiagnosticAnalyzer[] analyzer,
@@ -108,7 +108,7 @@ namespace SonarAnalyzer.Test.TestFramework
             onlyDiagnostics ??= Array.Empty<string>();
             var supportedDiagnostics = analyzer
                 .SelectMany(x => x.SupportedDiagnostics.Select(d => d.Id))
-                .Concat(new[] { AnalyzerFailedDiagnosticId })
+                .Concat(new[] { AD0001 })
                 .Select(x => new KeyValuePair<string, ReportDiagnostic>(x, Severity(x)))
                 .ToArray();
 
@@ -130,7 +130,7 @@ namespace SonarAnalyzer.Test.TestFramework
 
             ReportDiagnostic Severity(string id)
             {
-                if (id == AnalyzerFailedDiagnosticId)
+                if (id == AD0001)
                 {
                     return ReportDiagnostic.Error;
                 }
@@ -184,7 +184,7 @@ namespace SonarAnalyzer.Test.TestFramework
         }
 
         public static void VerifyNoExceptionThrown(IEnumerable<Diagnostic> diagnostics) =>
-            diagnostics.Should().NotContain(d => d.Id == AnalyzerFailedDiagnosticId);
+            diagnostics.Should().NotContain(d => d.Id == AD0001);
 
         private static IEnumerable<IssueLocationPair> MatchPairs(CompilationIssues actual, CompilationIssues expected)
         {


### PR DESCRIPTION
Part of #8601

Next step: Rename `GetDiagnosticsNoExceptions` to `AnalyzerDiagnostics`