### PR TITLE
TestFramework: Make failed assertions clickable

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/Rules/CheckFileLicenseTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/CheckFileLicenseTest.cs
@@ -175,7 +175,7 @@ namespace SonarAnalyzer.Test.Rules
         [TestMethod]
         public void CheckFileLicense_WhenEmptyFile_ShouldBeNonCompliant_CS() =>
             // While we put Noncompliant annotation on 1st line of any file, in this case, the file needs to be empty
-            Builder(SingleLineHeader).AddPaths("CheckFileLicense_EmptyFile.cs").Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+            Builder(SingleLineHeader).AddPaths("CheckFileLicense_EmptyFile.cs").Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for CSharp7 CheckFileLicense_EmptyFile.Concurrent.cs:
                   Line 1: Unexpected issue 'Add or update the header of this file.' Rule S1451
 

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/DiagnosticVerifierException.Concurrent.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/DiagnosticVerifierException.Concurrent.cs
@@ -1,0 +1,1 @@
+﻿// This file needs to exists with .Concurrent. in the name

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/DiagnosticVerifierException.File1.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/DiagnosticVerifierException.File1.cs
@@ -1,0 +1,1 @@
+﻿// This file needs to exists for DiagnosticVerifierException.StackTrace to be rendered

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/DiagnosticVerifierException.File2.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/DiagnosticVerifierException.File2.cs
@@ -1,0 +1,1 @@
+﻿// This file needs to exists for DiagnosticVerifierException.StackTrace to be rendered

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/DiagnosticVerifierExceptionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/DiagnosticVerifierExceptionTest.cs
@@ -1,0 +1,123 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.Test.Common;
+using SonarAnalyzer.Test.Helpers;
+
+namespace SonarAnalyzer.Test.TestFramework.Tests
+{
+    [TestClass]
+    public class DiagnosticVerifierExceptionTest
+    {
+        [TestMethod]
+        public void Ctor_Empty_Throws() =>
+            ((Func<DiagnosticVerifierException>)(() => new([]))).Should().Throw<ArgumentException>().WithMessage("messages cannot be empty*");
+
+        [TestMethod]
+        public void Message_SerializesAllFullDescriptions() =>
+            new DiagnosticVerifierException(
+                [
+                    new("Short 1", "Full 1", "File.cs", 1),
+                    new("Short 2", "Full 2", "File.cs", 1),
+                    new("Short 3", "Full 3 { Does not break formatting", "File.cs", 1),
+                    new("Short 4", "Full 4 } Does not break formatting", "File.cs", 1)
+                ])
+                .Message
+                .Should()
+                .BeIgnoringLineEndings("""
+                    Full 1
+                    Full 2
+                    Full 3 { Does not break formatting
+                    Full 4 } Does not break formatting
+                    """);
+
+        [TestMethod]
+        public void StackTrace_SerializesShortDescriptions() =>
+            new DiagnosticVerifierException(
+                [
+                    new("Short 1", "Full 1", "DiagnosticVerifierException.File1.cs", 11),
+                    new("Short 2", "Full 2", "DiagnosticVerifierException.File1.cs", 22),
+                    new("Short 3", "Full 3", "DiagnosticVerifierException.File1.cs", 33),
+                    new("Short 4", "Full 4", "DiagnosticVerifierException.File1.cs", 44),
+                ])
+                .StackTrace
+                .Should()
+                .BeIgnoringLineEndings($"""
+                    DiagnosticVerifierException.File1.cs
+                    at Short 1 in {Paths.TestsRoot}\SonarAnalyzer.TestFramework.Test\TestCases\DiagnosticVerifierException.File1.cs:line 11
+                    at Short 2 in {Paths.TestsRoot}\SonarAnalyzer.TestFramework.Test\TestCases\DiagnosticVerifierException.File1.cs:line 22
+                    at Short 3 in {Paths.TestsRoot}\SonarAnalyzer.TestFramework.Test\TestCases\DiagnosticVerifierException.File1.cs:line 33
+                    at Short 4 in {Paths.TestsRoot}\SonarAnalyzer.TestFramework.Test\TestCases\DiagnosticVerifierException.File1.cs:line 44
+                    ---
+
+                    """);
+
+        [TestMethod]
+        public void StackTrace_SeparatesMultipleFiles() =>
+            new DiagnosticVerifierException(
+                [
+                    new("Short 1", "Full 1", "DiagnosticVerifierException.File1.cs", 11),
+                    new("Short 2", "Full 2", "DiagnosticVerifierException.File1.cs", 22),
+                    new("Short 3", "Full 3", "DiagnosticVerifierException.File2.cs", 33),
+                    new("Short 4", "Full 4", "DiagnosticVerifierException.File2.cs", 44),
+                    new("Concurrent", "Full 5", "DiagnosticVerifierException.Concurrent.cs", 55) // This file has ".Concurent." in the name and exists on the disk, so it should be listed.
+                ])
+                .StackTrace
+                .Should()
+                .BeIgnoringLineEndings($"""
+                    DiagnosticVerifierException.Concurrent.cs
+                    at Concurrent in {Paths.TestsRoot}\SonarAnalyzer.TestFramework.Test\TestCases\DiagnosticVerifierException.Concurrent.cs:line 55
+                    ---
+                    DiagnosticVerifierException.File1.cs
+                    at Short 1 in {Paths.TestsRoot}\SonarAnalyzer.TestFramework.Test\TestCases\DiagnosticVerifierException.File1.cs:line 11
+                    at Short 2 in {Paths.TestsRoot}\SonarAnalyzer.TestFramework.Test\TestCases\DiagnosticVerifierException.File1.cs:line 22
+                    ---
+                    DiagnosticVerifierException.File2.cs
+                    at Short 3 in {Paths.TestsRoot}\SonarAnalyzer.TestFramework.Test\TestCases\DiagnosticVerifierException.File2.cs:line 33
+                    at Short 4 in {Paths.TestsRoot}\SonarAnalyzer.TestFramework.Test\TestCases\DiagnosticVerifierException.File2.cs:line 44
+                    ---
+
+                    """);
+
+        [TestMethod]
+        public void StackTrace_Ignore_NullShortDescription() =>
+            new DiagnosticVerifierException(
+                [
+                    new(null, "Full 1", "DiagnosticVerifierException.File1.cs", 11),
+                    new(null, "Full 2", "DiagnosticVerifierException.File1.cs", 22),
+                ])
+                .StackTrace
+                .Should()
+                .BeEmpty();
+
+        [TestMethod]
+        public void StackTrace_Ignore_NonexistentFiles() =>
+            new DiagnosticVerifierException(
+                [
+                    new("Short 1", "Full 1", "Nonexistent.cs", 11),
+                    new("Short 2", "Full 2", "Nonexistent.Concurrent.cs", 22),
+                    new("Short 3", "Full 3", "Snippet0.cs", 33),
+                    new("Short 4", "Full 4", "Snippet1.cs", 44),
+                ])
+                .StackTrace
+                .Should()
+                .BeEmpty();
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/DiagnosticVerifierTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/DiagnosticVerifierTest.cs
@@ -251,7 +251,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             new VerifierBuilder<DummyAnalyzerVB>().AddSnippet("Public Class UnexpectedBuildError")
                 .WithConcurrentAnalysis(false)
                 .Invoking(x => x.Verify())
-                .Should().Throw<AssertFailedException>().Which.Message.Should().ContainIgnoringLineEndings("""
+                .Should().Throw<DiagnosticVerifierException>().Which.Message.Should().ContainIgnoringLineEndings("""
                     There are differences for VisualBasic12 snippet0.vb:
                       Line 1: Unexpected error, use ' Error [BC30481] 'Class' statement must end with a matching 'End Class'.
                     """);
@@ -325,7 +325,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 .AddPaths("ExpectedIssuesNotRaised.cs", "ExpectedIssuesNotRaised2.cs")
                 .WithConcurrentAnalysis(false)
                 .Invoking(x => x.Verify())
-                .Should().Throw<AssertFailedException>().WithMessage("""
+                .Should().Throw<DiagnosticVerifierException>().WithMessage("""
                     There are differences for CSharp7 DiagnosticsVerifier\ExpectedIssuesNotRaised.cs:
                       Line 3: Missing expected issue ID MyId0
                       Line 5: Missing expected issue
@@ -344,7 +344,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 .AddProject(AnalyzerLanguage.VisualBasic)
                 .AddSnippet("' Noncompliant ^1#0 {{This is not the correct message.}}");
             var compilation = project.GetCompilation(null, new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optionExplicit: false));
-            ((Action)(() => DiagnosticVerifier.Verify(compilation, new VB.OptionExplicitOn()))).Should().Throw<AssertFailedException>().WithMessage("""
+            ((Action)(() => DiagnosticVerifier.Verify(compilation, new VB.OptionExplicitOn()))).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for VisualBasic16_9 <project-level-issue>:
                   Line 1: The expected message 'This is not the correct message.' does not match the actual message 'Configure 'Option Explicit On' for assembly 'project0'.' Rule S6146
                 """);
@@ -357,12 +357,12 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 .AddProject(AnalyzerLanguage.VisualBasic)
                 .AddSnippet("' Noncompliant@+1 {{This is expected on a wrong line.}}");
             var compilation = project.GetCompilation(null, new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optionExplicit: false));
-            ((Action)(() => DiagnosticVerifier.Verify(compilation, new VB.OptionExplicitOn()))).Should().Throw<AssertFailedException>().WithMessage("""
+            ((Action)(() => DiagnosticVerifier.Verify(compilation, new VB.OptionExplicitOn()))).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for VisualBasic16_9 <project-level-issue>:
                   Line 1: Unexpected issue 'Configure 'Option Explicit On' for assembly 'project0'.' Rule S6146
 
                 There are differences for VisualBasic16_9 snippet0.vb:
-                  Line 2: Missing issue 'This is expected on a wrong line.'
+                  Line 2: Missing expected issue 'This is expected on a wrong line.'
                 """);
         }
 

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationPairTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/IssueValidation/IssueLocationPairTest.cs
@@ -70,7 +70,8 @@ public class IssueLocationPairTest
     [TestMethod]
     public void CreateMessage_WrongStartLocation()
     {
-        ValidateMessage(ActualSecondary,
+        ValidateMessage(
+            ActualSecondary,
             new(IssueType.Secondary, "File.cs", 42, "Lorem ipsum", "Flag1", 2, 2),
             "Secondary Different Location",
             "  Line 42 Secondary location: Should start on column 2 but got column 42 Rule S1234 ID Flag1");

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierTest.cs
@@ -140,13 +140,13 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
         public void Verify_RazorWithAssociatedCS() =>
             DummyCS.AddPaths(WriteFile("File.razor", """<p @bind="pValue">Dynamic content</p>"""))
                 .AddPaths(WriteFile("File.razor.cs", """public partial class File { string pValue = "The value bound"; int a = 42;  }"""))
-                .Invoking(x => x.Verify()).Should().Throw<AssertFailedException>();
+                .Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>();
 
         [TestMethod]
         public void Verify_RazorWithUnrelatedCS() =>
             DummyCS.AddPaths(WriteFile("File.razor", """<p @bind="pValue">Dynamic content</p>"""))
                 .AddPaths(WriteFile("SomeSource.cs", """class SomeSource { int a = 42; }"""))
-                .Invoking(x => x.Verify()).Should().Throw<AssertFailedException>();
+                .Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>();
 
         [TestMethod]
         public void Verify_RazorWithUnrelatedIssues() =>
@@ -160,7 +160,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                         private bool c = true;
                     }
                     """))
-                .Invoking(x => x.Verify()).Should().Throw<AssertFailedException>();
+                .Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>();
 
         [DataTestMethod]
         [DataRow("Dummy.SecondaryLocation.razor")]
@@ -329,7 +329,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                     private int b = 42;     // FP
                     private bool c = true;
                 }
-                """).Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+                """).Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for CSharp7 File.Concurrent.cs:
                   Line 3: Unexpected issue 'Message for SDummy' Rule SDummy
                   Line 4: Unexpected issue 'Message for SDummy' Rule SDummy
