### PR TITLE
ITs: Fix ITs.JsonParser.exe build under Visual Studio

### DIFF
--- a/analyzers/SonarAnalyzer.sln
+++ b/analyzers/SonarAnalyzer.sln
@@ -65,6 +65,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SonarAnalyzer.TestFramework", "tests\SonarAnalyzer.TestFramework\SonarAnalyzer.TestFramework.csproj", "{4C1DB1C4-C1FC-4AA1-B855-0D1948E68FB8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ITs.JsonParser", "src\ITs.JsonParser\ITs.JsonParser.csproj", "{0F9FD323-6E4A-42BE-ADBD-9D7958838E37}"
+	ProjectSection(ProjectDependencies) = postProject
+		{8A8A663E-1318-4361-BC97-2E63666FEADB} = {8A8A663E-1318-4361-BC97-2E63666FEADB}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ITs.JsonParser.Test", "tests\ITs.JsonParser.Test\ITs.JsonParser.Test.csproj", "{A60741AF-6809-430E-AD3D-F4B91C52BD95}"
 EndProject


### PR DESCRIPTION
Fixes #8752

Add build order solution dependency to prevent running the Clear target twice.
https://github.com/SonarSource/sonar-dotnet/blob/8e491ee2944b481970c80991716920ba614e655a/analyzers/src/Directory.Build.targets#L10-L12
