### PR TITLE
Improve discoverability of nuget packages

### DIFF
--- a/analyzers/packaging/SonarAnalyzer.CSharp.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.CSharp.nuspec
@@ -16,7 +16,7 @@
     <releaseNotes>https://github.com/SonarSource/sonar-dotnet/releases/tag/9.24.0.0</releaseNotes>
     <language>en-US</language>
     <copyright>Copyright © 2015-2024 SonarSource SA</copyright>
-    <tags>Roslyn Analyzers Refactoring CodeAnalysis CleanCode Clean Code</tags>
+    <tags>Roslyn Analyzer Analyzers Refactoring CodeAnalysis CleanCode Clean Code Sonar SonarAnalyzer Dotnet CSharp CodeQuality CodeReview StaticCodeAnalysis SonarQube SonarCloud SonarLint</tags>
     <developmentDependency>true</developmentDependency>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />

--- a/analyzers/packaging/SonarAnalyzer.VisualBasic.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.VisualBasic.nuspec
@@ -16,7 +16,7 @@
     <releaseNotes>https://github.com/SonarSource/sonar-dotnet/releases/tag/9.24.0.0</releaseNotes>
     <language>en-US</language>
     <copyright>Copyright © 2015-2024 SonarSource SA</copyright>
-    <tags>Roslyn Analyzers Refactoring CodeAnalysis CleanCode Clean Code</tags>
+    <tags>Roslyn Analyzer Analyzers Refactoring CodeAnalysis CleanCode Clean Code Sonar SonarAnalyzer Dotnet VisualBasic CodeQuality CodeReview StaticCodeAnalysis SonarQube SonarCloud SonarLint</tags>
     <developmentDependency>true</developmentDependency>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="" />

--- a/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.csproj
@@ -9,6 +9,7 @@
     <DefineConstants>TRACE;CS</DefineConstants>
     <!-- Avoid CS0436. see also https://github.com/dotnet/roslyn-analyzers/blob/main/src/PerformanceSensitiveAnalyzers/PerformanceSensitiveAnalyzers.md -->
     <GeneratePerformanceSensitiveAttribute>false</GeneratePerformanceSensitiveAttribute>
+    <PackageTags>Roslyn;Analyzer;Analyzers;Refactoring;CodeAnalysis;CleanCode;Clean Code;Sonar;SonarAnalyzer;Sonar Anlyzer;Dotnet;CSharp;CodeQuality;CodeReview;StaticCodeAnalysis;SonarQube;SonarCloud;SonarLint</PackageTags>
   </PropertyGroup>
 
   <!-- Warning: when adding a package reference, we must make sure this package is available on oldest supported .NET version (currently netstandard2.0) or packaged with the analyzer.

--- a/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.csproj
@@ -7,6 +7,7 @@
     <!-- .NET Standard target does not copy referenced DLLs into bin folder, so we need to enable it explicitly. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <DefineConstants>TRACE;VB</DefineConstants>
+    <PackageTags>Roslyn;Analyzer;Analyzers;Refactoring;CodeAnalysis;CleanCode;Clean Code;Sonar;SonarAnalyzer;Sonar Anlyzer;Dotnet;Visual Basic;CodeQuality;CodeReview;StaticCodeAnalysis;SonarQube;SonarCloud;SonarLint</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The search "sonar dotnet" only reports the scanner, whereas "sonar" also returns the CSharp analyzer in the first position. 
Adding more tags would help discoverability on nuget.org.

See original ticket [here](https://trello.com/c/9TqRfMco/1306-improve-discoverability-of-sonar-analyzers-nuget-packages-on-vs-extensions-management).

Tested in https://int.nugettest.org/

Resources:
* https://learn.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package-using-visual-studio?tabs=netcore-cli
* https://learn.microsoft.com/en-us/nuget/reference/nuspec?WT.mc_id=DT-MVP-5003978#tags