### PR TITLE
TestFramework: Change IssueLocation.IsPrimary to IssueType

### DIFF
--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/CompilationIssuesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/CompilationIssuesTest.cs
@@ -29,11 +29,12 @@ public class CompilationIssuesTest
     public void UniqueKeys() =>
         CreateSut().UniqueKeys().Should().BeEquivalentTo(new IssueLocationKey[]
         {
-            new("First.cs", 11, true),
-            new("First.cs", 11, false),
-            new("First.cs", 99, true),
-            new("Second.cs", 11, true),
-            new("Third.cs", 1, false)
+            new("First.cs", 11, IssueType.Primary),
+            new("First.cs", 11, IssueType.Secondary),
+            new("First.cs", 11, IssueType.Error),
+            new("First.cs", 99, IssueType.Primary),
+            new("Second.cs", 11, IssueType.Primary),
+            new("Third.cs", 1, IssueType.Secondary)
         });
 
     [TestMethod]
@@ -50,27 +51,27 @@ public class CompilationIssuesTest
     public void Remove_NoMatch()
     {
         var sut = CreateSut();
-        sut.Should().HaveCount(13);
-        sut.Remove(new("ThisKeyIsNotPresent.cs", 11, true)).Should().BeEmpty();
-        sut.Should().HaveCount(13);
+        sut.Should().HaveCount(14);
+        sut.Remove(new("ThisKeyIsNotPresent.cs", 11, IssueType.Primary)).Should().BeEmpty();
+        sut.Should().HaveCount(14);
     }
 
     [TestMethod]
     public void Remove_WhenPresent()
     {
         var sut = CreateSut();
-        sut.Should().HaveCount(13);
-        sut.Remove(new("Second.cs", 11, true)).Should().HaveCount(5);
-        sut.Should().HaveCount(8);
+        sut.Should().HaveCount(14);
+        sut.Remove(new("Second.cs", 11, IssueType.Primary)).Should().HaveCount(5);
+        sut.Should().HaveCount(9);
     }
 
     [TestMethod]
     public void Remove_WhenPresent_ReturnsAllOccurances()
     {
         var sut = CreateSut();
-        sut.Should().HaveCount(13);
-        sut.Remove(new("Third.cs", 1, false)).Should().HaveCount(3);
-        sut.Should().HaveCount(10);
+        sut.Should().HaveCount(14);
+        sut.Remove(new("Third.cs", 1, IssueType.Secondary)).Should().HaveCount(3);
+        sut.Should().HaveCount(11);
     }
 
     [TestMethod]
@@ -84,6 +85,7 @@ public class CompilationIssuesTest
                 S1111, Line: 11, [9, 10] Lorem ipsum
                 S2222, Line: 11, [1, 10] Lorem 2222 ipsum
                 S2222, Line: 11, [1, 10] Lorem 2222 ipsum
+                CS000, Line: 11, [1, 10] Compilation error
                 S2222, Line: 99, [1, 10] Lorem 2222 ipsum
             Actual C# 99 diagnostics Second.cs:
                 S2222, Line: 11, [1, 11] Lorem 2222 ipsum
@@ -97,18 +99,19 @@ public class CompilationIssuesTest
     private static CompilationIssues CreateSut() =>
         new("C# 99", new IssueLocation[]
         {
-            new() { RuleId = "S1111", FilePath = "First.cs", LineNumber = 11, IsPrimary = true, Start = 1, Length = 10, Message = "Lorem ipsum" },
-            new() { RuleId = "S1111", FilePath = "First.cs", LineNumber = 11, IsPrimary = true, Start = 9, Length = 10, Message = "Lorem ipsum" },
-            new() { RuleId = "S2222", FilePath = "First.cs", LineNumber = 99, IsPrimary = true, Start = 1, Length = 10, Message = "Lorem 2222 ipsum" },
-            new() { RuleId = "S2222", FilePath = "First.cs", LineNumber = 11, IsPrimary = true, Start = 1, Length = 10, Message = "Lorem 2222 ipsum" },
-            new() { RuleId = "S2222", FilePath = "First.cs", LineNumber = 11, IsPrimary = false, Start = 1, Length = 10, Message = "Lorem 2222 ipsum" },
-            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, IsPrimary = true, Start = 1, Length = 11, Message = "Lorem 2222 ipsum" },
-            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, IsPrimary = true, Start = 2, Length = 12, Message = "Lorem 2222 ipsum" },
-            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, IsPrimary = true, Start = 3, Length = 13, Message = "Lorem 2222 ipsum" },
-            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, IsPrimary = true, Start = 4, Length = 14, Message = "Lorem 2222 ipsum" },
-            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, IsPrimary = true, Start = 5, Length = 15, Message = "Lorem 2222 ipsum" },
-            new() { RuleId = "S3333", FilePath = "Third.cs", LineNumber = 1, IsPrimary = false, Start = 1, Length = 10, Message = "Multiple identical secondaries" },
-            new() { RuleId = "S3333", FilePath = "Third.cs", LineNumber = 1, IsPrimary = false, Start = 1, Length = 10, Message = "Multiple identical secondaries" },
-            new() { RuleId = "S3333", FilePath = "Third.cs", LineNumber = 1, IsPrimary = false, Start = 1, Length = 10, Message = "Multiple identical secondaries" }
+            new() { RuleId = "S1111", FilePath = "First.cs", LineNumber = 11, Type = IssueType.Primary, Start = 1, Length = 10, Message = "Lorem ipsum" },
+            new() { RuleId = "S1111", FilePath = "First.cs", LineNumber = 11, Type = IssueType.Primary, Start = 9, Length = 10, Message = "Lorem ipsum" },
+            new() { RuleId = "S2222", FilePath = "First.cs", LineNumber = 99, Type = IssueType.Primary, Start = 1, Length = 10, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "First.cs", LineNumber = 11, Type = IssueType.Primary, Start = 1, Length = 10, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "First.cs", LineNumber = 11, Type = IssueType.Secondary, Start = 1, Length = 10, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "CS000", FilePath = "First.cs", LineNumber = 11, Type = IssueType.Error, Start = 1, Length = 10, Message = "Compilation error" },
+            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, Type = IssueType.Primary, Start = 1, Length = 11, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, Type = IssueType.Primary, Start = 2, Length = 12, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, Type = IssueType.Primary, Start = 3, Length = 13, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, Type = IssueType.Primary, Start = 4, Length = 14, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S2222", FilePath = "Second.cs", LineNumber = 11, Type = IssueType.Primary, Start = 5, Length = 15, Message = "Lorem 2222 ipsum" },
+            new() { RuleId = "S3333", FilePath = "Third.cs", LineNumber = 1, Type = IssueType.Secondary, Start = 1, Length = 10, Message = "Multiple identical secondaries" },
+            new() { RuleId = "S3333", FilePath = "Third.cs", LineNumber = 1, Type = IssueType.Secondary, Start = 1, Length = 10, Message = "Multiple identical secondaries" },
+            new() { RuleId = "S3333", FilePath = "Third.cs", LineNumber = 1, Type = IssueType.Secondary, Start = 1, Length = 10, Message = "Multiple identical secondaries" }
         });
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationCollectorTest.ExpectedBuildErrors.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationCollectorTest.ExpectedBuildErrors.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             var expectedErrors = IssueLocationCollector.ExpectedBuildErrors("File.cs", SourceText.From(code).Lines).ToList();
 
             expectedErrors.Should().HaveCount(2);
