### PR TITLE
Disable RS1036

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -232,6 +232,7 @@ dotnet_diagnostic.CS7035.severity = none    # CS7035: it expects the build numbe
 dotnet_diagnostic.CA1822.severity = warning # Increase visibility for Member 'xxx' does not access instance data and can be marked as static
 dotnet_diagnostic.CS8785.severity = error   # Do not hide root cause for: Generator 'xxx' failed to generate source. It will not contribute to the output and compilation errors may occur as a result. Exception was of type 'xxx' with message 'xxx'
 dotnet_diagnostic.RS2008.severity = none    # Enable analyzer release tracking - we don't use the release tracking analyzer
+dotnet_diagnostic.RS1036.severity = none    # A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>' - we're intentially violating a lot of those types
 dotnet_diagnostic.IDE0057.severity = none   # Use range operator
 dotnet_diagnostic.IDE0290.severity = none   # Use primary constructors
 

--- a/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextTest.Register.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextTest.Register.cs
@@ -621,7 +621,6 @@ public partial class SonarAnalysisContextTest
         }
     }
 
-#pragma warning disable RS1036 // Specify analyzer banned API enforcement setting
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     private class DummyAnalyzerForGenerated : SonarDiagnosticAnalyzer
     {
@@ -630,7 +629,7 @@ public partial class SonarAnalysisContextTest
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterNodeActionInAllFiles(c => c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation())), SyntaxKind.ClassDeclaration);
+            context.RegisterNodeActionInAllFiles(c => c.ReportIssue(rule, c.Node), SyntaxKind.ClassDeclaration);
     }
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarSyntaxNodeReportingContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarSyntaxNodeReportingContextTest.cs
@@ -109,9 +109,7 @@ public class SonarSyntaxNodeReportingContextTest
     }
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-#pragma warning disable RS1036 // Specify analyzer banned API enforcement setting
     private sealed class TestAnalyzer : SonarDiagnosticAnalyzer
-#pragma warning restore RS1036 // Specify analyzer banned API enforcement setting
     {
         private readonly SyntaxKind[] syntaxKinds;
         private readonly Func<SonarSyntaxNodeReportingContext, string> message;
@@ -128,7 +126,6 @@ public class SonarSyntaxNodeReportingContextTest
         }
 
         protected override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterNodeAction(CSharpGeneratedCodeRecognizer.Instance, c =>
-                c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation(), message(c))), syntaxKinds);
+            context.RegisterNodeAction(CSharpGeneratedCodeRecognizer.Instance, c => c.ReportIssue(Rule, c.Node, message(c)), syntaxKinds);
     }
 }


### PR DESCRIPTION
I don't know why it doesn't raise on Common, CSharp and VisualBasic projects.

We intentionally use a lot of symbols that are prohibited by the rule, see https://github.com/dotnet/roslyn-analyzers/blob/89c1a9dd4775efb2c55af106c23d5415d8177d5e/src/Microsoft.CodeAnalysis.Analyzers/Core/AnalyzerBannedSymbols.txt