### PR TITLE
Fix S2259 FP: `PropertyReference` does not learn from underlying symbol

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Data;
 using Microsoft.CodeAnalysis.Operations;
 using SonarAnalyzer.SymbolicExecution;
 using SonarAnalyzer.SymbolicExecution.Constraints;
@@ -1079,9 +1078,9 @@ Sample UntrackedSymbol() => this;";
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.PropertyReference);
         validator.TagValue("AfterSetNull").Should().HaveOnlyConstraints(ObjectConstraint.Null);
-        validator.TagValue("AfterSetNull_Operation").Should().BeNull();          // Should be .HaveOnlyConstraints(ObjectConstraint.Null)
+        validator.TagValue("AfterSetNull_Operation").Should().HaveOnlyConstraints(ObjectConstraint.Null);
         validator.TagValue("AfterReadReference").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
-        validator.TagValue("AfterReadReference_Operation").Should().BeNull();    // Should be .HaveOnlyConstraints(ObjectConstraint.NotNull)
+        validator.TagValue("AfterReadReference_Operation").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/SymbolicExecution/Roslyn/RoslynSymbolicExecutionTest.Operations.cs
@@ -1066,16 +1066,22 @@ Sample UntrackedSymbol() => this;";
     [TestMethod]
     public void PropertyReference_AutoProperty_IsTracked()
     {
-        const string code = """
-                AutoProperty = null;
-                Tag("AfterSetNull", AutoProperty);
-                AutoProperty.ToString();
-                Tag("AfterReadReference", AutoProperty);
-                """;
+        var code = """
+            AutoProperty = null;
+            var x = AutoProperty;
+            Tag("AfterSetNull", AutoProperty);
+            Tag("AfterSetNull_Operation", x);
+            AutoProperty.ToString();
+            x = AutoProperty;
+            Tag("AfterReadReference", AutoProperty);
+            Tag("AfterReadReference_Operation", x);
+            """;
         var validator = SETestContext.CreateCS(code).Validator;
         validator.ValidateContainsOperation(OperationKind.PropertyReference);
         validator.TagValue("AfterSetNull").Should().HaveOnlyConstraints(ObjectConstraint.Null);
+        validator.TagValue("AfterSetNull_Operation").Should().BeNull();          // Should be .HaveOnlyConstraints(ObjectConstraint.Null)
         validator.TagValue("AfterReadReference").Should().HaveOnlyConstraints(ObjectConstraint.NotNull);
+        validator.TagValue("AfterReadReference_Operation").Should().BeNull();    // Should be .HaveOnlyConstraints(ObjectConstraint.NotNull)
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -140,7 +140,7 @@ namespace Tests.Diagnostics
                 Property = null;
                 _ = Property.HasValue;  // Compliant
                 Property = null;
-                Property.GetType();     // FN https://github.com/SonarSource/sonar-dotnet/issues/6930
+                Property.GetType();     // Noncompliant
                 Property = default(T);
                 Property.GetType();     // Compliant
             }
@@ -366,7 +366,7 @@ namespace Tests.Diagnostics
             public void M()
             {
                 Property = null;
-                Property.ToString();  // FN https://github.com/SonarSource/sonar-dotnet/issues/6930
+                Property.ToString();  // Noncompliant
             }
         }
 
@@ -2123,7 +2123,7 @@ class Repro_8905
 
         if (Value != null)                      // Both branches enter here because PropertyReference is not learning from TrackedSymbol
         {
-            Console.WriteLine(value.Length);    // Noncompliant FP
+            Console.WriteLine(value.Length);    // Compliant
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.vb
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.vb
@@ -133,9 +133,7 @@ Public Class Program
             Prop = Nothing
             Dim X = Prop.HasValue   ' Compliant
             Prop = Nothing
-            Prop.GetType()          ' FN https://github.com/SonarSource/sonar-dotnet/issues/6930
-            Prop = Nothing
-            Prop.GetType()          ' Compliant
+            Prop.GetType()          ' Noncompliant
         End Sub
     End Class
 


### PR DESCRIPTION
Fixes #8905