### PR TITLE
Fix S2094 FP: Implicit parameterless constructor widens the scope of the base class constructor 

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.CSharp9.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.CSharp9.cs
@@ -54,6 +54,15 @@ namespace Noncompliant
     record EmptyGenericRecord<T>();                              // Noncompliant
     //     ^^^^^^^^^^^^^^^^^^
     record EmptyGenericRecordWithContraint<T>() where T : class; // Noncompliant
+
+    record ConstructorIsPublicAlready : EmptyRecord { }          // Noncompliant
+
+    record BaseRecordWithProtectedConstructor
+    {
+        protected BaseRecordWithProtectedConstructor() { }
+    }
+
+    record WidensConstructorVisibility : BaseRecordWithProtectedConstructor { } // Compliant
 }
 
 namespace Ignore
@@ -68,4 +77,3 @@ namespace Repro_7709
     record ImplementsMarker : IMarker { }
     record ImplementsEmptyRecordAndMarker : Noncompliant.EmptyRecord, IMarker { }
 }
-

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
@@ -138,4 +138,11 @@ namespace Ignore
     class Command { }                            // Compliant, ignored because of the suffix
     class Event { }                              // Compliant, ignored because of the suffix
     class Message { }                            // Compliant, ignored because of the suffix
+
+    public class BaseWithNonPublicConstructor
+    {
+        protected BaseWithNonPublicConstructor() { }
+    }
+
+    public class WidensTheConstructorVisibility : BaseWithNonPublicConstructor { }  // Noncompliant FP
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
@@ -139,10 +139,28 @@ namespace Ignore
     class Event { }                              // Compliant, ignored because of the suffix
     class Message { }                            // Compliant, ignored because of the suffix
 
-    public class BaseWithNonPublicConstructor
+    class BaseWithProtectedConstructor
     {
-        protected BaseWithNonPublicConstructor() { }
+        protected BaseWithProtectedConstructor() { }
     }
 
-    public class WidensTheConstructorVisibility : BaseWithNonPublicConstructor { }  // Compliant
+    class WidensConstructorVisibility1 : BaseWithProtectedConstructor { }           // Compliant
+
+    class BaseWithInternalConstructor
+    {
+        internal BaseWithInternalConstructor() { }
+    }
+
+    class WidensConstructorVisibility2 : BaseWithInternalConstructor { }            // Compliant
+
+    class BaseWithPublicConstructor
+    {
+        public BaseWithPublicConstructor() { }
+    }
+
+    class ConstructorIsPublicAlready1 : BaseWithPublicConstructor { }               // Noncompliant
+
+    class BaseWithDefaultConstructor { }                                            // Noncompliant
+
+    class ConstructorIsPublicAlready2 : BaseWithDefaultConstructor { }              // Noncompliant
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
@@ -144,5 +144,5 @@ namespace Ignore
         protected BaseWithNonPublicConstructor() { }
     }
 
-    public class WidensTheConstructorVisibility : BaseWithNonPublicConstructor { }  // Noncompliant FP
+    public class WidensTheConstructorVisibility : BaseWithNonPublicConstructor { }  // Compliant
 }


### PR DESCRIPTION
Fixes #7591
