### PR TITLE
Improve S6670: Ignore when Trace.Write() called with category parameter

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DontUseTraceWrite.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DontUseTraceWrite.cs
@@ -34,5 +34,11 @@ public sealed class DontUseTraceWrite : DoNotCallMethodsBase<SyntaxKind, Invocat
 
     protected override ILanguageFacade<SyntaxKind> Language => CSharpFacade.Instance;
 
+    protected override bool ShouldReportOnMethodCall(InvocationExpressionSyntax invocation, SemanticModel semanticModel, MemberDescriptor memberDescriptor)
+    {
+        var methodSymbol = (IMethodSymbol)semanticModel.GetSymbolInfo(invocation).Symbol;
+        return !methodSymbol.Parameters.Any(x => x.Name == "category");
+    }
+
     public DontUseTraceWrite() : base(DiagnosticId) { }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/DontUseTraceWrite.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/DontUseTraceWrite.cs
@@ -24,19 +24,21 @@ public class Program
 
         Trace.TraceWarning("Message");
         Trace.TraceWarning("Message: {0}", arg);
+
+        Trace.Write("Message", "Category");             // Compliant - the developer wants to use a specific category, other than the predefined ones
+        Trace.Write(42, "Category");
+
+        Trace.WriteLine("Message", "Category");
+        Trace.WriteLine(42, "Category");
     }
 
     public void Write_Overloads()
     {
         Trace.Write("Message");                         // Noncompliant
         Trace.Write(42);                                // Noncompliant
-        Trace.Write("Message", "Category");             // Noncompliant
-        Trace.Write(42, "Category");                    // Noncompliant
 
         Trace.WriteLine("Message");                     // Noncompliant
         Trace.WriteLine(42);                            // Noncompliant
-        Trace.WriteLine("Message", "Category");         // Noncompliant
-        Trace.WriteLine(42, "Category");                // Noncompliant
     }
 
     public void Not_TraceClass(string arg)


### PR DESCRIPTION
Improves #8841 
Adds an exception to the rule for cases like this:
```cs
Trace.Write(message: "Login failed!", category: "Security"); // uses it's own custom category
```