### PR TITLE
Improve S6967: Add check for base classes with ApiController attribute

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/CallModelStateIsValid.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/CallModelStateIsValid.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using SonarAnalyzer.Helpers;
+
 namespace SonarAnalyzer.Rules.CSharp;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -88,12 +90,10 @@ public sealed class CallModelStateIsValid : SonarDiagnosticAnalyzer
     }
 
     private static bool HasApiControllerAttribute(ITypeSymbol type) =>
-        type is not null
-        && (type.HasAttribute(KnownType.Microsoft_AspNetCore_Mvc_ApiControllerAttribute)
-            || HasApiControllerAttribute(type.BaseType));
+        type.GetAttributesWithInherited().Any(x => x.AttributeClass.DerivesFrom(KnownType.Microsoft_AspNetCore_Mvc_ApiControllerAttribute));
 
     private static bool HasActionFilterAttribute(ISymbol symbol) =>
-        symbol.GetAttributes().Any(x => x.AttributeClass.DerivesFrom(KnownType.Microsoft_AspNetCore_Mvc_Filters_ActionFilterAttribute));
+        symbol.GetAttributesWithInherited().Any(x => x.AttributeClass.DerivesFrom(KnownType.Microsoft_AspNetCore_Mvc_Filters_ActionFilterAttribute));
 
     private static bool IsCheckingValidityProperty(SyntaxNode node, SemanticModel semanticModel) =>
         node.GetIdentifier() is { ValueText: "IsValid" or "ValidationState" } nodeIdentifier

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/CallModelStateIsValid.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/CallModelStateIsValid.cs
@@ -18,9 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-
 namespace SonarAnalyzer.Rules.CSharp;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -54,7 +51,7 @@ public sealed class CallModelStateIsValid : SonarDiagnosticAnalyzer
                 {
                     var type = (INamedTypeSymbol)symbolStart.Symbol;
                     if (type.DerivesFrom(KnownType.Microsoft_AspNetCore_Mvc_ControllerBase)
-                        && !type.HasAttribute(KnownType.Microsoft_AspNetCore_Mvc_ApiControllerAttribute)
+                        && !HasApiControllerAttribute(type)
                         && !HasActionFilterAttribute(type))
                     {
                         symbolStart.RegisterCodeBlockStartAction<SyntaxKind>(ProcessCodeBlock);
@@ -89,6 +86,11 @@ public sealed class CallModelStateIsValid : SonarDiagnosticAnalyzer
             });
         }
     }
+
+    private static bool HasApiControllerAttribute(ITypeSymbol type) =>
+        type is not null
+        && (type.HasAttribute(KnownType.Microsoft_AspNetCore_Mvc_ApiControllerAttribute)
+            || HasApiControllerAttribute(type.BaseType));
 
     private static bool HasActionFilterAttribute(ISymbol symbol) =>
         symbol.GetAttributes().Any(x => x.AttributeClass.DerivesFrom(KnownType.Microsoft_AspNetCore_Mvc_Filters_ActionFilterAttribute));

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/AspNet/CallModelStateIsValid.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/AspNet/CallModelStateIsValid.cs
@@ -102,6 +102,15 @@ public class ControllerWithApiAttributeAtTheClassLevel : ControllerBase
     }
 }
 
+public class BaseClassHasApiControllerAttribute : ControllerWithApiAttributeAtTheClassLevel
+{
+    [HttpDelete("/[controller]")]
+    public string Remove(Movie movie)                                           // Compliant, base class is decorated with the ApiController attribute
+    {
+        return "Hello!";
+    }
+}
+
 [Controller]
 public class ControllerThatDoesNotInheritFromControllerBase
 {


### PR DESCRIPTION
Improves #9095
The rule currently doesn't raise for classes decorated with the `[ApiController]` attribute, as it adds automatic request validation to the action methods.
This PR improves that by also checking whether any of the base classes of the Controller is decorated with that attribute.
This eliminates [FPs like this](https://peach.aws-prd.sonarsource.com/issues?projects=jellyfin&resolved=false&rules=csharpsquid%3AS6967&open=AY8vcfEsPfBcX2L0QXhf), where [the base class is marked with [ApiController]](https://github.com/jellyfin/jellyfin/blob/16b2483d848e9f66de48cb5eaa4ed40e14360617/Jellyfin.Api/BaseJellyfinApiController.cs#L12).