### PR TITLE
UTs: Fix language versions

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/Metrics/CSharpExecutableLinesMetricTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Metrics/CSharpExecutableLinesMetricTest.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis.CSharp;
 using SonarAnalyzer.Test.Helpers;
 using SonarAnalyzer.Test.TestFramework.Tests;
 
@@ -1040,6 +1041,7 @@ class Program
         {
             var compilation = new VerifierBuilder<DummyAnalyzerWithLocation>()
                 .AddSnippet(code, fileName)
+                .WithLanguageVersion(LanguageVersion.Latest)
                 .Build()
                 .Compile(false)
                 .Single();

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/CallerInformationParametersShouldBeLastTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/CallerInformationParametersShouldBeLastTest.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis.CSharp;
 using SonarAnalyzer.Rules.CSharp;
 
 namespace SonarAnalyzer.Test.Rules
@@ -49,6 +50,6 @@ namespace SonarAnalyzer.Test.Rules
 
         [TestMethod]
         public void CallerInformationParametersShouldBeLastInvalidSyntax() =>
-            builder.AddPaths("CallerInformationParametersShouldBeLastInvalidSyntax.cs").WithConcurrentAnalysis(false).Verify();
+            builder.AddPaths("CallerInformationParametersShouldBeLastInvalidSyntax.cs").WithLanguageVersion(LanguageVersion.CSharp7).WithConcurrentAnalysis(false).Verify();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/DeclareTypesInNamespacesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/DeclareTypesInNamespacesTest.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis.CSharp;
 using CS = SonarAnalyzer.Rules.CSharp;
 using VB = SonarAnalyzer.Rules.VisualBasic;
 
@@ -34,8 +35,8 @@ namespace SonarAnalyzer.Test.Rules
             builder.AddPaths("DeclareTypesInNamespaces.cs", "DeclareTypesInNamespaces2.cs").WithAutogenerateConcurrentFiles(false).Verify();
 
         [TestMethod]
-        public void DeclareTypesInNamespaces_CS_Before8() =>
-            nonConcurrent.AddPaths("DeclareTypesInNamespaces.BeforeCSharp8.cs").WithOptions(ParseOptionsHelper.BeforeCSharp8).Verify();
+        public void DeclareTypesInNamespaces_CSharp7() =>
+            nonConcurrent.AddPaths("DeclareTypesInNamespaces.CSharp7.cs").WithLanguageVersion(LanguageVersion.CSharp7).Verify();
 
         [TestMethod]
         public void DeclareTypesInNamespaces_CS_After8() =>

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/NativeMethodsShouldBeWrappedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/NativeMethodsShouldBeWrappedTest.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis.CSharp;
 using SonarAnalyzer.Rules.CSharp;
 
 namespace SonarAnalyzer.Test.Rules
@@ -69,7 +70,7 @@ namespace SonarAnalyzer.Test.Rules
                     {
                         Extern3(x);             // Error [CS1014, CS1513, CS8124, CS1519]
                     }
-                    public void Wrapper(        // Error [CS8803, CS0106, CS8805, CS8107, CS8112, CS1001]
+                    public void Wrapper(        // Error [CS0106, CS8107, CS8803, CS8805, CS8112, CS1001]
                     {
                         Extern3(x);             // Error [CS0246, CS1003, CS0246, CS8124, CS1001, CS1026, CS1001]
                     }                           // Error [CS1022]
@@ -78,6 +79,6 @@ namespace SonarAnalyzer.Test.Rules
                         Extern3(x);             // Error [CS0103, CS0103]
                     }
                 }                               // Error [CS1022]
-                """).Verify();
+                """).WithLanguageVersion(LanguageVersion.CSharp7).Verify();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/DeclareTypesInNamespaces.BeforeCSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/DeclareTypesInNamespaces.BeforeCSharp8.cs
@@ -1,6 +1,0 @@
-﻿public interface Int // Noncompliant {{Move 'Int' into a named namespace.}}
-{
-    interface InnerInt // Error [CS8026] - interface can't host types | we want to report only on the outer struct
-    {
-    }
-}

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/DeclareTypesInNamespaces.CSharp7.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/DeclareTypesInNamespaces.CSharp7.cs
@@ -1,0 +1,7 @@
+﻿public interface Int // Noncompliant {{Move 'Int' into a named namespace.}}
+{
+    // Interface can't have nested types, we want to report only on the outer struct
+    interface InnerInt // Error [CS8107] Feature 'default interface implementation' is not available in C# 7
+    {
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierTest.cs
@@ -270,6 +270,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
         {
             var compilations = DummyWithLocation.AddPaths("Dummy.razor")
                 .AddReferences(NuGetMetadataReference.MicrosoftAzureDocumentDB())
+                .WithLanguageVersion(LanguageVersion.Latest)
                 .Build()
                 .Compile(false);
             var references = compilations.Single().Compilation.References;
@@ -280,6 +281,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
         public void Compile_Razor_NoReferences()
         {
             var compilations = DummyWithLocation.AddPaths("Dummy.razor")
+                .WithLanguageVersion(LanguageVersion.Latest)
                 .Build()
                 .Compile(false);
             var references = compilations.Single().Compilation.References;


### PR DESCRIPTION
Fix broken master after #8621. All of the changes are related to that.

UTs on `master` run for all language version. This causes some UTs to fail due to different error number on different language versions, like
```
// Error [CS8026] Feature 'default interface implementation' is not available in C# 5. Please use language version 8.0 or greater.
// Error [CS8059] Feature 'default interface implementation' is not available in C# 6. Please use language version 8.0 or greater.
// Error [CS8107] Feature 'default interface implementation' is not available in C# 7.0. Please use language version 8.0 or greater.
```

We don't really need to test the invalid syntax scenarios on multiple versions.