-            expectedErrors.Select(l => l.IsPrimary).Should().Equal(true, true);
+            expectedErrors.Select(l => l.Type).Should().Equal(IssueType.Primary, IssueType.Primary);
             expectedErrors.Select(l => l.LineNumber).Should().Equal(3, 6);
         }
 
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             var expectedErrors = IssueLocationCollector.ExpectedBuildErrors("File.cs", SourceText.From(code).Lines).ToList();
 
             expectedErrors.Should().HaveCount(3);
-            expectedErrors.Select(l => l.IsPrimary).Should().Equal(true, true, true);
+            expectedErrors.Select(l => l.Type).Should().Equal(IssueType.Primary, IssueType.Primary, IssueType.Primary);
             expectedErrors.Select(l => l.LineNumber).Should().Equal(3, 3, 3);
             expectedErrors.Select(l => l.IssueId).Should().Equal("CS1234", "CS2345", "CS3456");
         }
@@ -88,7 +88,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             var expectedErrors = IssueLocationCollector.ExpectedBuildErrors("File.cs", SourceText.From(code).Lines).ToList();
 
             expectedErrors.Should().ContainSingle();
-            expectedErrors[0].IsPrimary.Should().BeTrue();
+            expectedErrors[0].Type.Should().Be(IssueType.Primary);
             expectedErrors[0].LineNumber.Should().Be(1);
             expectedErrors[0].IssueId.Should().Be("CS1234");
         }
@@ -99,7 +99,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             const string code = "<p>Test @Content something</p> @* Error [CS1234,CS2345,CS3456] *@";
             var expectedErrors = IssueLocationCollector.ExpectedBuildErrors("File.cs", SourceText.From(code).Lines).ToList();
 
-            expectedErrors.Select(l => l.IsPrimary).Should().Equal(true, true, true);
+            expectedErrors.Select(l => l.Type).Should().Equal(IssueType.Primary, IssueType.Primary, IssueType.Primary);
             expectedErrors.Select(l => l.LineNumber).Should().Equal(1, 1, 1);
             expectedErrors.Select(l => l.IssueId).Should().Equal("CS1234", "CS2345", "CS3456");
         }
@@ -113,7 +113,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 """;
             var expectedErrors = IssueLocationCollector.ExpectedBuildErrors("File.cs", SourceText.From(code).Lines).ToList();
 
-            expectedErrors[0].IsPrimary.Should().BeTrue();
+            expectedErrors[0].Type.Should().Be(IssueType.Primary);
             expectedErrors[0].LineNumber.Should().Be(2);
             expectedErrors[0].IssueId.Should().Be("CS1234");
         }

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationCollectorTest.ExpectedIssueLocations.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationCollectorTest.ExpectedIssueLocations.cs
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             var locations = IssueLocationCollector.ExpectedIssueLocations("File.cs", SourceText.From(code).Lines);
 
             locations.Should().HaveCount(2);
-            locations.Select(x => x.IsPrimary).Should().Equal(true, true);
+            locations.Select(x => x.Type).Should().Equal(IssueType.Primary, IssueType.Primary);
             locations.Select(x => x.LineNumber).Should().Equal(3, 6);
         }
 
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             var locations = IssueLocationCollector.ExpectedIssueLocations("File.cs", SourceText.From(code).Lines);
 
             locations.Should().HaveCount(2);
-            locations.Select(x => x.IsPrimary).Should().Equal(true, true);
+            locations.Select(x => x.Type).Should().Equal(IssueType.Primary, IssueType.Primary);
             locations.Select(x => x.LineNumber).Should().Equal(3, 5);
         }
 
@@ -100,7 +100,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             var locations = IssueLocationCollector.ExpectedIssueLocations("File.cs", SourceText.From(code).Lines);
 
             locations.Should().HaveCount(5);
-            locations.Select(x => x.IsPrimary).Should().Equal(true, true, true, false, true);
+            locations.Select(x => x.Type).Should().Equal(IssueType.Primary, IssueType.Primary, IssueType.Primary, IssueType.Secondary, IssueType.Primary);
             locations.Select(x => x.LineNumber).Should().Equal(2, 3, 5, 6, 8);
         }
 
@@ -117,7 +117,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             var locations = IssueLocationCollector.ExpectedIssueLocations("File.cs", SourceText.From(code).Lines);
 
             locations.Should().HaveCount(3);
-            locations.Select(x => x.IsPrimary).Should().Equal(true, true, false);
+            locations.Select(x => x.Type).Should().Equal(IssueType.Primary, IssueType.Primary, IssueType.Secondary);
             locations.Select(x => x.LineNumber).Should().Equal(1, 2, 4);
         }
 
@@ -136,7 +136,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             var locations = IssueLocationCollector.ExpectedIssueLocations("File.cs", SourceText.From(code).Lines);
 
             locations.Should().ContainSingle();
-            locations.Select(x => x.IsPrimary).Should().Equal(true);
+            locations.Select(x => x.Type).Should().Equal(IssueType.Primary);
             locations.Select(x => x.LineNumber).Should().Equal(5);
         }
 
@@ -159,7 +159,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             var locations = IssueLocationCollector.ExpectedIssueLocations("File.cs", SourceText.From(code).Lines);
 
             locations.Should().HaveCount(4);
-            locations.Select(x => x.IsPrimary).Should().BeEquivalentTo(new[] { true, false, false, false });
+            locations.Select(x => x.Type).Should().BeEquivalentTo(new[] { IssueType.Primary, IssueType.Secondary, IssueType.Secondary, IssueType.Secondary });
             locations.Select(x => x.LineNumber).Should().Equal(3, 3, 3, 3);
             locations.Select(x => x.Start).Should().Equal(16, 27, 20, 21);
             locations.Select(x => x.Length).Should().Equal(3, 1, 6, 4);
@@ -180,7 +180,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 """;
             var locations = IssueLocationCollector.ExpectedIssueLocations("File.cs", SourceText.From(code).Lines);
             locations.Should().HaveCount(2);
