### PR TITLE
Replace XmlSerializer in AnalysisConfigReader

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisConfigReader.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/AnalysisConfigReader.cs
@@ -19,7 +19,7 @@
  */
 
 using System.IO;
-using System.Xml.Serialization;
+using System.Xml.Linq;
 
 namespace SonarAnalyzer.Helpers;
 
@@ -34,9 +34,7 @@ public class AnalysisConfigReader
     {
         try
         {
-            var serializer = new XmlSerializer(typeof(AnalysisConfig));
-            using var stream = new FileStream(analysisConfigPath, FileMode.Open, FileAccess.Read);
-            analysisConfig = (AnalysisConfig)serializer.Deserialize(stream);
+            analysisConfig = new(XDocument.Load(analysisConfigPath));
         }
         catch (Exception e)
         {

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/ConfigSetting.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/ConfigSetting.cs
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Xml.Serialization;
+using System.Xml.Linq;
 
 namespace SonarAnalyzer.Helpers;
 
@@ -26,13 +26,9 @@ namespace SonarAnalyzer.Helpers;
 /// Data class to describe an analysis setting.
 /// </summary>
 /// <remarks>
-/// This class is the counterpart of SonarScanner.MSBuild.Common.ConfigSetting, and is used for easy deserialization.
+/// This class is the counterpart of SonarScanner.MSBuild.Common.ConfigSetting.
 /// </remarks>
-public class ConfigSetting
+internal sealed record ConfigSetting(string Id, string Value)
 {
-    [XmlAttribute]
-    public string Id { get; set; }
-
-    [XmlAttribute]
-    public string Value { get; set; }
+    public ConfigSetting(XElement element) : this(element.Attribute("Id").Value, element.Attribute("Value")?.Value) { }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/Helpers/AnalysisConfigReaderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Helpers/AnalysisConfigReaderTest.cs
@@ -20,51 +20,66 @@
 
 using System.IO;
 
-namespace SonarAnalyzer.Test.Helpers
+namespace SonarAnalyzer.Test.Helpers;
+
+[TestClass]
+public class AnalysisConfigReaderTest
 {
-    [TestClass]
-    public class AnalysisConfigReaderTest
+    public TestContext TestContext { get; set; }
+
+    [TestMethod]
+    public void MissingFile_Throws()
     {
-        public TestContext TestContext { get; set; }
+        var path = Path.GetFullPath("ThisFileDoesNotExist.xml");
+        ((Func<AnalysisConfigReader>)(() => new AnalysisConfigReader(path))).Should().Throw<InvalidOperationException>().WithMessage($"File '{path}' could not be parsed.");
+    }
 
-        [TestMethod]
-        public void MissingFile_Throws()
-        {
-            var path = Path.GetFullPath("ThisFileDoesNotExist.xml");
-            ((Func<AnalysisConfigReader>)(() => new AnalysisConfigReader(path))).Should().Throw<InvalidOperationException>().WithMessage($"File '{path}' could not be parsed.");
-        }
+    [TestMethod]
+    [DataRow(@"<?xml that is invalid")]
+    [DataRow(@"<ValidXml><UnexpectedContent /></ValidXml>")]
+    [DataRow(@"<WrongRootCorrectNamespace xmlns=""http://www.sonarsource.com/msbuild/integration/2015/1"" />")]
+    [DataRow(@"<AnalysisConfig xmlns=""http://wrong.namespace"" />")]
+    [DataRow(@"<AnalysisConfig xmlns=""http://www.sonarsource.com/msbuild/integration/2015/1""><AdditionalConfig><ConfigSetting /></AdditionalConfig></AnalysisConfig>")] // No Id attribute
+    public void UnexpectedXml_Throws(string xml)
+    {
+        var path = TestHelper.WriteFile(TestContext, "SonarQubeAnalysisConfig.xml", xml);
+        ((Func<AnalysisConfigReader>)(() => new AnalysisConfigReader(path))).Should().Throw<InvalidOperationException>().WithMessage($"File '{path}' could not be parsed.");
+    }
 
-        [TestMethod]
-        [DataRow(@"<?xml that is invalid")]
-        [DataRow(@"<ValidXml><UnexpectedContent /></ValidXml>")]
-        public void UnexpectedXml_Throws(string xml)
-        {
-            var path = TestHelper.WriteFile(TestContext, "SonarQubeAnalysisConfig.xml", xml);
-            ((Func<AnalysisConfigReader>)(() => new AnalysisConfigReader(path))).Should().Throw<InvalidOperationException>().WithMessage($"File '{path}' could not be parsed.");
-        }
+    [TestMethod]
+    [DataRow(@"<AnalysisConfig xmlns=""http://www.sonarsource.com/msbuild/integration/2015/1""><AdditionalConfig><ConfigSetting Id=""wrong"" Value=""42"" /></AdditionalConfig></AnalysisConfig>")]
+    [DataRow(@"<AnalysisConfig xmlns=""http://www.sonarsource.com/msbuild/integration/2015/1""><AdditionalConfig><ConfigSetting Id=""UnchangedFilesPath"" /></AdditionalConfig></AnalysisConfig>")]
+    [DataRow(@"<AnalysisConfig xmlns=""http://www.sonarsource.com/msbuild/integration/2015/1""><AdditionalConfig><X Id=""UnchangedFilesPath"" Value=""42"" /></AdditionalConfig></AnalysisConfig>")]
+    [DataRow(@"<AnalysisConfig xmlns=""http://www.sonarsource.com/msbuild/integration/2015/1""><AdditionalConfig></AdditionalConfig></AnalysisConfig>")]
+    [DataRow(@"<AnalysisConfig xmlns=""http://www.sonarsource.com/msbuild/integration/2015/1""></AnalysisConfig>")]
+    public void MissingContent_ReturnsEmpty(string xml)
+    {
+        var path = TestHelper.WriteFile(TestContext, "SonarQubeAnalysisConfig.xml", xml);
+        var sut = new AnalysisConfigReader(path);
+        sut.UnchangedFiles().Should().BeEmpty();
+    }
 
-        [TestMethod]
-        public void UnchangedFiles_NotPresent_ReturnsEmpty()
-        {
-            var path = AnalysisScaffolding.CreateAnalysisConfig(TestContext, "SomeOtherProperty", "This is not UnchangedFilesPath");
-            var sut = new AnalysisConfigReader(path);
-            sut.UnchangedFiles().Should().BeEmpty();
-        }
+    [TestMethod]
+    public void UnchangedFiles_NotPresent_ReturnsEmpty()
+    {
+        var path = AnalysisScaffolding.CreateAnalysisConfig(TestContext, "SomeOtherProperty", "This is not UnchangedFilesPath");
+        var sut = new AnalysisConfigReader(path);
+        sut.UnchangedFiles().Should().BeEmpty();
+    }
 
-        [TestMethod]
-        public void UnchangedFiles_Empty_ReturnsEmpty()
-        {
-            var path = AnalysisScaffolding.CreateAnalysisConfig(TestContext, Array.Empty<string>());
-            var sut = new AnalysisConfigReader(path);
-            sut.UnchangedFiles().Should().BeEmpty();
-        }
+    [TestMethod]
+    public void UnchangedFiles_Empty_ReturnsEmpty()
+    {
+        var path = AnalysisScaffolding.CreateAnalysisConfig(TestContext, []);
+        var sut = new AnalysisConfigReader(path);
+        sut.UnchangedFiles().Should().BeEmpty();
+    }
 
-        [TestMethod]
-        public void UnchangedFiles_Present_ReturnsContent()
-        {
-            var path = AnalysisScaffolding.CreateAnalysisConfig(TestContext, new[] { @"C:\File1.cs", @"C:\File2.cs", "Any other string" });
-            var sut = new AnalysisConfigReader(path);
-            sut.UnchangedFiles().Should().BeEquivalentTo(@"C:\File1.cs", @"C:\File2.cs", "Any other string");
-        }
+    [TestMethod]
+    public void UnchangedFiles_Present_ReturnsContent()
+    {
+        var path = AnalysisScaffolding.CreateAnalysisConfig(TestContext, [@"C:\File1.cs", @"C:\File2.cs", "Any other string"]);
+        var sut = new AnalysisConfigReader(path);
+        sut.UnchangedFiles().Should().BeEquivalentTo(@"C:\File1.cs", @"C:\File2.cs", "Any other string");
     }
 }


### PR DESCRIPTION
Prerequisite for https://github.com/SonarSource/sonar-dotnet/issues/9061

We need to ILMerge styling analyzer, because it would collide with SonarAnalyzer otherwise.
We will eventually need to ILMerge CSharp analyzer too.

Inside ILMerged assembly, all merged types are internal and that breaks XmlSerializer.

XmlSerializer is evil anyway, so it's good to get rid of it.

We can't use DataContractSerializer here, because it does not support Xml attributes.