### PR TITLE
Rename TypeHelper to ITypeSymbolExtensions

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Extensions/IParameterSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/IParameterSymbolExtensions.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarAnalyzer.Extensions;
+
+internal static class IParameterSymbolExtensions
+{
+    public static bool IsType(this IParameterSymbol parameter, KnownType type) =>
+        parameter is not null && parameter.Type.Is(type);
+}

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/ISymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/ISymbolExtensions.cs
@@ -20,7 +20,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace SonarAnalyzer.Helpers
+namespace SonarAnalyzer.Extensions // FIXME: file-scoped namespace
 {
     internal static class ISymbolExtensions
     {
@@ -73,5 +73,14 @@ namespace SonarAnalyzer.Helpers
             checkDerivedTypes
                 ? method.ContainingType.DerivesOrImplements(containingType)
                 : method.ContainingType.Is(containingType);
+
+        public static bool IsInType(this ISymbol symbol, KnownType type) =>
+            symbol is not null && symbol.ContainingType.Is(type);
+
+        public static bool IsInType(this ISymbol symbol, ITypeSymbol type) =>
+            symbol?.ContainingType is not null && symbol.ContainingType.Equals(type);
+
+        public static bool IsInType(this ISymbol symbol, ImmutableArray<KnownType> types) =>
+            symbol is not null && symbol.ContainingType.IsAny(types);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/ISymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/ISymbolExtensions.cs
@@ -20,67 +20,66 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-namespace SonarAnalyzer.Extensions // FIXME: file-scoped namespace
+namespace SonarAnalyzer.Extensions;
+
+internal static class ISymbolExtensions
 {
-    internal static class ISymbolExtensions
+    public static bool HasAttribute(this ISymbol symbol, KnownType type) =>
+        symbol.GetAttributes(type).Any();
+
+    public static SyntaxNode GetFirstSyntaxRef(this ISymbol symbol) =>
+        symbol?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
+
+    public static bool IsAutoProperty(this ISymbol symbol) =>
+        symbol.Kind == SymbolKind.Property && symbol.ContainingType.GetMembers().OfType<IFieldSymbol>().Any(x => symbol.Equals(x.AssociatedSymbol));
+
+    public static bool IsTopLevelMain(this ISymbol symbol) =>
+        symbol is IMethodSymbol { Name: TopLevelStatements.MainMethodImplicitName };
+
+    public static bool IsGlobalNamespace(this ISymbol symbol) =>
+        symbol is INamespaceSymbol { Name: "" };
+
+    public static bool IsInSameAssembly(this ISymbol symbol, ISymbol anotherSymbol) =>
+        symbol.ContainingAssembly.Equals(anotherSymbol.ContainingAssembly);
+
+    public static bool HasNotNullAttribute(this ISymbol parameter) =>
+        parameter.GetAttributes() is { Length: > 0 } attributes && attributes.Any(IsNotNullAttribute);
+
+    // https://docs.microsoft.com/dotnet/api/microsoft.validatednotnullattribute
+    // https://docs.microsoft.com/dotnet/csharp/language-reference/attributes/nullable-analysis#postconditions-maybenull-and-notnull
+    // https://www.jetbrains.com/help/resharper/Reference__Code_Annotation_Attributes.html#NotNullAttribute
+    private static bool IsNotNullAttribute(AttributeData attribute) =>
+        attribute.HasAnyName("ValidatedNotNullAttribute", "NotNullAttribute");
+
+    // https://github.com/dotnet/roslyn/blob/2a594fa2157a734a988f7b5dbac99484781599bd/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs#L93
+    [ExcludeFromCodeCoverage]
+    public static ImmutableArray<ISymbol> ExplicitOrImplicitInterfaceImplementations(this ISymbol symbol)
     {
-        public static bool HasAttribute(this ISymbol symbol, KnownType type) =>
-            symbol.GetAttributes(type).Any();
-
-        public static SyntaxNode GetFirstSyntaxRef(this ISymbol symbol) =>
-            symbol?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax();
-
-        public static bool IsAutoProperty(this ISymbol symbol) =>
-            symbol.Kind == SymbolKind.Property && symbol.ContainingType.GetMembers().OfType<IFieldSymbol>().Any(x => symbol.Equals(x.AssociatedSymbol));
-
-        public static bool IsTopLevelMain(this ISymbol symbol) =>
-            symbol is IMethodSymbol { Name: TopLevelStatements.MainMethodImplicitName };
-
-        public static bool IsGlobalNamespace(this ISymbol symbol) =>
-            symbol is INamespaceSymbol { Name: "" };
-
-        public static bool IsInSameAssembly(this ISymbol symbol, ISymbol anotherSymbol) =>
-            symbol.ContainingAssembly.Equals(anotherSymbol.ContainingAssembly);
-
-        public static bool HasNotNullAttribute(this ISymbol parameter) =>
-            parameter.GetAttributes() is { Length: > 0 } attributes && attributes.Any(IsNotNullAttribute);
-
-        // https://docs.microsoft.com/dotnet/api/microsoft.validatednotnullattribute
-        // https://docs.microsoft.com/dotnet/csharp/language-reference/attributes/nullable-analysis#postconditions-maybenull-and-notnull
-        // https://www.jetbrains.com/help/resharper/Reference__Code_Annotation_Attributes.html#NotNullAttribute
-        private static bool IsNotNullAttribute(AttributeData attribute) =>
-            attribute.HasAnyName("ValidatedNotNullAttribute", "NotNullAttribute");
-
-        // https://github.com/dotnet/roslyn/blob/2a594fa2157a734a988f7b5dbac99484781599bd/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs#L93
-        [ExcludeFromCodeCoverage]
-        public static ImmutableArray<ISymbol> ExplicitOrImplicitInterfaceImplementations(this ISymbol symbol)
+        if (symbol.Kind is not SymbolKind.Method and not SymbolKind.Property and not SymbolKind.Event)
         {
-            if (symbol.Kind is not SymbolKind.Method and not SymbolKind.Property and not SymbolKind.Event)
-            {
-                return ImmutableArray<ISymbol>.Empty;
-            }
-
-            var containingType = symbol.ContainingType;
-            var query = from iface in containingType.AllInterfaces
-                        from interfaceMember in iface.GetMembers()
-                        let impl = containingType.FindImplementationForInterfaceMember(interfaceMember)
-                        where symbol.Equals(impl)
-                        select interfaceMember;
-            return query.ToImmutableArray();
+            return ImmutableArray<ISymbol>.Empty;
         }
 
-        public static bool HasContainingType(this ISymbol method, KnownType containingType, bool checkDerivedTypes) =>
-            checkDerivedTypes
-                ? method.ContainingType.DerivesOrImplements(containingType)
-                : method.ContainingType.Is(containingType);
-
-        public static bool IsInType(this ISymbol symbol, KnownType type) =>
-            symbol is not null && symbol.ContainingType.Is(type);
-
-        public static bool IsInType(this ISymbol symbol, ITypeSymbol type) =>
-            symbol?.ContainingType is not null && symbol.ContainingType.Equals(type);
-
-        public static bool IsInType(this ISymbol symbol, ImmutableArray<KnownType> types) =>
-            symbol is not null && symbol.ContainingType.IsAny(types);
+        var containingType = symbol.ContainingType;
+        var query = from iface in containingType.AllInterfaces
+                    from interfaceMember in iface.GetMembers()
+                    let impl = containingType.FindImplementationForInterfaceMember(interfaceMember)
+                    where symbol.Equals(impl)
+                    select interfaceMember;
+        return query.ToImmutableArray();
     }
+
+    public static bool HasContainingType(this ISymbol method, KnownType containingType, bool checkDerivedTypes) =>
+        checkDerivedTypes
+            ? method.ContainingType.DerivesOrImplements(containingType)
+            : method.ContainingType.Is(containingType);
+
+    public static bool IsInType(this ISymbol symbol, KnownType type) =>
+        symbol is not null && symbol.ContainingType.Is(type);
+
+    public static bool IsInType(this ISymbol symbol, ITypeSymbol type) =>
+        symbol?.ContainingType is not null && symbol.ContainingType.Equals(type);
+
+    public static bool IsInType(this ISymbol symbol, ImmutableArray<KnownType> types) =>
+        symbol is not null && symbol.ContainingType.IsAny(types);
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/ITypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/ITypeSymbolExtensions.cs
@@ -18,9 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Helpers;
+namespace SonarAnalyzer.Extensions;
 
-public static class TypeHelper
+public static class ITypeSymbolExtensions
 {
     #region TypeKind
 

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/ITypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/ITypeSymbolExtensions.cs
@@ -39,9 +39,6 @@ public static class ITypeSymbolExtensions
     public static bool IsClassOrStruct(this ITypeSymbol self) =>
         self.IsStruct() || self.IsClass();
 
-    public static bool Is(this ITypeSymbol self, TypeKind typeKind) =>
-        self?.TypeKind == typeKind;
-
     public static bool IsNullableValueType(this ITypeSymbol self) =>
         self.IsStruct() && self is { SpecialType: SpecialType.System_Nullable_T } or { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T };
 
@@ -58,6 +55,9 @@ public static class ITypeSymbolExtensions
 
     public static bool CanBeNull(this ITypeSymbol self) =>
         self is { IsReferenceType: true } || self.IsNullableValueType();
+
+    public static bool Is(this ITypeSymbol self, TypeKind typeKind) =>
+        self?.TypeKind == typeKind;
 
     public static bool Is(this ITypeSymbol typeSymbol, KnownType type) =>
         typeSymbol is not null && type.Matches(typeSymbol);

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/ITypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/ITypeSymbolExtensions.cs
@@ -22,8 +22,6 @@ namespace SonarAnalyzer.Extensions;
 
 public static class ITypeSymbolExtensions
 {
-    #region TypeKind
-
     public static bool IsInterface(this ITypeSymbol self) =>
         self is { TypeKind: TypeKind.Interface };
 
@@ -61,16 +59,12 @@ public static class ITypeSymbolExtensions
     public static bool CanBeNull(this ITypeSymbol self) =>
         self is { IsReferenceType: true } || self.IsNullableValueType();
 
-    #endregion TypeKind
-
-    #region TypeName
-
     public static bool Is(this ITypeSymbol typeSymbol, KnownType type) =>
-        typeSymbol != null && type.Matches(typeSymbol);
+        typeSymbol is not null && type.Matches(typeSymbol);
 
     public static bool IsAny(this ITypeSymbol typeSymbol, params KnownType[] types)
     {
-        if (typeSymbol == null)
+        if (typeSymbol is null)
         {
             return false;
         }
@@ -89,7 +83,7 @@ public static class ITypeSymbolExtensions
 
     public static bool IsAny(this ITypeSymbol typeSymbol, ImmutableArray<KnownType> types)
     {
-        if (typeSymbol == null)
+        if (typeSymbol is null)
         {
             return false;
         }
@@ -112,20 +106,6 @@ public static class ITypeSymbolExtensions
     public static bool IsNullableOf(this ITypeSymbol type, KnownType typeArgument) =>
         NullableTypeArgument(type).Is(typeArgument);
 
-    public static bool IsType(this IParameterSymbol parameter, KnownType type) =>
-        parameter != null && parameter.Type.Is(type);
-
-    public static bool IsInType(this ISymbol symbol, KnownType type) =>
-        symbol != null && symbol.ContainingType.Is(type);
-
-    public static bool IsInType(this ISymbol symbol, ITypeSymbol type) =>
-        symbol?.ContainingType != null && symbol.ContainingType.Equals(type);
-
-    public static bool IsInType(this ISymbol symbol, ImmutableArray<KnownType> types) =>
-        symbol != null && symbol.ContainingType.IsAny(types);
-
-    #endregion TypeName
-
     public static bool IsNullableBoolean(this ITypeSymbol type) =>
         type.IsNullableOf(KnownType.System_Boolean);
 
@@ -139,12 +119,12 @@ public static class ITypeSymbolExtensions
 
     public static bool ImplementsAny(this ITypeSymbol typeSymbol, ImmutableArray<KnownType> types) =>
         typeSymbol is { }
-        && typeSymbol.AllInterfaces.Any(symbol => symbol.ConstructedFrom.IsAny(types));
+        && typeSymbol.AllInterfaces.Any(x => x.ConstructedFrom.IsAny(types));
 
     public static bool DerivesFrom(this ITypeSymbol typeSymbol, KnownType type)
     {
         var currentType = typeSymbol;
-        while (currentType != null)
+        while (currentType is not null)
         {
             if (currentType.Is(type))
             {
@@ -159,7 +139,7 @@ public static class ITypeSymbolExtensions
     public static bool DerivesFrom(this ITypeSymbol typeSymbol, ITypeSymbol type)
     {
         var currentType = typeSymbol;
-        while (currentType != null)
+        while (currentType is not null)
         {
             if (currentType.Equals(type))
             {
@@ -174,7 +154,7 @@ public static class ITypeSymbolExtensions
     public static bool DerivesFromAny(this ITypeSymbol typeSymbol, ImmutableArray<KnownType> baseTypes)
     {
         var currentType = typeSymbol;
-        while (currentType != null)
+        while (currentType is not null)
         {
             if (currentType.IsAny(baseTypes))
             {

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/ITypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/ITypeSymbolExtensions.cs
@@ -110,15 +110,15 @@ public static class ITypeSymbolExtensions
         type.IsNullableOf(KnownType.System_Boolean);
 
     public static bool Implements(this ITypeSymbol typeSymbol, KnownType type) =>
-        typeSymbol is { }
+        typeSymbol is not null
         && typeSymbol.AllInterfaces.Any(x => x.ConstructedFrom.Is(type));
 
     private static bool Implements(this ITypeSymbol typeSymbol, ISymbol type) =>
-        typeSymbol is { }
+        typeSymbol is not null
         && typeSymbol.AllInterfaces.Any(x => type.IsDefinition ? x.OriginalDefinition.Equals(type) : x.Equals(type));
 
     public static bool ImplementsAny(this ITypeSymbol typeSymbol, ImmutableArray<KnownType> types) =>
-        typeSymbol is { }
+        typeSymbol is not null
         && typeSymbol.AllInterfaces.Any(x => x.ConstructedFrom.IsAny(types));
 
     public static bool DerivesFrom(this ITypeSymbol typeSymbol, KnownType type)

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/Extensions/IOperationExtensions.cs
@@ -34,8 +34,7 @@ internal static class IOperationExtensions
             OperationKindEx.DeclarationExpression => IDeclarationExpressionOperationWrapper.FromOperation(operation).Expression.TrackedSymbol(state),
             OperationKindEx.PropertyReference when operation.ToPropertyReference() is { Property: { IsVirtual: false } property } propertyReference
                 && IsStaticOrThis(propertyReference, state)
-                && property.IsAutoProperty()
-                => property,
+                && property.IsAutoProperty() => property,
             _ => null
         };
 
@@ -160,7 +159,7 @@ internal static class IOperationExtensions
         IUnaryOperationWrapper.FromOperation(operation);
 
     public static bool IsStaticOrThis(this IMemberReferenceOperationWrapper reference, ProgramState state) =>
-        reference.Instance == null // static fields
+        reference.Instance is null // static fields
         || state.ResolveCaptureAndUnwrapConversion(reference.Instance).Kind == OperationKindEx.InstanceReference;
 
     public static IOperation UnwrapConversion(this IOperation operation)

--- a/analyzers/tests/SonarAnalyzer.Test/CFG/Roslyn/RoslynControlFlowGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/CFG/Roslyn/RoslynControlFlowGraphTest.cs
@@ -24,19 +24,19 @@ using SonarAnalyzer.CFG.Roslyn;
 using StyleCop.Analyzers.Lightup;
 using FlowAnalysis = Microsoft.CodeAnalysis.FlowAnalysis;
 
-namespace SonarAnalyzer.Test.CFG.Roslyn
-{
-    [TestClass]
-    public class RoslynControlFlowGraphTest
-    {
-        [TestMethod]
-        public void IsAvailable_IsTrue() =>
-            ControlFlowGraph.IsAvailable.Should().BeTrue();
+namespace SonarAnalyzer.Test.CFG.Roslyn;
 
-        [TestMethod]
-        public void Create_ReturnsCfg_CS()
-        {
-            const string code = @"
+[TestClass]
+public class RoslynControlFlowGraphTest
+{
+    [TestMethod]
+    public void IsAvailable_IsTrue() =>
+        ControlFlowGraph.IsAvailable.Should().BeTrue();
+
+    [TestMethod]
+    public void Create_ReturnsCfg_CS()
+    {
+        const string code = @"
 public class Sample
 {
     public int Method()
@@ -44,38 +44,38 @@ public class Sample
         return 42;
     }
 }";
-            TestHelper.CompileCfgCS(code).Should().NotBeNull();
-        }
+        TestHelper.CompileCfgCS(code).Should().NotBeNull();
+    }
 
-        [TestMethod]
-        public void Create_ReturnsCfg_TopLevelStatements()
-        {
-            const string code = """
-                MethodA();
-                MethodB();
+    [TestMethod]
+    public void Create_ReturnsCfg_TopLevelStatements()
+    {
+        const string code = """
+            MethodA();
+            MethodB();
 
-                void MethodA() { }
-                void MethodB() { }
-                """;
-            TestHelper.CompileCfg(code, AnalyzerLanguage.CSharp, outputKind: OutputKind.ConsoleApplication).Should().NotBeNull();
-        }
+            void MethodA() { }
+            void MethodB() { }
+            """;
+        TestHelper.CompileCfg(code, AnalyzerLanguage.CSharp, outputKind: OutputKind.ConsoleApplication).Should().NotBeNull();
+    }
 
-        [TestMethod]
-        public void Create_ReturnsCfg_VB()
-        {
-            const string code = @"
+    [TestMethod]
+    public void Create_ReturnsCfg_VB()
+    {
+        const string code = @"
 Public Class Sample
     Public Function Method() As Integer
         Return 42
     End Function
 End Class";
-            TestHelper.CompileCfg(code, AnalyzerLanguage.VisualBasic).Should().NotBeNull();
-        }
+        TestHelper.CompileCfg(code, AnalyzerLanguage.VisualBasic).Should().NotBeNull();
+    }
 
-        [TestMethod]
-        public void ValidateReflection()
-        {
-            const string code = @"
+    [TestMethod]
+    public void ValidateReflection()
+    {
+        const string code = @"
 public class Sample
 {
     public int Method()
@@ -86,26 +86,26 @@ public class Sample
         int LocalMethod() => 42;
     }
 }";
-            var cfg = TestHelper.CompileCfgCS(code);
-            cfg.Should().NotBeNull();
-            cfg.Root.Should().NotBeNull();
-            cfg.Blocks.Should().NotBeNull().And.HaveCount(3); // Enter, Instructions, Exit
-            cfg.OriginalOperation.Should().NotBeNull().And.BeAssignableTo<IMethodBodyOperation>();
-            cfg.Parent.Should().BeNull();
-            cfg.LocalFunctions.Should().HaveCount(1);
+        var cfg = TestHelper.CompileCfgCS(code);
+        cfg.Should().NotBeNull();
+        cfg.Root.Should().NotBeNull();
+        cfg.Blocks.Should().NotBeNull().And.HaveCount(3); // Enter, Instructions, Exit
+        cfg.OriginalOperation.Should().NotBeNull().And.BeAssignableTo<IMethodBodyOperation>();
+        cfg.Parent.Should().BeNull();
+        cfg.LocalFunctions.Should().HaveCount(1);
 
-            var localFunctionCfg = cfg.GetLocalFunctionControlFlowGraph(cfg.LocalFunctions.Single(), default);
-            localFunctionCfg.Should().NotBeNull();
-            localFunctionCfg.Parent.Should().Be(cfg);
+        var localFunctionCfg = cfg.GetLocalFunctionControlFlowGraph(cfg.LocalFunctions.Single(), default);
+        localFunctionCfg.Should().NotBeNull();
+        localFunctionCfg.Parent.Should().Be(cfg);
 
-            var anonymousFunction = cfg.Blocks.SelectMany(x => x.Operations).SelectMany(x => x.DescendantsAndSelf()).OfType<FlowAnalysis.IFlowAnonymousFunctionOperation>().Single();
-            cfg.GetAnonymousFunctionControlFlowGraph(IFlowAnonymousFunctionOperationWrapper.FromOperation(anonymousFunction), default).Should().NotBeNull();
-        }
+        var anonymousFunction = cfg.Blocks.SelectMany(x => x.Operations).SelectMany(x => x.DescendantsAndSelf()).OfType<FlowAnalysis.IFlowAnonymousFunctionOperation>().Single();
+        cfg.GetAnonymousFunctionControlFlowGraph(IFlowAnonymousFunctionOperationWrapper.FromOperation(anonymousFunction), default).Should().NotBeNull();
+    }
 
-        [TestMethod]
-        public void FlowAnonymousFunctionOperations_FindsAll()
-        {
-            const string code = @"
+    [TestMethod]
+    public void FlowAnonymousFunctionOperations_FindsAll()
+    {
+        const string code = @"
 public class Sample {
     private System.Action<int> Simple(int a)
     {
@@ -117,22 +117,21 @@ public class Sample {
         return x => {  };
     }
 }";
-            var cfg = TestHelper.CompileCfgCS(code);
-            var anonymousFunctionOperations = SonarAnalyzer.Extensions.ControlFlowGraphExtensions.FlowAnonymousFunctionOperations(cfg).ToList();
-            anonymousFunctionOperations.Should().HaveCount(2);
-            cfg.GetAnonymousFunctionControlFlowGraph(anonymousFunctionOperations[0], default).Should().NotBeNull();
-            cfg.GetAnonymousFunctionControlFlowGraph(anonymousFunctionOperations[1], default).Should().NotBeNull();
-        }
+        var cfg = TestHelper.CompileCfgCS(code);
+        var anonymousFunctionOperations = SonarAnalyzer.Extensions.ControlFlowGraphExtensions.FlowAnonymousFunctionOperations(cfg).ToList();
+        anonymousFunctionOperations.Should().HaveCount(2);
+        cfg.GetAnonymousFunctionControlFlowGraph(anonymousFunctionOperations[0], default).Should().NotBeNull();
+        cfg.GetAnonymousFunctionControlFlowGraph(anonymousFunctionOperations[1], default).Should().NotBeNull();
+    }
 
-        [TestMethod]
-        public void RoslynCfgSupportedVersions()
-        {
-            // We are running on 3 rd major version - it is the minimum requirement
-            RoslynHelper.IsRoslynCfgSupported().Should().BeTrue();
-            // If we set minimum requirement to 2 - we will able to pass the check even with old MsBuild
-            RoslynHelper.IsRoslynCfgSupported(2).Should().BeTrue();
-            // If we set minimum requirement to 100 - we won't be able to pass the check
-            RoslynHelper.IsRoslynCfgSupported(100).Should().BeFalse();
-        }
+    [TestMethod]
+    public void RoslynCfgSupportedVersions()
+    {
+        // We are running on 3 rd major version - it is the minimum requirement
+        RoslynHelper.IsRoslynCfgSupported().Should().BeTrue();
+        // If we set minimum requirement to 2 - we will able to pass the check even with old MsBuild
+        RoslynHelper.IsRoslynCfgSupported(2).Should().BeTrue();
+        // If we set minimum requirement to 100 - we won't be able to pass the check
+        RoslynHelper.IsRoslynCfgSupported(100).Should().BeFalse();
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/CFG/Roslyn/RoslynControlFlowGraphTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/CFG/Roslyn/RoslynControlFlowGraphTest.cs
@@ -36,14 +36,15 @@ public class RoslynControlFlowGraphTest
     [TestMethod]
     public void Create_ReturnsCfg_CS()
     {
-        const string code = @"
-public class Sample
-{
-    public int Method()
-    {
-        return 42;
-    }
-}";
+        const string code = """
+            public class Sample
+            {
+                public int Method()
+                {
+                    return 42;
+                }
+            }
+            """;
         TestHelper.CompileCfgCS(code).Should().NotBeNull();
     }
 
@@ -63,29 +64,31 @@ public class Sample
     [TestMethod]
     public void Create_ReturnsCfg_VB()
     {
-        const string code = @"
-Public Class Sample
-    Public Function Method() As Integer
-        Return 42
-    End Function
-End Class";
+        const string code = """
+            Public Class Sample
+                Public Function Method() As Integer
+                    Return 42
+                End Function
+            End Class
+            """;
         TestHelper.CompileCfg(code, AnalyzerLanguage.VisualBasic).Should().NotBeNull();
     }
 
     [TestMethod]
     public void ValidateReflection()
     {
-        const string code = @"
-public class Sample
-{
-    public int Method()
-    {
-        System.Action a = () => { };
-        return LocalMethod();
+        const string code = """
+            public class Sample
+            {
+                public int Method()
+                {
+                    System.Action a = () => { };
+                    return LocalMethod();
 
-        int LocalMethod() => 42;
-    }
-}";
+                    int LocalMethod() => 42;
+                }
+            }
+            """;
         var cfg = TestHelper.CompileCfgCS(code);
         cfg.Should().NotBeNull();
         cfg.Root.Should().NotBeNull();
@@ -105,18 +108,19 @@ public class Sample
     [TestMethod]
     public void FlowAnonymousFunctionOperations_FindsAll()
     {
-        const string code = @"
-public class Sample {
-    private System.Action<int> Simple(int a)
-    {
-        var x = 42;
-        if (a == 42)
-        {
-            return (x) => {  };
-        }
-        return x => {  };
-    }
-}";
+        const string code = """
+            public class Sample {
+                private System.Action<int> Simple(int a)
+                {
+                    var x = 42;
+                    if (a == 42)
+                    {
+                        return (x) => {  };
+                    }
+                    return x => {  };
+                }
+            }
+            """;
         var cfg = TestHelper.CompileCfgCS(code);
         var anonymousFunctionOperations = SonarAnalyzer.Extensions.ControlFlowGraphExtensions.FlowAnonymousFunctionOperations(cfg).ToList();
         anonymousFunctionOperations.Should().HaveCount(2);

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/IParameterSymbolExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/IParameterSymbolExtensionsTest.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarAnalyzer.Extensions;
+
+namespace SonarAnalyzer.Test.Extensions;
+
+[TestClass]
+public class IParameterSymbolExtensionsTest
+{
+    [TestMethod]
+    public void IsType_Null() =>
+        IParameterSymbolExtensions.IsType(null, KnownType.System_Boolean).Should().BeFalse();
+}

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/ISymbolExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/ISymbolExtensionsTest.cs
@@ -18,13 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-extern alias vbnet;
+extern alias common;
 extern alias csharp;
+extern alias vbnet;
 
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using CodeAnalysisCS = Microsoft.CodeAnalysis.CSharp;
 using CodeAnalysisVB = Microsoft.CodeAnalysis.VisualBasic;
-using ISymbolExtensionsCommon = SonarAnalyzer.Helpers.ISymbolExtensions;
+using ISymbolExtensionsCommon = common::SonarAnalyzer.Extensions.ISymbolExtensions;
 using ISymbolExtensionsCS = csharp::SonarAnalyzer.Extensions.ISymbolExtensions;
 using ISymbolExtensionsVB = vbnet::SonarAnalyzer.Extensions.ISymbolExtensions;
 
@@ -59,13 +60,9 @@ public class ISymbolExtensionsTest
     [DataRow("{ get; }")]
     [DataRow("{ get; } = string.Empty;")]
     [DataRow("{ get; set; } = string.Empty;")]
-
 #if NET
-
     [DataRow("{ get; init; }")]
-
 #endif
-
     public void IsAutoProperty_AutoProperty_CS(string getterSetter)
     {
         var code = $$"""
@@ -80,74 +77,79 @@ public class ISymbolExtensionsTest
     [TestMethod]
     public void IsAutoProperty_AutoProperty_VB()
     {
-        const string code = @"
-Public Class Sample
+        const string code = """
+            Public Class Sample
 
-    Public Property SymbolMember As String
+                Public Property SymbolMember As String
 
-End Class";
+            End Class
+            """;
         ISymbolExtensionsCommon.IsAutoProperty(CreateSymbol(code, AnalyzerLanguage.VisualBasic)).Should().BeTrue();
     }
 
     [TestMethod]
     public void IsAutoProperty_ExplicitProperty_CS()
     {
-        const string code = @"
-public class Sample
-{
-    private string _SymbolMember; // Try to confuse the method with auto-like implementation
+        const string code = """
+            public class Sample
+            {
+                private string _SymbolMember; // Try to confuse the method with auto-like implementation
 
-    public string SymbolMember
-    {
-        get => _SymbolMember;
-        set { _SymbolMember = value; }
-    }
-}";
+                public string SymbolMember
+                {
+                    get => _SymbolMember;
+                    set { _SymbolMember = value; }
+                }
+            }
+            """;
         ISymbolExtensionsCommon.IsAutoProperty(CreateSymbol(code, AnalyzerLanguage.CSharp)).Should().BeFalse();
     }
 
     [TestMethod]
     public void IsAutoProperty_ExplicitProperty_VB()
     {
-        const string code = @"
-Public Class Sample
+        const string code = """
+            Public Class Sample
 
-    Private _SymbolMember As String ' Try to confuse the method with auto-like implementation
+                Private _SymbolMember As String ' Try to confuse the method with auto-like implementation
 
-    Public Property SymbolMember As String
-        Get
-            Return _SymbolMember
-        End Get
-        Set(value As String)
-            _SymbolMember = value
-        End Set
-    End Property
+                Public Property SymbolMember As String
+                    Get
+                        Return _SymbolMember
+                    End Get
+                    Set(value As String)
+                        _SymbolMember = value
+                    End Set
+                End Property
 
-End Class";
+            End Class
+            """;
         ISymbolExtensionsCommon.IsAutoProperty(CreateSymbol(code, AnalyzerLanguage.VisualBasic)).Should().BeFalse();
     }
 
     [TestMethod]
     public void IsAutoProperty_NonpropertySymbol_CS()
     {
-        const string code = @"
-public class Sample
-{
-    public void SymbolMember() { }
-}";
+        const string code = """
+            public class Sample
+            {
+                public void SymbolMember() { }
+            }
+            """;
         ISymbolExtensionsCommon.IsAutoProperty(CreateSymbol(code, AnalyzerLanguage.CSharp)).Should().BeFalse();
     }
 
     [TestMethod]
     public void IsAutoProperty_NonpropertySymbol_VB()
     {
-        const string code = @"
-Public Class Sample
+        const string code = """
+            Public Class Sample
 
-    Public Sub SymbolMember()
-    End Sub
+                Public Sub SymbolMember()
+                End Sub
 
-End Class";
+            End Class
+            """;
         ISymbolExtensionsCommon.IsAutoProperty(CreateSymbol(code, AnalyzerLanguage.VisualBasic)).Should().BeFalse();
     }
 
@@ -162,12 +164,12 @@ End Class";
     [DataRow("class SymbolMember { SymbolMember() { } };", false)]
     [DataRow("class Base(int i); class SymbolMember() : Base(1);", true)]
     [DataRow("""
-    class Base(int i);
-    class SymbolMember : Base
-    {
-        @SymbolMember() : base(1) { }
-    }
-    """, false)]
+        class Base(int i);
+        class SymbolMember : Base
+        {
+            @SymbolMember() : base(1) { }
+        }
+        """, false)]
     [DataRow("struct SymbolMember();", true)]
     [DataRow("struct SymbolMember() { }", true)]
     [DataRow("struct SymbolMember(int a) { }", true)]

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/ISymbolExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/ISymbolExtensionsTest.cs
@@ -55,6 +55,18 @@ public class ISymbolExtensionsTest
         ISymbolExtensionsVB.GetDescendantNodes(tree.GetRoot().GetLocation(), tree.GetRoot()).Should().BeEmpty();
     }
 
+    [TestMethod]
+    public void IsInType_Null_KnownType() =>
+        ISymbolExtensionsCommon.IsInType(null, KnownType.System_Boolean).Should().BeFalse();
+
+    [TestMethod]
+    public void IsInType_Null_TypeSymbol() =>
+        ISymbolExtensionsCommon.IsInType(null, (ITypeSymbol)null).Should().BeFalse();
+
+    [TestMethod]
+    public void IsInType_Null_ArrayOfTypeSymbols() =>
+        ISymbolExtensionsCommon.IsInType(null, []).Should().BeFalse();
+
     [DataTestMethod]
     [DataRow("{ get; set; }")]
     [DataRow("{ get; }")]

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/ITypeSymbolExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/ITypeSymbolExtensionsTest.cs
@@ -19,6 +19,7 @@
  */
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SonarAnalyzer.Extensions;
 using SonarAnalyzer.Test.Helpers;
 
 namespace SonarAnalyzer.Test.Extensions;
@@ -35,22 +36,16 @@ public class ITypeSymbolExtensionsTest
     [TestInitialize]
     public void Compile()
     {
-        using (var workspace = new AdhocWorkspace())
-        {
-            var document = workspace.CurrentSolution.AddProject("foo", "foo.dll", LanguageNames.CSharp)
-                .AddDocument("test", SymbolHelperTest.TestInput);
-            var compilation = document.Project.GetCompilationAsync().Result;
-            var tree = compilation.SyntaxTrees.First();
-            semanticModel = compilation.GetSemanticModel(tree);
+        using var workspace = new AdhocWorkspace();
+        var document = workspace.CurrentSolution.AddProject("foo", "foo.dll", LanguageNames.CSharp).AddDocument("test", SymbolHelperTest.TestInput);
+        var compilation = document.Project.GetCompilationAsync().Result;
+        var tree = compilation.SyntaxTrees.First();
+        semanticModel = compilation.GetSemanticModel(tree);
 
-            root = tree.GetRoot();
-            baseClassDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
-                .First(m => m.Identifier.ValueText == "Base");
-            derivedClassDeclaration1 = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
-                .First(m => m.Identifier.ValueText == "Derived1");
-            derivedClassDeclaration2 = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
-                .First(m => m.Identifier.ValueText == "Derived2");
-        }
+        root = tree.GetRoot();
+        baseClassDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First(x => x.Identifier.ValueText == "Base");
+        derivedClassDeclaration1 = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First(x => x.Identifier.ValueText == "Derived1");
+        derivedClassDeclaration2 = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First(x => x.Identifier.ValueText == "Derived2");
     }
 
     [TestMethod]
@@ -134,14 +129,14 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             struct CustomStruct { }
-                record struct RecordStruct { }
-                ref struct CustomRefStruct { }
+            record struct RecordStruct { }
+            ref struct CustomRefStruct { }
 
-                ref struct Test
-                {
-                    {{type}} field;
-                }
-                """);
+            ref struct Test
+            {
+                {{type}} field;
+            }
+            """);
         fieldSymbol.Type.IsStruct().Should().BeTrue();
     }
 
@@ -152,10 +147,10 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             class Test
-                {
-                    {{type}} field;
-                }
-                """);
+            {
+                {{type}} field;
+            }
+            """);
         fieldSymbol.Type.IsStruct().Should().BeFalse();
     }
 
@@ -166,11 +161,11 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             using System;
-                class Test<T> where T: {{typeConstraint}}
-                {
-                    T field;
-                }
-                """);
+            class Test<T> where T: {{typeConstraint}}
+            {
+                T field;
+            }
+            """);
         fieldSymbol.Type.IsStruct().Should().BeTrue();
     }
 
@@ -182,11 +177,11 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             using System;
-                class Test<T> where T: struct
-                {
-                    {{type}} field;
-                }
-                """);
+            class Test<T> where T: struct
+            {
+                {{type}} field;
+            }
+            """);
         fieldSymbol.Type.IsStruct().Should().BeTrue();
     }
 
@@ -205,11 +200,11 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             using System;
-                class Test<T> {{typeConstraint}}
-                {
-                    T field;
-                }
-                """);
+            class Test<T> {{typeConstraint}}
+            {
+                T field;
+            }
+            """);
         fieldSymbol.Type.IsStruct().Should().BeFalse();
     }
 
@@ -230,12 +225,12 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             #nullable enable
-                using System;
-                class Test<T> {{typeConstraint}}
-                {
-                    T? field;
-                }
-                """);
+            using System;
+            class Test<T> {{typeConstraint}}
+            {
+                T? field;
+            }
+            """);
         fieldSymbol.Type.IsStruct().Should().BeFalse();
     }
 
@@ -244,11 +239,11 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             using System;
-                class Test<T, U> where U: T
-                {
-                    U field;
-                }
-                """);
+            class Test<T, U> where U: T
+            {
+                U field;
+            }
+            """);
         fieldSymbol.Type.IsStruct().Should().BeFalse();
     }
 
@@ -281,14 +276,14 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             struct CustomStruct { }
-                record struct RecordStruct { }
-                ref struct CustomRefStruct { }
+            record struct RecordStruct { }
+            ref struct CustomRefStruct { }
 
-                ref struct Test
-                {
-                    {{type}} field;
-                }
-                """);
+            ref struct Test
+            {
+                {{type}} field;
+            }
+            """);
         fieldSymbol.Type.IsNonNullableValueType().Should().BeTrue();
     }
 
@@ -301,10 +296,10 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             class Test
-                {
-                    {{type}} field;
-                }
-                """);
+            {
+                {{type}} field;
+            }
+            """);
         fieldSymbol.Type.IsNonNullableValueType().Should().BeFalse();
     }
 
@@ -315,11 +310,11 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             using System;
-                class Test<T> where T: {{typeConstraint}}
-                {
-                    T field;
-                }
-                """);
+            class Test<T> where T: {{typeConstraint}}
+            {
+                T field;
+            }
+            """);
         fieldSymbol.Type.IsNonNullableValueType().Should().BeTrue();
     }
 