@@ -347,7 +347,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                     Private B As Integer = 42   ' FP
                     Private C As Boolean = True
                 End Class
-                """).Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+                """).Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for VisualBasic12 File.Concurrent.vb:
                   Line 2: Unexpected issue 'Message for SDummy' Rule SDummy
                   Line 3: Unexpected issue 'Message for SDummy' Rule SDummy
@@ -366,7 +366,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                     private bool b = true;   // Noncompliant - FN
                     private bool c = true;
                 }
-                """).Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+                """).Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for CSharp7 File.Concurrent.cs:
                   Line 3: Missing expected issue
                   Line 4: Missing expected issue
@@ -407,7 +407,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """))
             .WithConcurrentAnalysis(false)
-            .Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+            .Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for CSharp7 File.cs:
                   Line 3: Missing expected issue
 
@@ -420,7 +420,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
         {
             var builder = WithSnippetCS("// Noncompliant - FN");
             // Concurrent analysis by-default automatically generates concurrent files - File.Concurrent.cs
-            builder.Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+            builder.Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for CSharp7 File.Concurrent.cs:
                   Line 1: Missing expected issue
 
@@ -429,7 +429,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
 
                 """);
             // When AutogenerateConcurrentFiles is turned off, only the provided snippet is analyzed
-            builder.WithAutogenerateConcurrentFiles(false).Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+            builder.WithAutogenerateConcurrentFiles(false).Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for CSharp7 File.cs:
                   Line 1: Missing expected issue
 
