### PR TITLE
TestFramework: Fix codesmells

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/Rules/ClassAndMethodNameTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/ClassAndMethodNameTest.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Test.Rules
         [TestMethod]
         public void ClassAndMethodName_CS() =>
             builderCS.AddPaths("ClassAndMethodName.cs", "ClassAndMethodName.Partial.cs")
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .WithConcurrentAnalysis(false)
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/DeadStoresTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/DeadStoresTest.cs
@@ -28,10 +28,10 @@ namespace SonarAnalyzer.Test.Rules
         private readonly VerifierBuilder sonarCfg = new VerifierBuilder()
             .AddAnalyzer(() => new DeadStores(AnalyzerConfiguration.AlwaysEnabledWithSonarCfg))
             .WithOptions(ParseOptionsHelper.FromCSharp8)
-            .AddReferences(MetadataReferenceFacade.NETStandard21);
+            .AddReferences(MetadataReferenceFacade.NetStandard21);
 
         private readonly VerifierBuilder roslynCfg = new VerifierBuilder<DeadStores>()
-            .AddReferences(MetadataReferenceFacade.NETStandard21);
+            .AddReferences(MetadataReferenceFacade.NetStandard21);
 
         [TestMethod]
         public void DeadStores_SonarCfg() =>

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/DoNotDecreaseMemberVisibilityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/DoNotDecreaseMemberVisibilityTest.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Test.Rules
         [TestMethod]
         public void DoNotDecreaseMemberVisibility() =>
             builder.AddPaths("DoNotDecreaseMemberVisibility.cs", "DoNotDecreaseMemberVisibility2.cs")
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/EmptyMethodTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/EmptyMethodTest.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Test.Rules
         public void EmptyMethod() =>
             builderCS.AddPaths("EmptyMethod.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .Verify();
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/EncryptionAlgorithmsShouldBeSecureTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/EncryptionAlgorithmsShouldBeSecureTest.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Test.Rules
 
         [TestMethod]
         public void EncryptionAlgorithmsShouldBeSecure_CS_NetStandard21() =>
-            builderCS.AddPaths(@"EncryptionAlgorithmsShouldBeSecure_NetStandard21.cs").AddReferences(MetadataReferenceFacade.NETStandard21.Concat(GetAdditionalReferences())).Verify();
+            builderCS.AddPaths(@"EncryptionAlgorithmsShouldBeSecure_NetStandard21.cs").AddReferences(MetadataReferenceFacade.NetStandard21.Concat(GetAdditionalReferences())).Verify();
 
         [TestMethod]
         public void EncryptionAlgorithmsShouldBeSecure_VB() =>
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Test.Rules
         [TestMethod]
         public void EncryptionAlgorithmsShouldBeSecure_VB_NetStandard21() =>
             builderVB.AddPaths(@"EncryptionAlgorithmsShouldBeSecure_NetStandard21.vb")
-                     .AddReferences(MetadataReferenceFacade.NETStandard21.Concat(GetAdditionalReferences()))
+                     .AddReferences(MetadataReferenceFacade.NetStandard21.Concat(GetAdditionalReferences()))
                      .Verify();
 
 #if NET
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Test.Rules
         public void EncryptionAlgorithmsShouldBeSecure_VB_NetStandard21_Net7() =>
             builderVB.AddPaths(@"EncryptionAlgorithmsShouldBeSecure_NetStandard21.Net7.vb")
                 .WithOptions(ParseOptionsHelper.VisualBasicLatest)
-                .AddReferences(MetadataReferenceFacade.NETStandard21.Concat(GetAdditionalReferences()))
+                .AddReferences(MetadataReferenceFacade.NetStandard21.Concat(GetAdditionalReferences()))
                 .Verify();
 
 #else
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Test.Rules
         public void EncryptionAlgorithmsShouldBeSecure_VB_NetStandard21_Net48() =>
             builderVB.AddPaths(@"EncryptionAlgorithmsShouldBeSecure_NetStandard21.Net48.vb")
                      .WithOptions(ParseOptionsHelper.VisualBasicLatest)
-                     .AddReferences(MetadataReferenceFacade.NETStandard21.Concat(GetAdditionalReferences()))
+                     .AddReferences(MetadataReferenceFacade.NetStandard21.Concat(GetAdditionalReferences()))
                      .Verify();
 
 #endif

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/InfiniteRecursionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/InfiniteRecursionTest.cs
@@ -27,10 +27,10 @@ namespace SonarAnalyzer.Test.Rules
     {
         private readonly VerifierBuilder sonarCfg = new VerifierBuilder()
             .AddAnalyzer(() => new InfiniteRecursion(AnalyzerConfiguration.AlwaysEnabledWithSonarCfg))
-            .AddReferences(MetadataReferenceFacade.NETStandard21);
+            .AddReferences(MetadataReferenceFacade.NetStandard21);
 
         private readonly VerifierBuilder roslynCfg = new VerifierBuilder<InfiniteRecursion>()
-            .AddReferences(MetadataReferenceFacade.NETStandard21);
+            .AddReferences(MetadataReferenceFacade.NetStandard21);
 
         [TestMethod]
         public void InfiniteRecursion_SonarCfg() =>

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/InheritedCollidingInterfaceMembersTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/InheritedCollidingInterfaceMembersTest.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Test.Rules
         public void InheritedCollidingInterfaceMembers_CSharp8() =>
             builder.AddPaths("InheritedCollidingInterfaceMembers.CSharp8.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .Verify();
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/LdapConnectionShouldBeSecureTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/LdapConnectionShouldBeSecureTest.cs
@@ -32,7 +32,7 @@ namespace SonarAnalyzer.Test.Rules
             builder.AddPaths("LdapConnectionShouldBeSecure.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .AddReferences(MetadataReferenceFacade.SystemDirectoryServices)
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .Verify();
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/MemberShouldBeStaticTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/MemberShouldBeStaticTest.cs
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Test.Rules
         public void MemberShouldBeStatic_CSharp8() =>
             builder.AddPaths("MemberShouldBeStatic.CSharp8.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .Verify();
 
 #if NETFRAMEWORK // HttpApplication is available only on .Net Framework

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/MethodOverloadOptionalParameterTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/MethodOverloadOptionalParameterTest.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Test.Rules
 
         [TestMethod]
         public void MethodOverloadOptionalParameter() =>
-            builder.AddPaths("MethodOverloadOptionalParameter.cs").AddReferences(MetadataReferenceFacade.NETStandard21).WithOptions(ParseOptionsHelper.FromCSharp8).Verify();
+            builder.AddPaths("MethodOverloadOptionalParameter.cs").AddReferences(MetadataReferenceFacade.NetStandard21).WithOptions(ParseOptionsHelper.FromCSharp8).Verify();
 
 #if NET
 

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/MethodOverrideAddsParamsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/MethodOverrideAddsParamsTest.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Test.Rules
 
         [TestMethod]
         public void MethodOverrideAddsParams() =>
-            builder.AddPaths("MethodOverrideAddsParams.cs").WithOptions(ParseOptionsHelper.FromCSharp8).AddReferences(MetadataReferenceFacade.NETStandard21).Verify();
+            builder.AddPaths("MethodOverrideAddsParams.cs").WithOptions(ParseOptionsHelper.FromCSharp8).AddReferences(MetadataReferenceFacade.NetStandard21).Verify();
 
 #if NET
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/MethodOverrideChangedDefaultValueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/MethodOverrideChangedDefaultValueTest.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Test.Rules
         [TestMethod]
         public void MethodOverrideChangedDefaultValue() =>
             builder.AddPaths("MethodOverrideChangedDefaultValue.cs")
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/MethodParameterUnusedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/MethodParameterUnusedTest.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Test.Rules
 
         [TestMethod]
         public void MethodParameterUnused_CSharp8_CS() =>
-            roslynCS.AddPaths("MethodParameterUnused.CSharp8.cs").WithOptions(ParseOptionsHelper.FromCSharp8).AddReferences(MetadataReferenceFacade.NETStandard21).Verify();
+            roslynCS.AddPaths("MethodParameterUnused.CSharp8.cs").WithOptions(ParseOptionsHelper.FromCSharp8).AddReferences(MetadataReferenceFacade.NetStandard21).Verify();
 
         [TestMethod]
         public void MethodParameterUnused_DoubleCompilation_CS()

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/MethodShouldBeNamedAccordingToSynchronicityTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/MethodShouldBeNamedAccordingToSynchronicityTest.cs
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Test.Rules
 
         [TestMethod]
         public void MethodShouldBeNamedAccordingToSynchronicity_CSharp8() =>
-            builder.AddPaths("MethodShouldBeNamedAccordingToSynchronicity.CSharp8.cs").WithOptions(ParseOptionsHelper.FromCSharp8).AddReferences(MetadataReferenceFacade.NETStandard21).Verify();
+            builder.AddPaths("MethodShouldBeNamedAccordingToSynchronicity.CSharp8.cs").WithOptions(ParseOptionsHelper.FromCSharp8).AddReferences(MetadataReferenceFacade.NetStandard21).Verify();
 
 #if NET
 

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/ParameterNameMatchesOriginalTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/ParameterNameMatchesOriginalTest.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Test.Rules
         public void ParameterNameMatchesOriginal_CS() =>
             builderCS.AddPaths("ParameterNameMatchesOriginal.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .Verify();
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/RedundantArgumentTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/RedundantArgumentTest.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Test.Rules
         [TestMethod]
         public void RedundantArgument_CSharp8() =>
             builder.AddPaths("RedundantArgument.cs")
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/RedundantJumpStatementTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/RedundantJumpStatementTest.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Test.Rules
         [TestMethod]
         public void RedundantJumpStatement_CSharp8() =>
             builder.AddPaths("RedundantJumpStatement.cs")
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/StaticFieldInitializerOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/StaticFieldInitializerOrderTest.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Test.Rules
         public void StaticFieldInitializerOrder() =>
             builder.AddPaths("StaticFieldInitializerOrder.cs", "StaticFieldInitializerOrder_PartialClass.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .Verify();
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/StaticFieldWrittenFromInstanceMemberTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/StaticFieldWrittenFromInstanceMemberTest.cs
@@ -31,7 +31,7 @@ namespace SonarAnalyzer.Test.Rules
 
         [TestMethod]
         public void StaticFieldWrittenFromInstanceMember() =>
-            builder.AddPaths(@"StaticFieldWrittenFromInstanceMember.cs").WithOptions(ParseOptionsHelper.FromCSharp8).AddReferences(MetadataReferenceFacade.NETStandard21).Verify();
+            builder.AddPaths(@"StaticFieldWrittenFromInstanceMember.cs").WithOptions(ParseOptionsHelper.FromCSharp8).AddReferences(MetadataReferenceFacade.NetStandard21).Verify();
 
         [TestMethod]
         public async Task SecondaryIssueInReferencedCompilation()

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/StringOrIntegralTypesForIndexersTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/StringOrIntegralTypesForIndexersTest.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Test.Rules
         [TestMethod]
         public void StringOrIntegralTypesForIndexers_CSharp8() =>
             builder.AddPaths("StringOrIntegralTypesForIndexers.cs")
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/SymbolicExecution/ConditionEvaluatesToConstantTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/SymbolicExecution/ConditionEvaluatesToConstantTest.cs
@@ -85,14 +85,14 @@ public class ConditionEvaluatesToConstantTest
     [TestMethod]
     public void ConditionEvaluatesToConstant_Sonar_CSharp8() =>
         sonar.AddPaths("ConditionEvaluatesToConstant.CSharp8.cs")
-            .AddReferences(MetadataReferenceFacade.NETStandard21)
+            .AddReferences(MetadataReferenceFacade.NetStandard21)
             .WithOptions(ParseOptionsHelper.FromCSharp8)
             .Verify();
 
     [TestMethod]
     public void ConditionEvaluatesToConstant_Roslyn_CSharp8() =>
         roslynCS.AddPaths("ConditionEvaluatesToConstant.CSharp8.cs")
-            .AddReferences(MetadataReferenceFacade.NETStandard21)
+            .AddReferences(MetadataReferenceFacade.NetStandard21)
             .WithOptions(ParseOptionsHelper.FromCSharp8)
             .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/SymbolicExecution/EmptyNullableValueAccessTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/SymbolicExecution/EmptyNullableValueAccessTest.cs
@@ -47,7 +47,7 @@ public class EmptyNullableValueAccessTest
     [DataRow(ProjectType.Test)]
     public void EmptyNullableValueAccess_Sonar_CSharp8(ProjectType projectType) =>
         sonar.AddPaths("EmptyNullableValueAccess.cs")
-            .AddReferences(TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NETStandard21))
+            .AddReferences(TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NetStandard21))
             .WithOptions(ParseOptionsHelper.FromCSharp8)
             .Verify();
 
@@ -56,7 +56,7 @@ public class EmptyNullableValueAccessTest
     [DataRow(ProjectType.Test)]
     public void EmptyNullableValueAccess_Roslyn_CSharp8(ProjectType projectType) =>
         roslynCS.AddPaths("EmptyNullableValueAccess.cs")
-            .AddReferences(TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NETStandard21))
+            .AddReferences(TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NetStandard21))
             .WithOptions(ParseOptionsHelper.FromCSharp8)
             .Verify();
 
@@ -69,7 +69,7 @@ public class EmptyNullableValueAccessTest
     [DataRow(ProjectType.Test)]
     public void EmptyNullableValueAccess_Roslyn_VB(ProjectType projectType) =>
         roslynVB.AddPaths("EmptyNullableValueAccess.vb")
-            .AddReferences(TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NETStandard21))
+            .AddReferences(TestHelper.ProjectTypeReference(projectType).Concat(MetadataReferenceFacade.NetStandard21))
             .Verify();
 
 #if NET

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/SymbolicExecution/InvalidCastToInterfaceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/SymbolicExecution/InvalidCastToInterfaceTest.cs
@@ -47,7 +47,7 @@ public class InvalidCastToInterfaceTest
     [DataRow(ProjectType.Test)]
     public void InvalidCastToInterface_Sonar_CS(ProjectType projectType) =>
         sonar.AddPaths("InvalidCastToInterface.cs")
-            .AddReferences(TestHelper.ProjectTypeReference(projectType).Union(MetadataReferenceFacade.NETStandard21))
+            .AddReferences(TestHelper.ProjectTypeReference(projectType).Union(MetadataReferenceFacade.NetStandard21))
             .WithOptions(ParseOptionsHelper.FromCSharp8)
             .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/SymbolicExecution/NullPointerDereferenceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/SymbolicExecution/NullPointerDereferenceTest.cs
@@ -80,7 +80,7 @@ namespace SonarAnalyzer.Test.Rules
 
         [TestMethod]
         public void NullPointerDereference_Sonar_CSharp8() =>
-            sonar.AddPaths("NullPointerDereference.CSharp8.cs").AddReferences(MetadataReferenceFacade.NETStandard21).WithOptions(ParseOptionsHelper.FromCSharp8).Verify();
+            sonar.AddPaths("NullPointerDereference.CSharp8.cs").AddReferences(MetadataReferenceFacade.NetStandard21).WithOptions(ParseOptionsHelper.FromCSharp8).Verify();
 
         [TestMethod]
         public void NullPointerDereference_Roslyn_CSharp8() =>

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/SymbolicExecution/ObjectsShouldNotBeDisposedMoreThanOnceTest.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Test.Rules
             sonar.AddPaths("ObjectsShouldNotBeDisposedMoreThanOnce.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .AddReferences(TestHelper.ProjectTypeReference(projectType))
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .Verify();
 
         [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/TrackNotImplementedExceptionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/TrackNotImplementedExceptionTest.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Test.Rules
         [TestMethod]
         public void TrackNotImplementedException_CSharp8() =>
             builder.AddPaths("TrackNotImplementedException.cs")
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
                 .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/UnusedPrivateMemberTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/UnusedPrivateMemberTest.cs
@@ -166,7 +166,7 @@ namespace EntityFrameworkMigrations
         public void UnusedPrivateMember_FromCSharp8() =>
             builder.AddPaths("UnusedPrivateMember.CSharp8.cs")
                 .WithOptions(ParseOptionsHelper.FromCSharp8)
-                .AddReferences(MetadataReferenceFacade.NETStandard21)
+                .AddReferences(MetadataReferenceFacade.NetStandard21)
                 .AddReferences(MetadataReferenceFacade.MicrosoftExtensionsDependencyInjectionAbstractions)
                 .Verify();
 

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Analyzers/DummyAnalyzer.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Analyzers/DummyAnalyzer.cs
@@ -38,13 +38,13 @@ public class DummyAnalyzerVB : DummyAnalyzer<VB.SyntaxKind>
 
 public abstract class DummyAnalyzer<TSyntaxKind> : SonarDiagnosticAnalyzer where TSyntaxKind : struct
 {
-    private static readonly DiagnosticDescriptor Rule = AnalysisScaffolding.CreateDescriptorMain("SDummy");
+    private readonly DiagnosticDescriptor rule = AnalysisScaffolding.CreateDescriptorMain("SDummy");
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
     public int DummyProperty { get; set; }
 
     protected abstract TSyntaxKind NumericLiteralExpression { get; }
 
     protected sealed override void Initialize(SonarAnalysisContext context) =>
-        context.RegisterNodeAction(TestGeneratedCodeRecognizer.Instance, c => c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation())), NumericLiteralExpression);
+        context.RegisterNodeAction(TestGeneratedCodeRecognizer.Instance, c => c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation())), NumericLiteralExpression);
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Analyzers/DummyCodeFix.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Analyzers/DummyCodeFix.cs
@@ -57,5 +57,5 @@ public abstract class DummyCodeFix : SonarCodeFix
 
 internal class DummyCodeFixNoAttribute : DummyCodeFix
 {
-    protected override SyntaxNode NewNode() => throw new System.NotImplementedException();
+    protected override SyntaxNode NewNode() => throw new NotSupportedException();
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/FixAllDiagnosticProvider.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/FixAllDiagnosticProvider.cs
@@ -33,8 +33,8 @@ public class FixAllDiagnosticProvider : FixAllContext.DiagnosticProvider
         Task.FromResult(diagnostics);
 
     public override Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancel) =>
-        throw new NotImplementedException();
+        throw new NotSupportedException();
 
     public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancel) =>
