### PR TITLE
Rule S6668: Handle the rule exceptions

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/Rules/LoggingArgumentsShouldBePassedCorrectlyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/LoggingArgumentsShouldBePassedCorrectlyTest.cs
@@ -50,7 +50,7 @@ public class LoggingArgumentsShouldBePassedCorrectlyTest
                 {
                     logger.{{methodName}}("Expected exception.");
                     logger.{{methodName}}(e, "Expected exception.");
-                    logger.{{methodName}}(null, message, e);                                                                                   // FN
+                    logger.{{methodName}}(null, "Expected exception.", e);                                                                     // FN
                     logger.{{methodName}}(new EventId(), "Expected exception.");
                     logger.{{methodName}}(new EventId(), e, "Expected exception.");
                     LoggerExtensions.{{methodName}}(logger, "Expected exception.");

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/LoggingArgumentsShouldBePassedCorrectlyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/LoggingArgumentsShouldBePassedCorrectlyTest.cs
@@ -50,6 +50,7 @@ public class LoggingArgumentsShouldBePassedCorrectlyTest
                 {
                     logger.{{methodName}}("Expected exception.");
                     logger.{{methodName}}(e, "Expected exception.");
+                    logger.{{methodName}}(null, message, e);                                                                                   // FN
                     logger.{{methodName}}(new EventId(), "Expected exception.");
                     logger.{{methodName}}(new EventId(), e, "Expected exception.");
                     LoggerExtensions.{{methodName}}(logger, "Expected exception.");

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/LoggingArgumentsShouldBePassedCorrectlyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/LoggingArgumentsShouldBePassedCorrectlyTest.cs
@@ -32,14 +32,13 @@ public class LoggingArgumentsShouldBePassedCorrectlyTest
         builder.AddPaths("LoggingArgumentsShouldBePassedCorrectly.cs").AddReferences(NuGetMetadataReference.MicrosoftExtensionsLoggingAbstractions()).Verify();
 
     [DataTestMethod]
-    [DataRow("Log", "LogLevel.Warning,")]
     [DataRow("LogCritical")]
     [DataRow("LogDebug")]
     [DataRow("LogError")]
     [DataRow("LogInformation")]
     [DataRow("LogTrace")]
     [DataRow("LogWarning")]
-    public void LoggingArgumentsShouldBePassedCorrectly_MicrosoftExtensionsLogging_NonCompliant_CS(string methodName, string logLevel = "") =>
+    public void LoggingArgumentsShouldBePassedCorrectly_MicrosoftExtensionsLogging_NonCompliant_CS(string methodName) =>
         builder.AddSnippet($$"""
             using System;
             using Microsoft.Extensions.Logging;
@@ -49,37 +48,67 @@ public class LoggingArgumentsShouldBePassedCorrectlyTest
             {
                 public void Method(ILogger logger, Exception e)
                 {
-                    logger.{{methodName}}({{logLevel}} "Expected exception.");
-                    logger.{{methodName}}({{logLevel}} e, "Expected exception.");
-                    logger.{{methodName}}({{logLevel}} new EventId(), "Expected exception.");
-                    logger.{{methodName}}({{logLevel}} new EventId(), e, "Expected exception.");
-                    LoggerExtensions.{{methodName}}(logger, {{logLevel}} "Expected exception.");
-                    LoggerExtensions.{{methodName}}(logger, {{logLevel}} new EventId(), e, "Expected exception.");
+                    logger.{{methodName}}("Expected exception.");
+                    logger.{{methodName}}(e, "Expected exception.");
+                    logger.{{methodName}}(new EventId(), "Expected exception.");
+                    logger.{{methodName}}(new EventId(), e, "Expected exception.");
+                    LoggerExtensions.{{methodName}}(logger, "Expected exception.");
+                    LoggerExtensions.{{methodName}}(logger, new EventId(), e, "Expected exception.");
 
-                    logger.{{methodName}}({{logLevel}} new EventId(), e, "Expected exception.", e, new EventId(), LogLevel.Critical);                       // Noncompliant (exception, event id, log level)
-                                                                                                                                                            // Secondary @-1
-                                                                                                                                                            // Secondary @-2
-                                                                                                                                                            // Secondary @-3
-                    logger.{{methodName}}({{logLevel}} new EventId(), "Expected exception.", e, new EventId(), LogLevel.Critical);                          // Noncompliant (exception, event id, log level)
-                                                                                                                                                            // Secondary @-1
-                                                                                                                                                            // Secondary @-2
-                                                                                                                                                            // Secondary @-3
-                    logger.{{methodName}}({{logLevel}} e, "Expected exception.", e, new EventId(), LogLevel.Critical);                                      // Noncompliant (event id, log level)
-                                                                                                                                                            // Secondary @-1
-                                                                                                                                                            // Secondary @-2
-                                                                                                                                                            // Secondary @-3
-                    logger.{{methodName}}({{logLevel}} "Expected exception.", e, new EventId(), LogLevel.Critical);                                         // Noncompliant (exception, event id, log level)
-                                                                                                                                                            // Secondary @-1
-                                                                                                                                                            // Secondary @-2
-                                                                                                                                                            // Secondary @-3
-                    LoggerExtensions.{{methodName}}(logger, {{logLevel}} "Expected exception.", e, new EventId(), LogLevel.Critical);                       // Noncompliant (exception, event id, log level)
-                                                                                                                                                            // Secondary @-1
-                                                                                                                                                            // Secondary @-2
-                                                                                                                                                            // Secondary @-3
-                    LoggerExtensions.{{methodName}}(logger, {{logLevel}} new EventId(), e, "Expected exception.", e, new EventId(), LogLevel.Critical);     // Noncompliant (event id, log level)
-                                                                                                                                                            // Secondary @-1
-                                                                                                                                                            // Secondary @-2
-                                                                                                                                                            // Secondary @-3
+                    logger.{{methodName}}(new EventId(), e, "Expected exception.", e, new EventId(), LogLevel.Critical);                       // Noncompliant (log level)
+                                                                                                                                               // Secondary @-1
+                    logger.{{methodName}}(new EventId(), "Expected exception.", e, new EventId(), LogLevel.Critical);                          // Noncompliant (exception, log level)
+                                                                                                                                               // Secondary @-1
+                                                                                                                                               // Secondary @-2
+                    logger.{{methodName}}(e, "Expected exception.", e, new EventId(), LogLevel.Critical);                                      // Noncompliant (event id, log level)
+                                                                                                                                               // Secondary @-1
+                                                                                                                                               // Secondary @-2
+                    logger.{{methodName}}("Expected exception.", e, new EventId(), LogLevel.Critical);                                         // Noncompliant (exception, event id, log level)
+                                                                                                                                               // Secondary @-1
+                                                                                                                                               // Secondary @-2
+                                                                                                                                               // Secondary @-3
+                    LoggerExtensions.{{methodName}}(logger, "Expected exception.", e, new EventId(), LogLevel.Critical);                       // Noncompliant (exception, event id, log level)
+                                                                                                                                               // Secondary @-1
+                                                                                                                                               // Secondary @-2
+                                                                                                                                               // Secondary @-3
+                    LoggerExtensions.{{methodName}}(logger, new EventId(), e, "Expected exception.", e, new EventId(), LogLevel.Critical);     // Noncompliant (log level)
+                                                                                                                                               // Secondary @-1
+                }
+            }
+            """)
+           .AddReferences(NuGetMetadataReference.MicrosoftExtensionsLoggingAbstractions())
+           .Verify();
+
+    [TestMethod]
+    public void LoggingArgumentsShouldBePassedCorrectly_MicrosoftExtensionsLogging_Log_CS() =>
+        builder.AddSnippet("""
+            using System;
+            using Microsoft.Extensions.Logging;
+            using Microsoft.Extensions.Logging.Abstractions;
+
+            public class Program
+            {
+                public void Method(ILogger logger, Exception e)
+                {
+                    logger.Log(LogLevel.Warning, "Expected exception.");
+                    logger.Log(LogLevel.Warning, e, "Expected exception.");
+                    logger.Log(LogLevel.Warning, new EventId(), "Expected exception.");
+                    logger.Log(LogLevel.Warning, new EventId(), e, "Expected exception.");
+                    LoggerExtensions.Log(logger, LogLevel.Warning, "Expected exception.");
+                    LoggerExtensions.Log(logger, LogLevel.Warning, new EventId(), e, "Expected exception.");
+
+                    logger.Log(LogLevel.Warning, new EventId(), e, "Expected exception.", e, new EventId(), LogLevel.Critical);
+                    logger.Log(LogLevel.Warning, new EventId(), "Expected exception.", e, new EventId(), LogLevel.Critical);                          // Noncompliant (exception)
+                                                                                                                                                      // Secondary @-1
+                    logger.Log(LogLevel.Warning, e, "Expected exception.", e, new EventId(), LogLevel.Critical);                                      // Noncompliant (event id)
+                                                                                                                                                      // Secondary @-1
+                    logger.Log(LogLevel.Warning, "Expected exception.", e, new EventId(), LogLevel.Critical);                                         // Noncompliant (exception, event id)
+                                                                                                                                                      // Secondary @-1
+                                                                                                                                                      // Secondary @-2
+                    LoggerExtensions.Log(logger, LogLevel.Warning, "Expected exception.", e, new EventId(), LogLevel.Critical);                       // Noncompliant (exception, event id)
+                                                                                                                                                      // Secondary @-1
+                                                                                                                                                      // Secondary @-2
+                    LoggerExtensions.Log(logger, LogLevel.Warning, new EventId(), e, "Expected exception.", e, new EventId(), LogLevel.Critical);
                 }
             }
             """)
@@ -110,11 +139,9 @@ public class LoggingArgumentsShouldBePassedCorrectlyTest
                     logger.{{methodName}}(CultureInfo.CurrentCulture, message, e);        // Noncompliant
                                                                                           // Secondary @-1
                     logger.{{methodName}}(e, message);                                    // Compliant
-                    logger.{{methodName}}(e, message, e);                                 // Noncompliant
-                                                                                          // Secondary @-1
+                    logger.{{methodName}}(e, message, e);                                 // Compliant
                     logger.{{methodName}}(e, CultureInfo.CurrentCulture, message);        // Compliant
-                    logger.{{methodName}}(e, CultureInfo.CurrentCulture, message, e);     // Noncompliant
-                                                                                          // Secondary @-1
+                    logger.{{methodName}}(e, CultureInfo.CurrentCulture, message, e);     // Compliant
                 }
             }
             """)
@@ -122,7 +149,7 @@ public class LoggingArgumentsShouldBePassedCorrectlyTest
         .Verify();
 
     [DataTestMethod]
-    [DataRow("Log", "LogLevel.Debug,")]
+    [DataRow("Log", "LogLevel.Debug,", "")]
     [DataRow("Debug")]
     [DataRow("ConditionalDebug")]
     [DataRow("Error")]
@@ -131,7 +158,7 @@ public class LoggingArgumentsShouldBePassedCorrectlyTest
     [DataRow("Trace")]
     [DataRow("ConditionalTrace")]
     [DataRow("Warn")]
-    public void LoggingArgumentsShouldBePassedCorrectly_NLog_CS(string methodName, string logLevel = "") =>
+    public void LoggingArgumentsShouldBePassedCorrectly_NLog_CS(string methodName, string logLevel = "", string logLevelExpectation = "// Secondary @-2") =>
         builder.AddSnippet($$"""
             using System;
             using System.Globalization;
