### PR TITLE
Template rules update after peach validation

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/MessageTemplateAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/MessageTemplateAnalyzer.cs
@@ -41,6 +41,7 @@ public sealed class MessageTemplateAnalyzer : SonarDiagnosticAnalyzer
             var enabledChecks = Checks.Where(x => x.Rule.IsEnabled(c)).ToArray();
             if (enabledChecks.Length > 0
                 && TemplateArgument(invocation, c.SemanticModel) is { } argument
+                && argument.Expression.IsKind(SyntaxKind.StringLiteralExpression)
                 && Helpers.MessageTemplates.Parse(argument.Expression.ToString()) is { Success: true } result)
             {
                 foreach (var check in enabledChecks)
@@ -54,7 +55,7 @@ public sealed class MessageTemplateAnalyzer : SonarDiagnosticAnalyzer
     private static ArgumentSyntax TemplateArgument(InvocationExpressionSyntax invocation, SemanticModel model) =>
         TemplateArgument(invocation, model, KnownType.Microsoft_Extensions_Logging_LoggerExtensions, MicrosoftExtensionsLogging, "message")
         ?? TemplateArgument(invocation, model, KnownType.Serilog_Log, Serilog, "messageTemplate")
-        ?? TemplateArgument(invocation, model, KnownType.Serilog_ILogger, Serilog, "messageTemplate")
+        ?? TemplateArgument(invocation, model, KnownType.Serilog_ILogger, Serilog, "messageTemplate", checkDerivedTypes: true)
         ?? TemplateArgument(invocation, model, KnownType.NLog_ILoggerExtensions, NLogLoggingMethods, "message")
         ?? TemplateArgument(invocation, model, KnownType.NLog_ILogger, NLogLoggingMethods, "message", checkDerivedTypes: true)
         ?? TemplateArgument(invocation, model, KnownType.NLog_ILoggerBase, NLogILoggerBase, "message", checkDerivedTypes: true);

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/NamedPlaceholdersShouldBeUniqueTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/NamedPlaceholdersShouldBeUniqueTest.cs
@@ -104,6 +104,32 @@ public class NamedPlaceholdersShouldBeUniqueTest
             }
             """).Verify();
 
+#if NET
+    [DataTestMethod]
+    [DataRow("Debug")]
+    [DataRow("Error")]
+    [DataRow("Information")]
+    [DataRow("Fatal")]
+    [DataRow("Warning")]
+    [DataRow("Verbose")]
+    public void NamedPlaceholdersShouldBeUnique_Serilog_Derived_CS(string methodName) =>
+    Builder.AddSnippet($$"""
+            using Serilog;
+            using Serilog.Events;
+            using Serilog.Core;
+
+            public class Program
+            {
+                public void Method(Logger logger, int arg)
+                {
+                    logger.{{methodName}}("Hey {foo} and {bar}", arg, arg);                       // Compliant
+                    logger.{{methodName}}("Hey {foo} and {foo}", arg, arg);                       // Noncompliant
+                                                                                                  // Secondary @-1
+                }
+            }
+            """).Verify();
+#endif
+
     [DataTestMethod]
     [DataRow("Debug")]
     [DataRow("ConditionalDebug")]

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/NamedPlaceholdersShouldBeUnique.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/NamedPlaceholdersShouldBeUnique.cs
@@ -47,6 +47,8 @@ namespace MicrosoftTests
 
             // Not string literal
             logger.LogWarning($"Hey {foo} and {foo}", foo, foo);             // Compliant
+
+            logger.LogInformation($"Hey {{foo}} and {{foo}}", foo, foo); // FN, we do not parse interpolated strings
         }
 
         void Noncompliant(ILogger logger, string foo, string bar, string baz, Exception ex, EventId eventId)

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/NamedPlaceholdersShouldBeUnique.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/NamedPlaceholdersShouldBeUnique.cs
@@ -44,6 +44,9 @@ namespace MicrosoftTests
             // Escaped
             logger.LogInformation("Hey {{foo}} and {{foo}}", foo, foo);      // Compliant
             logger.LogInformation("Hey {foo} and {{foo}}", foo, foo);        // Compliant
+
+            // Not string literal
+            logger.LogWarning($"Hey {foo} and {foo}", foo, foo);             // Compliant
         }
 
         void Noncompliant(ILogger logger, string foo, string bar, string baz, Exception ex, EventId eventId)


### PR DESCRIPTION
Fixes two issues:
- Deriving from serilog should raise.
- Using interpolated strings should not raise.