### PR TITLE
Extract LoggingFrameworkIdentifier

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeLogged.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeLogged.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using static Roslyn.Utilities.SonarAnalyzer.Shared.LoggingFrameworkIdentifier;
+
 namespace SonarAnalyzer.Rules.CSharp;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -52,65 +54,6 @@ public sealed class ExceptionsShouldBeLogged : SonarDiagnosticAnalyzer
     // - if the exception is not logged, it will visit all the invocations
     private sealed class CatchLoggingInvocationWalker : SafeCSharpSyntaxWalker
     {
-        private static readonly HashSet<string> MicrosoftExtensionsLoggingMethods =
-        [
-            "Log",
-            "LogCritical",
-            "LogDebug",
-            "LogError",
-            "LogInformation",
-            "LogTrace",
-            "LogWarning"
-        ];
-
-        private static readonly HashSet<string> CastleCoreOrCommonCoreLoggingMethods =
-        [
-            "Debug",
-            "DebugFormat",
-            "Error",
-            "ErrorFormat",
-            "Fatal",
-            "FatalFormat",
-            "Info",
-            "InfoFormat",
-            "Trace",
-            "TraceFormat",
-            "Warn",
-            "WarnFormat"
-        ];
-
-        private static readonly HashSet<string> Log4NetLoggingMethods =
-        [
-            "Debug",
-            "Error",
-            "Fatal",
-            "Info",
-            "Warn"
-        ];
-
-        private static readonly HashSet<string> Log4NetLoggingExtensionMethods =
-        [
-            "DebugExt",
-            "ErrorExt",
-            "FatalExt",
-            "InfoExt",
-            "WarnExt"
-        ];
-
-        private static readonly HashSet<string> NLogLoggingMethods =
-        [
-            "Debug",
-            "ConditionalDebug",
-            "Error",
-            "Fatal",
-            "Info",
-            "Trace",
-            "ConditionalTrace",
-            "Warn"
-        ];
-
-        private static readonly HashSet<string> NLogILoggerBaseLoggingMethods = ["Log"];
-
         private readonly SemanticModel model;
         private bool isFirstCatchClauseVisited;
         private bool hasWhenFilterWithDeclarations;

--- a/analyzers/src/SonarAnalyzer.Shared/LoggingFrameworkIdentifier.cs
+++ b/analyzers/src/SonarAnalyzer.Shared/LoggingFrameworkIdentifier.cs
@@ -1,0 +1,82 @@
+namespace Roslyn.Utilities.SonarAnalyzer.Shared;
+
+public static class LoggingFrameworkIdentifier
+{
+    public static readonly HashSet<string> MicrosoftExtensionsLoggingMethods =
+    [
+        "Log",
+        "LogCritical",
+        "LogDebug",
+        "LogError",
+        "LogInformation",
+        "LogTrace",
+        "LogWarning"
+    ];
+
+    public static readonly HashSet<string> CastleCoreOrCommonCoreLoggingMethods =
+    [
+        "Debug",
+        "DebugFormat",
+        "Error",
+        "ErrorFormat",
+        "Fatal",
+        "FatalFormat",
+        "Info",
+        "InfoFormat",
+        "Trace",
+        "TraceFormat",
+        "Warn",
+        "WarnFormat"
+    ];
+
+    public static readonly HashSet<string> Log4NetLoggingMethods =
+    [
+        "Debug",
+        "Error",
+        "Fatal",
+        "Info",
+        "Warn"
+    ];
+
+    public static readonly HashSet<string> Log4NetLoggingExtensionMethods =
+    [
+        "DebugExt",
+        "ErrorExt",
+        "FatalExt",
+        "InfoExt",
+        "WarnExt"
+    ];
+
+    public static readonly HashSet<string> NLogLoggingMethods =
+    [
+        "Debug",
+        "ConditionalDebug",
+        "Error",
+        "Fatal",
+        "Info",
+        "Trace",
+        "ConditionalTrace",
+        "Warn"
+    ];
+
+    public static readonly HashSet<string> NLogILoggerBaseLoggingMethods = ["Log"];
+
+    public static bool IsLoggingInvocation(InvocationExpressionSyntax invocation, SemanticModel model) =>
+        IsLoggingInvocation(invocation, model, MicrosoftExtensionsLoggingMethods, KnownType.Microsoft_Extensions_Logging_LoggerExtensions, true)
+        || IsLoggingInvocation(invocation, model, CastleCoreOrCommonCoreLoggingMethods, KnownType.Castle_Core_Logging_ILogger, false)
+        || IsLoggingInvocation(invocation, model, CastleCoreOrCommonCoreLoggingMethods, KnownType.Common_Logging_ILog, false)
+        || IsLoggingInvocation(invocation, model, Log4NetLoggingMethods, KnownType.log4net_ILog, false)
+        || IsLoggingInvocation(invocation, model, Log4NetLoggingExtensionMethods, KnownType.log4net_Util_ILogExtensions, true)
+        || IsLoggingInvocation(invocation, model, NLogLoggingMethods, KnownType.NLog_ILogger, false)
+        || IsLoggingInvocation(invocation, model, NLogILoggerBaseLoggingMethods, KnownType.NLog_ILoggerBase, false);
+
+    public static bool IsLoggingInvocation(InvocationExpressionSyntax invocation, SemanticModel model, ICollection<string> methodNames, KnownType containingType, bool isExtensionMethod) =>
+        methodNames.Contains(invocation.GetIdentifier().ToString())
+        && model.GetSymbolInfo(invocation).Symbol is { } invocationSymbol
+        && HasMatchingContainingType(invocationSymbol, containingType, isExtensionMethod);
+
+    private static bool HasMatchingContainingType(ISymbol symbol, KnownType containingType, bool isExtensionMethod) =>
+        isExtensionMethod
+            ? symbol.ContainingType.Is(containingType)
+            : symbol.ContainingType.DerivesOrImplements(containingType);
+}

--- a/analyzers/src/SonarAnalyzer.Shared/LoggingFrameworkIdentifier.cs
+++ b/analyzers/src/SonarAnalyzer.Shared/LoggingFrameworkIdentifier.cs
@@ -60,23 +60,4 @@ public static class LoggingFrameworkIdentifier
     ];
 
     public static readonly HashSet<string> NLogILoggerBaseLoggingMethods = ["Log"];
