### PR TITLE
SE: Move CollectionConstraint from S4158 to the engine (part 3)

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Argument.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/Argument.cs
@@ -44,6 +44,11 @@ internal sealed class Argument : SimpleProcessor<IArgumentOperationWrapper>
         {
             state = state.SetSymbolConstraint(notNullSymbol, ObjectConstraint.NotNull);
         }
+        if (argument.WrappedOperation.TrackedSymbol(state) is { } symbol
+            && state[symbol] is { } symbolValue)
+        {
+            state = state.SetSymbolValue(symbol, symbolValue.WithoutConstraint<CollectionConstraint>());
+        }
         return state.SetOperationValue(argument, state[argument.Value]);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/EmptyCollectionsShouldNotBeEnumeratedBase.cs
@@ -135,12 +135,6 @@ public abstract class EmptyCollectionsShouldNotBeEnumeratedBase : SymbolicRuleCh
         {
             return context.State.SetOperationConstraint(operation, constraint);
         }
-        else if (operation.Kind == OperationKindEx.Argument
-            && operation.TrackedSymbol(context.State) is { } symbol
-            && context.State[symbol] is { } symbolValue)
-        {
-            return context.State.SetSymbolValue(symbol, symbolValue.WithoutConstraint<CollectionConstraint>());
-        }
         else
         {
             return context.State;

--- a/analyzers/tests/SonarAnalyzer.Test/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -768,8 +768,8 @@ Tag(""End"")";
 
         // Canot use Tag("If", list) because the Tag invocation will clear the CollectionConstraint from "list".
         var validator = SETestContext.CreateCS(code, "List<int> list", new PreserveTestCheck("list")).Validator;
-        validator.ValidateSymbolConstraintsAtTag("if", "list", ObjectConstraint.NotNull, Constraint(emptyInIf));
-        validator.ValidateSymbolConstraintsAtTag("else", "list", ObjectConstraint.NotNull, Constraint(emptyInElse));
+        validator.TagValue("if", "list").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, Constraint(emptyInIf));
+        validator.TagValue("else", "list").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, Constraint(emptyInElse));
 
         static CollectionConstraint Constraint(bool? empty) =>
             empty switch

--- a/analyzers/tests/SonarAnalyzer.Test/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Binary.cs
@@ -755,19 +755,21 @@ Tag(""End"")";
     public void Binary_Collections(string expression, bool? emptyInIf, bool? emptyInElse)
     {
         var code = $$"""
+            string tag;
             if ({{expression}})
             {
-                Tag("If", list);
+                tag = "if";
             }
             else
             {
-                Tag("Else", list);
+                tag = "else";
             }
             """;
 
-        var validator = SETestContext.CreateCS(code, "List<int> list").Validator;
-        validator.TagValue("If").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, Constraint(emptyInIf));
-        validator.TagValue("Else").Should().HaveOnlyConstraints(ObjectConstraint.NotNull, Constraint(emptyInElse));
+        // Canot use Tag("If", list) because the Tag invocation will clear the CollectionConstraint from "list".
+        var validator = SETestContext.CreateCS(code, "List<int> list", new PreserveTestCheck("list")).Validator;
+        validator.ValidateSymbolConstraintsAtTag("if", "list", ObjectConstraint.NotNull, Constraint(emptyInIf));
+        validator.ValidateSymbolConstraintsAtTag("else", "list", ObjectConstraint.NotNull, Constraint(emptyInElse));
 
         static CollectionConstraint Constraint(bool? empty) =>
             empty switch

--- a/analyzers/tests/SonarAnalyzer.Test/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Data;
 using Microsoft.CodeAnalysis.Operations;
 using SonarAnalyzer.SymbolicExecution;
 using SonarAnalyzer.SymbolicExecution.Constraints;
@@ -503,7 +504,7 @@ Tag(""Anonymous"", anonymous);";
         Verify("arrJagged2", CollectionConstraint.Empty);
 
         void Verify(string symbol, CollectionConstraint collectionConstraint) =>
-            validator.ValidateSymbolConstraintsAtTag("tag", symbol, ObjectConstraint.NotNull, collectionConstraint);
+            validator.TagValue("tag", symbol).Should().HaveOnlyConstraints(ObjectConstraint.NotNull, collectionConstraint);
     }
 
     [TestMethod]
@@ -564,7 +565,7 @@ Tag(""S"", s);";
         Verify("collection2", ObjectConstraint.NotNull, CollectionConstraint.Empty);
 
         void Verify(string symbol, params SymbolicConstraint[] constraints) =>
-            validator.ValidateSymbolConstraintsAtTag("tag", symbol, constraints);
+            validator.TagValue("tag", symbol).Should().HaveOnlyConstraints(constraints);
     }
 
     [TestMethod]
@@ -1168,10 +1169,10 @@ Tag(""AfterRemove"", remove);";
         VerifyAfter("Fourth", ObjectConstraint.NotNull);
 
         void VerifyBefore(string symbol, params SymbolicConstraint[] constraints) =>