@@ -144,11 +171,9 @@ public class LoggingArgumentsShouldBePassedCorrectlyTest
                     logger.{{methodName}}({{logLevel}} e);                                                    // Compliant
                     logger.{{methodName}}({{logLevel}} CultureInfo.CurrentCulture, e);                        // Compliant
                     logger.{{methodName}}({{logLevel}} e, "Message!");                                        // Compliant
-                    logger.{{methodName}}({{logLevel}} e, "Message!", e);                                     // Noncompliant
-                                                                                                              // Secondary @-1
-                    logger.{{methodName}}({{logLevel}}e, CultureInfo.CurrentCulture, "Message!", e);          // Noncompliant
-                                                                                                              // Secondary @-1
-                    logger.{{methodName}}({{logLevel}}CultureInfo.CurrentCulture, "Message!", 1, 2, 3, e);    // Noncompliant
+                    logger.{{methodName}}({{logLevel}} e, "Message!", e);                                     // Compliant
+                    logger.{{methodName}}({{logLevel}} e, CultureInfo.CurrentCulture, "Message!", e);         // Compliant
+                    logger.{{methodName}}({{logLevel}} CultureInfo.CurrentCulture, "Message!", 1, 2, 3, e);   // Noncompliant
                                                                                                               // Secondary @-1
                     logger.{{methodName}}({{logLevel}} "Message!");                                           // Compliant
                     logger.{{methodName}}({{logLevel}} "Message!", 1, 2, 3, e);                               // Noncompliant
