### PR TITLE
Increase Regex timeout for S1075

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/UriShouldNotBeHardcodedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UriShouldNotBeHardcodedBase.cs
@@ -39,9 +39,10 @@ namespace SonarAnalyzer.Rules
         private const string AbsoluteDiskUri = @"^[A-Za-z]:(/|\\)";
         private const string AbsoluteMappedDiskUri = @"^\\\\\w[ \w\.]*";
 
-        protected static readonly Regex UriRegex = new($"{UriScheme}|{AbsoluteDiskUri}|{AbsoluteMappedDiskUri}", RegexOptions.Compiled, RegexConstants.DefaultTimeout);
+        private static TimeSpan RegexTimeout => TimeSpan.FromMilliseconds(500);
+        protected static readonly Regex UriRegex = new($"{UriScheme}|{AbsoluteDiskUri}|{AbsoluteMappedDiskUri}", RegexOptions.Compiled, RegexTimeout);
 
-        protected static readonly Regex PathDelimiterRegex = new(@"^(\\|/)$", RegexOptions.Compiled, RegexConstants.DefaultTimeout);
+        protected static readonly Regex PathDelimiterRegex = new(@"^(\\|/)$", RegexOptions.Compiled, RegexTimeout);
 
         protected static readonly ISet<string> CheckedVariableNames =
             new HashSet<string>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UriShouldNotBeHardcodedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UriShouldNotBeHardcodedBase.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules
         private const string AbsoluteDiskUri = @"^[A-Za-z]:(/|\\)";
         private const string AbsoluteMappedDiskUri = @"^\\\\\w[ \w\.]*";
 
-        private static TimeSpan RegexTimeout => TimeSpan.FromMilliseconds(500);
+        private static TimeSpan RegexTimeout => TimeSpan.FromMilliseconds(500); // see also RegexConstants.DefaultTimeout
         protected static readonly Regex UriRegex = new($"{UriScheme}|{AbsoluteDiskUri}|{AbsoluteMappedDiskUri}", RegexOptions.Compiled, RegexTimeout);
 
         protected static readonly Regex PathDelimiterRegex = new(@"^(\\|/)$", RegexOptions.Compiled, RegexTimeout);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UriShouldNotBeHardcodedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UriShouldNotBeHardcodedBase.cs
@@ -41,7 +41,6 @@ namespace SonarAnalyzer.Rules
 
         private static TimeSpan RegexTimeout => TimeSpan.FromMilliseconds(500); // see also RegexConstants.DefaultTimeout
         protected static readonly Regex UriRegex = new($"{UriScheme}|{AbsoluteDiskUri}|{AbsoluteMappedDiskUri}", RegexOptions.Compiled, RegexTimeout);
-
         protected static readonly Regex PathDelimiterRegex = new(@"^(\\|/)$", RegexOptions.Compiled, RegexTimeout);
 
         protected static readonly ISet<string> CheckedVariableNames =


### PR DESCRIPTION
We had an AD0001 on this rule on cirrus https://cirrus-ci.com/task/6479785799450624 see also our [internal slack conversation](https://sonarsource.slack.com/archives/C012KBFFYD6/p1707387101212299?thread_ts=1707294010.300419&cid=C012KBFFYD6).

```
CSC : error AD0001: Analyzer 'SonarAnalyzer.Rules.CSharp.UriShouldNotBeHardcoded' threw an exception of type 'System.Text.RegularExpressions.RegexMatchTimeoutException' with message 'The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.'. [C:\sonar-ci\Project\src\dotnet-svcutil\lib\src\dotnet-svcutil-lib.csproj]
```

This PR increases the timeout from the default 100ms to 500ms

https://github.com/SonarSource/sonar-dotnet/blob/8e87ce09658e0e137eed4588034039135ef7ac43/analyzers/src/SonarAnalyzer.Common/Common/RegexConstants.cs#L25
