### PR TITLE
TestFramework: Bump coverage

### DIFF
--- a/analyzers/tests/ITs.JsonParser.Test/ITs.JsonParser.Test.csproj
+++ b/analyzers/tests/ITs.JsonParser.Test/ITs.JsonParser.Test.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SonarAnalyzer.TestFramework\SonarAnalyzer.TestFramework.csproj" />
-    <ProjectReference Include="..\..\src\ITs.JsonParser\ITs.JsonParser.csproj"/>
+    <ProjectReference Include="..\..\src\ITs.JsonParser\ITs.JsonParser.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/analyzers/tests/ITs.JsonParser.Test/TestFramework/PathsTest.cs
+++ b/analyzers/tests/ITs.JsonParser.Test/TestFramework/PathsTest.cs
@@ -18,30 +18,15 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Globalization;
+using SonarAnalyzer.TestFramework.Common;
 
-namespace SonarAnalyzer.TestFramework.Common;
+namespace ITs.JsonParser.Test;
 
-public sealed class CurrentCultureScope : IDisposable
+// This file does not belong in this project. It must be here, because this is the only test project that doesn't have TestCases directory in it.
+[TestClass]
+public class PathsTest
 {
-    private readonly CultureInfo oldCulture;
-    private readonly CultureInfo oldUiCulture;
-
-    public CurrentCultureScope() : this(CultureInfo.InvariantCulture) { }
-
-    public CurrentCultureScope(CultureInfo culture)
-    {
-        var thread = Thread.CurrentThread;
-        oldCulture = thread.CurrentCulture;
-        oldUiCulture = thread.CurrentUICulture;
-        thread.CurrentCulture = culture;
-        thread.CurrentUICulture = culture;
-    }
-
-    public void Dispose()
-    {
-        var thread = Thread.CurrentThread;
-        thread.CurrentCulture = oldCulture;
-        thread.CurrentUICulture = oldUiCulture;
-    }
+    [TestMethod]
+    public void CurrentTestCases_NoTestCases_Throws() =>
+        ((Func<string>)(() => Paths.CurrentTestCases())).Should().Throw<InvalidOperationException>().WithMessage("Could not find TestCases directory from current path:*");
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Build/ProjectBuilderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Build/ProjectBuilderTest.cs
@@ -27,6 +27,24 @@ public class ProjectBuilderTest
     private static readonly ProjectBuilder EmptyVB = SolutionBuilder.Create().AddProject(AnalyzerLanguage.VisualBasic);
 
     [TestMethod]
+    public void AddDocument_Null_Throws() =>
+        EmptyCS.Invoking(x => x.AddDocument(null)).Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("path");
+
+    [TestMethod]
+    public void AddDocument_NoTestCases_Throws() =>
+        EmptyCS.Invoking(x => x.AddDocument("FileOutsideExpectedDirectory.cs")).Should()
+            .Throw<ArgumentException>()
+            .WithMessage(@"path must contain 'TestCases\'*")
+            .Which.ParamName.Should().Be("path");
+
+    [TestMethod]
+    public void AddDocument_UnsupportedExtension_Throws() =>
+        EmptyCS.Invoking(x => x.AddDocument(@"TestCases\File.vb")).Should()
+            .Throw<ArgumentException>()
+            .WithMessage("The file extension '.vb' does not match the project language 'C#' nor Razor.*")
+            .Which.ParamName.Should().Be("path");
+
+    [TestMethod]
     public void AddDocument_ValidExtension()
     {
         EmptyCS.AddDocument(@"TestCases\ProjectBuilder.AddDocument.cs").FindDocument("ProjectBuilder.AddDocument.cs").Should().NotBeNull();
@@ -69,4 +87,8 @@ public class ProjectBuilderTest
     [TestMethod]
     public void AddDocument_VbnetDoesntSupportVbnetFiles() =>
         EmptyVB.Invoking(x => x.AddDocument(@"TestCases\ProjectBuilder.AddDocument.vbhtml").FindDocument("ProjectBuilder.AddDocument.vbhtml").Should().NotBeNull()).Should().Throw<ArgumentException>();
+
+    [TestMethod]
+    public void AddSnippet_Null_Throws() =>
+        EmptyCS.Invoking(x => x.AddSnippet(null)).Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("code");
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Build/SnippetCompilerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Build/SnippetCompilerTest.cs
@@ -26,18 +26,19 @@ public class SnippetCompilerTest
     [TestMethod]
     public void AllowsUnsafe_CS()
     {
-        const string code = @"
-public class Sample
-{
-    public void Main()
-    {
-        int i = 0;
-        unsafe
-        {
-            i = 42;
-        }
-    }
-}";
+        const string code = """
+            public class Sample
+            {
+                public void Main()
+                {
+                    int i = 0;
+                    unsafe
+                    {
+                        i = 42;
+                    }
+                }
+            }
+            """;
         var sut = new SnippetCompiler(code);
         sut.SyntaxTree.Should().NotBeNull();
         sut.SemanticModel.Should().NotBeNull();
@@ -46,12 +47,13 @@ public class Sample
     [TestMethod]
     public void ImportsDefaultNamespaces_VB()
     {
-        const string code = @"
-' No Using statement for System.Exception
-Public Class Sample
-    Inherits Exception
+        const string code = """
+            ' No Using statement for System.Exception
+            Public Class Sample
+                Inherits Exception
 
-End Class";
+            End Class
+            """;
         var sut = new SnippetCompiler(code, false, AnalyzerLanguage.VisualBasic);
         sut.SyntaxTree.Should().NotBeNull();
         sut.SemanticModel.Should().NotBeNull();
@@ -60,12 +62,13 @@ End Class";
     [TestMethod]
     public void IgnoreErrors_CreatesCompilation()
     {
-        const string code = @"
-public class Sample
-{
-// Error CS1519 Invalid token '{' in class, record, struct, or interface member declaration
-// Error CS1513 } expected
-{";
+        const string code = """
+            public class Sample
+            {
+            // Error CS1519 Invalid token '{' in class, record, struct, or interface member declaration
+            // Error CS1513 } expected
+            {
+            """;
         var sut = new SnippetCompiler(code, true, AnalyzerLanguage.CSharp);
         sut.SyntaxTree.Should().NotBeNull();
         sut.SemanticModel.Should().NotBeNull();
@@ -74,13 +77,14 @@ public class Sample
     [TestMethod]
     public void ValidCode_DoNotIgnoreErrors_CreatesCompilation()
     {
-        const string code = @"
-public class Sample
-{
-    public void Main()
-    {
-    }
-}";
+        const string code = """
+            public class Sample
+            {
+                public void Main()
+                {
+                }
+            }
+            """;
         var sut = new SnippetCompiler(code);
         sut.SyntaxTree.Should().NotBeNull();
         sut.SemanticModel.Should().NotBeNull();
@@ -89,17 +93,18 @@ public class Sample
     [TestMethod]
     public void CodeWithWarning_DoNotIgnoreErrors_CreatesCompilation()
     {
-        const string code = @"
-public class Sample
-{
-    public void Main()
-    {
-        // Warning CS0219 The variable 'i' is assigned but its value is never used
-        int i = 42;
-        // Warning CS1030 #warning: 'Show CS1030' on this line
-#warning Show CS1030 on this line
-    }
-}";
+        const string code = """
+            public class Sample
+            {
+                public void Main()
+                {
+                    // Warning CS0219 The variable 'i' is assigned but its value is never used
+                    int i = 42;
+                    // Warning CS1030 #warning: 'Show CS1030' on this line
+            #warning Show CS1030 on this line
+                }
+            }
+            """;
         // Severity=Warning is not an error and should not throw
         var sut = new SnippetCompiler(code);
         sut.SyntaxTree.Should().NotBeNull();
@@ -109,26 +114,28 @@ public class Sample
     [TestMethod]
     public void InvalidCode_DoNotIgnoreErrors_Throws()
     {
-        const string code = @"
-public class Sample
-{
-// Error CS1519 Invalid token '{' in class, record, struct, or interface member declaration
-// Error CS1513 } expected
-{";
+        const string code = """
+            public class Sample
+            {
+            // Error CS1519 Invalid token '{' in class, record, struct, or interface member declaration
+            // Error CS1513 } expected
+            {
+            """;
         using var log = new LogTester();
         Func<SnippetCompiler> f = () => new SnippetCompiler(code);
         f.Should().Throw<InvalidOperationException>();
-        log.AssertContain("CS1519 Line: 5: Invalid token '{' in class, record, struct, or interface member declaration");
-        log.AssertContain("CS1513 Line: 5: } expected");
+        log.AssertContain("CS1519 Line: 4: Invalid token '{' in class, record, struct, or interface member declaration");
+        log.AssertContain("CS1513 Line: 4: } expected");
     }
 
     [TestMethod]
     public void GetNamespaceSymbol_NamespaceExists_ReturnsSymbol()
     {
-        const string code = @"
-namespace Test {
-    public class Sample { }
-}";
+        const string code = """
+            namespace Test {
+                public class Sample { }
+            }
+            """;
         var sut = new SnippetCompiler(code);
         var namespaceSymbol = sut.GetNamespaceSymbol("Test");
         namespaceSymbol.Name.Should().Be("Test");
@@ -137,12 +144,13 @@ namespace Test {
     [TestMethod]
     public void GetNamespaceSymbol_NestedNamespaces_ReturnsSymbols()
     {
-        const string code = @"
-namespace Test {
-    namespace Nested {
-        public class Sample { }
-    }
-}";
+        const string code = """
+            namespace Test {
+                namespace Nested {
+                    public class Sample { }
+                }
+            }
+            """;
         var sut = new SnippetCompiler(code);
         var namespaceSymbol = sut.GetNamespaceSymbol("Test");
         namespaceSymbol.Name.Should().Be("Test");
@@ -153,10 +161,11 @@ namespace Test {
     [TestMethod]
     public void GetNamespaceSymbol_NestedNamespacesWithDot_ReturnsSymbols()
     {
-        const string code = @"
-namespace Test.Nested {
-     public class Sample { }
-}";
+        const string code = """
+            namespace Test.Nested {
+                 public class Sample { }
+            }
+            """;
         var sut = new SnippetCompiler(code);
         // Searching in nested namespaces of the form Namespace.NestedNamespace
         // is not supported by this method. We can get back the symbol of the most nested namespace.
@@ -167,12 +176,58 @@ namespace Test.Nested {
     [TestMethod]
     public void GetNamespaceSymbol_FileScopedNamespace_ReturnsSymbol()
     {
-        const string code = @"
-namespace Test;
-public class Sample { }
-";
+        const string code = """
+            namespace Test;
+            public class Sample { }
+
+            """;
         var sut = new SnippetCompiler(code);
         var namespaceSymbol = sut.GetNamespaceSymbol("Test");
         namespaceSymbol.Name.Should().Be("Test");
+    }
+
+    [TestMethod]
+    public void GetMethodDeclaration_CS()
+    {
+        var sut = new SnippetCompiler("""
+            public class Sample
+            {
+                public int WrongOne() => 42;
+                public int Method() => 42;
+            }
+            """);
+        sut.GetMethodDeclaration("Sample.Method").Should().NotBeNull().And.Subject.ToString().Should().Contain("Method()");
+    }
+
+    [TestMethod]
+    public void GetMethodDeclaration_VB()
+    {
+        var sut = new SnippetCompiler("""
+            Public Class Sample
+                Public Sub WrongOne() : End Sub
+                Public Sub Method1() : End Sub
+                Public Function Method2() : End Function
+            End Class
+            """, false, AnalyzerLanguage.VisualBasic);
+        sut.GetMethodDeclaration("Sample.Method1").Should().NotBeNull().And.Subject.ToString().Should().Contain("Method1()");
+        sut.GetMethodDeclaration("Sample.Method2").Should().NotBeNull().And.Subject.ToString().Should().Contain("Method2()");
+    }
+
+    [TestMethod]
+    public void GetTypeSymbol_CS()
+    {
+        var sut = new SnippetCompiler("public class Sample { public class Nested { } }");
+        var type = sut.GetTypeSymbol("Nested");
+        type.Should().NotBeNull();
+        type.Name.Should().Be("Nested");
+    }
+
+    [TestMethod]
+    public void GetTypeSymbol_VB()
+    {
+        var sut = new SnippetCompiler("Public Class Sample : Public Class Nested : End Class : End Class", false, AnalyzerLanguage.VisualBasic);
+        var type = sut.GetTypeSymbol("Nested");
+        type.Should().NotBeNull();
+        type.Name.Should().Be("Nested");
     }
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Common/EnvironmentVariableScopeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Common/EnvironmentVariableScopeTest.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Test.TestFramework.Tests.Common;
+
+[TestClass]
+public class EnvironmentVariableScopeTest
+{
+    private const string VariableName = "RANDOM__ENVIRONMENT__VARIABLE__THAT__DOES__NOT__EXIST__ANYWHERE";
+
+    [TestMethod]
+    public void SetVariable_SetsAndRestores()
+    {
+        Environment.GetEnvironmentVariable(VariableName).Should().BeNullOrEmpty();
+        using (var scope = new EnvironmentVariableScope(false))
+        {
+            scope.SetVariable(VariableName, "Lorem ipsum");
+            Environment.GetEnvironmentVariable(VariableName).Should().Be("Lorem ipsum");
+            scope.SetVariable(VariableName, "Dolor sit amet");
+            Environment.GetEnvironmentVariable(VariableName).Should().Be("Dolor sit amet");
+        }
+        Environment.GetEnvironmentVariable(VariableName).Should().BeNullOrEmpty();
+    }
+
+    [TestMethod]
+    public void Dispose_Twice_DoesNotFail()
+    {
+        using var outer = new EnvironmentVariableScope(false);
+        outer.SetVariable(VariableName, "Original");
+        var sut = new EnvironmentVariableScope(false);
+        sut.SetVariable(VariableName, "SUT");
+        Environment.GetEnvironmentVariable(VariableName).Should().Be("SUT");
+        sut.Dispose();
+        sut.Invoking(x => x.Dispose()).Should().NotThrow();  // Invoked for the second time
+        Environment.GetEnvironmentVariable(VariableName).Should().Be("Original");
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Common/TestHelperTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Common/TestHelperTest.cs
@@ -1,0 +1,64 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.CFG.Roslyn;
+
+namespace SonarAnalyzer.Test.TestFramework.Tests.Common;
+
+[TestClass]
+public class TestHelperTest
+{
+    private const string CompileCfgLambda = """
+        public class Sample
+        {
+            public void Method()
+            {
+                System.Func<int> f = () => 42;
+            }
+        }
+        """;
+
+    public TestContext TestContext { get; set; }
+
+    [TestMethod]
+    public void CompileCfg_LocalfunctionNameAndAnonymousFunctionFragment_Throws() =>
+        ((Func<ControlFlowGraph>)(() => TestHelper.CompileCfg(CompileCfgLambda, AnalyzerLanguage.CSharp, false, "LocalFunctionName", "AnonymousFunctionFragment")))
+            .Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("Specify localFunctionName or anonymousFunctionFragment.");
+
+    [TestMethod]
+    public void CompileCfg_InvalidAnonymousFunctionFragment_Throws() =>
+        ((Func<ControlFlowGraph>)(() => TestHelper.CompileCfg(CompileCfgLambda, AnalyzerLanguage.CSharp, false, null, "InvalidFragment")))
+            .Should()
+            .Throw<ArgumentException>()
+            .WithMessage("Anonymous function with 'InvalidFragment' fragment was not found.");
+
+    [TestMethod]
+    public void Serialize_Default_Throws() =>
+        ((Func<string>)(() => TestHelper.Serialize(default))).Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("operation");
+
+    [TestMethod]
+    public void TestPath_ThisTestHasArbitraryLongNameSoWeTestTheBranchThatDependsOnVeryLongTestNames_ThisIsAFunctionalName_DoNotGetInspiredExlamationMark_ThisIsNotCleanAtAllExclamationMark()
+    {
+        TestHelper.TestPath(TestContext, "This is also pretty long file name that will make sure we exceed the maximum reasonable file length 1.txt").Should().Contain("TooLongTestName.0");
+        TestHelper.TestPath(TestContext, "This is also pretty long file name that will make sure we exceed the maximum reasonable file length 2.txt").Should().Contain("TooLongTestName.1");
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Extensions/CompilationExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Extensions/CompilationExtensionsTest.cs
@@ -18,30 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Globalization;
+using Moq;
 
-namespace SonarAnalyzer.TestFramework.Common;
+namespace SonarAnalyzer.Test.TestFramework.Tests.MetadataReferences;
 
-public sealed class CurrentCultureScope : IDisposable
+[TestClass]
+public class CompilationExtensionsTest
 {
-    private readonly CultureInfo oldCulture;
-    private readonly CultureInfo oldUiCulture;
-
-    public CurrentCultureScope() : this(CultureInfo.InvariantCulture) { }
-
-    public CurrentCultureScope(CultureInfo culture)
-    {
-        var thread = Thread.CurrentThread;
-        oldCulture = thread.CurrentCulture;
-        oldUiCulture = thread.CurrentUICulture;
-        thread.CurrentCulture = culture;
-        thread.CurrentUICulture = culture;
-    }
-
-    public void Dispose()
-    {
-        var thread = Thread.CurrentThread;
-        thread.CurrentCulture = oldCulture;
-        thread.CurrentUICulture = oldUiCulture;
-    }
+    [TestMethod]
+    public void LanguageVersionString_Null() =>
+        ((Func<string>)(() => CompilationExtensions.LanguageVersionString(null))).Should().Throw<NotSupportedException>().WithMessage("Not supported compilation type: ''");
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/VerifierTest.cs
@@ -582,6 +582,10 @@ public class VerifierTest
                 """);
 
     [TestMethod]
+    public void VerifyCodeFix_NoCodeFix() =>
+        DummyCS.AddSnippet("// Nothing to see here").Invoking(x => x.VerifyCodeFix()).Should().Throw<InvalidOperationException>().WithMessage("CodeFix was not set.");
+
+    [TestMethod]
     public void VerifyCodeFix_FixExpected_CS()
     {
         var originalPath = WriteFile("File.cs", """
@@ -674,6 +678,14 @@ public class VerifierTest
                 Private C As Boolean = True
             End Class" has a length of 151, differs near "Not" (index 47).
             """);
+    }
+
+    [TestMethod]
+    public void VerifyCodeFix_NoIssueRaised()
+    {
+        var path = WriteFile("File.cs", "// Nothing to see here");
+        DummyCS.AddPaths(path).WithCodeFix<DummyCodeFixCS>().WithCodeFixedPaths(path).Invoking(x => x.VerifyCodeFix()).Should().Throw<AssertFailedException>()
+            .WithMessage("Expected state.Diagnostics not to be empty.");
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Build/ProjectBuilder.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Build/ProjectBuilder.cs
@@ -78,10 +78,9 @@ public readonly struct ProjectBuilder
         var relativePathFromTestCases = testCasesIndex < 0
             ? throw new ArgumentException($"{nameof(path)} must contain '{TestCases}'", nameof(path))
             : fileInfo.FullName.Substring(testCasesIndex + TestCases.Length);
-        return
-            IsExtensionOfSupportedType(fileInfo)
+        return IsExtensionOfSupportedType(fileInfo)
             ? AddDocument(project, relativePathFromTestCases, File.ReadAllText(fileInfo.FullName, Encoding.UTF8))
-            : throw new ArgumentException($"The file extension '{fileInfo.Extension}' does not match the project language '{project.Language}' nor razor.", nameof(path));
+            : throw new ArgumentException($"The file extension '{fileInfo.Extension}' does not match the project language '{project.Language}' nor Razor.", nameof(path));
     }
 
     public ProjectBuilder AddSnippets(params string[] snippets) =>

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Build/SnippetCompiler.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Build/SnippetCompiler.cs
@@ -79,7 +79,7 @@ public class SnippetCompiler
         else
         {
             var type = GetNodes<VB.TypeStatementSyntax>().First(m => m.Identifier.ValueText == nameParts[0]);
-            method = type.DescendantNodes().OfType<VB.MethodStatementSyntax>().First(m => m.Identifier.ValueText == nameParts[1]);
+            method = type.Parent.DescendantNodes().OfType<VB.MethodStatementSyntax>().First(m => m.Identifier.ValueText == nameParts[1]);
         }
 
         method.Should().NotBeNull("Test setup error: could not find method declaration in code snippet: Type: {nameParts[0]}, Method: {nameParts[1]}");
@@ -139,7 +139,7 @@ public class SnippetCompiler
 
     public SonarSyntaxNodeReportingContext CreateAnalysisContext(SyntaxNode node)
     {
-        var nodeContext =  new SyntaxNodeAnalysisContext(node, SemanticModel, null, null, null, default);
+        var nodeContext = new SyntaxNodeAnalysisContext(node, SemanticModel, null, null, null, default);
         return new(AnalysisScaffolding.CreateSonarAnalysisContext(), nodeContext);
     }
 

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/AssertIgnoreScope.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/AssertIgnoreScope.cs
@@ -21,7 +21,7 @@
 namespace SonarAnalyzer.TestFramework.Common;
 
 /// <summary>
-/// Some of the tests cover exceptions in which we have asserts as well, we want to ignore those asserts during tests
+/// Some of the tests cover exceptions in which we have asserts as well, we want to ignore those asserts during tests.
 /// </summary>
 public sealed class AssertIgnoreScope : IDisposable
 {
@@ -30,17 +30,9 @@ public sealed class AssertIgnoreScope : IDisposable
     public AssertIgnoreScope()
     {
         listener = Trace.Listeners.OfType<DefaultTraceListener>().FirstOrDefault();
-        if (listener != null)
-        {
-            Trace.Listeners.Remove(listener);
-        }
+        Trace.Listeners.Remove(listener);
     }
 
-    public void Dispose()
-    {
-        if (listener != null)
-        {
-            Trace.Listeners.Add(listener);
-        }
-    }
+    public void Dispose() =>
+        Trace.Listeners.Add(listener);
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/TestHelper.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/TestHelper.cs
@@ -129,7 +129,7 @@ End Class", AnalyzerLanguage.VisualBasic);
 
     public static string TestPath(TestContext context, string fileName)
     {
-        var root = Path.Combine(context.TestDir, context.FullyQualifiedTestClassName.Replace("SonarAnalyzer.Test.", null));
+        var root = Path.Combine(context.TestRunDirectory, context.FullyQualifiedTestClassName.Replace("SonarAnalyzer.Test.", null));
         var directoryName = root.Length + context.TestName.Length + fileName.Length > 250   // 260 can throw PathTooLongException
             ? $"TooLongTestName.{RootSubdirectoryCount()}"
             : context.TestName;

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Extensions/CompilationExtensions.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Extensions/CompilationExtensions.cs
@@ -30,6 +30,6 @@ internal static class CompilationExtensions
         {
             CSharpCompilation cs => cs.LanguageVersion.ToString(),
             VisualBasicCompilation vb => vb.LanguageVersion.ToString(),
-            _ => throw new NotSupportedException($"Not supported compilation: {compilation.GetType()}")
+            _ => throw new NotSupportedException($"Not supported compilation type: '{compilation?.GetType()}'")
         };
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/Verifier.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/Verifier.cs
@@ -268,10 +268,7 @@ internal class Verifier
         {
             var filePath = Path.Combine(projectRoot, snippet.FileName);
             File.WriteAllText(filePath, snippet.Content);
-            if (IsRazorOrCshtml(filePath))
-            {
-                razorFiles.Add(filePath);
-            }
+            razorFiles.Add(filePath);
         }
         return razorFiles;
     }


### PR DESCRIPTION
Follow up of #8542 

The coverage of this PR itself is laying in a big picture, as it shows the number isolated to this PR, not to the whole changes of Test Framework.

CompilationExtensions.cs: There was an uncovered condition on line 29 and uncovered line 33. That changed to uncovered condition on line 33 as planned. 
ProjectBuilder.cs: It shows 3/4 on a condition that should be 2/2: Tooling issue with #8696