### PR TITLE
UTs: Add .runsettings to run UTs in parallel

### DIFF
--- a/analyzers/.runsettings
+++ b/analyzers/.runsettings
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- 0 will run all Test DLL in parallel locally -->
+    <MaxCpuCount>0</MaxCpuCount>
+  </RunConfiguration>
+</RunSettings>


### PR DESCRIPTION
This reduces UTs runtime from 7 to 3 minutes. It could have been down to 2 minutes if we solve the Razor problem.

This will instruct test adapter to run all test DLLs in parallel when running UTs via Test Explorer.

Because SonarAnalyzer.Test (net48) and SonarAnalyzer.Test (net7.0) have bot roughly 7000+ UTs, the whole UT run is as short as the longer of those.

The key follow up problem to solve is extremely slow Razor UTs.