### PR TITLE
Replace XmlSerializer in ProjectConfigReader

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/ProjectConfig.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/ProjectConfig.cs
@@ -18,50 +18,69 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Xml.Serialization;
+using System.Xml.Linq;
 
-namespace SonarAnalyzer.Helpers
+namespace SonarAnalyzer.Helpers;
+
+/// <summary>
+/// Data class to describe a single project configuration for our analyzers.
+/// </summary>
+/// <remarks>
+/// This class is the counterpart of SonarScanner.MSBuild.Common.ProjectConfig, and is used for easy deserialization.
+/// This class should not be used directly in this codebase. To get configuration properties, use <see cref="ProjectConfigReader"/>.
+/// </remarks>
+internal class ProjectConfig
 {
+    public static readonly ProjectConfig Empty = new(nameof(Helpers.ProjectType.Unknown));
+
     /// <summary>
-    /// Data class to describe a single project configuration for our analyzers.
+    /// Full path to the SonarQubeAnalysisConfig.xml file.
     /// </summary>
-    /// <remarks>
-    /// This class is the counterpart of SonarScanner.MSBuild.Common.ProjectConfig, and is used for easy deserialization.
-    /// This class should not be used in this codebase. To get configuration properties, use <see cref="ProjectConfigReader"/>.
-    /// </remarks>
-    [XmlRoot(ElementName = "SonarProjectConfig", Namespace = "http://www.sonarsource.com/msbuild/analyzer/2021/1")]
-    public class ProjectConfig
+    public string AnalysisConfigPath { get; set; }
+
+    /// <summary>
+    /// The full name and path of the project file.
+    /// </summary>
+    public string ProjectPath { get; set; }
+
+    /// <summary>
+    /// The full name and path of the text file containing all files to analyze.
+    /// </summary>
+    public string FilesToAnalyzePath { get; set; }
+
+    /// <summary>
+    /// Root of the project-specific output directory. Analyzer should write protobuf and other files there.
+    /// </summary>
+    public string OutPath { get; set; }
+
+    /// <summary>
+    /// The kind of the project.
+    /// </summary>
+    public string ProjectType { get; set; }
+
+    /// <summary>
+    /// MSBuild target framework for the current build.
+    /// </summary>
+    public string TargetFramework { get; set; }
+
+    public ProjectConfig(XDocument document)
     {
-        public static readonly ProjectConfig Empty = new ProjectConfig { ProjectType = nameof(Helpers.ProjectType.Unknown) };
+        var xmlns = XNamespace.Get("http://www.sonarsource.com/msbuild/analyzer/2021/1");
+        if (document.Root.Name != xmlns + "SonarProjectConfig")
+        {
+            throw new InvalidOperationException("Unexpected Root: " + document.Root.Name);
+        }
+        AnalysisConfigPath = Read(nameof(AnalysisConfigPath));
+        ProjectPath = Read(nameof(ProjectPath));
+        FilesToAnalyzePath = Read(nameof(FilesToAnalyzePath));
+        OutPath = Read(nameof(OutPath));
+        ProjectType = Read(nameof(ProjectType));
+        TargetFramework = Read(nameof(TargetFramework));
 
-        /// <summary>
-        /// Full path to the SonarQubeAnalysisConfig.xml file.
-        /// </summary>
-        public string AnalysisConfigPath { get; set; }
-
-        /// <summary>
-        /// The full name and path of the project file.
-        /// </summary>
-        public string ProjectPath { get; set; }
-
-        /// <summary>
-        /// The full name and path of the text file containing all files to analyze.
-        /// </summary>
-        public string FilesToAnalyzePath { get; set; }
-
-        /// <summary>
-        /// Root of the project-specific output directory. Analyzer should write protobuf and other files there.
-        /// </summary>
-        public string OutPath { get; set; }
-
-        /// <summary>
-        /// The kind of the project.
-        /// </summary>
-        public string ProjectType { get; set; }
-
-        /// <summary>
-        /// MSBuild target framework for the current build.
-        /// </summary>
-        public string TargetFramework { get; set; }
+        string Read(string name) =>
+            document.Root.Element(xmlns + name)?.Value;
     }
+
+    private ProjectConfig(string projectType) =>
+        ProjectType = projectType;
 }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/ProjectConfigReader.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/ProjectConfigReader.cs
@@ -18,8 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.IO;
-using System.Xml.Serialization;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Text;
 
 namespace SonarAnalyzer.Helpers
@@ -58,9 +57,7 @@ namespace SonarAnalyzer.Helpers
         {
             try
             {
-                var serializer = new XmlSerializer(typeof(ProjectConfig));
-                using var sr = new StringReader(sonarProjectConfig.ToString());
-                return (ProjectConfig)serializer.Deserialize(sr);
+                return new(XDocument.Parse(sonarProjectConfig.ToString()));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Prerequisite for #9061

We need to ILMerge styling analyzer, because it would collide with SonarAnalyzer otherwise.
We will eventually need to ILMerge CSharp analyzer too.

Inside ILMerged assembly, all merged types are internal and that breaks XmlSerializer.

XmlSerializer is evil anyway, so it's good to get rid of it.

We don't want to use use DataContractSerializer to be consistent with #9117, and because it puts too many constraints about element order in place.