### PR TITLE
Fix S2094 FP: Implicit parameterless constructor widens the scope of the base class constructor

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/ClassShouldNotBeEmptyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ClassShouldNotBeEmptyBase.cs
@@ -79,5 +79,5 @@ public abstract class ClassShouldNotBeEmptyBase<TSyntaxKind, TDeclarationSyntax>
 
     private static bool HasNonPublicDefaultConstructor(TDeclarationSyntax declaration, SemanticModel model) =>
         model.GetDeclaredSymbol(declaration) is INamedTypeSymbol classSymbol
-        && classSymbol.BaseType.Constructors.FirstOrDefault(x => x.Parameters.Length == 0) is { DeclaredAccessibility: not Accessibility.Public };
+        && classSymbol.BaseType.Constructors.FirstOrDefault(x => x.Parameters.Length == 0)?.GetEffectiveAccessibility() < classSymbol.DeclaredAccessibility;
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ClassShouldNotBeEmptyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ClassShouldNotBeEmptyBase.cs
@@ -79,5 +79,8 @@ public abstract class ClassShouldNotBeEmptyBase<TSyntaxKind, TDeclarationSyntax>
 
     private static bool HasNonPublicDefaultConstructor(TDeclarationSyntax declaration, SemanticModel model) =>
         model.GetDeclaredSymbol(declaration) is INamedTypeSymbol classSymbol
-        && classSymbol.BaseType.Constructors.FirstOrDefault(x => x.Parameters.Length == 0)?.GetEffectiveAccessibility() < classSymbol.DeclaredAccessibility;
+        && classSymbol.BaseType.Constructors.FirstOrDefault(x => x.Parameters.Length == 0) is { } constructor
+        && (constructor.GetEffectiveAccessibility() < classSymbol.DeclaredAccessibility
+            // GetEffectiveAccessibility is not handling Protected
+            || (constructor.DeclaredAccessibility == Accessibility.Protected && classSymbol.DeclaredAccessibility > Accessibility.Protected));
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ClassShouldNotBeEmptyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ClassShouldNotBeEmptyBase.cs
@@ -82,5 +82,6 @@ public abstract class ClassShouldNotBeEmptyBase<TSyntaxKind, TDeclarationSyntax>
         && classSymbol.BaseType.Constructors.FirstOrDefault(x => x.Parameters.Length == 0) is { } constructor
         && (constructor.GetEffectiveAccessibility() < classSymbol.DeclaredAccessibility
             // GetEffectiveAccessibility is not handling Protected
-            || (constructor.DeclaredAccessibility == Accessibility.Protected && classSymbol.DeclaredAccessibility > Accessibility.Protected));
+            || (constructor.DeclaredAccessibility == Accessibility.Protected && classSymbol.DeclaredAccessibility > Accessibility.Protected)
+            || (constructor.GetEffectiveAccessibility() == Accessibility.Internal && classSymbol.DeclaredAccessibility == Accessibility.Protected));
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
@@ -186,13 +186,38 @@ namespace ConstructorAccessibility
     internal class ConstructorIsInternalAlready3 : InternalClassWithInternalConstructor { }     // Noncompliant
     internal class WidensConstructorAccessibility4 : InternalClassWithProtectedConstructor { }  // Compliant
 
