### PR TITLE
Rule S6667: Update after peach validation

### DIFF
--- a/analyzers/its/expected/Ember-MM/S6667-Ember.Plugins.json
+++ b/analyzers/its/expected/Ember-MM/S6667-Ember.Plugins.json
@@ -2,13 +2,13 @@
   "Issues": [
     {
       "Id": "S6667",
-      "Message": "Logging in a catch clause should include the exception.",
+      "Message": "Logging in a catch clause should pass the caught exception as a parameter.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/sources/Ember-MM/Ember.Plugins/PluginSectionHandler.cs#L85",
       "Location": "Line 85 Position 25-115"
     },
     {
       "Id": "S6667",
-      "Message": "Logging in a catch clause should include the exception.",
+      "Message": "Logging in a catch clause should pass the caught exception as a parameter.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/sources/Ember-MM/Ember.Plugins/PluginSectionHandler.cs#L95",
       "Location": "Line 95 Position 25-125"
     }

--- a/analyzers/rspec/cs/S6667.html
+++ b/analyzers/rspec/cs/S6667.html
@@ -12,6 +12,14 @@ href="https://learn.microsoft.com/en-us/dotnet/api/system.exception">Exception</
 accept an <code>Exception</code> as a parameter and <a href="https://learn.microsoft.com/en-us/dotnet/core/extensions/logging-providers">logging
 providers</a> persist the <code>Exception</code> in a structured way to facilitate the tracking of system failures. Therefore <code>Exceptions</code>
 should be passed to the logger.</p>
+<p>The rule covers the following logging frameworks:</p>
+<ul>
+  <li> Nuget package - <a href="https://www.nuget.org/packages/Castle.Core">Castle.Core</a> </li>
+  <li> Nuget package - <a href="https://www.nuget.org/packages/Common.Logging.Core">Common.Core</a> </li>
+  <li> Nuget package - <a href="https://www.nuget.org/packages/log4net">log4net</a> </li>
+  <li> Nuget package - <a href="https://www.nuget.org/packages/NLog">NLog</a> </li>
+  <li> Nuget package - <a href="https://www.nuget.org/packages/Microsoft.Extensions.Logging">Microsoft.Extensions.Logging</a> </li>
+</ul>
 <h2>How to fix it</h2>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>

--- a/analyzers/rspec/cs/S6667.json
+++ b/analyzers/rspec/cs/S6667.json
@@ -1,5 +1,5 @@
 {
-  "title": "Logging in a catch clause should include the exception",
+  "title": "Logging in a catch clause should pass the caught exception as a parameter.",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/ArgumentSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/ArgumentSyntaxExtensions.cs
@@ -34,11 +34,6 @@ namespace SonarAnalyzer.Extensions
                 .GetArgumentsOfKnownType(knownType, semanticModel)
                 .Select(argument => semanticModel.GetSymbolInfo(argument.Expression).Symbol);
 
-        internal static IEnumerable<ISymbol> GetSymbolsDerivedFromKnownType(this SeparatedSyntaxList<ArgumentSyntax> syntaxList, KnownType knownType, SemanticModel semanticModel) =>
-            syntaxList
-                .Where(x => semanticModel.GetTypeInfo(x.Expression).Type.DerivesFrom(knownType))
-                .Select(x => semanticModel.GetSymbolInfo(x.Expression).Symbol);
-
         internal static bool NameIs(this ArgumentSyntax argument, string name) =>
             argument.NameColon?.Name.Identifier.Text == name;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/InvocationExpressionSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/InvocationExpressionSyntaxExtensions.cs
@@ -29,9 +29,6 @@ namespace SonarAnalyzer.Extensions
         internal static IEnumerable<ISymbol> GetArgumentSymbolsOfKnownType(this InvocationExpressionSyntax invocation, KnownType knownType, SemanticModel semanticModel) =>
             invocation.ArgumentList.Arguments.GetSymbolsOfKnownType(knownType, semanticModel);
 
-        internal static IEnumerable<ISymbol> GetArgumentSymbolsDerivedFromKnownType(this InvocationExpressionSyntax invocation, KnownType knownType, SemanticModel semanticModel) =>
-            invocation.ArgumentList.Arguments.GetSymbolsDerivedFromKnownType(knownType, semanticModel);
-
         internal static bool HasExactlyNArguments(this InvocationExpressionSyntax invocation, int count) =>
             invocation?.ArgumentList != null && invocation.ArgumentList.Arguments.Count == count;
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeLogged.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeLogged.cs
@@ -26,7 +26,7 @@ namespace SonarAnalyzer.Rules.CSharp;
 public sealed class ExceptionsShouldBeLogged : SonarDiagnosticAnalyzer
 {
     private const string DiagnosticId = "S6667";
-    private const string MessageFormat = "Logging in a catch clause should include the exception.";
+    private const string MessageFormat = "Logging in a catch clause should pass the caught exception as a parameter.";
 
     private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeLogged.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeLogged.cs
@@ -117,7 +117,8 @@ public sealed class ExceptionsShouldBeLogged : SonarDiagnosticAnalyzer
                 .Select(x => x.Expression);
             foreach (var expression in expressions)
             {
-                if (expression is MemberAccessExpressionSyntax memberAccess && memberAccess.NameIs("InnerException"))
+                if (expression is MemberAccessExpressionSyntax memberAccess
+                    && memberAccess.NameIs("InnerException"))
                 {
                     yield return semanticModel.GetSymbolInfo(memberAccess.Expression).Symbol;
                 }
@@ -131,7 +132,8 @@ public sealed class ExceptionsShouldBeLogged : SonarDiagnosticAnalyzer
             || IsLoggingInvocation(invocation, model, CastleCoreOrCommonCore, KnownType.Common_Logging_ILog, true)
             || IsLoggingInvocation(invocation, model, Log4NetILog, KnownType.log4net_ILog, true)
             || IsLoggingInvocation(invocation, model, Log4NetILogExtensions, KnownType.log4net_Util_ILogExtensions, false)
-            || IsLoggingInvocation(invocation, model, NLogILogger, KnownType.NLog_ILogger, true)
+            || IsLoggingInvocation(invocation, model, NLogLoggingMethods, KnownType.NLog_ILogger, true)
+            || IsLoggingInvocation(invocation, model, NLogLoggingMethods, KnownType.NLog_ILoggerExtensions, false)
             || IsLoggingInvocation(invocation, model, NLogILoggerBase, KnownType.NLog_ILoggerBase, true);
 
         private static bool IsLoggingInvocation(InvocationExpressionSyntax invocation, SemanticModel model, ICollection<string> methodNames, KnownType containingType, bool checkDerivedTypes) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/MessageTemplateAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/MessageTemplateAnalyzer.cs
@@ -54,8 +54,8 @@ public sealed class MessageTemplateAnalyzer : SonarDiagnosticAnalyzer
         TemplateArgument(invocation, model, KnownType.Microsoft_Extensions_Logging_LoggerExtensions, MicrosoftExtensionsLogging, "message")
         ?? TemplateArgument(invocation, model, KnownType.Serilog_Log, Serilog, "messageTemplate")
         ?? TemplateArgument(invocation, model, KnownType.Serilog_ILogger, Serilog, "messageTemplate")
-        ?? TemplateArgument(invocation, model, KnownType.NLog_ILoggerExtensions, NLogILoggerExtensions, "message")
-        ?? TemplateArgument(invocation, model, KnownType.NLog_ILogger, NLogILogger, "message", checkDerivedTypes: true)
+        ?? TemplateArgument(invocation, model, KnownType.NLog_ILoggerExtensions, NLogLoggingMethods, "message")
+        ?? TemplateArgument(invocation, model, KnownType.NLog_ILogger, NLogLoggingMethods, "message", checkDerivedTypes: true)
         ?? TemplateArgument(invocation, model, KnownType.NLog_ILoggerBase, NLogILoggerBase, "message", checkDerivedTypes: true);
 
     private static ArgumentSyntax TemplateArgument(InvocationExpressionSyntax invocation,

--- a/analyzers/src/SonarAnalyzer.Shared/LoggingFrameworkMethods.cs
+++ b/analyzers/src/SonarAnalyzer.Shared/LoggingFrameworkMethods.cs
@@ -78,7 +78,7 @@ public static class LoggingFrameworkMethods
         "Verbose",
     ];
 
-    public static readonly HashSet<string> NLogILogger =
+    public static readonly HashSet<string> NLogLoggingMethods =
     [
         "Debug",
         "ConditionalDebug",
@@ -88,12 +88,6 @@ public static class LoggingFrameworkMethods
         "Trace",
         "ConditionalTrace",
         "Warn"
-    ];
-
-    public static readonly HashSet<string> NLogILoggerExtensions =
-    [
-        "ConditionalTrace",
-        "ConditionalDebug",
     ];
 
     public static readonly HashSet<string> NLogILoggerBase = ["Log"];

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/ExceptionsShouldBeLoggedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/ExceptionsShouldBeLoggedTest.cs
@@ -238,6 +238,7 @@ public class ExceptionsShouldBeLoggedTest
                         logger.{{methodName}}("Message");                               // Noncompliant
                         logger.{{methodName}}("Message", parameters);                   // Secondary
                         logger.{{methodName}}(CultureInfo.CurrentCulture, "Message");   // Secondary
+                        ILoggerExtensions.{{methodName}}(logger, null, null);           // Secondary
                     }
                     try { }
                     catch (Exception e)
@@ -245,6 +246,7 @@ public class ExceptionsShouldBeLoggedTest
                         logger.{{methodName}}(e, "Message");
                         logger.{{methodName}}(e, "Message", parameters);
                         logger.{{methodName}}(e, CultureInfo.CurrentCulture, "Message");
+                        ILoggerExtensions.{{methodName}}(logger, null, null);
                     }
                 }
             }
