### PR TITLE
Execute `CleanBinaries` target only once

### DIFF
--- a/analyzers/src/Directory.Build.targets
+++ b/analyzers/src/Directory.Build.targets
@@ -9,7 +9,9 @@
     <BinariesFolderInternal>$(BinariesFolder)internal\</BinariesFolderInternal>
   </PropertyGroup>
 
-  <Target Name="CleanBinaries" AfterTargets="Clean">
+  <!-- The condition causes the target to only be executed once during the outer build step.
+       Without it, it will be executed multiple times, which can introduce race conditions. -->
+  <Target Name="CleanBinaries" AfterTargets="Clean" Condition="'$(IsCrossTargetingBuild)' == 'true'">
     <RemoveDir Directories="$(BinariesFolder)" Condition="Exists('$(BinariesFolder)')" />
   </Target>
 </Project>

--- a/analyzers/src/Directory.Build.targets
+++ b/analyzers/src/Directory.Build.targets
@@ -11,7 +11,7 @@
 
   <!-- The condition causes the target to only be executed once during the outer build step.
        Without it, it will be executed multiple times, which can introduce race conditions. -->
-  <Target Name="CleanBinaries" AfterTargets="Clean" Condition="'$(IsCrossTargetingBuild)' == 'true'">
-    <RemoveDir Directories="$(BinariesFolder)" Condition="Exists('$(BinariesFolder)')" />
+  <Target Name="CleanBinaries" AfterTargets="Clean" Condition="'$(IsCrossTargetingBuild)' == 'true' And Exists('$(BinariesFolder)')">
+    <RemoveDir Directories="$(BinariesFolder)" />
   </Target>
 </Project>

--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/SonarAnalyzer.CSharp.Styling.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/SonarAnalyzer.CSharp.Styling.csproj
@@ -50,9 +50,4 @@
   <Target Name="CopyBinaries" AfterTargets="Build" DependsOnTargets="SignDlls">
     <Copy SourceFiles="$(OutputPath)$(TargetFileName)" DestinationFolder="$(BinariesFolderInternal)" />
   </Target>
-
-  <Target Name="CleanInternal" AfterTargets="Clean">
-    <RemoveDir Directories="$(BinariesFolderInternal)" Condition="Exists('$(BinariesFolderInternal)')" />
-  </Target>
-
 </Project>


### PR DESCRIPTION
`CleanBinaries` is responsible for deleting the `packaging/binaries` folder on `clean` or `rebuild`. It is potentially executed multiple times, which can cause problems if projects are not built in the same step (e.g., because of dependencies).
This PR adds a condition to the target to prevent it from being executed multiple times.
The idea for the solution comes from this [StackOverflow post](https://stackoverflow.com/a/46679661).