### PR TITLE
ITs: Update minimum dotnet sdk version for .NET 3.1 projects

### DIFF
--- a/analyzers/its/sources/NetCore31/global.json
+++ b/analyzers/its/sources/NetCore31/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.201",
+    "version": "3.1.424",
     "rollForward": "feature"
   }
 }

--- a/analyzers/its/sources/NetCore31WithConfigurableRules/global.json
+++ b/analyzers/its/sources/NetCore31WithConfigurableRules/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.201",
+    "version": "3.1.424",
     "rollForward": "feature"
   }
 }


### PR DESCRIPTION
When compiling the `NetCore31WithConfigurableRules` and `NetCore31` projects with dotnet SDK  `3.1.201`,  the autogenerated files are dropped in a generated path in the `%Temp%` folder instead of the expected `analyzers/its`.
This creates confusion when we compute the expected vs. actual since we keep the file location as info in the JSON.
I set the version to be the current one we use in the CI, which seems to work as expected locally and on the CI.