@@ -168,7 +193,7 @@ public class LoggingArgumentsShouldBePassedCorrectlyTest
                                                                                                               // Secondary @-1
                     logger.{{methodName}}({{logLevel}} "Message!", 1, LogLevel.Debug, e);                     // Noncompliant
                                                                                                               // Secondary @-1
-                                                                                                              // Secondary @-2
+                                                                                                              {{logLevelExpectation}}
                     ILoggerExtensions.{{methodName}}(logger, {{logLevel}} e, null);                           // Compliant
                 }
             }
@@ -192,10 +217,8 @@ public class LoggingArgumentsShouldBePassedCorrectlyTest
                     ILoggerExtensions.{{methodName}}(logger, e);                                                    // Compliant
                     ILoggerExtensions.{{methodName}}(logger, CultureInfo.CurrentCulture, e);                        // Compliant
                     ILoggerExtensions.{{methodName}}(logger, e, "Message!");                                        // Compliant
-                    ILoggerExtensions.{{methodName}}(logger, e, "Message!", e);                                     // Noncompliant
-                                                                                                                    // Secondary @-1
-                    ILoggerExtensions.{{methodName}}(logger, e, CultureInfo.CurrentCulture, "Message!", e);         // Noncompliant
-                                                                                                                    // Secondary @-1
+                    ILoggerExtensions.{{methodName}}(logger, e, "Message!", e);                                     // Compliant
+                    ILoggerExtensions.{{methodName}}(logger, e, CultureInfo.CurrentCulture, "Message!", e);         // Compliant
                     ILoggerExtensions.{{methodName}}(logger, CultureInfo.CurrentCulture, "Message!", 1, 2, 3, e);   // Noncompliant
                                                                                                                     // Secondary @-1
                     ILoggerExtensions.{{methodName}}(logger, "Message!");                                           // Compliant
