### PR TITLE
Revert Bump SonarSource/gh-action_release from 5 to 6 (#8986)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6 #uses the latest v5.x.y version rather than a specific version
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5 #uses the latest v5.x.y version rather than a specific version
     with:
       publishToBinaries: true
       mavenCentralSync: true


### PR DESCRIPTION
This reverts commit 649688dd53550bf53e72ee4a5755b61fe07c0ee3.

v6 was unexpectedly deleted