-
-    public static bool IsLoggingInvocation(InvocationExpressionSyntax invocation, SemanticModel model) =>
-        IsLoggingInvocation(invocation, model, MicrosoftExtensionsLoggingMethods, KnownType.Microsoft_Extensions_Logging_LoggerExtensions, true)
-        || IsLoggingInvocation(invocation, model, CastleCoreOrCommonCoreLoggingMethods, KnownType.Castle_Core_Logging_ILogger, false)
-        || IsLoggingInvocation(invocation, model, CastleCoreOrCommonCoreLoggingMethods, KnownType.Common_Logging_ILog, false)
-        || IsLoggingInvocation(invocation, model, Log4NetLoggingMethods, KnownType.log4net_ILog, false)
-        || IsLoggingInvocation(invocation, model, Log4NetLoggingExtensionMethods, KnownType.log4net_Util_ILogExtensions, true)
-        || IsLoggingInvocation(invocation, model, NLogLoggingMethods, KnownType.NLog_ILogger, false)
-        || IsLoggingInvocation(invocation, model, NLogILoggerBaseLoggingMethods, KnownType.NLog_ILoggerBase, false);
-
-    public static bool IsLoggingInvocation(InvocationExpressionSyntax invocation, SemanticModel model, ICollection<string> methodNames, KnownType containingType, bool isExtensionMethod) =>
-        methodNames.Contains(invocation.GetIdentifier().ToString())
-        && model.GetSymbolInfo(invocation).Symbol is { } invocationSymbol
-        && HasMatchingContainingType(invocationSymbol, containingType, isExtensionMethod);
-
-    private static bool HasMatchingContainingType(ISymbol symbol, KnownType containingType, bool isExtensionMethod) =>
-        isExtensionMethod
-            ? symbol.ContainingType.Is(containingType)
-            : symbol.ContainingType.DerivesOrImplements(containingType);
 }


### PR DESCRIPTION
Contains the method names used by the logging frameworks so they can be reused by all logging rules.