@@ -330,11 +325,11 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             using System;
-                class Test<T> where T: struct
-                {
-                    {{type}} field;
-                }
-                """);
+            class Test<T> where T: struct
+            {
+                {{type}} field;
+            }
+            """);
         fieldSymbol.Type.IsNonNullableValueType().Should().BeFalse();
     }
 
@@ -360,12 +355,12 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             #nullable enable
-                using System;
-                class Test<T> {{constraint}}
-                {
-                    T? field;
-                }
-                """);
+            using System;
+            class Test<T> {{constraint}}
+            {
+                T? field;
+            }
+            """);
         fieldSymbol.Type.IsNonNullableValueType().Should().BeFalse();
     }
 
@@ -376,10 +371,10 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             class Test
-                {
-                    {{type}} field;
-                }
-                """);
+            {
+                {{type}} field;
+            }
+            """);
         fieldSymbol.Type.IsNullableValueType().Should().BeTrue();
     }
 
@@ -395,14 +390,14 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             struct CustomStruct { }
-                record struct RecordStruct { }
-                ref struct CustomRefStruct { }
+            record struct RecordStruct { }
+            ref struct CustomRefStruct { }
 
-                ref struct Test
-                {
-                    {{type}} field;
-                }
-                """);
+            ref struct Test
+            {
+                {{type}} field;
+            }
+            """);
         fieldSymbol.Type.IsNullableValueType().Should().BeFalse();
     }
 
