### PR TITLE
Fix S2094 FP: Primary constructors for classes should be handled equal to records

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeEmpty.cs
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Xml.Linq;
-
 namespace SonarAnalyzer.Rules.CSharp;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -44,7 +42,7 @@ public sealed class ClassShouldNotBeEmpty : ClassShouldNotBeEmptyBase<SyntaxKind
         || declaration.BaseList.Types.Any(x => x.Type is GenericNameSyntax); // or a generic class/interface
 
     protected override bool HasAnyAttribute(SyntaxNode node) =>
-        node is TypeDeclarationSyntax { AttributeLists.Count: > 0  };
+        node is TypeDeclarationSyntax { AttributeLists.Count: > 0 };
 
     protected override string DeclarationTypeKeyword(SyntaxNode node) =>
         ((TypeDeclarationSyntax)node).Keyword.ValueText;
@@ -61,22 +59,16 @@ public sealed class ClassShouldNotBeEmpty : ClassShouldNotBeEmptyBase<SyntaxKind
         || IsParameterlessRecord(node);
 
     private static bool IsParameterlessClass(SyntaxNode node) =>
-        ClassDeclarationSyntax(node) is { } declaration
-            ? LacksParameters(declaration.ParameterList, declaration.BaseList)
-            : node is ClassDeclarationSyntax;
+        node is ClassDeclarationSyntax declaration
+        && LacksParameters(declaration.ParameterList(), declaration.BaseList);
 
     private static bool IsParameterlessRecord(SyntaxNode node) =>
         RecordDeclarationSyntax(node) is { } declaration
         && LacksParameters(declaration.ParameterList, declaration.BaseList);
 
     private static bool LacksParameters(ParameterListSyntax parameterList, BaseListSyntax baseList) =>
-        parameterList?.Parameters is not { Count: >= 1 }
-        && BaseTypeSyntax(baseList) is not { ArgumentList.Arguments.Count: >= 1 };
-
-    private static ClassDeclarationSyntaxWrapper? ClassDeclarationSyntax(SyntaxNode node) =>
-       ClassDeclarationSyntaxWrapper.IsInstance(node)
-           ? (ClassDeclarationSyntaxWrapper)node
-           : null;
+        parameterList?.Parameters is not { Count: > 0 }
+        && BaseTypeSyntax(baseList) is not { ArgumentList.Arguments.Count: > 0 };
 
     private static RecordDeclarationSyntaxWrapper? RecordDeclarationSyntax(SyntaxNode node) =>
         RecordDeclarationSyntaxWrapper.IsInstance(node)

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/ClassShouldNotBeEmptyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/ClassShouldNotBeEmptyTest.cs
@@ -43,12 +43,12 @@ public class ClassShouldNotBeEmptyTest
 
 #if NET
 
-    private static readonly MetadataReference[] AdditionalReferences = new[]
-    {
+    private static readonly MetadataReference[] AdditionalReferences =
+    [
         AspNetCoreMetadataReference.MicrosoftAspNetCoreMvcAbstractions,
         AspNetCoreMetadataReference.MicrosoftAspNetCoreMvcCore,
         AspNetCoreMetadataReference.MicrosoftAspNetCoreRazorPages,
-    };
+    ];
 
     [TestMethod]
     public void ClassShouldNotBeEmpty_CSharp9() =>

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.CSharp12.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.CSharp12.cs
@@ -1,12 +1,8 @@
-
-
-}
-
-namespace Compliant
+﻿namespace Compliant
 {
     class ChildClass() : BaseClass(42) { } // Compliant
     
-    class ChildClassWithParamters(int value) : BaseClass(value) { } // Compliant
+    class ChildClassWithParameters(int value) : BaseClass(value) { } // Compliant
 
     class BaseClass(int value) { }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.CSharp12.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.CSharp12.cs
@@ -1,10 +1,22 @@
-﻿using System.Collections.Generic;
 
-public class TestCaseData(List<int> list, int expectedCount)
-{
-    public List<int> List { get; }
-    public int ExpectedCount { get; }
+
 }
 
-// See https://github.com/SonarSource/sonar-dotnet/issues/9011
-public class CountTestCaseData(List<int> list, int expectedCount) : TestCaseData(list, expectedCount); // Noncompliant - FP
+namespace Compliant
+{
+    class ChildClass() : BaseClass(42) { } // Compliant
+    
+    class ChildClassWithParamters(int value) : BaseClass(value) { } // Compliant
+
+    class BaseClass(int value) { }
+}
+
+namespace Noncompliant
+{
+    class ChildClass() : BaseClass() { } // Noncompliant
+
+    class BaseClass()
+    {
+        public int Value { get; init; }
+    }
+}


### PR DESCRIPTION
Consider the following piece of code:

``` C#
class ChildClass() : BaseClass(42){ }

class BaseClass(int value) { }
```

Than `ChildClass` should not be considered an empty class, and hence should not raise [S2094](https://rules.sonarsource.com/csharp/RSPEC-2094),

I'm in doubt if S2094 should raise on `BaseClass`, but you could argue that there should be a different rule, that checks if the parameters of a primary constructor (on classes only) is actually used.
