### PR TITLE
Fix TypeInitializationException in SymbolStartAnalysisContextWrapper

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/AnalysisContext/SymbolStartAnalysisContextWrapper.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/AnalysisContext/SymbolStartAnalysisContextWrapper.cs
@@ -76,6 +76,10 @@ public readonly struct SymbolStartAnalysisContextWrapper
         // receiverParameter => ((symbolStartAnalysisContextType)receiverParameter)."propertyName"
         Func<object, TProperty> CreatePropertyAccessor<TProperty>(string propertyName)
         {
+            if (symbolStartAnalysisContextType == null)
+            {
+                return static _ => default;
+            }
             var receiverParameter = Parameter(typeof(object));
             return Lambda<Func<object, TProperty>>(
                 Property(Convert(receiverParameter, symbolStartAnalysisContextType), propertyName),
@@ -86,6 +90,10 @@ public readonly struct SymbolStartAnalysisContextWrapper
         //     ((symbolStartAnalysisContextType)receiverParameter)."registrationMethodName"<typeArguments>(registerActionParameter)
         Action<object, Action<TContext>> CreateRegistrationMethod<TContext>(string registrationMethodName, params Type[] typeArguments)
         {
+            if (symbolStartAnalysisContextType == null)
+            {
+                return static (_, _) => { };
+            }
             var receiverParameter = Parameter(typeof(object));
             var registerActionParameter = Parameter(typeof(Action<TContext>));
             return Lambda<Action<object, Action<TContext>>>(
@@ -98,6 +106,10 @@ public readonly struct SymbolStartAnalysisContextWrapper
         //     ((symbolStartAnalysisContextType)receiverParameter)."registrationMethodName"<typeArguments>(registerActionParameter, additionalParameter)
         Action<object, Action<TContext>, TParameter> CreateRegistrationMethodWithAdditionalParameter<TContext, TParameter>(string registrationMethodName, params Type[] typeArguments)
         {
+            if (symbolStartAnalysisContextType == null)
+            {
+                return static (_, _, _) => { };
+            }
             var receiverParameter = Parameter(typeof(object));
             var registerActionParameter = Parameter(typeof(Action<TContext>));
             var additionalParameter = Parameter(typeof(TParameter));


### PR DESCRIPTION
Fixes AD0001
See https://cirrus-ci.com/task/5657719948967936?logs=build#L1542
```
CSC : error AD0001: Analyzer 
'SonarAnalyzer.Rules.CSharp.RouteTemplateShouldNotStartWithSlash' threw an exception of type 
'System.TypeInitializationException' with message 'The type initializer for 
'SonarAnalyzer.ShimLayer.AnalysisContext.SymbolStartAnalysisContextWrapper' 
threw an exception.'.
```

I had a UT for the fix, but it broke all the other tests because the type initializer is called only once per assembly load. I tried with AppDomains, but that didn't work. The only solution would be to isolate the test in a dedicated UT assembly, which does seem to be overkill.