### PR TITLE
ILMerge SonarAnalyzer.CSharp.Styling into a single DLL

### DIFF
--- a/analyzers/NuGet.Config
+++ b/analyzers/NuGet.Config
@@ -33,7 +33,7 @@
       <!-- jamesnk = author of Newtonsoft.Json -->
       <!-- commandlineparser = author of CommandLineParser -->
       <!-- grpc-packages = author of Grpc.Tools -->
-      <owners>protobuf-packages;Microsoft;sharwell;meirb;kzu;dotnetfoundation;castleproject;jonorossi;onovotny;fluentassertions;SteveGilham;jamesnk;commandlineparser;grpc-packages</owners>
+      <owners>protobuf-packages;Microsoft;sharwell;meirb;kzu;dotnetfoundation;castleproject;jonorossi;onovotny;fluentassertions;SteveGilham;jamesnk;commandlineparser;grpc-packages;Fody;</owners>
     </repository>
     <author name="SonarSource">
       <certificate fingerprint="FC4D3F3F815C1B56A656F1A5D9456AF04B469267D945786057175049B15A62A0" hashAlgorithm="SHA256" allowUntrustedRoot="false" />

--- a/analyzers/packaging/SonarAnalyzer.CSharp.Styling.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.CSharp.Styling.nuspec
@@ -13,7 +13,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Internal Sonar styling analyzer for C#</summary>
     <description>This package contains a set of coding style rules to follow in Sonar code base. Coding style changes as well as breaking changes will appear between minor versions without prior notice. We do not provide support for this package.</description>
-    <releaseNotes>https://github.com/SonarSource/sonar-dotnet/releases/tag/9.23.2.0</releaseNotes>
+    <releaseNotes>https://github.com/SonarSource/sonar-dotnet/releases/tag/9.24.0.0</releaseNotes>
     <language>en-US</language>
     <copyright>Copyright © 2015-2024 SonarSource SA</copyright>
     <developmentDependency>true</developmentDependency>
@@ -22,10 +22,6 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="binaries\internal\Google.Protobuf.dll" target="analyzers" />
-    <file src="binaries\internal\SonarAnalyzer.dll" target="analyzers" />
-    <file src="binaries\internal\SonarAnalyzer.CFG.dll" target="analyzers" />
-    <file src="binaries\internal\SonarAnalyzer.CSharp.dll" target="analyzers" />
     <file src="binaries\internal\Internal.SonarAnalyzer.CSharp.Styling.dll" target="analyzers" />
     <file src="logos\sonarsource_64.png" target="images\" />
     <file src="..\..\THIRD-PARTY-NOTICES.txt" target="license\" />

--- a/analyzers/src/Directory.Build.targets
+++ b/analyzers/src/Directory.Build.targets
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <Target Name="CleanBinaries" AfterTargets="Clean">
-    <RemoveDir Directories="$(BinariesFolder)" />
+    <RemoveDir Directories="$(BinariesFolder)" Condition="Exists('$(BinariesFolder)')" />
   </Target>
 </Project>

--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/SonarAnalyzer.CSharp.Styling.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/SonarAnalyzer.CSharp.Styling.csproj
@@ -10,7 +10,18 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <!-- Fody with ILMerge are buggy. Consult SONARSEC-4584 if you see TypeInitializationException, TypeLoadException, or similar at ITs runtime locally -->
+    <PackageReference Include="Fody" Version="6.8.0" PrivateAssets="All" />
+    <PackageReference Include="ILMerge.Fody" Version="1.24.0" PrivateAssets="All" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <WeaverConfiguration>
+      <Weavers>
+        <ILMerge IncludeAssemblies="Google.Protobuf|SonarAnalyzer.*" />
+      </Weavers>
+    </WeaverConfiguration>
+  </PropertyGroup>
 
   <ItemGroup>
     <!-- We need to update NuGet packaging after changing references -->
@@ -32,18 +43,11 @@
   </ItemGroup>
 
   <Target Name="CopyBinaries" AfterTargets="Build">
-    <ItemGroup>
-      <BinariesToCopy Include="$(OutputPath)Google.Protobuf.dll" />
-      <BinariesToCopy Include="$(OutputPath)SonarAnalyzer.dll" />
-      <BinariesToCopy Include="$(OutputPath)SonarAnalyzer.CSharp.dll" />
-      <BinariesToCopy Include="$(OutputPath)SonarAnalyzer.CFG.dll" />
-      <BinariesToCopy Include="$(OutputPath)$(TargetFileName)" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(BinariesFolderInternal)" />
+    <Copy SourceFiles="$(OutputPath)$(TargetFileName)" DestinationFolder="$(BinariesFolderInternal)" />
   </Target>
 
   <Target Name="CleanInternal" AfterTargets="Clean">
-    <RemoveDir Directories="$(BinariesFolderInternal)" />
+    <RemoveDir Directories="$(BinariesFolderInternal)" Condition="Exists('$(BinariesFolderInternal)')" />
   </Target>
 
 </Project>

--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/packages.lock.json
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/packages.lock.json
@@ -2,6 +2,21 @@
   "version": 1,
   "dependencies": {
     ".NETStandard,Version=v2.0": {
+      "Fody": {
+        "type": "Direct",
+        "requested": "[6.8.0, )",
+        "resolved": "6.8.0",
+        "contentHash": "hfZ/f8Mezt8aTkgv9nsvFdYoQ809/AqwsJlOGOPYIfBcG2aAIG3v3ex9d8ZqQuFYyMoucjRg4eKy3VleeGodKQ=="
+      },
+      "ILMerge.Fody": {
+        "type": "Direct",
+        "requested": "[1.24.0, )",
+        "resolved": "1.24.0",
+        "contentHash": "Jg13T22kxyVUCP1lAfjSDKkL01XzMIM+GWd5kv9Hohi/9L2dhHZK55KQe2Yu/sHoQsYvRToeCDuIBKrNOJza7A==",
+        "dependencies": {
+          "Fody": "6.6.4"
+        }
+      },
       "Microsoft.CodeAnalysis.CSharp.Workspaces": {
         "type": "Direct",
         "requested": "[4.9.2, )",


### PR DESCRIPTION
Fixes #9061

Rebase will be needed, these two commits do not need a review as they are in other PRs:
* Replace XmlSerializer in AnalysisConfigReader #9117 
* Replace XmlSerializer in ProjectConfigReader #9116 
