### PR TITLE
Bump vbnet plugin size

### DIFF
--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -201,8 +201,8 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>4700000</maxsize>
-                  <minsize>4500000</minsize>
+                  <maxsize>4800000</maxsize>
+                  <minsize>4600000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>


### PR DESCRIPTION
The former range of acceptable size was 4.5 MB to 4.7 MB.
The size has slightly exceeded its upper bound (by 255B) after 9 months since the last increase (#7538).
The size is lower than it used to be on Jan 2022, when it exceeded the 5 MB (#5685).
For the reasons above, the increment seems more physiological than pathological.