### PR TITLE
Fix AD0001 for pattern matching operations

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsPattern.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsPattern.cs
@@ -182,7 +182,7 @@ internal sealed class IsPattern : BranchingProcessor<IIsPatternOperationWrapper>
         declaration switch
         {
             _ when valueConstraint == ObjectConstraint.Null => BoolConstraint.False,
-            _ when declaration.InputType?.DerivesOrImplements(declaration.NarrowedType) is true => BoolConstraint.From(valueConstraint == ObjectConstraint.NotNull),
+            _ when declaration.InputType.DerivesOrImplements(declaration.NarrowedType) => BoolConstraint.From(valueConstraint == ObjectConstraint.NotNull),
             _ => null,
         };
 


### PR DESCRIPTION
Fixes #8957 

I couldn't yet replicate the NRE. I tried using `object`, `dynamic`, or generic types in declaration patterns.
The only place where this can happen is [this line](https://github.com/SonarSource/sonar-dotnet/blob/28b72bbfbf8211d1c52c7d58067f6ade07ae5abe/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/OperationProcessors/IsPattern.cs#L182), if `declaration.InputType` is null. Then, the null value ends up in the extension methods where [an NRE is thrown](https://github.com/SonarSource/sonar-dotnet/issues/8957#issue-2195081066).
I've added null checks to prevent that from happening, but it's going to lower the code coverage.

This might be a bug in Roslyn. The `InputType` property should not be null, it's declared as a non-nullable reference type in the Roslyn repo (the code is generated that's why I'm not linking to it):

<img width="1027" alt="image" src="https://github.com/SonarSource/sonar-dotnet/assets/121798625/a94c578a-6780-4ecc-9912-9555a09a4ff7">