-    class ClassWithNestedClasses
+    public class ClassWithNestedClasses
     {
-        private class PrivateClass1 : PublicClassWithPublicConstructor { }                      // Noncompliant
-        private class PrivateClass2 : PublicClassWithInternalConstructor { }                    // Noncompliant
-        private class PrivateClass3 : PublicClassWithProtectedConstructor { }                   // Noncompliant
-        private class PrivateClass4 : InternalClassWithPublicConstructor { }                    // Noncompliant
-        private class PrivateClass5 : InternalClassWithInternalConstructor { }                  // Noncompliant
-        private class PrivateClass6 : InternalClassWithProtectedConstructor { }                 // Noncompliant
+        protected class ProtectedClassWithPublicConstructor
+        {
+            public ProtectedClassWithPublicConstructor() { }
+        }
+
+        protected class ProtectedClassWithInternalConstructor
+        {
+            internal ProtectedClassWithInternalConstructor() { }
+        }
+
+        protected class ProtectedClassWithProtectedConstructor
+        {
+            protected ProtectedClassWithProtectedConstructor() { }
+        }
+
+        protected class ConstructorIsPublicAlready3 : PublicClassWithPublicConstructor { }              // Noncompliant
+        protected class WidensConstructorAccessibility5 : PublicClassWithInternalConstructor { }        // Noncompliant FP
+        protected class ConstructorIsProtectedAlready1 : PublicClassWithProtectedConstructor { }        // Noncompliant
+        protected class ConstructorIsProtectedAlready2 : ProtectedClassWithPublicConstructor { }        // Noncompliant
+        protected class WidensConstructorAccessibility6 : ProtectedClassWithInternalConstructor { }     // Noncompliant FP
+        protected class ConstructorIsProtectedAlready3 : ProtectedClassWithProtectedConstructor { }     // Noncompliant
+
+        private class PrivateClass1 : PublicClassWithPublicConstructor { }                              // Noncompliant
+        private class PrivateClass2 : PublicClassWithInternalConstructor { }                            // Noncompliant
+        private class PrivateClass3 : PublicClassWithProtectedConstructor { }                           // Noncompliant
+        private class PrivateClass4 : InternalClassWithPublicConstructor { }                            // Noncompliant
+        private class PrivateClass5 : InternalClassWithInternalConstructor { }                          // Noncompliant
+        private class PrivateClass6 : InternalClassWithProtectedConstructor { }                         // Noncompliant
+        private class PrivateClass7 : ProtectedClassWithPublicConstructor { }                           // Noncompliant
+        private class PrivateClass8 : ProtectedClassWithInternalConstructor { }                         // Noncompliant
+        private class PrivateClass9 : ProtectedClassWithProtectedConstructor { }                        // Noncompliant
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
@@ -204,10 +204,10 @@ namespace ConstructorAccessibility
         }
 
         protected class ConstructorIsPublicAlready3 : PublicClassWithPublicConstructor { }              // Noncompliant
-        protected class WidensConstructorAccessibility5 : PublicClassWithInternalConstructor { }        // Noncompliant FP
+        protected class WidensConstructorAccessibility5 : PublicClassWithInternalConstructor { }        // Compliant
         protected class ConstructorIsProtectedAlready1 : PublicClassWithProtectedConstructor { }        // Noncompliant
         protected class ConstructorIsProtectedAlready2 : ProtectedClassWithPublicConstructor { }        // Noncompliant
-        protected class WidensConstructorAccessibility6 : ProtectedClassWithInternalConstructor { }     // Noncompliant FP
+        protected class WidensConstructorAccessibility6 : ProtectedClassWithInternalConstructor { }     // Compliant
         protected class ConstructorIsProtectedAlready3 : ProtectedClassWithProtectedConstructor { }     // Noncompliant
 
         private class PrivateClass1 : PublicClassWithPublicConstructor { }                              // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
