### PR TITLE
New rule T0001: Use FileScoped namespaces

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/Common/StylingAnalyzer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/Common/StylingAnalyzer.cs
@@ -18,16 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Rules.CSharp.Styling;
+namespace SonarAnalyzer.CSharp.Styling.Common;
 
-[DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class FileScopeNamespace : StylingAnalyzer
+public abstract class StylingAnalyzer : SonarDiagnosticAnalyzer
 {
-    public FileScopeNamespace() : base("T0001", "Use file-scoped namespace.") { }
+    protected DiagnosticDescriptor Rule { get; }
 
-    protected override void Initialize(SonarAnalysisContext context) =>
-        // ToDo: Rework reporting
-        context.RegisterNodeAction(
-            c => c.ReportIssue(Diagnostic.Create(Rule, ((NamespaceDeclarationSyntax)c.Node).Name.GetLocation())),
-            SyntaxKind.NamespaceDeclaration);
+    public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    protected StylingAnalyzer(string id, string messageFormat, SourceScope scope = SourceScope.All) =>
+       Rule = DescriptorFactory.Create(id, messageFormat, scope);
 }

--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/FileScopeNamespace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/FileScopeNamespace.cs
@@ -23,16 +23,13 @@ namespace SonarAnalyzer.Rules.CSharp.Styling;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class FileScopeNamespace : SonarDiagnosticAnalyzer    // ToDo: https://github.com/SonarSource/sonar-dotnet/issues/9035 Extract into a usefull base class
 {
-    private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create("T0001", "Use file-scoped namespaces");
+    private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create("T0001", "Use file-scoped namespace.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);   // ToDo: https://github.com/SonarSource/sonar-dotnet/issues/9035 Remove this
 
-    protected override void Initialize(SonarAnalysisContext context)
-    {
-        // ToDo: https://github.com/SonarSource/sonar-dotnet/issues/9035
-        if (context is null)
-        {
-            return; // This is a useless coverage test for now. It will be removed
-        }
-    }
+    protected override void Initialize(SonarAnalysisContext context) =>
+        // ToDo: Rework reporting
+        context.RegisterNodeAction(
+            c => c.ReportIssue(Diagnostic.Create(Rule, ((NamespaceDeclarationSyntax)c.Node).Name.GetLocation())),
+            SyntaxKind.NamespaceDeclaration);
 }

--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/SonarAnalyzer.CSharp.Styling.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/SonarAnalyzer.CSharp.Styling.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- We need to update NuGet and JAR packaging after changing references -->
+    <!-- We need to update NuGet packaging after changing references -->
     <ProjectReference Include="..\SonarAnalyzer.Common\SonarAnalyzer.Common.csproj" />
-    <ProjectReference Include="..\SonarAnalyzer.Common\SonarAnalyzer.CSharp.csproj" />
+    <ProjectReference Include="..\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/packages.lock.json
@@ -941,6 +941,14 @@
           "Microsoft.Composition": "[1.0.27, )",
           "System.Collections.Immutable": "[1.1.37, )"
         }
+      },
+      "sonaranalyzer.csharp": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "SonarAnalyzer": "[1.0.0, )",
+          "System.Collections.Immutable": "[1.1.37, )"
+        }
       }
     }
   }

--- a/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/Rules/FileScopeNamespaceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/Rules/FileScopeNamespaceTest.cs
@@ -23,7 +23,13 @@ namespace SonarAnalyzer.CSharp.Styling.Test.Rules;
 [TestClass]
 public class FileScopeNamespaceTest
 {
+    private readonly VerifierBuilder builder = new VerifierBuilder<FileScopeNamespace>().WithOptions(ParseOptionsHelper.CSharpLatest).WithConcurrentAnalysis(false);
+
     [TestMethod]
     public void FileScopeNamespace() =>
-        new VerifierBuilder<FileScopeNamespace>().WithOptions(ParseOptionsHelper.CSharpLatest).AddPaths("FileScopeNamespace.cs").Verify();
+        builder.AddPaths("FileScopeNamespace.cs").Verify();
+
+    [TestMethod]
+    public void FileScopeNamespace_Compliant() =>
+        builder.AddPaths("FileScopeNamespace.Compliant.cs").Verify();
 }

--- a/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/Rules/FileScopeNamespaceTest.cs
+++ b/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/Rules/FileScopeNamespaceTest.cs
@@ -31,5 +31,5 @@ public class FileScopeNamespaceTest
 
     [TestMethod]
     public void FileScopeNamespace_Compliant() =>
-        builder.AddPaths("FileScopeNamespace.Compliant.cs").Verify();
+        builder.AddPaths("FileScopeNamespace.Compliant.cs").VerifyNoIssueReported();
 }

--- a/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/FileScopeNamespace.Compliant.cs
+++ b/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/FileScopeNamespace.Compliant.cs
@@ -1,0 +1,6 @@
+﻿namespace Outer; // Compliant
+
+public class NotRelevant
+{
+
+}

--- a/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/FileScopeNamespace.cs
+++ b/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/FileScopeNamespace.cs
@@ -1,1 +1,20 @@
-﻿// FIXME: Rewrite this file in https://github.com/SonarSource/sonar-dotnet/issues/9035
+﻿
+namespace Outer // Noncompliant {{Use file-scoped namespace.}}
+//        ^^^^^
+{
+    public class NotRelevant
+    {
+
+    }
+
+    namespace Inner // Noncompliant, nested namespace should not be used in general
+    {
+
+    }
+}
+
+
+namespace   // Error [CS1001] Identifier expected
+{           // Noncompliant^-1#0
+
+}

--- a/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/packages.lock.json
+++ b/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/packages.lock.json
@@ -552,11 +552,20 @@
           "System.Collections.Immutable": "[1.1.37, )"
         }
       },
+      "sonaranalyzer.csharp": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
+          "SonarAnalyzer": "[1.0.0, )",
+          "System.Collections.Immutable": "[1.1.37, )"
+        }
+      },
       "sonaranalyzer.csharp.styling": {
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "[1.3.2, )",
-          "SonarAnalyzer": "[1.0.0, )"
+          "SonarAnalyzer": "[1.0.0, )",
+          "SonarAnalyzer.CSharp": "[1.0.0, )"
         }
       },
       "sonaranalyzer.testframework": {


### PR DESCRIPTION
Fixes #9035

~~This is based on #9048 and #9049. These commits do not need review:~~
* ~~Simplify registration extensions~~
* ~~Create SonarAnalyzer.CSharp.Styling project~~
* ~~Update locks~~