@@ -455,7 +455,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                 }
                 """);
             builder.WithOptions(ParseOptionsHelper.FromCSharp9).Invoking(x => x.Verify()).Should().NotThrow();
-            builder.WithOptions(ParseOptionsHelper.BeforeCSharp9).Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+            builder.WithOptions(ParseOptionsHelper.BeforeCSharp9).Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for CSharp5 File.Concurrent.cs:
                   Line 3: Unexpected error, use // Error [CS8026] Feature 'target-typed object creation' is not available in C# 5. Please use language version 9.0 or greater.
 
@@ -476,7 +476,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
         public void Verify_ErrorBehavior()
         {
             var builder = WithSnippetCS("undefined");
-            builder.Invoking(x => x.Verify()).Should().Throw<AssertFailedException>()
+            builder.Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>()
                 .WithMessage("""
                 There are differences for CSharp7 File.Concurrent.cs:
                   Line 1: Unexpected error, use // Error [CS0116] A namespace cannot directly contain members such as fields, methods or statements
@@ -488,7 +488,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                   Line 1: Unexpected error, use // Error [CS1001] Identifier expected
                   Line 1: Unexpected error, use // Error [CS1002] ; expected
                 """);
-            builder.WithErrorBehavior(CompilationErrorBehavior.FailTest).Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+            builder.WithErrorBehavior(CompilationErrorBehavior.FailTest).Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for CSharp7 File.Concurrent.cs:
                   Line 1: Unexpected error, use // Error [CS0116] A namespace cannot directly contain members such as fields, methods or statements
 
@@ -520,7 +520,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                     }
                 }
                 """));