-            locations.Select(x => x.IsPrimary).Should().BeEquivalentTo(new[] { true, false });
+            locations.Select(x => x.Type).Should().BeEquivalentTo(new[] { IssueType.Primary, IssueType.Secondary });
             locations.Select(x => x.LineNumber).Should().Equal(3, 3);
             locations.Select(x => x.Start).Should().Equal(16, 27);
             locations.Select(x => x.Length).Should().Equal(3, 1);
@@ -219,7 +219,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """;
             var location = IssueLocationCollector.ExpectedIssueLocations("File.cs", SourceText.From(code).Lines).Should().ContainSingle().Subject;
-            location.IsPrimary.Should().BeTrue();
+            location.Type.Should().Be(IssueType.Primary);
             location.Message.Should().Be("A message with brackets [].");
             location.IssueId.Should().Be("myId1");
         }

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationCollectorTest.FindIssueLocations.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationCollectorTest.FindIssueLocations.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true, true },
+                expectedTypes: new[] { IssueType.Primary, IssueType.Primary },
                 expectedLineNumbers: new[] { 3, 3 },
                 expectedMessages: new string[] { null, null },
                 expectedIssueIds: new[] { "flow1", "flow2" });
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true, true },
+                expectedTypes: new[] { IssueType.Primary, IssueType.Primary },
                 expectedLineNumbers: new[] { 2, 2 },
                 expectedMessages: new[] { "Some message", "Some message" },
                 expectedIssueIds: new[] { "flow1", "flow2" });
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true },
+                expectedTypes: new[] { IssueType.Primary },
                 expectedLineNumbers: new[] { 3 },
                 expectedMessages: new[] { "Some message" },
                 expectedIssueIds: new string[] { null });
@@ -82,7 +82,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true },
+                expectedTypes: new[] { IssueType.Primary },
                 expectedLineNumbers: new[] { 2 },
                 expectedMessages: new string[] { null },
                 expectedIssueIds: new string[] { null });
@@ -98,7 +98,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true, true },
+                expectedTypes: new[] { IssueType.Primary, IssueType.Primary },
                 expectedLineNumbers: new[] { 3, 3 },
                 expectedMessages: new[] { "Some message", "Some message" },
                 expectedIssueIds: new[] { "flow1", "flow2" });
@@ -114,7 +114,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true },
+                expectedTypes: new[] { IssueType.Primary },
                 expectedLineNumbers: new[] { 3 },
                 expectedMessages: new[] { "Some message" },
                 expectedIssueIds: new string[] { null });
@@ -130,7 +130,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true },
+                expectedTypes: new[] { IssueType.Primary },
                 expectedLineNumbers: new[] { 3 },
                 expectedMessages: new string[] { null },
                 expectedIssueIds: new string[] { null });
@@ -146,7 +146,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true, true, true },
+                expectedTypes: new[] { IssueType.Primary, IssueType.Primary, IssueType.Primary },
                 expectedLineNumbers: new[] { 3, 3, 3 },
                 expectedMessages: new string[] { null, null, null },
                 expectedIssueIds: new[] { "flow1", "flow2", "last" });
@@ -162,7 +162,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true },
+                expectedTypes: new[] { IssueType.Primary },
                 expectedLineNumbers: new[] { 3 },
                 expectedMessages: new string[] { null },
                 expectedIssueIds: new string[] { null });
@@ -178,7 +178,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { false, false },
+                expectedTypes: new[] { IssueType.Secondary, IssueType.Secondary },
                 expectedLineNumbers: new[] { 2, 2 },
                 expectedMessages: new[] { "Some message", "Some message" },
                 expectedIssueIds: new[] { "flow1", "flow2" });
@@ -206,7 +206,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true },
+                expectedTypes: new[] { IssueType.Primary },
                 expectedLineNumbers: new[] { 3 },
                 expectedMessages: new string[] { null },
                 expectedIssueIds: new string[] { null });
@@ -222,7 +222,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { false },
+                expectedTypes: new[] { IssueType.Secondary },
                 expectedLineNumbers: new[] { 3 },
                 expectedMessages: new string[] { null },
                 expectedIssueIds: new[] { "myId" });
@@ -239,7 +239,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 """);
             var result = IssueLocationCollector.FindIssueLocations("File.cs", line).ToArray();
             VerifyIssueLocations(result,
-                expectedIsPrimary: new[] { true },
+                expectedTypes: new[] { IssueType.Primary },
                 expectedLineNumbers: new[] { 1 },
                 expectedMessages: new[] { "MyMessage" },
                 expectedIssueIds: new[] { "myIssueId" });
