### PR TITLE
Fix S3993 FP: Allow abstract attributes not to decorate Attribute usage

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RequireAttributeUsageAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RequireAttributeUsageAttribute.cs
@@ -53,6 +53,6 @@ public sealed class RequireAttributeUsageAttribute : SonarDiagnosticAnalyzer
     private static bool InheritsAttributeUsage(INamedTypeSymbol classSymbol) =>
         classSymbol.GetSelfAndBaseTypes()
             // System.Attribute already has AttributeUsage, we don't want to report it
-            .TakeWhile(t => !t.Is(KnownType.System_Attribute))
-            .Any(t => t.HasAttribute(KnownType.System_AttributeUsageAttribute));
+            .TakeWhile(x => !x.Is(KnownType.System_Attribute))
+            .Any(x => x.HasAttribute(KnownType.System_AttributeUsageAttribute));
 }

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/MarkAssemblyWithAttributeUsageAttributeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/MarkAssemblyWithAttributeUsageAttributeTest.cs
@@ -20,13 +20,12 @@
 
 using SonarAnalyzer.Rules.CSharp;
 
-namespace SonarAnalyzer.Test.Rules
+namespace SonarAnalyzer.Test.Rules;
+
+[TestClass]
+public class MarkAssemblyWithAttributeUsageAttributeTest
 {
-    [TestClass]
-    public class MarkAssemblyWithAttributeUsageAttributeTest
-    {
-        [TestMethod]
-        public void RequireAttributeUsageAttribute() =>
-            new VerifierBuilder<RequireAttributeUsageAttribute>().AddPaths(@"RequireAttributeUsageAttribute.cs").Verify();
-    }
+    [TestMethod]
+    public void RequireAttributeUsageAttribute() =>
+        new VerifierBuilder<RequireAttributeUsageAttribute>().AddPaths(@"RequireAttributeUsageAttribute.cs").Verify();
 }

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/RequireAttributeUsageAttributeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/RequireAttributeUsageAttributeTest.cs
@@ -20,26 +20,25 @@
 
 using SonarAnalyzer.Rules.CSharp;
 
-namespace SonarAnalyzer.Test.Rules
-{
-    [TestClass]
-    public class RequireAttributeUsageAttributeTest
-    {
-        private readonly VerifierBuilder builder = new VerifierBuilder<RequireAttributeUsageAttribute>();
+namespace SonarAnalyzer.Test.Rules;
 
-        [TestMethod]
-        public void RequireAttributeUsageAttribute() =>
-            builder.AddPaths("RequireAttributeUsageAttribute.cs").Verify();
+[TestClass]
+public class RequireAttributeUsageAttributeTest
+{
+    private readonly VerifierBuilder builder = new VerifierBuilder<RequireAttributeUsageAttribute>();
+
+    [TestMethod]
+    public void RequireAttributeUsageAttribute() =>
+        builder.AddPaths("RequireAttributeUsageAttribute.cs").Verify();
 
 #if NET
 
-        [TestMethod]
-        public void RequireAttributeUsageAttribute_CSharp11() =>
-            builder.AddPaths("RequireAttributeUsageAttribute.CSharp11.cs")
-                .WithOptions(ParseOptionsHelper.FromCSharp11)
-                .Verify();
+    [TestMethod]
+    public void RequireAttributeUsageAttribute_CSharp11() =>
+        builder.AddPaths("RequireAttributeUsageAttribute.CSharp11.cs")
+            .WithOptions(ParseOptionsHelper.FromCSharp11)
+            .Verify();
 
 #endif
 
-    }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/RequireAttributeUsageAttribute.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/RequireAttributeUsageAttribute.cs
@@ -1,24 +1,25 @@
 ﻿using System;
 
-namespace Tests.Diagnostics
+public class MyInvalidAttribute : Attribute
+//           ^^^^^^^^^^^^^^^^^^ {{Specify AttributeUsage on 'MyInvalidAttribute'.}}
 {
-    public class MyInvalidAttribute : Attribute
-//               ^^^^^^^^^^^^^^^^^^ {{Specify AttributeUsage on 'MyInvalidAttribute'.}}
-    {
-    }
+}
 
-    [AttributeUsage(AttributeTargets.Class)]
-    public class MyCompliantAttribute : Attribute
-    {
-    }
+[AttributeUsage(AttributeTargets.Class)]
+public class MyCompliantAttribute : Attribute
+{
+}
 
-    public class MyInvalidInheritedAttribute : MyCompliantAttribute
-//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ {{Specify AttributeUsage on 'MyInvalidInheritedAttribute' to improve readability, even though it inherits it from its base type.}}
-    {
-    }
+public class MyInvalidInheritedAttribute : MyCompliantAttribute
+//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ {{Specify AttributeUsage on 'MyInvalidInheritedAttribute' to improve readability, even though it inherits it from its base type.}}
+{
+}
 
-    [AttributeUsage(AttributeTargets.Class)]
-    public class MyInheritedAttribute : MyCompliantAttribute
-    {
-    }
+[AttributeUsage(AttributeTargets.Class)]
+public class MyInheritedAttribute : MyCompliantAttribute
+{
+}
+
+public abstract class AbstractAttribute : Attribute // Compliant
+{
 }


### PR DESCRIPTION
As reported at [Sonar Community](https://community.sonarsource.com/t/fp-s3993-requires-abstract-attributes-to-be-decorated-with-attributeusage/110870), Abstract attributes should not report S3993.

Not that due to the latest changes, I can not build Sonar locally, as I have no JFrog account, and I could not find how to set this up in the documentation.