### PR TITLE
Coding Style update: Do not use `ValueTuples`

### DIFF
--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -218,6 +218,10 @@ It can still be used when and where it makes sense. For instance, when a class h
 implementing generic interfaces (such as `IComparable`, `IDisposable`), it can make sense to have regions 
 for the implementation of these interfaces.
 
+## ValueTuples
+
+Do not use `ValueTuples` in production code. The usage in test projects is fine. `ValueTuples` are not supported in MsBuild 14 and while MsBuild 14 is not officially supported anymore, we still don't want to break it, if we can avoid it.
+
 ## VB.NET Specifics
 
 Empty lines should be used between blocks, `Namespace`/`End Namespace` statements, `Class`/`End Class` statements


### PR DESCRIPTION
`ValueTuples` are not available for users with MsBuild 14. While MsBuild 14 is not officially supported anymore, we still want to avoid breaking it, if possible.
Since we do not have tests for MsBuild 14 anymore, pipelines will not turn red, when using `ValueTuples`. Thus it needs to be added to our coding style (and eventually checked via Analyzer).