### PR TITLE
Bump FluentAssertions.Analyzers to 0.31.0

### DIFF
--- a/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/SonarAnalyzer.CSharp.Styling.Test.csproj
+++ b/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/SonarAnalyzer.CSharp.Styling.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿  <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- The -windows suffix is needed because SonarAnalyzer.TestFramework references Microsoft.WindowsDesktop.App.WindowsForms framework reference. -->

--- a/analyzers/tests/SonarAnalyzer.TestFramework/SonarAnalyzer.TestFramework.csproj
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/SonarAnalyzer.TestFramework.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.23.0">
+    <PackageReference Include="FluentAssertions.Analyzers" Version="0.31.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/analyzers/tests/SonarAnalyzer.TestFramework/packages.lock.json
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/packages.lock.json
@@ -13,9 +13,9 @@
       },
       "FluentAssertions.Analyzers": {
         "type": "Direct",
-        "requested": "[0.23.0, )",
-        "resolved": "0.23.0",
-        "contentHash": "NIaSIXAargF7WoHWdDjP/n48EEOP0ypTQI+7AHAtF3+aV8QQQCI6WL0q8rH2e0DM5YuBXcv0YaV7hM6bgJznBg=="
+        "requested": "[0.31.0, )",
+        "resolved": "0.31.0",
+        "contentHash": "KWyAnqT5gCx1vHr/oNhyEV8HV1aCJswREoxEbZcWOWBGTWm7aAeMnzwjfAPNNYumzhT8Y8IafgcLur0OXrLZrA=="
       },
       "Microsoft.Build.Locator": {
         "type": "Direct",
@@ -551,9 +551,9 @@
       },
       "FluentAssertions.Analyzers": {
         "type": "Direct",
-        "requested": "[0.23.0, )",
-        "resolved": "0.23.0",
-        "contentHash": "NIaSIXAargF7WoHWdDjP/n48EEOP0ypTQI+7AHAtF3+aV8QQQCI6WL0q8rH2e0DM5YuBXcv0YaV7hM6bgJznBg=="
+        "requested": "[0.31.0, )",
+        "resolved": "0.31.0",
+        "contentHash": "KWyAnqT5gCx1vHr/oNhyEV8HV1aCJswREoxEbZcWOWBGTWm7aAeMnzwjfAPNNYumzhT8Y8IafgcLur0OXrLZrA=="
       },
       "Microsoft.Build.Locator": {
         "type": "Direct",


### PR DESCRIPTION
While some projects already had 0.31.0, this one was few versions being. It was causing CS8036 error about not begin able to load types.

GH had some issues yesterday, the pipeline is fully green on Azure DevOps