### PR TITLE
Disable IDE0057

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -232,6 +232,7 @@ dotnet_diagnostic.CS7035.severity = none    # CS7035: it expects the build numbe
 dotnet_diagnostic.CA1822.severity = warning # Increase visibility for Member 'xxx' does not access instance data and can be marked as static
 dotnet_diagnostic.CS8785.severity = error   # Do not hide root cause for: Generator 'xxx' failed to generate source. It will not contribute to the output and compilation errors may occur as a result. Exception was of type 'xxx' with message 'xxx'
 dotnet_diagnostic.RS2008.severity = none    # Enable analyzer release tracking - we don't use the release tracking analyzer
+dotnet_diagnostic.IDE0057.severity = none   # Use range operator
 
 # ----------------------------------------------------------------------------------------------------------------------
 # SyleCop.Analyzers rules - note that the URLs below are for tag 1.1.118


### PR DESCRIPTION
This asks to replace
```
var filePath = Location.Uri.Substring(Location.Uri.IndexOf("analyzers/its"));
```
with fairly unreadable
```
var filepath = Location.Uri[Location.Uri.IndexOf("analyzers/its")..];
```