### PR TITLE
ITs: Use Microsoft.NETFramework.ReferenceAssemblies

### DIFF
--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework35/NetFramework35.csproj
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework35/NetFramework35.csproj
@@ -11,6 +11,8 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -45,5 +47,15 @@
     <Compile Include="XmlTextReaderTest.cs" />
     <Compile Include="XPathDocumentTest.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.NETFramework.ReferenceAssemblies.net35.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net35.targets" Condition="Exists('..\packages\Microsoft.NETFramework.ReferenceAssemblies.net35.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net35.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.NETFramework.ReferenceAssemblies.net35.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net35.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NETFramework.ReferenceAssemblies.net35.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net35.targets'))" />
+  </Target>
 </Project>

--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework35/packages.config
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework35/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.NETFramework.ReferenceAssemblies" version="1.0.3" targetFramework="net35" developmentDependency="true" />
+  <package id="Microsoft.NETFramework.ReferenceAssemblies.net35" version="1.0.3" targetFramework="net35" developmentDependency="true" />
+</packages>

--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework4/NetFramework4.csproj
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework4/NetFramework4.csproj
@@ -11,6 +11,8 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -47,5 +49,15 @@
     <Compile Include="XmlTextReaderTest.cs" />
     <Compile Include="XPathDocumentTest.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.NETFramework.ReferenceAssemblies.net40.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net40.targets" Condition="Exists('..\packages\Microsoft.NETFramework.ReferenceAssemblies.net40.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net40.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.NETFramework.ReferenceAssemblies.net40.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net40.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NETFramework.ReferenceAssemblies.net40.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net40.targets'))" />
+  </Target>
 </Project>

--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework4/packages.config
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework4/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.NETFramework.ReferenceAssemblies" version="1.0.3" targetFramework="net40" developmentDependency="true" />
+  <package id="Microsoft.NETFramework.ReferenceAssemblies.net40" version="1.0.3" targetFramework="net40" developmentDependency="true" />
+</packages>

--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework45/NetFramework45.csproj
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework45/NetFramework45.csproj
@@ -11,6 +11,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -50,6 +52,14 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.NETFramework.ReferenceAssemblies.net45.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net45.targets" Condition="Exists('..\packages\Microsoft.NETFramework.ReferenceAssemblies.net45.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net45.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.NETFramework.ReferenceAssemblies.net45.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net45.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NETFramework.ReferenceAssemblies.net45.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net45.targets'))" />
+  </Target>
 </Project>

--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework45/packages.config
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework45/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.NETFramework.ReferenceAssemblies" version="1.0.3" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.NETFramework.ReferenceAssemblies.net45" version="1.0.3" targetFramework="net45" developmentDependency="true" />
+</packages>

--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework452/NetFramework452.csproj
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework452/NetFramework452.csproj
@@ -12,6 +12,8 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -51,6 +53,14 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.NETFramework.ReferenceAssemblies.net452.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net452.targets" Condition="Exists('..\packages\Microsoft.NETFramework.ReferenceAssemblies.net452.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net452.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.NETFramework.ReferenceAssemblies.net452.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net452.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NETFramework.ReferenceAssemblies.net452.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net452.targets'))" />
+  </Target>
 </Project>

--- a/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework452/packages.config
+++ b/analyzers/its/sources/ManuallyAddedNoncompliantIssues.CS/NetFramework452/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.NETFramework.ReferenceAssemblies" version="1.0.3" targetFramework="net452" developmentDependency="true" />
+  <package id="Microsoft.NETFramework.ReferenceAssemblies.net452" version="1.0.3" targetFramework="net452" developmentDependency="true" />
+</packages>


### PR DESCRIPTION
Part of #8883

The `Microsoft.NETFramework.ReferenceAssemblies` package is a wrapper around all versions of .NET Framework reference assemblies packages, like 
```
Microsoft.NETFramework.ReferenceAssemblies.net35
Microsoft.NETFramework.ReferenceAssemblies.net40
Microsoft.NETFramework.ReferenceAssemblies.net45
Microsoft.NETFramework.ReferenceAssemblies.net452
...
```
These packages contain rather empty .NET Framework DLLs with references only. Their purpose is to be able to build a project targeting specific old .NET Framework versions on a build machine, that doesn't have it installed.

I don't have any of those installed at my current PC and I'm able to build the project. I cannot open it in VS and work with it, but that's fine.