@@ -415,13 +410,13 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             using System;
-                struct CustomStruct { }
-                record struct RecordStruct { }
-                class Test<T> where T: struct
-                {
-                    {{type}} field;
-                }
-                """);
+            struct CustomStruct { }
+            record struct RecordStruct { }
+            class Test<T> where T: struct
+            {
+                {{type}} field;
+            }
+            """);
         fieldSymbol.Type.IsNullableValueType().Should().BeTrue();
     }
 
@@ -434,11 +429,11 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             using System;
-                class Test<T> where T: {{constraint}}
-                {
-                    T? field;
-                }
-                """);
+            class Test<T> where T: {{constraint}}
+            {
+                T? field;
+            }
+            """);
         fieldSymbol.Type.IsNullableValueType().Should().BeTrue();
     }
 
@@ -449,11 +444,11 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             using System;
-                class Test<T> where T: {{typeConstraint}}
-                {
-                    T field;
-                }
-                """);
+            class Test<T> where T: {{typeConstraint}}
+            {
+                T field;
+            }
+            """);
         fieldSymbol.Type.IsNullableValueType().Should().BeFalse();
     }
 
@@ -475,12 +470,12 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             #nullable enable
-                using System;
-                class Test<T> {{typeConstraint}}
-                {
-                    T? field;
-                }
-                """);
+            using System;
+            class Test<T> {{typeConstraint}}
+            {
+                T? field;
+            }
+            """);
         fieldSymbol.Type.IsNullableValueType().Should().BeFalse();
     }
 