-            validator.ValidateSymbolConstraintsAtTag("before", symbol, constraints);
+            validator.TagValue("before", symbol).Should().HaveOnlyConstraints(constraints);
 
         void VerifyAfter(string symbol, params SymbolicConstraint[] constraints) =>
-            validator.ValidateSymbolConstraintsAtTag("after", symbol, constraints);
+            validator.TagValue("after", symbol).Should().HaveOnlyConstraints(constraints);
     }
 
     [TestMethod]
@@ -1196,10 +1197,10 @@ Tag(""AfterRemove"", remove);";
         VerifyAfter("Second", ObjectConstraint.NotNull, CollectionConstraint.NotEmpty);
 
         void VerifyBefore(string symbol, params SymbolicConstraint[] constraints) =>
-            validator.ValidateSymbolConstraintsAtTag("before", symbol, constraints);
+            validator.TagValue("before", symbol).Should().HaveOnlyConstraints(constraints);
 
         void VerifyAfter(string symbol, params SymbolicConstraint[] constraints) =>
-            validator.ValidateSymbolConstraintsAtTag("after", symbol, constraints);
+            validator.TagValue("after", symbol).Should().HaveOnlyConstraints(constraints);
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/TestFramework/SymbolicExecution/ValidatorTestCheck.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestFramework/SymbolicExecution/ValidatorTestCheck.cs
@@ -76,6 +76,9 @@ namespace SonarAnalyzer.Test.TestFramework.SymbolicExecution
         public SymbolicValue TagValue(string tag) =>
             TagValues(tag).Should().ContainSingle().Subject;
 
+        public SymbolicValue TagValue(string tag, string symbol) =>
+            TagState(tag)[Symbol(symbol)];
+
         public SymbolicValue[] TagValues(string tag) =>
             tags.Where(x => x.Name == tag).Select(x => TagValue(x.Context)).ToArray();
 
@@ -99,9 +102,6 @@ namespace SonarAnalyzer.Test.TestFramework.SymbolicExecution
 
         public void ValidateHasSingleExitStateAndNoException() =>
             ExitStates.Should().ContainSingle().And.ContainSingle(x => x.Exception == null);
-
-        public void ValidateSymbolConstraintsAtTag(string tag, string symbol, params SymbolicConstraint[] constraints) =>
-            TagState(tag)[Symbol(symbol)].Should().HaveOnlyConstraints(constraints);
 
         protected override ProgramState PostProcessSimple(SymbolicContext context)
         {

--- a/analyzers/tests/SonarAnalyzer.Test/TestFramework/SymbolicExecution/ValidatorTestCheck.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestFramework/SymbolicExecution/ValidatorTestCheck.cs
@@ -21,8 +21,8 @@
 using Microsoft.CodeAnalysis.Operations;
 using SonarAnalyzer.CFG.Roslyn;
 using SonarAnalyzer.Extensions;
+using SonarAnalyzer.SymbolicExecution;
 using SonarAnalyzer.SymbolicExecution.Roslyn;
-using SonarAnalyzer.Test.Helpers;
 using StyleCop.Analyzers.Lightup;
 
 namespace SonarAnalyzer.Test.TestFramework.SymbolicExecution
@@ -67,6 +67,9 @@ namespace SonarAnalyzer.Test.TestFramework.SymbolicExecution
         public void Validate(string operation, Action<SymbolicContext> action) =>
             action(postProcessed.Single(x => TestHelper.Serialize(x.Operation) == operation));
 
+        public ProgramState TagState(string tag) =>
+            TagStates(tag).Should().ContainSingle().Subject;
+
         public ProgramState[] TagStates(string tag) =>
             tags.Where(x => x.Name == tag).Select(x => x.Context.State).ToArray();
 
@@ -96,6 +99,9 @@ namespace SonarAnalyzer.Test.TestFramework.SymbolicExecution
 
         public void ValidateHasSingleExitStateAndNoException() =>
             ExitStates.Should().ContainSingle().And.ContainSingle(x => x.Exception == null);
+
+        public void ValidateSymbolConstraintsAtTag(string tag, string symbol, params SymbolicConstraint[] constraints) =>
+            TagState(tag)[Symbol(symbol)].Should().HaveOnlyConstraints(constraints);
 
         protected override ProgramState PostProcessSimple(SymbolicContext context)
         {


### PR DESCRIPTION
Part of https://github.com/SonarSource/sonar-dotnet/issues/7866

Moves out of the rule the `ArgumentOperation` part.

Applies to this code:

```csharp
var x = new List<int>(); // CollectionConstraint set to "Empty"

// x is used as an argument, CollectionConstraint is removed. 
// Because we have no idea what the method does.
AddStuff(x); 

x.Clear(); // We do not raise, because there is no constraint here. (intended)