### PR TITLE
ITs: Write Sarif in different directory

### DIFF
--- a/analyzers/its/Directory.Build.targets
+++ b/analyzers/its/Directory.Build.targets
@@ -5,7 +5,7 @@
     <PropertyGroup>
       <BinariesFolder>$(MSBuildStartupDirectory)\..\packaging\binaries</BinariesFolder>
       <AnalysisOutputPath>$(MSBuildStartupDirectory)\output\$(PROJECT)\$(AssemblyName)</AnalysisOutputPath>
-      <ErrorLogFolder>$(MSBuildStartupDirectory)\output\Issues\$(PROJECT)</ErrorLogFolder>
+      <ErrorLogFolder>$(MSBuildStartupDirectory)\output\$(PROJECT)\issues</ErrorLogFolder>
       <ErrorLogPrefix Condition="'$(TargetFramework)' == ''">$(ErrorLogFolder)\$(AssemblyName)</ErrorLogPrefix>
       <ErrorLogPrefix Condition="'$(TargetFramework)' != ''">$(ErrorLogFolder)\$(AssemblyName)-$(TargetFramework)</ErrorLogPrefix>
       <SonarAnalysisConfigPath>$(MSBuildStartupDirectory)\SonarQubeAnalysisConfig.xml</SonarAnalysisConfigPath>

--- a/analyzers/its/regression-test.ps1
+++ b/analyzers/its/regression-test.ps1
@@ -130,8 +130,8 @@ function Initialize-OutputFolder() {
         Remove-Item -Recurse -Force output
     }
 
-    Write-Debug "Creating folder 'output\Issues'"
-    New-Item -ItemType directory -Path .\output\Issues | out-null
+    Write-Debug "Creating folder 'output'"
+    New-Item -ItemType directory -Path .\output | out-null
 
     if ($ruleId) {
         Write-Host "Running ITs with only rule ${ruleId} turned on."

--- a/analyzers/src/ITs.JsonParser/IssueParser.cs
+++ b/analyzers/src/ITs.JsonParser/IssueParser.cs
@@ -47,10 +47,17 @@ public static class IssueParser
         ConsoleHelper.WriteLineColor("Successfully wrote all Rule reports.", ConsoleColor.Green);
     }
 
-    private static InputReport[] Read(string rootPath) =>
-        Directory.GetFiles(rootPath, "*.json", SearchOption.AllDirectories)
-            .Select(x => new InputReport(x, SerializerOptions))
-            .ToArray();
+    private static InputReport[] Read(string rootPath)
+    {
+        var projects = Directory.GetDirectories(rootPath);
+        var inputReports = new List<InputReport>();
+        foreach (var project in projects)
+        {
+            inputReports.AddRange(Directory.GetFiles(Path.Combine(rootPath, project, "issues"))
+                .Select(x => new InputReport(x, SerializerOptions)));
+        }
+        return inputReports.ToArray();
+    }
 
     // One SARIF contains all the issues for the project. We need to split it by rule Id.
     private static IEnumerable<OutputReport> ExplodeToRuleIssues(InputReport inputReport)

--- a/analyzers/src/ITs.JsonParser/Program.cs
+++ b/analyzers/src/ITs.JsonParser/Program.cs
@@ -42,7 +42,7 @@ public static class Program
         var sw = Stopwatch.StartNew();
         ConsoleHelper.WriteLineColor("Splitting the SARIF reports to actual folder", ConsoleColor.Yellow);
         var here = Directory.GetCurrentDirectory();
-        var inputRoot = Path.Combine(here, "output", "Issues");
+        var inputRoot = Path.Combine(here, "output");
         var outputRoot = Path.Combine(here, "actual");
         IssueParser.Execute(inputRoot, outputRoot);
         ConsoleHelper.WriteLineColor($"Finished splitting the SARIF reports in '{sw.Elapsed}'", ConsoleColor.Yellow);

--- a/analyzers/src/ITs.JsonParser/Reports/InputReport.cs
+++ b/analyzers/src/ITs.JsonParser/Reports/InputReport.cs
@@ -42,7 +42,8 @@ public class InputReport
             ? (fileName.Substring(0, index), fileName.Substring(index + 1))
             : (fileName, null);
 
-        Project = Path.GetFileName(Path.GetDirectoryName(path));
+        var projectDirectory = Directory.GetParent(Path.GetDirectoryName(path)).FullName;
+        Project = Path.GetFileName(projectDirectory);
         Sarif = JsonSerializer.Deserialize<SarifReport>(File.ReadAllText(path), options);
         ConsoleHelper.WriteLineColor($"Successfully parsed {this}", ConsoleColor.Green);
     }

--- a/analyzers/tests/ITs.JsonParser.Test/IssueParserTest.cs
+++ b/analyzers/tests/ITs.JsonParser.Test/IssueParserTest.cs
@@ -34,7 +34,7 @@ public class IssueParserTest
         var root = TestDirectory();
         var inputPath = Path.Combine(root, "read");
         var outputPath = Path.Combine(root, "write");
-        Directory.CreateDirectory(Path.Combine(inputPath, "solution"));
+        Directory.CreateDirectory(Path.Combine(inputPath, "solution", "issues"));
         Sarif.CreateReport(inputPath, "solution", "project", "net6.0", Sarif.CreateIssue("S100", "Message_1", "foo/bar/File1.cs", 1, 1));
         var outFile = Path.Combine(outputPath, "solution", "S100-project-net6.0.json");
 
@@ -60,8 +60,8 @@ public class IssueParserTest
         var root = TestDirectory();
         var inputPath = Path.Combine(root, "read");
         var outputPath = Path.Combine(root, "write");
-        Directory.CreateDirectory(Path.Combine(inputPath, "solution1"));
-        Directory.CreateDirectory(Path.Combine(inputPath, "solution2"));
+        Directory.CreateDirectory(Path.Combine(inputPath, "solution1", "issues"));
+        Directory.CreateDirectory(Path.Combine(inputPath, "solution2", "issues"));
 
         // solution1/project1-net6.0.json
         Sarif.CreateReport(

--- a/analyzers/tests/ITs.JsonParser.Test/Sarif.cs
+++ b/analyzers/tests/ITs.JsonParser.Test/Sarif.cs
@@ -38,7 +38,7 @@ public static class Sarif
             }
             """;
         var suffix = tfm is null ? string.Empty : $"-{tfm}";
-        File.WriteAllText(Path.Combine(rootPath, solution, $"{project}{suffix}.json"), content);
+        File.WriteAllText(Path.Combine(rootPath, solution, "issues", $"{project}{suffix}.json"), content);
         return content;
     }
 


### PR DESCRIPTION
Instead of writing the sarif reports in `output/issues/$PROJECT`  write them in `output/$PROJECT/issues` instead.
This way we just iterate over the projects without the need to recursively find all the *.json files. And all files produced by a build of a single project will be stored in a single directory