@@ -493,12 +488,12 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             #nullable enable
-                using System;
-                class Test<T> {{typeConstraint}}
-                {
-                    {{fieldType}} field;
-                }
-                """);
+            using System;
+            class Test<T> {{typeConstraint}}
+            {
+                {{fieldType}} field;
+            }
+            """);
         fieldSymbol.Type.IsEnum().Should().BeTrue();
     }
 
@@ -512,12 +507,12 @@ public class ITypeSymbolExtensionsTest
     {
         var fieldSymbol = FirstFieldSymbolFromCode($$"""
             #nullable enable
-                using System;
-                class Test<T> {{typeConstraint}}
-                {
-                    {{fieldType}} field;
-                }
-                """);
+            using System;
+            class Test<T> {{typeConstraint}}
+            {
+                {{fieldType}} field;
+            }
+            """);
         fieldSymbol.Type.IsEnum().Should().BeFalse();
     }
 

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/ITypeSymbolExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/ITypeSymbolExtensionsTest.cs
@@ -49,6 +49,14 @@ public class ITypeSymbolExtensionsTest
     }
 
     [TestMethod]
+    public void IsAny_Null() =>
+        ((ITypeSymbol)null).IsAny(KnownType.System_Boolean).Should().BeFalse();
+
+    [TestMethod]
+    public void ImplementsAny_Null() =>
+        ((ITypeSymbol)null).ImplementsAny([KnownType.System_Boolean]).Should().BeFalse();
+
+    [TestMethod]
     public void Type_DerivesOrImplementsAny()
     {
         var baseType = new KnownType("NS.Base");

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/ITypeSymbolExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/ITypeSymbolExtensionsTest.cs
@@ -19,11 +19,12 @@
  */
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SonarAnalyzer.Test.Helpers;
 
-namespace SonarAnalyzer.Test.Helpers
+namespace SonarAnalyzer.Test.Extensions
 {
     [TestClass]
-    public class TypeHelperTest
+    public class ITypeSymbolExtensionsTest
     {
         private ClassDeclarationSyntax baseClassDeclaration;
         private ClassDeclarationSyntax derivedClassDeclaration1;

--- a/analyzers/tests/SonarAnalyzer.Test/Helpers/KnownTypeTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Helpers/KnownTypeTest.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using SonarAnalyzer.Extensions;
 using CS = Microsoft.CodeAnalysis.CSharp.Syntax;
 using VB = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 

--- a/analyzers/tests/SonarAnalyzer.Test/SonarAnalyzer.Test.csproj
+++ b/analyzers/tests/SonarAnalyzer.Test/SonarAnalyzer.Test.csproj
@@ -28,7 +28,9 @@
   <ItemGroup>
     <ProjectReference Include="..\SonarAnalyzer.TestFramework\SonarAnalyzer.TestFramework.csproj" />
     <ProjectReference Include="..\..\src\SonarAnalyzer.CFG\SonarAnalyzer.CFG.csproj" />
-    <ProjectReference Include="..\..\src\SonarAnalyzer.Common\SonarAnalyzer.Common.csproj" />
+    <ProjectReference Include="..\..\src\SonarAnalyzer.Common\SonarAnalyzer.Common.csproj">
+      <Aliases>global,common</Aliases>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.csproj">
       <Aliases>global,csharp</Aliases>
     </ProjectReference>

--- a/analyzers/tests/SonarAnalyzer.Test/SymbolicExecution/Roslyn/IOperationExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/SymbolicExecution/Roslyn/IOperationExtensionsTest.cs
@@ -19,9 +19,10 @@
  */
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Operations;
+using SonarAnalyzer.Extensions;
 using SonarAnalyzer.SymbolicExecution.Roslyn;
 using StyleCop.Analyzers.Lightup;
+using Operations = Microsoft.CodeAnalysis.Operations;
 
 namespace SonarAnalyzer.Test.SymbolicExecution.Roslyn;
 
@@ -31,7 +32,7 @@ public class IOperationExtensionsTest
     [TestMethod]
     public void TrackedSymbol_LocalReference_IsVariableSymbol()
     {
-        var localReference = ((ISimpleAssignmentOperation)TestHelper.CompileCfgBodyCS("var a = true;").Blocks[1].Operations[0]).Target;
+        var localReference = ((Operations.ISimpleAssignmentOperation)TestHelper.CompileCfgBodyCS("var a = true;").Blocks[1].Operations[0]).Target;
         var symbol = localReference.ToLocalReference().Local;
         localReference.TrackedSymbol(ProgramState.Empty).Should().Be(symbol);
     }
@@ -39,8 +40,8 @@ public class IOperationExtensionsTest
     [TestMethod]
     public void TrackedSymbol_ParameterReference_IsParameterSymbol()
     {
-        var expressionStatement = (IExpressionStatementOperation)TestHelper.CompileCfgBodyCS("parameter = true;", "bool parameter").Blocks[1].Operations[0];
-        var parameterReference = ((ISimpleAssignmentOperation)expressionStatement.Operation).Target;
+        var expressionStatement = (Operations.IExpressionStatementOperation)TestHelper.CompileCfgBodyCS("parameter = true;", "bool parameter").Blocks[1].Operations[0];
+        var parameterReference = ((Operations.ISimpleAssignmentOperation)expressionStatement.Operation).Target;
         var symbol = IParameterReferenceOperationWrapper.FromOperation(parameterReference).Parameter;
         parameterReference.TrackedSymbol(ProgramState.Empty).Should().Be(symbol);
     }
@@ -54,8 +55,8 @@ public class IOperationExtensionsTest
     {
         var code = $"public class C {{ int field; static int StaticField; void Method() {{ {assignment}; }} }}";
         var graph = TestHelper.CompileCfgCS(code);
-        var expressionStatement = (IExpressionStatementOperation)graph.Blocks[1].Operations[0];
-        var assignmentTarget = ((ISimpleAssignmentOperation)expressionStatement.Operation).Target;
+        var expressionStatement = (Operations.IExpressionStatementOperation)graph.Blocks[1].Operations[0];
+        var assignmentTarget = ((Operations.ISimpleAssignmentOperation)expressionStatement.Operation).Target;
         var fieldReferenceSymbol = IFieldReferenceOperationWrapper.FromOperation(assignmentTarget).Field;
         assignmentTarget.TrackedSymbol(ProgramState.Empty).Should().Be(fieldReferenceSymbol);
     }
@@ -78,8 +79,8 @@ public class IOperationExtensionsTest
             }
             """;
         var cfg = TestHelper.CompileCfgCS(code);
-        var assignment = (ISimpleAssignmentOperation)cfg.Blocks[1].Operations.Single();
-        var enumReference = (IFieldReferenceOperation)assignment.Value;
+        var assignment = (Operations.ISimpleAssignmentOperation)cfg.Blocks[1].Operations.Single();
+        var enumReference = (Operations.IFieldReferenceOperation)assignment.Value;
         enumReference.TrackedSymbol(ProgramState.Empty).Should().BeNull();
     }
 