-        throw new NotImplementedException();
+        throw new NotSupportedException();
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/MetadataReferenceFacade.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/MetadataReferenceFacade.cs
@@ -65,7 +65,7 @@ public static class MetadataReferenceFacade
         new[] {CoreMetadataReference.MicrosoftWin32Primitives};
 #endif
 
-    public static References NETStandard21 =>
+    public static References NetStandard21 =>
 #if NETFRAMEWORK
         NuGetMetadataFactory.Create("NETStandard.Library.Ref", "2.1.0", "netstandard2.1");
 #else

--- a/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/NuGetMetadataFactory.Package.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/NuGetMetadataFactory.Package.cs
@@ -94,8 +94,8 @@ internal static partial class NuGetMetadataFactory
             var (nextCheck, latest) = File.Exists(path)
                 && File.ReadAllText(path).Split(';') is var values
                 && DateTime.TryParseExact(values[0], "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var nextCheckValue)
-                ? (nextCheckValue, values[1])
-                : (DateTime.MinValue, null);
+                    ? (nextCheckValue, values[1])
+                    : (DateTime.MinValue, null);
             LogMessage($"Next check for latest NuGets: {nextCheck}");
             if (nextCheck < DateTime.Now)
             {

--- a/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/NuGetMetadataFactory.Package.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/NuGetMetadataFactory.Package.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Globalization;
 using System.IO;
 using NuGet.Common;
 using NuGet.Packaging;
@@ -31,7 +32,7 @@ internal static partial class NuGetMetadataFactory
 {
     private const string PackageVersionPrefix = "Sonar.";
 
-    private class Package
+    private sealed class Package
     {
         private readonly string runtime;
         private readonly string version;
@@ -62,9 +63,9 @@ internal static partial class NuGetMetadataFactory
 
         private async Task InstallPackageAsync(string packageDir)
         {
-            var resource = await GetNuGetRepository();
+            var resource = await GetNuGetRepository().ConfigureAwait(false);
             using var packageStream = new MemoryStream();
-            await resource.CopyNupkgToStreamAsync(Id, new NuGetVersion(version), packageStream, new SourceCacheContext(), NullLogger.Instance, default);
+            await resource.CopyNupkgToStreamAsync(Id, new NuGetVersion(version), packageStream, new SourceCacheContext(), NullLogger.Instance, default).ConfigureAwait(false);
             using var packageReader = new PackageArchiveReader(packageStream);
             var dllFiles = packageReader.GetFiles().Where(f => f.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)).ToArray();
             if (dllFiles.Any())
@@ -76,28 +77,30 @@ internal static partial class NuGetMetadataFactory
             }
             else
             {
-                throw new ApplicationException($"Test setup error: required dlls files are missing in the downloaded package. Package: {Id} Runtime: {runtime}");
+                throw new InvalidOperationException($"Test setup error: required dlls files are missing in the downloaded package. Package: {Id} Runtime: {runtime}");
             }
         }
 
         private static async Task<FindPackageByIdResource> GetNuGetRepository()
         {
             var repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");   // Can't use our default NuGet.config, because of trustedSigners
-            return await repository.GetResourceAsync<FindPackageByIdResource>();
+            return await repository.GetResourceAsync<FindPackageByIdResource>().ConfigureAwait(false);
         }
 
         private async Task<string> GetLatestVersion()
         {
             const int VersionCheckDays = 5;
             var path = Path.Combine(PackagesFolder, Id, "Sonar.Latest.txt");
-            var (nextCheck, latest) = File.Exists(path) && File.ReadAllText(path).Split(';') is var values && DateTime.TryParse(values[0], out var nextCheckValue)
+            var (nextCheck, latest) = File.Exists(path)
+                && File.ReadAllText(path).Split(';') is var values
+                && DateTime.TryParseExact(values[0], "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var nextCheckValue)
                 ? (nextCheckValue, values[1])
                 : (DateTime.MinValue, null);
             LogMessage($"Next check for latest NuGets: {nextCheck}");
             if (nextCheck < DateTime.Now)
             {
-                var resource = await GetNuGetRepository();
-                var versions = await resource.GetAllVersionsAsync(Id, new SourceCacheContext(), NullLogger.Instance, default);
+                var resource = await GetNuGetRepository().ConfigureAwait(false);
+                var versions = await resource.GetAllVersionsAsync(Id, new SourceCacheContext(), NullLogger.Instance, default).ConfigureAwait(false);
                 latest = versions.OrderByDescending(x => x.Version).First(x => !x.IsPrerelease).OriginalVersion;
                 new FileInfo(path).Directory.Create(); // Ensure that folder exists, if not create one
                 File.WriteAllText(path, $"{DateTime.Today.AddDays(VersionCheckDays):yyyy-MM-dd};{latest}");

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/CodeFixVerifier.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/CodeFixVerifier.cs
@@ -99,7 +99,7 @@ internal class CodeFixVerifier
         return actions.Where(x => codeFixTitle is null || x.Title == codeFixTitle);
     }
 
-    private class State
+    private sealed class State
     {
         public readonly Document Document;
         public readonly ImmutableArray<Diagnostic> Diagnostics;


### PR DESCRIPTION
Final cleanup after Test Framework rework and extraction #8542 


Coverage is bad, because it changes unreachable code that is not worth testing. 