@@ -258,7 +258,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 """);
             var result = IssueLocationCollector.FindIssueLocations("File.cs", line).ToArray();
             VerifyIssueLocations(result,
-                expectedIsPrimary: new[] { true },
+                expectedTypes: new[] { IssueType.Primary },
                 expectedLineNumbers: new[] { 1 },
                 expectedMessages: new[] { "MyMessage" },
                 expectedIssueIds: new[] { "myIssueId" });
@@ -277,7 +277,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 """);
             var result = IssueLocationCollector.FindIssueLocations("File.cs", line).ToArray();
             VerifyIssueLocations(result,
-                expectedIsPrimary: new[] { true },
+                expectedTypes: new[] { IssueType.Primary },
                 expectedLineNumbers: new[] { 1 },
                 expectedMessages: new[] { "MyMessage" },
                 expectedIssueIds: new[] { "myIssueId" });

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationCollectorTest.FindPreciseIssueLocations.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationCollectorTest.FindPreciseIssueLocations.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindPreciseIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true },
+                expectedTypes: new[] { IssueType.Primary },
                 expectedLineNumbers: new[] { 3 },
                 expectedMessages: new string[] { null },
                 expectedIssueIds: new string[] { null });
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindPreciseIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true },
+                expectedTypes: new[] { IssueType.Primary },
                 expectedLineNumbers: new[] { 2 },
                 expectedMessages: new string[] { null },
                 expectedIssueIds: new string[] { null });
@@ -69,7 +69,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindPreciseIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { false },
+                expectedTypes: new[] { IssueType.Secondary },
                 expectedLineNumbers: new[] { 3 },
                 expectedMessages: new string[] { null },
                 expectedIssueIds: new string[] { null });
@@ -86,7 +86,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindPreciseIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { false },
+                expectedTypes: new[] { IssueType.Secondary },
                 expectedLineNumbers: new[] { 2 },
                 expectedMessages: new string[] { null },
                 expectedIssueIds: new string[] { null });
@@ -103,7 +103,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindPreciseIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true, true },
+                expectedTypes: new[] { IssueType.Primary, IssueType.Primary },
                 expectedLineNumbers: new[] { 3, 3 },
                 expectedMessages: new string[] { null, null },
                 expectedIssueIds: new[] { "flow1", "flow2" });
@@ -120,7 +120,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindPreciseIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { false, false, false },
+                expectedTypes: new[] { IssueType.Secondary, IssueType.Secondary, IssueType.Secondary },
                 expectedLineNumbers: new[] { 3, 3, 3 },
                 expectedMessages: new string[] { null, null, null },
                 expectedIssueIds: new[] { "flow1", "flow2", "last1" });
@@ -137,7 +137,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindPreciseIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true, true },
+                expectedTypes: new[] { IssueType.Primary, IssueType.Primary },
                 expectedLineNumbers: new[] { 3, 3 },
                 expectedMessages: new[] { "Some message", "Some message" },
                 expectedIssueIds: new[] { "flow1", "flow2" });
@@ -154,7 +154,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindPreciseIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { false, false },
+                expectedTypes: new[] { IssueType.Secondary, IssueType.Secondary },
                 expectedLineNumbers: new[] { 3, 3 },
                 expectedMessages: new[] { "Some message", "Some message" },
                 expectedIssueIds: new[] { "flow1", "flow2" });
@@ -170,7 +170,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 </Root>
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindPreciseIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { false, false },
+                expectedTypes: new[] { IssueType.Secondary, IssueType.Secondary },
                 expectedLineNumbers: new[] { 2, 2 },
                 expectedMessages: new[] { "Some message", "Some message" },
                 expectedIssueIds: new[] { "flow1", "flow2" });
@@ -187,7 +187,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindPreciseIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { true },
+                expectedTypes: new[] { IssueType.Primary },
                 expectedLineNumbers: new[] { 3 },
                 expectedMessages: new[] { "Some message" },
                 expectedIssueIds: new string[] { null });
@@ -204,7 +204,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindPreciseIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { false },
+                expectedTypes: new[] { IssueType.Secondary },
                 expectedLineNumbers: new[] { 3 },
                 expectedMessages: new[] { "Some message" },
                 expectedIssueIds: new string[] { null });
@@ -233,7 +233,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             var issueLocation = IssueLocationCollector.FindPreciseIssueLocations("File.cs", line).Should().ContainSingle().Subject;
-            issueLocation.IsPrimary.Should().BeTrue();
+            issueLocation.Type.Should().Be(IssueType.Primary);
             issueLocation.LineNumber.Should().Be(3);
             issueLocation.Start.Should().Be(12);
             issueLocation.Length.Should().Be(9);
