### PR TITLE
Simplify registration extensions

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarAnalysisContextExtensions.cs
@@ -18,45 +18,37 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Extensions
+namespace SonarAnalyzer.Extensions;
+
+public static class SonarAnalysisContextExtensions
 {
-    internal static class SonarAnalysisContextExtensions
-    {
-        public static void RegisterNodeAction<TSyntaxKind>(this SonarAnalysisContext context,
-                                                                               Action<SonarSyntaxNodeReportingContext> action,
-                                                                               params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-            context.RegisterNodeAction(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
+    public static void RegisterNodeAction(this SonarAnalysisContext context, Action<SonarSyntaxNodeReportingContext> action, params SyntaxKind[] syntaxKinds) =>
+        context.RegisterNodeAction(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterNodeAction<TSyntaxKind>(this SonarParametrizedAnalysisContext context,
-                                                                               Action<SonarSyntaxNodeReportingContext> action,
-                                                                               params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-            context.RegisterNodeAction(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
+    public static void RegisterNodeAction(this SonarParametrizedAnalysisContext context, Action<SonarSyntaxNodeReportingContext> action, params SyntaxKind[] syntaxKinds) =>
+        context.RegisterNodeAction(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterNodeAction<TSyntaxKind>(this SonarCompilationStartAnalysisContext context,
-                                                                               Action<SonarSyntaxNodeReportingContext> action,
-                                                                               params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-            context.RegisterNodeAction(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
+    public static void RegisterNodeAction(this SonarCompilationStartAnalysisContext context, Action<SonarSyntaxNodeReportingContext> action, params SyntaxKind[] syntaxKinds) =>
+        context.RegisterNodeAction(CSharpGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterTreeAction(this SonarAnalysisContext context, Action<SonarSyntaxTreeReportingContext> action) =>
-            context.RegisterTreeAction(CSharpGeneratedCodeRecognizer.Instance, action);
+    public static void RegisterTreeAction(this SonarAnalysisContext context, Action<SonarSyntaxTreeReportingContext> action) =>
+        context.RegisterTreeAction(CSharpGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterTreeAction(this SonarParametrizedAnalysisContext context, Action<SonarSyntaxTreeReportingContext> action) =>
-            context.RegisterTreeAction(CSharpGeneratedCodeRecognizer.Instance, action);
+    public static void RegisterTreeAction(this SonarParametrizedAnalysisContext context, Action<SonarSyntaxTreeReportingContext> action) =>
+        context.RegisterTreeAction(CSharpGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterSemanticModelAction(this SonarParametrizedAnalysisContext context, Action<SonarSemanticModelReportingContext> action) =>
-            context.RegisterSemanticModelAction(CSharpGeneratedCodeRecognizer.Instance, action);
+    public static void RegisterSemanticModelAction(this SonarParametrizedAnalysisContext context, Action<SonarSemanticModelReportingContext> action) =>
+        context.RegisterSemanticModelAction(CSharpGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterSemanticModelAction(this SonarAnalysisContext context, Action<SonarSemanticModelReportingContext> action) =>
-            context.RegisterSemanticModelAction(CSharpGeneratedCodeRecognizer.Instance, action);
+    public static void RegisterSemanticModelAction(this SonarAnalysisContext context, Action<SonarSemanticModelReportingContext> action) =>
+        context.RegisterSemanticModelAction(CSharpGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterCodeBlockStartAction<TSyntaxKind>(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action)
-            where TSyntaxKind : struct =>
-            context.RegisterCodeBlockStartAction(CSharpGeneratedCodeRecognizer.Instance, action);
+    public static void RegisterCodeBlockStartAction(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<SyntaxKind>> action) =>
+        context.RegisterCodeBlockStartAction(CSharpGeneratedCodeRecognizer.Instance, action);
 
-        public static void ReportIssue(this SonarCompilationReportingContext context, Diagnostic diagnostic) =>
-            context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
+    public static void ReportIssue(this SonarCompilationReportingContext context, Diagnostic diagnostic) =>
+        context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
 
-        public static void ReportIssue(this SonarSymbolReportingContext context, Diagnostic diagnostic) =>
-            context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
-    }
+    public static void ReportIssue(this SonarSymbolReportingContext context, Diagnostic diagnostic) =>
+        context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeEqualsOverride.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeEqualsOverride.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.CSharp
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterCodeBlockStartAction<SyntaxKind>(
+            context.RegisterCodeBlockStartAction(
                 cb =>
                 {
                     if (!(cb.CodeBlock is MethodDeclarationSyntax methodDeclaration))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GuardConditionOnEqualsOverride.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GuardConditionOnEqualsOverride.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
         private static readonly ISet<string> MethodNames = new HashSet<string> { GetHashCodeEqualsOverride.EqualsName };
 
         protected override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterCodeBlockStartAction<SyntaxKind>(
+            context.RegisterCodeBlockStartAction(
                 cb =>
                 {
                     if (!(cb.OwningSymbol is IMethodSymbol methodSymbol)

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldWrittenFrom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldWrittenFrom.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         protected sealed override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterCodeBlockStartAction<SyntaxKind>(cbc =>
+            context.RegisterCodeBlockStartAction(cbc =>
                 {
                     if (!IsValidCodeBlockContext(cbc.CodeBlock, cbc.OwningSymbol))
                     {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThisShouldNotBeExposedFromConstructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThisShouldNotBeExposedFromConstructors.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
         protected override void Initialize(SonarAnalysisContext context)
         {
-            context.RegisterCodeBlockStartAction<SyntaxKind>(
+            context.RegisterCodeBlockStartAction(
                 cbc =>
                 {
                     if (!IsInstanceConstructor(cbc.CodeBlock))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableUnused.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules.CSharp
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterCodeBlockStartAction<SyntaxKind>(cbc =>
+            context.RegisterCodeBlockStartAction(cbc =>
             {
                 var collector = new UnusedLocalsCollector();
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarAnalysisContextExtensions.cs
@@ -18,45 +18,37 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Extensions
+namespace SonarAnalyzer.Extensions;
+
+public static class SonarAnalysisContextExtensions
 {
-    public static class SonarAnalysisContextExtensions
-    {
-        public static void RegisterNodeAction<TSyntaxKind>(this SonarAnalysisContext context,
-                                                                               Action<SonarSyntaxNodeReportingContext> action,
-                                                                               params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-            context.RegisterNodeAction(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
+    public static void RegisterNodeAction(this SonarAnalysisContext context, Action<SonarSyntaxNodeReportingContext> action, params SyntaxKind[] syntaxKinds) =>
+        context.RegisterNodeAction(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterNodeAction<TSyntaxKind>(this SonarParametrizedAnalysisContext context,
-                                                                               Action<SonarSyntaxNodeReportingContext> action,
-                                                                               params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-            context.RegisterNodeAction(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
+    public static void RegisterNodeAction(this SonarParametrizedAnalysisContext context, Action<SonarSyntaxNodeReportingContext> action, params SyntaxKind[] syntaxKinds) =>
+        context.RegisterNodeAction(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterNodeAction<TSyntaxKind>(this SonarCompilationStartAnalysisContext context,
-                                                                               Action<SonarSyntaxNodeReportingContext> action,
-                                                                               params TSyntaxKind[] syntaxKinds) where TSyntaxKind : struct =>
-            context.RegisterNodeAction(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
+    public static void RegisterNodeAction(this SonarCompilationStartAnalysisContext context, Action<SonarSyntaxNodeReportingContext> action, params SyntaxKind[] syntaxKinds) =>
+        context.RegisterNodeAction(VisualBasicGeneratedCodeRecognizer.Instance, action, syntaxKinds);
 
-        public static void RegisterTreeAction(this SonarAnalysisContext context, Action<SonarSyntaxTreeReportingContext> action) =>
-            context.RegisterTreeAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
+    public static void RegisterTreeAction(this SonarAnalysisContext context, Action<SonarSyntaxTreeReportingContext> action) =>
+        context.RegisterTreeAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterTreeAction(this SonarParametrizedAnalysisContext context, Action<SonarSyntaxTreeReportingContext> action) =>
-            context.RegisterTreeAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
+    public static void RegisterTreeAction(this SonarParametrizedAnalysisContext context, Action<SonarSyntaxTreeReportingContext> action) =>
+        context.RegisterTreeAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterSemanticModelAction(this SonarAnalysisContext context, Action<SonarSemanticModelReportingContext> action) =>
-            context.RegisterSemanticModelAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
+    public static void RegisterSemanticModelAction(this SonarAnalysisContext context, Action<SonarSemanticModelReportingContext> action) =>
+        context.RegisterSemanticModelAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterSemanticModelAction(this SonarParametrizedAnalysisContext context, Action<SonarSemanticModelReportingContext> action) =>
-            context.RegisterSemanticModelAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
+    public static void RegisterSemanticModelAction(this SonarParametrizedAnalysisContext context, Action<SonarSemanticModelReportingContext> action) =>
+        context.RegisterSemanticModelAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-        public static void RegisterCodeBlockStartAction<TSyntaxKind>(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<TSyntaxKind>> action)
-            where TSyntaxKind : struct =>
-            context.RegisterCodeBlockStartAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
+    public static void RegisterCodeBlockStartAction(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<SyntaxKind>> action) =>
+        context.RegisterCodeBlockStartAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-        public static void ReportIssue(this SonarCompilationReportingContext context, Diagnostic diagnostic) =>
-            context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic);
+    public static void ReportIssue(this SonarCompilationReportingContext context, Diagnostic diagnostic) =>
+        context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic);
 
-        public static void ReportIssue(this SonarSymbolReportingContext context, Diagnostic diagnostic) =>
-            context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic);
-    }
+    public static void ReportIssue(this SonarSymbolReportingContext context, Diagnostic diagnostic) =>
+        context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic);
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/VariableUnused.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/VariableUnused.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterCodeBlockStartAction<SyntaxKind>(cbc =>
+            context.RegisterCodeBlockStartAction(cbc =>
             {
                 var collector = new UnusedLocalsCollector();
 


### PR DESCRIPTION
These `SonarAnalysisContextExtensions.cs` are specific to a language (CSharp vs. VisualBasic) therefore their `TSyntaxKind` is already given by the project they reside in.

Generic argument is needed only in the layer below these files.