### PR TITLE
Restore dependencies before compilation

### DIFF
--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/Verifier.cs
@@ -241,6 +241,9 @@ namespace SonarAnalyzer.Test.TestFramework
                     destinationXml.Descendants("LangVersion").Single().Value = lang;
                     destinationXml.Save(csprojPath);
 
+                    // To avoid reference loading issues, ensure that the project references are restored before compilation.
+                    Process.Start(Environment.GetEnvironmentVariable("MSBUILD_PATH"), $"restore {csprojPath}").WaitForExit();
+
                     yield return workspace.OpenProjectAsync(csprojPath).Result.GetCompilationAsync().Result;
                 }
             }


### PR DESCRIPTION
This fixes `Verify_Razor_WithFramework` test that fails due to missing dependencies.