### PR TITLE
Fix S2701 FP: avoid raising for xUnit Assert.True()

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseLiteralBoolInAssertions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseLiteralBoolInAssertions.cs
@@ -29,29 +29,29 @@ namespace SonarAnalyzer.Rules.CSharp
         private const string MessageFormat = "Remove or correct this assertion.";
 
         private static readonly Dictionary<KnownType, HashSet<string>> TrackedTypeAndMethods =
-            new ()
+            new()
             {
-                [KnownType.Xunit_Assert] = new HashSet<string>
-                {
-                    // "True" is not here because there was no Assert.Fail in Xunit until 2020 and Assert.True(false) was a way to simulate it.
-                    "Equal", "False", "NotEqual", "Same", "StrictEqual", "NotSame"
-                },
+                [KnownType.Xunit_Assert] =
+                [
+                    // "True" and "False" are not here because there was no Assert.Fail in Xunit until 2020 and Assert.True(false) and Assert.False(true) were some ways to simulate it.
+                    "Equal", "NotEqual", "Same", "StrictEqual", "NotSame"
+                ],
 
-                [KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_Assert] = new HashSet<string>
-                {
+                [KnownType.Microsoft_VisualStudio_TestTools_UnitTesting_Assert] =
+                [
                     "AreEqual", "AreNotEqual", "AreSame", "IsFalse", "IsTrue"
-                },
+                ],
 
-                [KnownType.NUnit_Framework_Assert] = new HashSet<string>
-                {
+                [KnownType.NUnit_Framework_Assert] =
+                [
                     "AreEqual", "AreNotEqual", "AreNotSame", "AreSame", "False",
                     "IsFalse", "IsTrue", "That", "True"
-                },
+                ],
 
-                [KnownType.System_Diagnostics_Debug] = new HashSet<string>
-                {
+                [KnownType.System_Diagnostics_Debug] =
+                [
                     "Assert"
-                }
+                ]
             };
 
         private static readonly ISet<SyntaxKind> BoolLiterals =

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/DoNotUseLiteralBoolInAssertions.Xunit.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/DoNotUseLiteralBoolInAssertions.Xunit.cs
@@ -9,7 +9,6 @@ namespace Tests.Diagnostics
             bool b = true;
 
             Xunit.Assert.Equal(true, b); // Noncompliant
-            Xunit.Assert.False(true); // Noncompliant
             Xunit.Assert.NotEqual(true, b); // Noncompliant
             Xunit.Assert.Same(true, b); // Noncompliant
             Xunit.Assert.StrictEqual(true, b); // Noncompliant
@@ -19,9 +18,12 @@ namespace Tests.Diagnostics
             Xunit.Assert.Equal(true, false); // Noncompliant
 
             Xunit.Assert.Equal(b, b);
-            Xunit.Assert.True(true);
-            // There is no Assert.Fail in Xunit. Assert.True(false) is way to simulate it.
-            Xunit.Assert.True(false);
+            Xunit.Assert.True(true); // FN
+            Xunit.Assert.False(false); // FN
+
+            // There is no Assert.Fail in Xunit. Assert.True(false) or Assert.False(true) are ways to simulate it.
+            Xunit.Assert.True(false); // Compliant
+            Xunit.Assert.False(true); // Compliant
 
             bool? x = false;
             Xunit.Assert.Equal(false, x); // Compliant, since the comparison triggers a conversion


### PR DESCRIPTION
S2701 is not raising for `Assert.True` in xUnit because `Assert.Fail` was introduced in 2020 version `2.4.2` and `Assert.True(false, message)` was a way to simulate it. Now that we are promoting this rule to SonarWay we want to play it safe and avoid raising also for `Assert.False` for the same reason `Assert.False(true, message)`.