-            builder.Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+            builder.Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for CSharp7 File.Concurrent.cs:
                   Line 6: Unexpected issue 'Change this condition so that it does not always evaluate to 'True'. Some code paths are unreachable.' Rule S2583
                   Line 10: Unexpected issue 'Change this condition so that it does not always evaluate to 'True'.' Rule S2589
@@ -531,7 +531,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
                   Line 10: Unexpected issue 'Change this condition so that it does not always evaluate to 'True'.' Rule S2589
                   Line 9 Secondary location: Unexpected issue '' Rule S2583
                 """);
-            builder.WithOnlyDiagnostics(ConditionEvaluatesToConstant.S2589).Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+            builder.WithOnlyDiagnostics(ConditionEvaluatesToConstant.S2589).Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for CSharp7 File.Concurrent.cs:
                   Line 10: Unexpected issue 'Change this condition so that it does not always evaluate to 'True'.' Rule S2589
 
@@ -545,7 +545,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
         public void Verify_NonConcurrentAnalysis()
         {
             var builder = WithSnippetCS("var topLevelStatement = true;").WithOptions(ParseOptionsHelper.FromCSharp9).WithOutputKind(OutputKind.ConsoleApplication);
-            builder.Invoking(x => x.Verify()).Should().Throw<AssertFailedException>("Default Verifier behavior duplicates the source file.").WithMessage("""
+            builder.Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>("Default Verifier behavior duplicates the source file.").WithMessage("""
                 There are differences for CSharp9 File.Concurrent.cs:
                   Line 1: Unexpected error, use // Error [CS0825] The contextual keyword 'var' may only appear within a local variable declaration or in script code
                   Line 1: Unexpected error, use // Error [CS0116] A namespace cannot directly contain members such as fields, methods or statements
@@ -559,7 +559,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
             var builder = WithSnippetCS("var topLevelStatement = true;").WithOptions(ParseOptionsHelper.FromCSharp9);
             builder.WithTopLevelStatements().Invoking(x => x.Verify()).Should().NotThrow();
             builder.WithOutputKind(OutputKind.ConsoleApplication).WithConcurrentAnalysis(false).Invoking(x => x.Verify()).Should().NotThrow();
-            builder.Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+            builder.Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                 There are differences for CSharp9 File.Concurrent.cs:
                   Line 1: Unexpected error, use // Error [CS0825] The contextual keyword 'var' may only appear within a local variable declaration or in script code
                   Line 1: Unexpected error, use // Error [CS0116] A namespace cannot directly contain members such as fields, methods or statements
@@ -573,7 +573,7 @@ namespace SonarAnalyzer.Test.TestFramework.Tests
         public void Verify_Snippets() =>
             DummyCS.AddSnippet("public class First { } // Noncompliant [first]  - not raised")
                 .AddSnippet("public class Second { } // Noncompliant [second] - not raised")
-                .Invoking(x => x.Verify()).Should().Throw<AssertFailedException>().WithMessage("""
+                .Invoking(x => x.Verify()).Should().Throw<DiagnosticVerifierException>().WithMessage("""
                     There are differences for CSharp7 snippet0.cs:
                       Line 1: Missing expected issue ID first
 

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/Paths.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/Paths.cs
@@ -42,6 +42,27 @@ namespace SonarAnalyzer.Test.Common
             Console.WriteLine("Rspec folder " + Rspec);
         }
 
+        /// <summary>
+        /// Returns path to the TestCases folder from the currently executed test project.
+        /// </summary>
+        public static string CurrentTestCases()
+        {
+            var current = Path.GetDirectoryName(Path.GetFullPath("."));
+            while (current != TestsRoot)
+            {
+                var testCases = Path.Combine(current, "TestCases");
+                if (Directory.Exists(testCases))
+                {
+                    return testCases;
+                }
+                else
+                {
+                    current = Path.GetDirectoryName(current);
+                }
+            }
+            throw new InvalidOperationException("Could not find TestCases directory from current path: " + Path.GetFullPath("."));
+        }
+
         private static string FindTestsRoot()
         {
             var current = Path.GetFullPath(".");

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/Paths.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/Paths.cs
@@ -47,7 +47,9 @@ namespace SonarAnalyzer.Test.Common
         /// </summary>
         public static string CurrentTestCases()
         {
-            var current = Path.GetDirectoryName(Path.GetFullPath("."));
+            // Under AltCover, this starts deeper than usually and we need to avoid the copied TestCases from TFM folder
+            // C:\...\sonar-dotnet\analyzers\tests\SonarAnalyzer.TestFramework.Test\bin\Debug\net7.0-windows\__Instrumented_SonarAnalyzer.TestFramework.Test\
+            var current = Path.GetDirectoryName(Path.GetDirectoryName(Path.GetFullPath(".")));
             while (current != TestsRoot)
             {
                 var testCases = Path.Combine(current, "TestCases");

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifier.cs
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Text;
-using FluentAssertions.Execution;
 using SonarAnalyzer.TestFramework.Verification.IssueValidation;
 
 namespace SonarAnalyzer.Test.TestFramework

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifier.cs
@@ -113,23 +113,23 @@ namespace SonarAnalyzer.Test.TestFramework
 
         private static void Compare(string languageVersion, CompilationIssues actual, CompilationIssues expected)
         {
-            var assertionMessages = new StringBuilder();
+            var messages = new List<VerificationMessage>();
             foreach (var filePairs in MatchPairs(actual, expected).GroupBy(x => x.FilePath).OrderBy(x => x.Key))
             {
-                assertionMessages.AppendLine($"There are differences for {languageVersion} {SerializePath(filePairs.Key)}:");
+                messages.Add(new(null, $"There are differences for {languageVersion} {SerializePath(filePairs.Key)}:", null, 0));
                 foreach (var pair in filePairs.OrderBy(x => (x.Type, x.LineNumber, x.Start, x.IssueId, x.RuleId)))
                 {
-                    pair.AppendAssertionMessage(assertionMessages);
+                    messages.Add(pair.CreateMessage());
                 }
-                assertionMessages.AppendLine();
+                messages.Add(VerificationMessage.EmptyLine);
             }
-            if (assertionMessages.Length == 0)
+            if (messages.Any())
             {
-                actual.Dump(languageVersion);
+                throw new DiagnosticVerifierException(messages);
             }
             else
             {
-                Execute.Assertion.FailWith(assertionMessages.ToString().Replace("{", "{{").Replace("}", "}}"));    // Replacing { and } to avoid invalid format for string.Format
+                actual.Dump(languageVersion);
             }
 
             static string SerializePath(string path) =>

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifierException.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifierException.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.IO;
+using System.Text;
+using SonarAnalyzer.TestFramework.Verification.IssueValidation;
+
+namespace SonarAnalyzer.Test.TestFramework;
+
+public sealed class DiagnosticVerifierException : AssertFailedException
+{
+    private readonly string stackTrace;
+
+    public override string StackTrace =>
+        stackTrace;
+
+    internal DiagnosticVerifierException(List<VerificationMessage> messages) : base(messages.Select(x => x.FullDescription).JoinStr(Environment.NewLine))
+    {
+        if (messages.Count == 0)
+        {
+            throw new ArgumentException($"{nameof(messages)} cannot be empty", nameof(messages));
+        }
+        var builder = new StringBuilder();
+        foreach (var fileMessages in messages.Where(x => x.ShortDescription is not null && File.Exists(x.FullPath)).GroupBy(x => x.FullPath).OrderBy(x => x.Key))
+        {
+            builder.AppendLine(Path.GetFileName(fileMessages.Key));
+            foreach (var message in fileMessages)
+            {
+                builder.AppendLine($"at {message.ShortDescription} in {message.FullPath}:line {message.LineNumber}");
+            }
+            builder.AppendLine("---");    // Empty lines are not rendered => force it with content
+        }
+        stackTrace = builder.ToString();
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifierException.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/DiagnosticVerifierException.cs
@@ -28,8 +28,7 @@ public sealed class DiagnosticVerifierException : AssertFailedException
 {
     private readonly string stackTrace;
 
-    public override string StackTrace =>
-        stackTrace;
+    public override string StackTrace => stackTrace;
 
     internal DiagnosticVerifierException(List<VerificationMessage> messages) : base(messages.Select(x => x.FullDescription).JoinStr(Environment.NewLine))
     {

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/VerificationMessage.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/VerificationMessage.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.IO;
+
+namespace SonarAnalyzer.TestFramework.Verification.IssueValidation;
+
+internal sealed record VerificationMessage(string ShortDescription, string FullDescription, string FilePath, int LineNumber)
+{
+    public static readonly VerificationMessage EmptyLine = new(null, null, null, 0);
+
+    public string FullPath => Path.GetFullPath(Path.Combine(@"..\..\..\TestCases", FilePath));
+}

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/VerificationMessage.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/VerificationMessage.cs
@@ -19,6 +19,7 @@
  */
 
 using System.IO;
+using SonarAnalyzer.Test.Common;
 
 namespace SonarAnalyzer.TestFramework.Verification.IssueValidation;
 
@@ -26,5 +27,5 @@ internal sealed record VerificationMessage(string ShortDescription, string FullD
 {
     public static readonly VerificationMessage EmptyLine = new(null, null, null, 0);
 
-    public string FullPath => Path.GetFullPath(Path.Combine(@"..\..\..\TestCases", FilePath));
+    public string FullPath => Path.Combine(Paths.CurrentTestCases(), FilePath);
 }


### PR DESCRIPTION
Fixes #8546 

The exact stack trace will change a bit to make it work in Rider too in #8725 