@@ -136,8 +137,8 @@ public class IOperationExtensionsTest
                 }
             """;
         var graph = TestHelper.CompileCfgCS(code);
-        var expressionStatement = (IExpressionStatementOperation)graph.Blocks[1].Operations[0];
-        var assignmentTarget = ((ISimpleAssignmentOperation)expressionStatement.Operation).Target;
+        var expressionStatement = (Operations.IExpressionStatementOperation)graph.Blocks[1].Operations[0];
+        var assignmentTarget = ((Operations.ISimpleAssignmentOperation)expressionStatement.Operation).Target;
         var propertyReferenceSymbol = IPropertyReferenceOperationWrapper.FromOperation(assignmentTarget).Property;
         assignmentTarget.TrackedSymbol(ProgramState.Empty).Should().Be(tracked ? propertyReferenceSymbol : null);
     }
@@ -191,7 +192,7 @@ public class IOperationExtensionsTest
 
     [TestMethod]
     public void TrackedSymbol_NullSafe() =>
-        IOperationExtensions.TrackedSymbol(null, ProgramState.Empty).Should().BeNull();
+        SonarAnalyzer.SymbolicExecution.Roslyn.IOperationExtensions.TrackedSymbol(null, ProgramState.Empty).Should().BeNull();
 
     [TestMethod]
     public void TrackedSymbol_DeclarationExpression_Tuple()


### PR DESCRIPTION
There are some file-scoped namespaces and file renames.  Review per commit should be easier