@@ -251,14 +274,10 @@ public class LoggingArgumentsShouldBePassedCorrectlyTest
                     Log.{{methodName}}("Message!", 1, 2, 3, e, true);                    // Noncompliant
                                                                                          // Secondary @-1
                     Log.{{methodName}}(e, "Message");
-                    Log.{{methodName}}<Exception>(e, "Message", e);                      // Noncompliant
-                                                                                         // Secondary @-1
-                    Log.{{methodName}}<int, Exception>(e, "Message", 1, e);              // Noncompliant
-                                                                                         // Secondary @-1
-                    Log.{{methodName}}<int, Exception, bool>(e, "Message", 1, e, true);  // Noncompliant
-                                                                                         // Secondary @-1
-                    Log.{{methodName}}(e, "Message!", 1, 2, 3, e, true);                 // Noncompliant
-                                                                                         // Secondary @-1
+                    Log.{{methodName}}<Exception>(e, "Message", e);
+                    Log.{{methodName}}<int, Exception>(e, "Message", 1, e);
+                    Log.{{methodName}}<int, Exception, bool>(e, "Message", 1, e, true);
+                    Log.{{methodName}}(e, "Message!", 1, 2, 3, e, true);
                 }
             }
             """)
@@ -278,28 +297,19 @@ public class LoggingArgumentsShouldBePassedCorrectlyTest
             {
                 Log.Write(logEvent);
                 Log.Write(level, "Message");
-                Log.Write(level, "Message", level);                                 // Noncompliant
-                                                                                    // Secondary @-1
+                Log.Write(level, "Message", level);
                 Log.Write(level, "Message", 1);
-                Log.Write(level, "Message", level, 1);                              // Noncompliant
+                Log.Write(level, "Message", level, exception);                      // Noncompliant
                                                                                     // Secondary @-1
                 Log.Write(level, "Message", 1, exception, 2);                       // Noncompliant
                                                                                     // Secondary @-1
                 Log.Write(level, "Message", level, exception, 1, 2);                // Noncompliant
                                                                                     // Secondary @-1
-                                                                                    // Secondary @-2
                 Log.Write(level, exception, "Message");
-                Log.Write(level, exception, "Message", level);                      // Noncompliant
-                                                                                    // Secondary @-1
-                Log.Write(level, exception, "Message", level, exception);           // Noncompliant
-                                                                                    // Secondary @-1
-                                                                                    // Secondary @-2
-                Log.Write(level, exception, "Message", level, exception, 1);        // Noncompliant
-                                                                                    // Secondary @-1
-                                                                                    // Secondary @-2
-                Log.Write(level, exception, "Message", level, exception, 1, 2);     // Noncompliant
-                                                                                    // Secondary @-1
-                                                                                    // Secondary @-2
+                Log.Write(level, exception, "Message", level);
+                Log.Write(level, exception, "Message", level, exception);
+                Log.Write(level, exception, "Message", level, exception, 1);
+                Log.Write(level, exception, "Message", level, exception, 1, 2);
             }
         }
         """)

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/LoggingArgumentsShouldBePassedCorrectly.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/LoggingArgumentsShouldBePassedCorrectly.cs
@@ -16,8 +16,9 @@ public class Program
         logger.LogWarning(new EventId(1), (Exception)e.InnerException, "Message!");
         logger.LogCritical(args: new object[] { e, LogLevel.Critical }, message: "Expected exception.");        // FN
         logger.LogCritical(message: "Expected exception.", eventId: new EventId(42), exception: new Exception(), args: e);
+        logger.LogCritical(message: "Expected exception.", eventId: new EventId(42), args: e);
 //      ^^^^^^^^^^^^^^^^^^
-//                                                                                                               ^^^^^^^ Secondary@-1
+//                                                                                   ^^^^^^^ Secondary@-1
         logger.LogCritical("Expected exception.", new NullReferenceException());    // Noncompliant
                                                                                     // Secondary@-1
     }


### PR DESCRIPTION
Rule S6668 has an exception in the specification that I did not implement in the first version of the rule:

> This rule will not raise an issue if one of the parameters mentioned above is passed twice, once as a separate argument to the invocation and once as an argument to the message format.

```csharp
try { }
catch (Exception ex)
{
    logger.LogDebug(ex, "An exception occured {Exception}.", ex); // Compliant
}
```