@@ -145,35 +145,12 @@ namespace Ignore
 
 namespace ConstructorAccessibility
 {
-    public class PublicClassWithPublicConstructor
-    {
-        public PublicClassWithPublicConstructor() { }
-    }
-
-    public class PublicClassWithInternalConstructor
-    {
-        internal PublicClassWithInternalConstructor() { }
-    }
-
-    public class PublicClassWithProtectedConstructor
-    {
-        protected PublicClassWithProtectedConstructor() { }
-    }
-
-    internal class InternalClassWithPublicConstructor
-    {
-        public InternalClassWithPublicConstructor() { }
-    }
-
-    internal class InternalClassWithInternalConstructor
-    {
-        internal InternalClassWithInternalConstructor() { }
-    }
-
-    internal class InternalClassWithProtectedConstructor
-    {
-        protected InternalClassWithProtectedConstructor() { }
-    }
+    public class PublicClassWithPublicConstructor { public PublicClassWithPublicConstructor() { } }
+    public class PublicClassWithInternalConstructor { internal PublicClassWithInternalConstructor() { } }
+    public class PublicClassWithProtectedConstructor { protected PublicClassWithProtectedConstructor() { } }
+    internal class InternalClassWithPublicConstructor { public InternalClassWithPublicConstructor() { } }
+    internal class InternalClassWithInternalConstructor { internal InternalClassWithInternalConstructor() { } }
+    internal class InternalClassWithProtectedConstructor { protected InternalClassWithProtectedConstructor() { } }
 
     public class ConstructorIsPublicAlready1 : PublicClassWithPublicConstructor { }             // Noncompliant
     public class WidensConstructorAccessibility1 : PublicClassWithInternalConstructor { }       // Compliant
@@ -188,20 +165,12 @@ namespace ConstructorAccessibility
 
     public class ClassWithNestedClasses
     {
-        protected class ProtectedClassWithPublicConstructor
-        {
-            public ProtectedClassWithPublicConstructor() { }
-        }
-
-        protected class ProtectedClassWithInternalConstructor
-        {
-            internal ProtectedClassWithInternalConstructor() { }
-        }
-
-        protected class ProtectedClassWithProtectedConstructor
-        {
-            protected ProtectedClassWithProtectedConstructor() { }
-        }
+        protected class ProtectedClassWithPublicConstructor { public ProtectedClassWithPublicConstructor() { } }
+        protected class ProtectedClassWithInternalConstructor { internal ProtectedClassWithInternalConstructor() { } }
+        protected class ProtectedClassWithProtectedConstructor { protected ProtectedClassWithProtectedConstructor() { } }
+        private class PrivateClassWithPublicConstructor { public PrivateClassWithPublicConstructor() { } }
+        private class PrivateClassWithInternalConstructor { internal PrivateClassWithInternalConstructor() { } }
+        private class PrivateClassWithProtectedConstructor { protected PrivateClassWithProtectedConstructor() { } }
 
         protected class ConstructorIsPublicAlready3 : PublicClassWithPublicConstructor { }              // Noncompliant
         protected class WidensConstructorAccessibility5 : PublicClassWithInternalConstructor { }        // Compliant
@@ -219,5 +188,8 @@ namespace ConstructorAccessibility
         private class PrivateClass7 : ProtectedClassWithPublicConstructor { }                           // Noncompliant
         private class PrivateClass8 : ProtectedClassWithInternalConstructor { }                         // Noncompliant
         private class PrivateClass9 : ProtectedClassWithProtectedConstructor { }                        // Noncompliant
+        private class PrivateClass10 : ProtectedClassWithPublicConstructor { }                          // Noncompliant
+        private class PrivateClass11 : ProtectedClassWithInternalConstructor { }                        // Noncompliant
+        private class PrivateClass12 : ProtectedClassWithProtectedConstructor { }                       // Noncompliant
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
@@ -185,4 +185,14 @@ namespace ConstructorAccessibility
     internal class ConstructorIsInternalAlready2 : InternalClassWithPublicConstructor { }       // Noncompliant
     internal class ConstructorIsInternalAlready3 : InternalClassWithInternalConstructor { }     // Noncompliant
     internal class WidensConstructorAccessibility4 : InternalClassWithProtectedConstructor { }  // Noncompliant FP
+
+    class ClassWithNestedClasses
+    {
+        private class PrivateClass1 : PublicClassWithPublicConstructor { }                      // Noncompliant
+        private class PrivateClass2 : PublicClassWithInternalConstructor { }                    // Noncompliant
+        private class PrivateClass3 : PublicClassWithProtectedConstructor { }                   // Noncompliant
+        private class PrivateClass4 : InternalClassWithPublicConstructor { }                    // Noncompliant
+        private class PrivateClass5 : InternalClassWithInternalConstructor { }                  // Noncompliant
+        private class PrivateClass6 : InternalClassWithProtectedConstructor { }                 // Noncompliant
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
@@ -184,7 +184,7 @@ namespace ConstructorAccessibility
     internal class WidensConstructorAccessibility3 : PublicClassWithProtectedConstructor { }    // Compliant
     internal class ConstructorIsInternalAlready2 : InternalClassWithPublicConstructor { }       // Noncompliant
     internal class ConstructorIsInternalAlready3 : InternalClassWithInternalConstructor { }     // Noncompliant
-    internal class WidensConstructorAccessibility4 : InternalClassWithProtectedConstructor { }  // Noncompliant FP
+    internal class WidensConstructorAccessibility4 : InternalClassWithProtectedConstructor { }  // Compliant
 
     class ClassWithNestedClasses
     {

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
@@ -142,28 +142,44 @@ namespace Ignore
     class AssemblyDoc { }                        // Compliant, used for DefaultDocumentation tool
     class NamespaceDoc { }                       // compliant, used for DefaultDocumentation tool
 
-    class BaseWithProtectedConstructor
+    public class PublicClassWithPublicConstructor
     {
-        protected BaseWithProtectedConstructor() { }
+        public PublicClassWithPublicConstructor() { }
     }
 
-    class WidensConstructorVisibility1 : BaseWithProtectedConstructor { }           // Compliant
-
-    class BaseWithInternalConstructor
+    public class PublicClassWithInternalConstructor
     {
-        internal BaseWithInternalConstructor() { }
+        internal PublicClassWithInternalConstructor() { }
     }
 
-    class WidensConstructorVisibility2 : BaseWithInternalConstructor { }            // Compliant
-
-    class BaseWithPublicConstructor
+    public class PublicClassWithProtectedConstructor
     {
-        public BaseWithPublicConstructor() { }
+        protected PublicClassWithProtectedConstructor() { }
     }
 
-    class ConstructorIsPublicAlready1 : BaseWithPublicConstructor { }               // Noncompliant
+    internal class InternalClassWithPublicConstructor
+    {
+        public InternalClassWithPublicConstructor() { }
+    }
 
-    class BaseWithDefaultConstructor { }                                            // Noncompliant
+    internal class InternalClassWithInternalConstructor
+    {
+        internal InternalClassWithInternalConstructor() { }
+    }
 
-    class ConstructorIsPublicAlready2 : BaseWithDefaultConstructor { }              // Noncompliant
+    internal class InternalClassWithProtectedConstructor
+    {
+        protected InternalClassWithProtectedConstructor() { }
+    }
+
+    public class ConstructorIsPublicAlready1 : PublicClassWithPublicConstructor { }             // Noncompliant
+    public class WidensConstructorAccessibility1 : PublicClassWithInternalConstructor { }       // Compliant
+    public class WidensConstructorAccessibility2 : PublicClassWithProtectedConstructor { }      // Compliant
+
+    internal class ConstructorIsPublicAlready2 : PublicClassWithPublicConstructor { }           // Noncompliant
+    internal class ConstructorIsInternalAlready1 : PublicClassWithInternalConstructor { }       // FN
+    internal class WidensConstructorAccessibility3 : PublicClassWithProtectedConstructor { }    // Compliant
+    internal class ConstructorIsInternalAlready2 : InternalClassWithPublicConstructor { }       // Noncompliant
+    internal class ConstructorIsInternalAlready3 : InternalClassWithInternalConstructor { }     // FN
+    internal class WidensConstructorAccessibility4 : InternalClassWithProtectedConstructor { }  // Compliant
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/ClassShouldNotBeEmpty.cs
@@ -121,7 +121,7 @@ namespace Ignore
 
     interface IMarker { }                        // Compliant - this rule only deals with classes
 
-    class ImplementsMarker: IMarker { }          // Compliant - implements a marker interface
+    class ImplementsMarker : IMarker { }          // Compliant - implements a marker interface
 
     struct EmptyStruct { }                       // Compliant - this rule only deals with classes
 
@@ -141,7 +141,10 @@ namespace Ignore
 
     class AssemblyDoc { }                        // Compliant, used for DefaultDocumentation tool
     class NamespaceDoc { }                       // compliant, used for DefaultDocumentation tool
+}
 
+namespace ConstructorAccessibility
+{
     public class PublicClassWithPublicConstructor
     {
         public PublicClassWithPublicConstructor() { }
@@ -177,9 +180,9 @@ namespace Ignore
     public class WidensConstructorAccessibility2 : PublicClassWithProtectedConstructor { }      // Compliant
 
     internal class ConstructorIsPublicAlready2 : PublicClassWithPublicConstructor { }           // Noncompliant
-    internal class ConstructorIsInternalAlready1 : PublicClassWithInternalConstructor { }       // FN
+    internal class ConstructorIsInternalAlready1 : PublicClassWithInternalConstructor { }       // Noncompliant
     internal class WidensConstructorAccessibility3 : PublicClassWithProtectedConstructor { }    // Compliant
     internal class ConstructorIsInternalAlready2 : InternalClassWithPublicConstructor { }       // Noncompliant
-    internal class ConstructorIsInternalAlready3 : InternalClassWithInternalConstructor { }     // FN
-    internal class WidensConstructorAccessibility4 : InternalClassWithProtectedConstructor { }  // Compliant
+    internal class ConstructorIsInternalAlready3 : InternalClassWithInternalConstructor { }     // Noncompliant
+    internal class WidensConstructorAccessibility4 : InternalClassWithProtectedConstructor { }  // Noncompliant FP
 }


### PR DESCRIPTION
Fixes #7591
Follow-up to #9081 