@@ -304,12 +306,14 @@ public class ExceptionsShouldBeLoggedTest
                     {
                         logger.{{methodName}}("Message");                               // Noncompliant
                         logger.{{methodName}}(CultureInfo.CurrentCulture, "Message");   // Secondary
+                        ILoggerExtensions.{{methodName}}(logger, "Message");            // Secondary
                     }
                     try { }
                     catch (Exception e)
                     {
                         logger.{{methodName}}(e, "Message");
                         logger.{{methodName}}(e, CultureInfo.CurrentCulture, "Message");
+                        ILoggerExtensions.{{methodName}}(logger, e, "Message");
                     }
                 }
             }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ExceptionsShouldBeLogged.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ExceptionsShouldBeLogged.cs
@@ -238,6 +238,15 @@ public class TestCases
         }
     }
 
+    public void LogInnerException()
+    {
+        try { }
+        catch (Exception e)
+        {
+            logger.LogWarning(new EventId(1), e.InnerException, "Message!");        // Compliant
+        }
+    }
+
     public class CustomLogger
     {
         public void LogCritical(string message) { }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ExceptionsShouldBeLogged.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ExceptionsShouldBeLogged.cs
@@ -243,7 +243,10 @@ public class TestCases
         try { }
         catch (Exception e)
         {
-            logger.LogWarning(new EventId(1), e.InnerException, "Message!");        // Compliant
+            logger.LogWarning(new EventId(1), e.InnerException, "Message!");                    // Compliant
+            logger.LogWarning(new EventId(1), e?.InnerException, "Message!");
+            logger.LogWarning(new EventId(1), e.InnerException.InnerException, "Message!");
+            logger.LogWarning(new EventId(1), (Exception)e.InnerException, "Message!");
         }
     }
 

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ExceptionsShouldBeLogged.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ExceptionsShouldBeLogged.cs
@@ -34,7 +34,7 @@ public class TestCases
         try { }
         catch (Exception e)
         {
-            logger.LogWarning(new EventId(1), "Message!");          // Noncompliant {{Logging in a catch clause should include the exception.}}
+            logger.LogWarning(new EventId(1), "Message!");          // Noncompliant {{Logging in a catch clause should pass the caught exception as a parameter.}}
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             logger.LogWarning(new EventId(1), "Message!");
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Secondary

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ExceptionsShouldBeLogged.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ExceptionsShouldBeLogged.cs
@@ -232,7 +232,7 @@ public class TestCases
         try { }
         catch (Exception e)
         {
-            logger.LogWarning(new EventId(1), e.InnerException, "Message!");        // Noncompliant
+            logger.LogWarning(new EventId(1), e.StackTrace, "Message!");        // Noncompliant
             logger.LogWarning(new EventId(1), (e.Message != null).ToString());
 //          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Secondary
         }
@@ -244,6 +244,15 @@ public class TestCases
         catch (Exception e)
         {
             logger.LogWarning(new EventId(1), e.InnerException, "Message!");        // Compliant
+        }
+    }
+
+    public void LogFromCatchWithoutExceptionType()
+    {
+        try { }
+        catch
+        {
+            logger.LogWarning("Message!");                                          // Noncompliant
         }
     }
 


### PR DESCRIPTION
- update rule title
- avoid FPs when the `InnerException` is logged
- add support for NLog logging extension methods