@@ -346,7 +346,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 @*                              ^^ Secondary [flow1,flow2] {{Some message}}         *@
                 """);
             VerifyIssueLocations(IssueLocationCollector.FindPreciseIssueLocations("File.cs", line),
-                expectedIsPrimary: new[] { false, false },
+                expectedTypes: new[] { IssueType.Secondary, IssueType.Secondary },
                 expectedLineNumbers: new[] { 1, 1 },
                 expectedMessages: new[] { "Some message", "Some message" },
                 expectedIssueIds: new[] { "flow1", "flow2" });

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationCollectorTest.MergeLocations.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationCollectorTest.MergeLocations.cs
@@ -49,13 +49,13 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
         {
             var primary = new[]
             {
-                new IssueLocation { FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "Primary 1" },
-                new IssueLocation { FilePath = "File.cs", LineNumber = 2, IsPrimary = true, Message = "Primary 2" }
+                new IssueLocation { FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Primary 1" },
+                new IssueLocation { FilePath = "File.cs", LineNumber = 2, Type = IssueType.Primary, Message = "Primary 2" }
             };
             var preciseSecondary = new List<IssueLocation>
             {
-                new() { FilePath = "File.cs", LineNumber = 3, IsPrimary = false, Message = "Secondary with same message and location", Start = 10, Length = 5 },
-                new() { FilePath = "File.cs", LineNumber = 3, IsPrimary = false, Message = "Secondary with same message and location", Start = 10, Length = 5 }
+                new() { FilePath = "File.cs", LineNumber = 3, Type = IssueType.Secondary, Message = "Secondary with same message and location", Start = 10, Length = 5 },
+                new() { FilePath = "File.cs", LineNumber = 3, Type = IssueType.Secondary, Message = "Secondary with same message and location", Start = 10, Length = 5 }
             };
             IssueLocationCollector.MergeLocations(primary, preciseSecondary).Should().BeEquivalentTo(primary.Concat(preciseSecondary));
         }

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationCollectorTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationCollectorTest.cs
@@ -30,14 +30,14 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             SourceText.From(code).Lines[lineNumber];
 
         private static void VerifyIssueLocations(IEnumerable<IssueLocation> result,
-                                                 IEnumerable<bool> expectedIsPrimary,
+                                                 IEnumerable<IssueType> expectedTypes,
                                                  IEnumerable<int> expectedLineNumbers,
                                                  IEnumerable<string> expectedMessages,
                                                  IEnumerable<string> expectedIssueIds)
         {
             var values = result.ToArray();
-            values.Should().HaveCount(expectedIsPrimary.Count());
-            result.Select(x => x.IsPrimary).Should().Equal(expectedIsPrimary);
+            values.Should().HaveSameCount(expectedTypes);
+            result.Select(x => x.Type).Should().Equal(expectedTypes);
             result.Select(x => x.LineNumber).Should().Equal(expectedLineNumbers);
             result.Select(x => x.Message).Should().Equal(expectedMessages);
             result.Select(x => x.IssueId).Should().Equal(expectedIssueIds);

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationPairTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationPairTest.cs
@@ -26,8 +26,8 @@ namespace SonarAnalyzer.TestFramework.Test.Verification.IssueValidation;
 [TestClass]
 public class IssueLocationPairTest
 {
-    private static readonly IssueLocation ActualPrimary = new() { RuleId = "S1234", LineNumber = 42, IsPrimary = true, Message = "Lorem ipsum", Start = 42, Length = 10 };
-    private static readonly IssueLocation ActualSecondary = new() { RuleId = "S1234", LineNumber = 42, IsPrimary = false, Message = "Lorem ipsum", Start = 42, Length = 10, IssueId = "Flag1" };
+    private static readonly IssueLocation ActualPrimary = new() { RuleId = "S1234", LineNumber = 42, Type = IssueType.Primary, Message = "Lorem ipsum", Start = 42, Length = 10 };
+    private static readonly IssueLocation ActualSecondary = new() { RuleId = "S1234", LineNumber = 42, Type = IssueType.Secondary, Message = "Lorem ipsum", Start = 42, Length = 10, IssueId = "Flag1" };
 
     [TestMethod]
     public void AppendAssertionMessage_DifferentKeys()
@@ -42,7 +42,7 @@ public class IssueLocationPairTest
 
     [TestMethod]
     public void AppendAssertionMessage_MissingIssue_NoMessage() =>
-        AssertionMessage(null, new() { LineNumber = 42, IsPrimary = true }).Should().Be("  Line 42: Missing expected issue");
+        AssertionMessage(null, new() { LineNumber = 42, Type = IssueType.Primary }).Should().Be("  Line 42: Missing expected issue");
 
     [TestMethod]
     public void AppendAssertionMessage_MissingIssue_WithExpectedMessage() =>
@@ -54,33 +54,34 @@ public class IssueLocationPairTest
 
     [TestMethod]
     public void AppendAssertionMessage_SecondaryText() =>
-        AssertionMessage(new IssueLocation { RuleId = "S1234", LineNumber = 42, Message = "Lorem ipsum" }, null).Should().Be("  Line 42 Secondary location: Unexpected issue 'Lorem ipsum' Rule S1234");
+        AssertionMessage(new IssueLocation { RuleId = "S1234", LineNumber = 42, Type = IssueType.Secondary, Message = "Lorem ipsum" }, null)
+            .Should().Be("  Line 42 Secondary location: Unexpected issue 'Lorem ipsum' Rule S1234");
 
     [TestMethod]
     public void AppendAssertionMessage_WrongMessage()
     {
-        var expected = new IssueLocation { LineNumber = 42, IsPrimary = false, Message = "Dolor sit", Start = 2, Length = 2, IssueId = "Flag1" };
+        var expected = new IssueLocation { LineNumber = 42, Type = IssueType.Secondary, Message = "Dolor sit", Start = 2, Length = 2, IssueId = "Flag1" };
         AssertionMessage(ActualSecondary, expected).Should().Be("  Line 42 Secondary location: The expected message 'Dolor sit' does not match the actual message 'Lorem ipsum' Rule S1234 ID Flag1");
     }
 
     [TestMethod]
     public void AppendAssertionMessage_WrongStartLocation()
     {
-        var expected = new IssueLocation { LineNumber = 42, IsPrimary = false, Message = "Lorem ipsum", Start = 2, Length = 2, IssueId = "Flag1" };
+        var expected = new IssueLocation { LineNumber = 42, Type = IssueType.Secondary, Message = "Lorem ipsum", Start = 2, Length = 2, IssueId = "Flag1" };
         AssertionMessage(ActualSecondary, expected).Should().Be("  Line 42 Secondary location: Should start on column 2 but got column 42 Rule S1234 ID Flag1");
     }
 
     [TestMethod]
     public void AppendAssertionMessage_WrongLength()
     {
-        var expected = new IssueLocation { LineNumber = 42, IsPrimary = false, Message = "Lorem ipsum", Start = 42, Length = 2, IssueId = "Flag1" };
+        var expected = new IssueLocation { LineNumber = 42, Type = IssueType.Secondary, Message = "Lorem ipsum", Start = 42, Length = 2, IssueId = "Flag1" };
         AssertionMessage(ActualSecondary, expected).Should().Be("  Line 42 Secondary location: Should have a length of 2 but got a length of 10 Rule S1234 ID Flag1");
     }
 
     [TestMethod]
     public void AppendAssertionMessage_WrongIssueId()
     {
-        var expected = new IssueLocation { LineNumber = 42, IsPrimary = false, Message = "Lorem ipsum", Start = 42, Length = 10, IssueId = "DifferentId" };
+        var expected = new IssueLocation { LineNumber = 42, Type = IssueType.Secondary, Message = "Lorem ipsum", Start = 42, Length = 10, IssueId = "DifferentId" };
         AssertionMessage(ActualSecondary, expected).Should().Be("  Line 42 Secondary location: The expected issueId 'DifferentId' does not match the actual issueId 'Flag1' Rule S1234 ID Flag1");
     }
 

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationTest.cs
@@ -26,7 +26,7 @@ namespace SonarAnalyzer.TestFramework.Test.Verification.IssueValidation;
 [TestClass]
 public class IssueLocationTest
 {
-    private static readonly IssueLocation Issue = new() { RuleId = "S1234", FilePath = "File.cs", LineNumber = 42, IsPrimary = true, Message = "Lorem ipsum", Start = 42, Length = 10 };
+    private static readonly IssueLocation Issue = new() { RuleId = "S1234", FilePath = "File.cs", LineNumber = 42, Type = IssueType.Primary, Message = "Lorem ipsum", Start = 42, Length = 10 };
 
     [TestMethod]
     public void IssueLocation_Ctor_NoSecondaryMessage_HasEmptyMessage() =>
@@ -44,42 +44,42 @@ public class IssueLocationTest
     [TestMethod]
     public void IssueLocation_GetHashCode_DependsOnlyOnKey()
     {
-        var hashcode = new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }.GetHashCode();
-        hashcode.Should().Be(new IssueLocation { RuleId = "Sdiff", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "Diff", IssueId = "diff", Start = 99, Length = 99 }.GetHashCode());
+        var hashcode = new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }.GetHashCode();
+        hashcode.Should().Be(new IssueLocation { RuleId = "Sdiff", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Diff", IssueId = "diff", Start = 99, Length = 99 }.GetHashCode());
         hashcode.Should().NotBe(0);
-        hashcode.Should().NotBe(new IssueLocation { RuleId = "Sxxx", FilePath = "Diff.cs", LineNumber = 1, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }.GetHashCode());
-        hashcode.Should().NotBe(new IssueLocation { RuleId = "Sxxx", FilePath = "File.cs", LineNumber = 9, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }.GetHashCode());
-        hashcode.Should().NotBe(new IssueLocation { RuleId = "Sxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = false, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }.GetHashCode());
+        hashcode.Should().NotBe(new IssueLocation { RuleId = "Sxxx", FilePath = "Diff.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }.GetHashCode());
+        hashcode.Should().NotBe(new IssueLocation { RuleId = "Sxxx", FilePath = "File.cs", LineNumber = 9, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }.GetHashCode());
+        hashcode.Should().NotBe(new IssueLocation { RuleId = "Sxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Secondary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }.GetHashCode());
     }
 
     [TestMethod]
     public void IssueLocation_Equals_FullMatch()
     {
-        var orig = new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 };
-        var same = new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 };
-        var proj = new IssueLocation { RuleId = "Sxxxx", FilePath = string.Empty, LineNumber = 1, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 };
+        var orig = new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 };
+        var same = new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 };
+        var proj = new IssueLocation { RuleId = "Sxxxx", FilePath = string.Empty, LineNumber = 1, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 };
         orig.Equals(same).Should().BeTrue();
         orig.Equals(proj).Should().BeTrue();
         proj.Equals(same).Should().BeTrue();
         orig.Equals(null).Should().BeFalse();
         orig.Equals("different type").Should().BeFalse();
-        orig.Equals(new IssueLocation { RuleId = "Syyyy", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }).Should().BeFalse();
-        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "Diff.cs", LineNumber = 1, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }).Should().BeFalse();
-        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 9, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }).Should().BeFalse();
-        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = false, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }).Should().BeFalse();
-        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "Xxxx", IssueId = "id1", Start = 2, Length = 4 }).Should().BeFalse();
-        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 9, Length = 4 }).Should().BeFalse();
-        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 2, Length = 9 }).Should().BeFalse();
+        orig.Equals(new IssueLocation { RuleId = "Syyyy", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }).Should().BeFalse();
+        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "Diff.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }).Should().BeFalse();
+        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 9, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }).Should().BeFalse();
+        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Secondary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 }).Should().BeFalse();
+        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Xxxx", IssueId = "id1", Start = 2, Length = 4 }).Should().BeFalse();
+        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 9, Length = 4 }).Should().BeFalse();
+        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 9 }).Should().BeFalse();
         // Special case, IssueId is not checked for IsPrimary issues
-        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "Msg1", IssueId = "xxxx", Start = 2, Length = 4 }).Should().BeTrue();
-        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = false, Message = "Msg1", IssueId = "xxx", Start = 2, Length = 4 }).Should().BeFalse();
+        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Msg1", IssueId = "xxxx", Start = 2, Length = 4 }).Should().BeTrue();
+        orig.Equals(new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Secondary, Message = "Msg1", IssueId = "xxx", Start = 2, Length = 4 }).Should().BeFalse();
     }
 
     [TestMethod]
     public void IssueLocation_Equals_IgnoreNull_RuleId()
     {
-        var hasValue = new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 };
-        var withNull = new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 };
+        var hasValue = new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 };
+        var withNull = new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "Msg1", IssueId = "id1", Start = 2, Length = 4 };
         hasValue.Equals(withNull).Should().BeTrue();
         withNull.Equals(hasValue).Should().BeTrue();
         withNull.Equals(withNull).Should().BeTrue();
@@ -89,26 +89,26 @@ public class IssueLocationTest
     [TestMethod]
     public void IssueLocation_Equals_IgnoreNull_Message() =>
         ValidateEqualsIgnoreNull(
-            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "M1", IssueId = "id1", Start = 2, Length = 4 },
-            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = null, IssueId = "id1", Start = 2, Length = 4 });
+            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "M1", IssueId = "id1", Start = 2, Length = 4 },
+            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = null, IssueId = "id1", Start = 2, Length = 4 });
 
     [TestMethod]
     public void IssueLocation_Equals_IgnoreNull_IssueId() =>
         ValidateEqualsIgnoreNull(
-            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "M1", IssueId = "i1", Start = 2, Length = 4 },
-            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "M1", IssueId = null, Start = 2, Length = 4 });
+            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "M1", IssueId = "i1", Start = 2, Length = 4 },
+            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "M1", IssueId = null, Start = 2, Length = 4 });
 
     [TestMethod]
     public void IssueLocation_Equals_IgnoreNull_Start() =>
         ValidateEqualsIgnoreNull(
-            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "M1", IssueId = "id1", Start = 2, Length = 4 },
-            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "M1", IssueId = "id1", Start = null, Length = 4 });
+            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "M1", IssueId = "id1", Start = 2, Length = 4 },
+            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "M1", IssueId = "id1", Start = null, Length = 4 });
 
     [TestMethod]
     public void IssueLocation__Equals_IgnoreNull_Length() =>
         ValidateEqualsIgnoreNull(
-            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "M1", IssueId = "id1", Start = 2, Length = 4 },
-            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, IsPrimary = true, Message = "M1", IssueId = "id1", Start = 2, Length = null });
+            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "M1", IssueId = "id1", Start = 2, Length = 4 },
+            new IssueLocation { RuleId = "Sxxxx", FilePath = "File.cs", LineNumber = 1, Type = IssueType.Primary, Message = "M1", IssueId = "id1", Start = 2, Length = null });
 
     [TestMethod]
     public void IssueLocationKey_CreatedFromIssue()
@@ -116,28 +116,28 @@ public class IssueLocationTest
         var sut = new IssueLocationKey(Issue);
         sut.FilePath.Should().Be("File.cs");
         sut.LineNumber.Should().Be(42);
-        sut.IsPrimary.Should().BeTrue();
+        sut.Type.Should().Be(IssueType.Primary);
     }
 
     [TestMethod]
     public void IssueLocationKey_IsMatch_MatchesSameKey() =>
-        new IssueLocationKey("File.cs", 42, true).IsMatch(Issue).Should().BeTrue();
+        new IssueLocationKey("File.cs", 42, IssueType.Primary).IsMatch(Issue).Should().BeTrue();
 
     [TestMethod]
     public void IssueLocationKey_IsMatch_ProjectLevelMatchesAnyPath() =>
-        new IssueLocationKey(string.Empty, 42, true).IsMatch(Issue).Should().BeTrue();
+        new IssueLocationKey(string.Empty, 42, IssueType.Primary).IsMatch(Issue).Should().BeTrue();
 
     [TestMethod]
     public void IssueLocationKey_IsMatch_DifferentFilePath() =>
-        new IssueLocationKey("Another.cs", 42, true).IsMatch(Issue).Should().BeFalse();
+        new IssueLocationKey("Another.cs", 42, IssueType.Primary).IsMatch(Issue).Should().BeFalse();
 
     [TestMethod]
     public void IssueLocationKey_IsMatch_DifferentLineNumber() =>
-        new IssueLocationKey("File.cs", 1024, true).IsMatch(Issue).Should().BeFalse();
+        new IssueLocationKey("File.cs", 1024, IssueType.Primary).IsMatch(Issue).Should().BeFalse();
 
     [TestMethod]
     public void IssueLocationKey_IsMatch_DifferentIsPrimary() =>
-        new IssueLocationKey("File.cs", 42, false).IsMatch(Issue).Should().BeFalse();
+        new IssueLocationKey("File.cs", 42, IssueType.Secondary).IsMatch(Issue).Should().BeFalse();
 
     private static void ValidateEqualsIgnoreNull(IssueLocation hasValue, IssueLocation withNull)
     {

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifier.cs
@@ -142,7 +142,7 @@ namespace SonarAnalyzer.Test.TestFramework
             foreach (var filePairs in MatchPairs(actual, expected).GroupBy(x => x.FilePath).OrderBy(x => x.Key))
             {
                 assertionMessages.AppendLine($"There are differences for {actual.LanguageVersion} {SerializePath(filePairs.Key)}:");
-                foreach (var pair in filePairs.OrderBy(x => x.IsPrimary ? 0 : 1).ThenBy(x => x.LineNumber).ThenBy(x => x.Start))
+                foreach (var pair in filePairs.OrderBy(x => x.Type).ThenBy(x => x.LineNumber).ThenBy(x => x.Start))
                 {
                     pair.AppendAssertionMessage(assertionMessages);
                 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifier.cs
@@ -186,7 +186,7 @@ namespace SonarAnalyzer.Test.TestFramework
             var ret = new List<IssueLocationPair>();
             // Process file-level issues before project-level that match to any expected file issue
             // Then process primary before secondary, so we can update primary.IssueId for the purpose of matching seconday issues correctly.
-            foreach (var key in actual.UniqueKeys().OrderBy(x => x.FilePath == string.Empty ? 1 : 0).ThenBy(x => x.IsPrimary ? 0 : 1))
+            foreach (var key in actual.UniqueKeys().OrderBy(x => x.FilePath == string.Empty ? 1 : 0).ThenBy(x => x.Type))
             {
                 ret.AddRange(MatchDifferences(actual.Remove(key), expected.Remove(key)));
             }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/IssueLocation.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/IssueLocation.cs
@@ -22,6 +22,7 @@ namespace SonarAnalyzer.TestFramework.Verification.IssueValidation;
 
 internal enum IssueType
 {
+    // Order of these member is important for DiagnosticVerifier.
     Primary,
     Secondary,
     Error
@@ -77,7 +78,7 @@ internal sealed class IssueLocation // ToDo: Refactor the relation between this 
         && (issue.FilePath == string.Empty || FilePath == string.Empty || issue.FilePath == FilePath)
         && issue.LineNumber == LineNumber
         && issue.Type == Type
-        && (IsPrimary || issue.IssueId == IssueId)   // We ignore issueId for primary issues, as we need to match them only for secondary
+        && (Type == IssueType.Primary || issue.IssueId == IssueId)   // We ignore issueId for primary issues, as we need to match them only for secondary
         && EqualOrNull(issue.RuleId, RuleId)
         && EqualOrNull(issue.Message, Message)
         && EqualOrNull(issue.Start, Start)

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/IssueLocation.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/IssueLocation.cs
@@ -20,14 +20,21 @@
 
 namespace SonarAnalyzer.TestFramework.Verification.IssueValidation;
 
-[DebuggerDisplay("ID:{RuleId} @{LineNumber} Primary:{IsPrimary} Start:{Start} Length:{Length} ID:{IssueId} {Message} {FilePath}")]
+internal enum IssueType
+{
+    Primary,
+    Secondary,
+    Error
+}
+
+[DebuggerDisplay("ID:{RuleId} {Type} @{LineNumber} Start:{Start} Length:{Length} ID:{IssueId} {Message} {FilePath}")]
 internal sealed class IssueLocation // ToDo: Refactor the relation between this and the Key
 {
     public IssueLocation Primary { get; }   // Only for actual secondary issues
     public string RuleId { get; init; }     // Diagnostic ID for actual issues
     public string FilePath { get; init; }
     public int LineNumber { get; init; }
-    public bool IsPrimary { get; init; }
+    public IssueType Type { get; init; }
     public string Message { get; init; }
     public string IssueId { get => Primary?.IssueId ?? issueId; init => issueId = value; }    // Issue location ID to pair primary and secondary locations
     public int? Start { get; set; }
@@ -35,21 +42,19 @@ internal sealed class IssueLocation // ToDo: Refactor the relation between this 
 
     private string issueId;
 
-    public IssueLocation(Diagnostic diagnostic) : this(diagnostic.GetMessage(), diagnostic.Location)
-    {
-        IsPrimary = true;
+    public IssueLocation(Diagnostic diagnostic) : this(IssueType.Primary, diagnostic.GetMessage(), diagnostic.Location) =>
         RuleId = diagnostic.Id;
-    }
 
-    public IssueLocation(IssueLocation primary, SecondaryLocation secondaryLocation) : this(secondaryLocation.Message ?? string.Empty, secondaryLocation.Location) =>
+    public IssueLocation(IssueLocation primary, SecondaryLocation secondaryLocation) : this(IssueType.Secondary, secondaryLocation.Message, secondaryLocation.Location) =>
         Primary = primary;
 
     public IssueLocation() { }
 
-    private IssueLocation(string message, Location location)
+    private IssueLocation(IssueType type, string message, Location location)
     {
         var span = location.GetLineSpan();
-        Message = message;
+        Type = type;
+        Message = message ?? string.Empty;
         LineNumber = location.GetLineNumberToReport();
         Start = span.StartLinePosition.Character;
         Length = location.SourceSpan.Length;
@@ -58,20 +63,20 @@ internal sealed class IssueLocation // ToDo: Refactor the relation between this 
 
     public void UpdatePrimaryIssueIdFrom(IssueLocation expected)
     {
-        if (IsPrimary)
+        if (Type == IssueType.Primary)
         {
             issueId = expected.IssueId;  // Let actual secondary issues find issueId of their expected primary via secondaryIssue.Primary.IssueId
         }
     }
 
     public override int GetHashCode() =>
-        Helpers.HashCode.Combine(FilePath.GetHashCode(), LineNumber, IsPrimary ? 0 : 1);
+        Helpers.HashCode.Combine(FilePath.GetHashCode(), LineNumber, Type);
 
     public override bool Equals(object obj) =>
         obj is IssueLocation issue
         && (issue.FilePath == string.Empty || FilePath == string.Empty || issue.FilePath == FilePath)
         && issue.LineNumber == LineNumber
-        && issue.IsPrimary == IsPrimary
+        && issue.Type == Type
         && (IsPrimary || issue.IssueId == IssueId)   // We ignore issueId for primary issues, as we need to match them only for secondary
         && EqualOrNull(issue.RuleId, RuleId)
         && EqualOrNull(issue.Message, Message)
@@ -85,13 +90,13 @@ internal sealed class IssueLocation // ToDo: Refactor the relation between this 
         first is null || second is null || first == second;
 }
 
-[DebuggerDisplay("@{LineNumber} Primary:{IsPrimary} {FilePath}")]
-internal record IssueLocationKey(string FilePath, int LineNumber, bool IsPrimary)
+[DebuggerDisplay("{Type} @{LineNumber} {FilePath}")]
+internal record IssueLocationKey(string FilePath, int LineNumber, IssueType Type)
 {
-    public IssueLocationKey(IssueLocation issue) : this(issue.FilePath, issue.LineNumber, issue.IsPrimary) { }
+    public IssueLocationKey(IssueLocation issue) : this(issue.FilePath, issue.LineNumber, issue.Type) { }
 
     public bool IsMatch(IssueLocation issue) =>
         (FilePath == string.Empty || FilePath == issue.FilePath)
         && issue.LineNumber == LineNumber
-        && issue.IsPrimary == IsPrimary;
+        && issue.Type == Type;
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/IssueLocationPair.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/IssueLocationPair.cs
@@ -26,7 +26,7 @@ internal sealed record IssueLocationPair(IssueLocation Actual, IssueLocation Exp
 {
     public string FilePath => Actual?.FilePath ?? Expected.FilePath;
     public int LineNumber => Actual?.LineNumber ?? Expected.LineNumber;
-    public bool IsPrimary => Actual?.IsPrimary ?? Expected.IsPrimary;
+    public IssueType Type => Actual?.Type ?? Expected.Type;
     public int? Start => Actual?.Start ?? Expected.Start;
 
     public void AppendAssertionMessage(StringBuilder builder)
@@ -36,7 +36,7 @@ internal sealed record IssueLocationPair(IssueLocation Actual, IssueLocation Exp
             throw new InvalidOperationException("Something went horribly wrong. This is supposed to be called only for issues with the same key.");
         }
         builder.Append("  Line ").Append(LineNumber);
-        if (!Actual?.IsPrimary ?? !Expected.IsPrimary)
+        if ((Actual?.Type ?? Expected.Type) == IssueType.Secondary)
         {
             builder.Append(" Secondary location");
         }


### PR DESCRIPTION
Part of #8601 

We will need 3 types of issues: `Primary`, `Secondary`, `Error` instead of the current `IsPrimary` flag

This doesn't do any functional changes.