### PR TITLE
Fix S1144 FP: Getters/Setters of property with attribute are being flagged

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -20,551 +20,550 @@
 
 using SonarAnalyzer.Common.Walkers;
 
-namespace SonarAnalyzer.Rules.CSharp
+namespace SonarAnalyzer.Rules.CSharp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UnusedPrivateMember : SonarDiagnosticAnalyzer
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class UnusedPrivateMember : SonarDiagnosticAnalyzer
-    {
-        internal const string S1144DiagnosticId = "S1144";
-        private const string S1144MessageFormat = "Remove the unused {0} {1} '{2}'.";
-        private const string S1144MessageFormatForPublicCtor = "Remove unused constructor of {0} type '{1}'.";
+    internal const string S1144DiagnosticId = "S1144";
+    private const string S1144MessageFormat = "Remove the unused {0} {1} '{2}'.";
+    private const string S1144MessageFormatForPublicCtor = "Remove unused constructor of {0} type '{1}'.";
 
-        private const string S4487DiagnosticId = "S4487";
-        private const string S4487MessageFormat = "Remove this unread {0} field '{1}' or refactor the code to use its value.";
+    private const string S4487DiagnosticId = "S4487";
+    private const string S4487MessageFormat = "Remove this unread {0} field '{1}' or refactor the code to use its value.";
 
-        private static readonly DiagnosticDescriptor RuleS1144 = DescriptorFactory.Create(S1144DiagnosticId, S1144MessageFormat);
-        private static readonly DiagnosticDescriptor RuleS1144ForPublicCtor = DescriptorFactory.Create(S1144DiagnosticId, S1144MessageFormatForPublicCtor);
-        private static readonly DiagnosticDescriptor RuleS4487 = DescriptorFactory.Create(S4487DiagnosticId, S4487MessageFormat);
+    private static readonly DiagnosticDescriptor RuleS1144 = DescriptorFactory.Create(S1144DiagnosticId, S1144MessageFormat);
+    private static readonly DiagnosticDescriptor RuleS1144ForPublicCtor = DescriptorFactory.Create(S1144DiagnosticId, S1144MessageFormatForPublicCtor);
+    private static readonly DiagnosticDescriptor RuleS4487 = DescriptorFactory.Create(S4487DiagnosticId, S4487MessageFormat);
 
-        private static readonly ImmutableArray<KnownType> IgnoredTypes = ImmutableArray.Create(
-            KnownType.UnityEditor_AssetModificationProcessor,
-            KnownType.UnityEditor_AssetPostprocessor,
-            KnownType.UnityEngine_MonoBehaviour,
-            KnownType.UnityEngine_ScriptableObject,
-            KnownType.Microsoft_EntityFrameworkCore_Migrations_Migration);
+    private static readonly ImmutableArray<KnownType> IgnoredTypes = ImmutableArray.Create(
+        KnownType.UnityEditor_AssetModificationProcessor,
+        KnownType.UnityEditor_AssetPostprocessor,
+        KnownType.UnityEngine_MonoBehaviour,
+        KnownType.UnityEngine_ScriptableObject,
+        KnownType.Microsoft_EntityFrameworkCore_Migrations_Migration);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(RuleS1144, RuleS4487);
-        protected override bool EnableConcurrentExecution => false;
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(RuleS1144, RuleS4487);
+    protected override bool EnableConcurrentExecution => false;
 
-        protected override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterCompilationStartAction(
-                c =>
-                {
-                    // Collect potentially removable internal types from the project to evaluate when
-                    // the compilation is over, depending on whether InternalsVisibleTo attribute is present
-                    // or not.
-                    var removableInternalTypes = new HashSet<ISymbol>();
+    protected override void Initialize(SonarAnalysisContext context) =>
+        context.RegisterCompilationStartAction(
+            c =>
+            {
+                // Collect potentially removable internal types from the project to evaluate when
+                // the compilation is over, depending on whether InternalsVisibleTo attribute is present
+                // or not.
+                var removableInternalTypes = new HashSet<ISymbol>();
 
-                    c.RegisterSymbolAction(x => NamedSymbolAction(x, removableInternalTypes), SymbolKind.NamedType);
-                    c.RegisterCompilationEndAction(
-                        cc =>
+                c.RegisterSymbolAction(x => NamedSymbolAction(x, removableInternalTypes), SymbolKind.NamedType);
+                c.RegisterCompilationEndAction(
+                    cc =>
+                    {
+                        var foundInternalsVisibleTo = cc.Compilation.Assembly.HasAttribute(KnownType.System_Runtime_CompilerServices_InternalsVisibleToAttribute);
+                        if (foundInternalsVisibleTo || removableInternalTypes.Count == 0)
                         {
-                            var foundInternalsVisibleTo = cc.Compilation.Assembly.HasAttribute(KnownType.System_Runtime_CompilerServices_InternalsVisibleToAttribute);
-                            if (foundInternalsVisibleTo || removableInternalTypes.Count == 0)
-                            {
-                                return;
-                            }
+                            return;
+                        }
 
-                            var usageCollector = new CSharpSymbolUsageCollector(c.Compilation, removableInternalTypes);
-                            foreach (var syntaxTree in c.Compilation.SyntaxTrees.Where(tree => !tree.IsConsideredGenerated(CSharpGeneratedCodeRecognizer.Instance, c.IsRazorAnalysisEnabled())))
-                            {
-                                usageCollector.SafeVisit(syntaxTree.GetRoot());
-                            }
-                            foreach (var diagnostic in DiagnosticsForUnusedPrivateMembers(usageCollector, removableInternalTypes, SyntaxConstants.Internal, new()))
-                            {
-                                cc.ReportIssue(diagnostic);
-                            }
-                        });
-                });
+                        var usageCollector = new CSharpSymbolUsageCollector(c.Compilation, removableInternalTypes);
+                        foreach (var syntaxTree in c.Compilation.SyntaxTrees.Where(tree => !tree.IsConsideredGenerated(CSharpGeneratedCodeRecognizer.Instance, c.IsRazorAnalysisEnabled())))
+                        {
+                            usageCollector.SafeVisit(syntaxTree.GetRoot());
+                        }
+                        foreach (var diagnostic in DiagnosticsForUnusedPrivateMembers(usageCollector, removableInternalTypes, SyntaxConstants.Internal, new()))
+                        {
+                            cc.ReportIssue(diagnostic);
+                        }
+                    });
+            });
 
-        private static void NamedSymbolAction(SonarSymbolReportingContext context, HashSet<ISymbol> removableInternalTypes)
+    private static void NamedSymbolAction(SonarSymbolReportingContext context, HashSet<ISymbol> removableInternalTypes)
+    {
+        var namedType = (INamedTypeSymbol)context.Symbol;
+        var privateSymbols = new HashSet<ISymbol>();
+        var fieldLikeSymbols = new BidirectionalDictionary<ISymbol, SyntaxNode>();
+        if (GatherSymbols(namedType, context.Compilation, privateSymbols, removableInternalTypes, fieldLikeSymbols, context)
+            && privateSymbols.Any()
+            && new CSharpSymbolUsageCollector(context.Compilation, AssociatedSymbols(privateSymbols)) is var usageCollector
+            && VisitDeclaringReferences(namedType, usageCollector, context, includeGeneratedFile: true))
         {
-            var namedType = (INamedTypeSymbol)context.Symbol;
-            var privateSymbols = new HashSet<ISymbol>();
-            var fieldLikeSymbols = new BidirectionalDictionary<ISymbol, SyntaxNode>();
-            if (GatherSymbols(namedType, context.Compilation, privateSymbols, removableInternalTypes, fieldLikeSymbols, context)
-                && privateSymbols.Any()
-                && new CSharpSymbolUsageCollector(context.Compilation, AssociatedSymbols(privateSymbols)) is var usageCollector
-                && VisitDeclaringReferences(namedType, usageCollector, context, includeGeneratedFile: true))
+            foreach (var diagnostic in DiagnosticsForUnusedPrivateMembers(usageCollector, privateSymbols, SyntaxConstants.Private, fieldLikeSymbols))
             {
-                foreach (var diagnostic in DiagnosticsForUnusedPrivateMembers(usageCollector, privateSymbols, SyntaxConstants.Private, fieldLikeSymbols))
-                {
-                    context.ReportIssue(diagnostic);
-                }
-                foreach (var diagnostic in DiagnosticsForUsedButUnreadFields(usageCollector, privateSymbols))
-                {
-                    context.ReportIssue(diagnostic);
-                }
+                context.ReportIssue(diagnostic);
+            }
+            foreach (var diagnostic in DiagnosticsForUsedButUnreadFields(usageCollector, privateSymbols))
+            {
+                context.ReportIssue(diagnostic);
+            }
+        }
+    }
+
+    private static IEnumerable<ISymbol> AssociatedSymbols(IEnumerable<ISymbol> privateSymbols) =>
+        privateSymbols.Select(x => x is IMethodSymbol { AssociatedSymbol: IPropertySymbol property } ? property : x);
+
+    private static bool GatherSymbols(INamedTypeSymbol namedType,
+                                      Compilation compilation,
+                                      HashSet<ISymbol> privateSymbols,
+                                      HashSet<ISymbol> internalSymbols,
+                                      BidirectionalDictionary<ISymbol, SyntaxNode> fieldLikeSymbols,
+                                      SonarSymbolReportingContext context)
+    {
+        if (namedType.ContainingType is not null
+            // We skip top level statements since they cannot have fields. Other declared types are analyzed separately.
+            || namedType.IsTopLevelProgram()
+            || namedType.DerivesFromAny(IgnoredTypes)
+            // Collect symbols of private members that could potentially be removed
+            || RetrieveRemovableSymbols(namedType, compilation, context) is not { } removableSymbolsCollector)
+        {
+            return false;
+        }
+
+        CopyRetrievedSymbols(removableSymbolsCollector, privateSymbols, internalSymbols, fieldLikeSymbols);
+
+        // Collect symbols of private members that could potentially be removed for the nested classes
+        foreach (var declaration in PrivateNestedMembersFromNonGeneratedCode(namedType, context))
+        {
+            if (compilation.GetSemanticModel(declaration.SyntaxTree) is { } semanticModel
+                && semanticModel.GetDeclaredSymbol(declaration) is { } declarationSymbol
+                && !declarationSymbol.HasAttribute(KnownType.System_Runtime_InteropServices_StructLayoutAttribute))
+            {
+                var symbolsCollector = RetrieveRemovableSymbols(declarationSymbol, compilation, context);
+                CopyRetrievedSymbols(symbolsCollector, privateSymbols, internalSymbols, fieldLikeSymbols);
             }
         }
 
-        private static IEnumerable<ISymbol> AssociatedSymbols(IEnumerable<ISymbol> privateSymbols) =>
-            privateSymbols.Select(x => x is IMethodSymbol { AssociatedSymbol: IPropertySymbol property } ? property : x);
+        return true;
 
-        private static bool GatherSymbols(INamedTypeSymbol namedType,
-                                          Compilation compilation,
-                                          HashSet<ISymbol> privateSymbols,
-                                          HashSet<ISymbol> internalSymbols,
-                                          BidirectionalDictionary<ISymbol, SyntaxNode> fieldLikeSymbols,
-                                          SonarSymbolReportingContext context)
+        static IEnumerable<BaseTypeDeclarationSyntax> PrivateNestedMembersFromNonGeneratedCode(INamedTypeSymbol namedType, SonarSymbolReportingContext context) =>
+            namedType.DeclaringSyntaxReferences
+                .Where(x => !x.SyntaxTree.IsConsideredGenerated(CSharpGeneratedCodeRecognizer.Instance, context.IsRazorAnalysisEnabled()))
+                .SelectMany(x => x.GetSyntax().ChildNodes().OfType<BaseTypeDeclarationSyntax>());
+    }
+
+    private static IEnumerable<Diagnostic> DiagnosticsForUnusedPrivateMembers(CSharpSymbolUsageCollector usageCollector,
+                                                                                 ISet<ISymbol> removableSymbols,
+                                                                                 string accessibility,
+                                                                                 BidirectionalDictionary<ISymbol, SyntaxNode> fieldLikeSymbols)
+    {
+        var unusedSymbols = GetUnusedSymbols(usageCollector, removableSymbols);
+
+        var propertiesWithUnusedAccessor = removableSymbols
+            .Intersect(usageCollector.UsedSymbols)
+            .OfType<IPropertySymbol>()
+            .Where(usageCollector.PropertyAccess.ContainsKey)
+            .Where(x => !IsMentionedInDebuggerDisplay(x, usageCollector))
+            .Select(x => GetDiagnosticsForProperty(x, usageCollector.PropertyAccess))
+            .WhereNotNull();
+
+        return GetDiagnosticsForMembers(unusedSymbols, accessibility, fieldLikeSymbols).Concat(propertiesWithUnusedAccessor);
+    }
+
+    private static bool IsMentionedInDebuggerDisplay(ISymbol symbol, CSharpSymbolUsageCollector usageCollector) =>
+            usageCollector.DebuggerDisplayValues.Any(x => x.Contains(symbol.Name));
+
+    private static IEnumerable<Diagnostic> DiagnosticsForUsedButUnreadFields(CSharpSymbolUsageCollector usageCollector, IEnumerable<ISymbol> removableSymbols)
+    {
+        var unusedSymbols = GetUnusedSymbols(usageCollector, removableSymbols);
+
+        var usedButUnreadFields = usageCollector.FieldSymbolUsages.Values
+            .Where(x => x.Symbol.DeclaredAccessibility == Accessibility.Private || x.Symbol.ContainingType?.DeclaredAccessibility == Accessibility.Private)
+            .Where(x => x.Symbol.Kind == SymbolKind.Field || x.Symbol.Kind == SymbolKind.Event)
+            .Where(x => !unusedSymbols.Contains(x.Symbol) && !IsMentionedInDebuggerDisplay(x.Symbol, usageCollector))
+            .Where(x => x.Declaration is not null && !x.Readings.Any());
+
+        return GetDiagnosticsForUnreadFields(usedButUnreadFields);
+    }
+
+    private static HashSet<ISymbol> GetUnusedSymbols(CSharpSymbolUsageCollector usageCollector, IEnumerable<ISymbol> removableSymbols) =>
+        removableSymbols
+            .Except(usageCollector.UsedSymbols)
+            .Where(x => !IsMentionedInDebuggerDisplay(x, usageCollector) && !IsAccessorUsed(x, usageCollector))
+            .ToHashSet();
+
+    private static IEnumerable<Diagnostic> GetDiagnosticsForUnreadFields(IEnumerable<SymbolUsage> unreadFields) =>
+        unreadFields.Select(x => Diagnostic.Create(RuleS4487, x.Declaration.GetLocation(), GetFieldAccessibilityForMessage(x.Symbol), x.Symbol.Name));
+
+    private static bool IsAccessorUsed(ISymbol symbol, CSharpSymbolUsageCollector usageCollector) =>
+        symbol is IMethodSymbol { } accessor
+            && accessor.AssociatedSymbol is IPropertySymbol { } property
+            && usageCollector.PropertyAccess.TryGetValue(property, out var access)
+            && ((access.HasFlag(AccessorAccess.Get) && accessor.MethodKind == MethodKind.PropertyGet)
+                || (access.HasFlag(AccessorAccess.Set) && accessor.MethodKind == MethodKind.PropertySet));
+
+    private static string GetFieldAccessibilityForMessage(ISymbol symbol) =>
+        symbol.DeclaredAccessibility == Accessibility.Private ? SyntaxConstants.Private : "private class";
+
+    private static IEnumerable<Diagnostic> GetDiagnosticsForMembers(ICollection<ISymbol> unusedSymbols,
+                                                                    string accessibility,
+                                                                    BidirectionalDictionary<ISymbol, SyntaxNode> fieldLikeSymbols)
+    {
+        var diagnostics = new List<Diagnostic>();
+        var alreadyReportedFieldLikeSymbols = new HashSet<ISymbol>();
+        var unusedSymbolSyntaxPairs = unusedSymbols.SelectMany(x => x.DeclaringSyntaxReferences.Select(syntax => new NodeAndSymbol(syntax.GetSyntax(), x)));
+
+        foreach (var unused in unusedSymbolSyntaxPairs)
         {
-            if (namedType.ContainingType != null
-                // We skip top level statements since they cannot have fields. Other declared types are analyzed separately.
-                || namedType.IsTopLevelProgram()
-                || namedType.DerivesFromAny(IgnoredTypes)
-                // Collect symbols of private members that could potentially be removed
-                || RetrieveRemovableSymbols(namedType, compilation, context) is not { } removableSymbolsCollector)
-            {
-                return false;
-            }
+            var syntaxForLocation = unused.Node;
 
-            CopyRetrievedSymbols(removableSymbolsCollector, privateSymbols, internalSymbols, fieldLikeSymbols);
-
-            // Collect symbols of private members that could potentially be removed for the nested classes
-            foreach (var declaration in PrivateNestedMembersFromNonGeneratedCode(namedType, context))
+            var isFieldOrEvent = unused.Symbol.Kind == SymbolKind.Field || unused.Symbol.Kind == SymbolKind.Event;
+            if (isFieldOrEvent && unused.Node.IsKind(SyntaxKind.VariableDeclarator))
             {
-                if (compilation.GetSemanticModel(declaration.SyntaxTree) is { } semanticModel
-                    && semanticModel.GetDeclaredSymbol(declaration) is { } declarationSymbol
-                    && !declarationSymbol.HasAttribute(KnownType.System_Runtime_InteropServices_StructLayoutAttribute))
+                if (alreadyReportedFieldLikeSymbols.Contains(unused.Symbol))
                 {
-                    var symbolsCollector = RetrieveRemovableSymbols(declarationSymbol, compilation, context);
-                    CopyRetrievedSymbols(symbolsCollector, privateSymbols, internalSymbols, fieldLikeSymbols);
-                }
-            }
-
-            return true;
-
-            static IEnumerable<BaseTypeDeclarationSyntax> PrivateNestedMembersFromNonGeneratedCode(INamedTypeSymbol namedType, SonarSymbolReportingContext context) =>
-                namedType.DeclaringSyntaxReferences
-                    .Where(r => !r.SyntaxTree.IsConsideredGenerated(CSharpGeneratedCodeRecognizer.Instance, context.IsRazorAnalysisEnabled()))
-                    .SelectMany(x => x.GetSyntax().ChildNodes().OfType<BaseTypeDeclarationSyntax>());
-        }
-
-        private static IEnumerable<Diagnostic> DiagnosticsForUnusedPrivateMembers(CSharpSymbolUsageCollector usageCollector,
-                                                                                     ISet<ISymbol> removableSymbols,
-                                                                                     string accessibility,
-                                                                                     BidirectionalDictionary<ISymbol, SyntaxNode> fieldLikeSymbols)
-        {
-            var unusedSymbols = GetUnusedSymbols(usageCollector, removableSymbols);
-
-            var propertiesWithUnusedAccessor = removableSymbols
-                .Intersect(usageCollector.UsedSymbols)
-                .OfType<IPropertySymbol>()
-                .Where(usageCollector.PropertyAccess.ContainsKey)
-                .Where(symbol => !IsMentionedInDebuggerDisplay(symbol, usageCollector))
-                .Select(symbol => GetDiagnosticsForProperty(symbol, usageCollector.PropertyAccess))
-                .WhereNotNull();
-
-            return GetDiagnosticsForMembers(unusedSymbols, accessibility, fieldLikeSymbols).Concat(propertiesWithUnusedAccessor);
-        }
-
-        private static bool IsMentionedInDebuggerDisplay(ISymbol symbol, CSharpSymbolUsageCollector usageCollector) =>
-                usageCollector.DebuggerDisplayValues.Any(value => value.Contains(symbol.Name));
-
-        private static IEnumerable<Diagnostic> DiagnosticsForUsedButUnreadFields(CSharpSymbolUsageCollector usageCollector, IEnumerable<ISymbol> removableSymbols)
-        {
-            var unusedSymbols = GetUnusedSymbols(usageCollector, removableSymbols);
-
-            var usedButUnreadFields = usageCollector.FieldSymbolUsages.Values
-                .Where(usage => usage.Symbol.DeclaredAccessibility == Accessibility.Private || usage.Symbol.ContainingType?.DeclaredAccessibility == Accessibility.Private)
-                .Where(usage => usage.Symbol.Kind == SymbolKind.Field || usage.Symbol.Kind == SymbolKind.Event)
-                .Where(usage => !unusedSymbols.Contains(usage.Symbol) && !IsMentionedInDebuggerDisplay(usage.Symbol, usageCollector))
-                .Where(usage => usage.Declaration != null && !usage.Readings.Any());
-
-            return GetDiagnosticsForUnreadFields(usedButUnreadFields);
-        }
-
-        private static HashSet<ISymbol> GetUnusedSymbols(CSharpSymbolUsageCollector usageCollector, IEnumerable<ISymbol> removableSymbols) =>
-            removableSymbols
-                .Except(usageCollector.UsedSymbols)
-                .Where(symbol => !IsMentionedInDebuggerDisplay(symbol, usageCollector) && !IsAccessorUsed(symbol, usageCollector))
-                .ToHashSet();
-
-        private static IEnumerable<Diagnostic> GetDiagnosticsForUnreadFields(IEnumerable<SymbolUsage> unreadFields) =>
-            unreadFields.Select(usage => Diagnostic.Create(RuleS4487, usage.Declaration.GetLocation(), GetFieldAccessibilityForMessage(usage.Symbol), usage.Symbol.Name));
-
-        private static bool IsAccessorUsed(ISymbol symbol, CSharpSymbolUsageCollector usageCollector) =>
-            symbol is IMethodSymbol { } accessor
-                && accessor.AssociatedSymbol is IPropertySymbol { } property
-                && usageCollector.PropertyAccess.TryGetValue(property, out var access)
-                && ((access.HasFlag(AccessorAccess.Get) && accessor.MethodKind == MethodKind.PropertyGet)
-                    || (access.HasFlag(AccessorAccess.Set) && accessor.MethodKind == MethodKind.PropertySet));
-
-        private static string GetFieldAccessibilityForMessage(ISymbol symbol) =>
-            symbol.DeclaredAccessibility == Accessibility.Private ? SyntaxConstants.Private : "private class";
-
-        private static IEnumerable<Diagnostic> GetDiagnosticsForMembers(ICollection<ISymbol> unusedSymbols,
-                                                                        string accessibility,
-                                                                        BidirectionalDictionary<ISymbol, SyntaxNode> fieldLikeSymbols)
-        {
-            var diagnostics = new List<Diagnostic>();
-            var alreadyReportedFieldLikeSymbols = new HashSet<ISymbol>();
-            var unusedSymbolSyntaxPairs = unusedSymbols.SelectMany(symbol => symbol.DeclaringSyntaxReferences.Select(x => new NodeAndSymbol(x.GetSyntax(), symbol)));
-
-            foreach (var unused in unusedSymbolSyntaxPairs)
-            {
-                var syntaxForLocation = unused.Node;
-
-                var isFieldOrEvent = unused.Symbol.Kind == SymbolKind.Field || unused.Symbol.Kind == SymbolKind.Event;
-                if (isFieldOrEvent && unused.Node.IsKind(SyntaxKind.VariableDeclarator))
-                {
-                    if (alreadyReportedFieldLikeSymbols.Contains(unused.Symbol))
-                    {
-                        continue;
-                    }
-
-                    var declarations = GetSiblingDeclarators(unused.Node).Select(fieldLikeSymbols.GetByB).ToList();
-                    if (declarations.All(unusedSymbols.Contains))
-                    {
-                        syntaxForLocation = unused.Node.Parent.Parent;
-                        alreadyReportedFieldLikeSymbols.UnionWith(declarations);
-                    }
+                    continue;
                 }
 
-                diagnostics.Add(CreateS1144Diagnostic(syntaxForLocation, unused.Symbol));
-            }
-
-            return diagnostics;
-
-            static IEnumerable<VariableDeclaratorSyntax> GetSiblingDeclarators(SyntaxNode variableDeclarator) =>
-                variableDeclarator.Parent.Parent switch
+                var declarations = GetSiblingDeclarators(unused.Node).Select(fieldLikeSymbols.GetByB).ToList();
+                if (declarations.TrueForAll(unusedSymbols.Contains))
                 {
-                    FieldDeclarationSyntax fieldDeclaration => fieldDeclaration.Declaration.Variables,
-                    EventFieldDeclarationSyntax eventDeclaration => eventDeclaration.Declaration.Variables,
-                    _ => Enumerable.Empty<VariableDeclaratorSyntax>(),
-                };
-
-            Diagnostic CreateS1144Diagnostic(SyntaxNode syntaxNode, ISymbol symbol) =>
-                symbol.IsConstructor() && !syntaxNode.GetModifiers().Any(SyntaxKind.PrivateKeyword)
-                    ? Diagnostic.Create(RuleS1144ForPublicCtor, syntaxNode.GetLocation(), accessibility, symbol.ContainingType.Name)
-                    : Diagnostic.Create(RuleS1144, GetIdentifierLocation(syntaxNode), accessibility, symbol.GetClassification(), GetMemberName(symbol));
-
-            static Location GetIdentifierLocation(SyntaxNode syntaxNode) =>
-                syntaxNode.GetIdentifier() is { } identifier
-                    ? identifier.GetLocation()
-                    : syntaxNode.GetLocation();
-        }
-
-        private static Diagnostic GetDiagnosticsForProperty(IPropertySymbol property, IReadOnlyDictionary<IPropertySymbol, AccessorAccess> propertyAccessorAccess)
-        {
-            var access = propertyAccessorAccess[property];
-            if (access == AccessorAccess.Get
-                && property.SetMethod is { }
-                && GetAccessorSyntax(property.SetMethod) is { } setter)
-            {
-                return Diagnostic.Create(RuleS1144, setter.Keyword.GetLocation(), SyntaxConstants.Private, "set accessor in property", property.Name);
-            }
-            else if (access == AccessorAccess.Set
-                     && property.GetMethod is { }
-                     && GetAccessorSyntax(property.GetMethod) is { } getter
-                     && getter.HasBodyOrExpressionBody())
-            {
-                return Diagnostic.Create(RuleS1144, getter.Keyword.GetLocation(), SyntaxConstants.Private, "get accessor in property", property.Name);
-            }
-            else
-            {
-                return null;
-            }
-
-            static AccessorDeclarationSyntax GetAccessorSyntax(ISymbol symbol) =>
-                symbol?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() as AccessorDeclarationSyntax;
-        }
-
-        private static string GetMemberName(ISymbol symbol) =>
-            symbol.IsConstructor() ? symbol.ContainingType.Name : symbol.Name;
-
-        private static bool VisitDeclaringReferences(ISymbol symbol, ISafeSyntaxWalker visitor, SonarSymbolReportingContext context, bool includeGeneratedFile)
-        {
-            var syntaxReferencesToVisit = includeGeneratedFile
-                ? symbol.DeclaringSyntaxReferences
-                : symbol.DeclaringSyntaxReferences.Where(r => !IsGenerated(r));
-
-            return syntaxReferencesToVisit.All(x => visitor.SafeVisit(x.GetSyntax()));
-
-            bool IsGenerated(SyntaxReference syntaxReference) =>
-                syntaxReference.SyntaxTree.IsConsideredGenerated(CSharpGeneratedCodeRecognizer.Instance, context.IsRazorAnalysisEnabled());
-        }
-
-        private static CSharpRemovableSymbolWalker RetrieveRemovableSymbols(INamedTypeSymbol namedType, Compilation compilation, SonarSymbolReportingContext context)
-        {
-            var removableSymbolsCollector = new CSharpRemovableSymbolWalker(compilation.GetSemanticModel, namedType.DeclaredAccessibility);
-            if (!VisitDeclaringReferences(namedType, removableSymbolsCollector, context, includeGeneratedFile: false))
-            {
-                return null;
-            }
-
-            return removableSymbolsCollector;
-        }
-
-        private static void CopyRetrievedSymbols(CSharpRemovableSymbolWalker removableSymbolCollector,
-                                                 HashSet<ISymbol> privateSymbols,
-                                                 HashSet<ISymbol> internalSymbols,
-                                                 BidirectionalDictionary<ISymbol, SyntaxNode> fieldLikeSymbols)
-        {
-            privateSymbols.AddRange(removableSymbolCollector.PrivateSymbols);
-
-            // Keep the removable internal types for when the compilation ends
-            internalSymbols.AddRange(removableSymbolCollector.InternalSymbols);
-
-            foreach (var keyValuePair in removableSymbolCollector.FieldLikeSymbols)
-            {
-                if (!fieldLikeSymbols.ContainsKeyByA(keyValuePair.Key))
-                {
-                    fieldLikeSymbols.Add(keyValuePair.Key, keyValuePair.Value);
+                    syntaxForLocation = unused.Node.Parent.Parent;
+                    alreadyReportedFieldLikeSymbols.UnionWith(declarations);
                 }
             }
+
+            diagnostics.Add(CreateS1144Diagnostic(syntaxForLocation, unused.Symbol));
         }
 
-        /// <summary>
-        /// Collects private or internal member symbols that could potentially be removed if they are not used.
-        /// Members that are overridden, overridable, have specific use, etc. are not removable.
-        /// </summary>
-        private sealed class CSharpRemovableSymbolWalker : SafeCSharpSyntaxWalker
+        return diagnostics;
+
+        static IEnumerable<VariableDeclaratorSyntax> GetSiblingDeclarators(SyntaxNode variableDeclarator) =>
+            variableDeclarator.Parent.Parent switch
+            {
+                FieldDeclarationSyntax fieldDeclaration => fieldDeclaration.Declaration.Variables,
+                EventFieldDeclarationSyntax eventDeclaration => eventDeclaration.Declaration.Variables,
+                _ => Enumerable.Empty<VariableDeclaratorSyntax>(),
+            };
+
+        Diagnostic CreateS1144Diagnostic(SyntaxNode syntaxNode, ISymbol symbol) =>
+            symbol.IsConstructor() && !syntaxNode.GetModifiers().Any(SyntaxKind.PrivateKeyword)
+                ? Diagnostic.Create(RuleS1144ForPublicCtor, syntaxNode.GetLocation(), accessibility, symbol.ContainingType.Name)
+                : Diagnostic.Create(RuleS1144, GetIdentifierLocation(syntaxNode), accessibility, symbol.GetClassification(), GetMemberName(symbol));
+
+        static Location GetIdentifierLocation(SyntaxNode syntaxNode) =>
+            syntaxNode.GetIdentifier() is { } identifier
+                ? identifier.GetLocation()
+                : syntaxNode.GetLocation();
+    }
+
+    private static Diagnostic GetDiagnosticsForProperty(IPropertySymbol property, IReadOnlyDictionary<IPropertySymbol, AccessorAccess> propertyAccessorAccess)
+    {
+        var access = propertyAccessorAccess[property];
+        if (access == AccessorAccess.Get
+            && property.SetMethod is { }
+            && GetAccessorSyntax(property.SetMethod) is { } setter)
         {
-            private readonly Func<SyntaxNode, SemanticModel> getSemanticModel;
-            private readonly Accessibility containingTypeAccessibility;
+            return Diagnostic.Create(RuleS1144, setter.Keyword.GetLocation(), SyntaxConstants.Private, "set accessor in property", property.Name);
+        }
+        else if (access == AccessorAccess.Set
+                 && property.GetMethod is { }
+                 && GetAccessorSyntax(property.GetMethod) is { } getter
+                 && getter.HasBodyOrExpressionBody())
+        {
+            return Diagnostic.Create(RuleS1144, getter.Keyword.GetLocation(), SyntaxConstants.Private, "get accessor in property", property.Name);
+        }
+        else
+        {
+            return null;
+        }
 
-            public Dictionary<ISymbol, SyntaxNode> FieldLikeSymbols { get; } = [];
-            public HashSet<ISymbol> InternalSymbols { get; } = [];
-            public HashSet<ISymbol> PrivateSymbols { get; } = [];
+        static AccessorDeclarationSyntax GetAccessorSyntax(ISymbol symbol) =>
+            symbol?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() as AccessorDeclarationSyntax;
+    }
 
-            public CSharpRemovableSymbolWalker(Func<SyntaxTree, bool, SemanticModel> getSemanticModel, Accessibility containingTypeAccessibility)
+    private static string GetMemberName(ISymbol symbol) =>
+        symbol.IsConstructor() ? symbol.ContainingType.Name : symbol.Name;
+
+    private static bool VisitDeclaringReferences(ISymbol symbol, ISafeSyntaxWalker visitor, SonarSymbolReportingContext context, bool includeGeneratedFile)
+    {
+        var syntaxReferencesToVisit = includeGeneratedFile
+            ? symbol.DeclaringSyntaxReferences
+            : symbol.DeclaringSyntaxReferences.Where(x => !IsGenerated(x));
+
+        return syntaxReferencesToVisit.All(x => visitor.SafeVisit(x.GetSyntax()));
+
+        bool IsGenerated(SyntaxReference syntaxReference) =>
+            syntaxReference.SyntaxTree.IsConsideredGenerated(CSharpGeneratedCodeRecognizer.Instance, context.IsRazorAnalysisEnabled());
+    }
+
+    private static CSharpRemovableSymbolWalker RetrieveRemovableSymbols(INamedTypeSymbol namedType, Compilation compilation, SonarSymbolReportingContext context)
+    {
+        var removableSymbolsCollector = new CSharpRemovableSymbolWalker(compilation.GetSemanticModel, namedType.DeclaredAccessibility);
+        if (!VisitDeclaringReferences(namedType, removableSymbolsCollector, context, includeGeneratedFile: false))
+        {
+            return null;
+        }
+
+        return removableSymbolsCollector;
+    }
+
+    private static void CopyRetrievedSymbols(CSharpRemovableSymbolWalker removableSymbolCollector,
+                                             HashSet<ISymbol> privateSymbols,
+                                             HashSet<ISymbol> internalSymbols,
+                                             BidirectionalDictionary<ISymbol, SyntaxNode> fieldLikeSymbols)
+    {
+        privateSymbols.AddRange(removableSymbolCollector.PrivateSymbols);
+
+        // Keep the removable internal types for when the compilation ends
+        internalSymbols.AddRange(removableSymbolCollector.InternalSymbols);
+
+        foreach (var keyValuePair in removableSymbolCollector.FieldLikeSymbols)
+        {
+            if (!fieldLikeSymbols.ContainsKeyByA(keyValuePair.Key))
             {
-                this.getSemanticModel = node => getSemanticModel(node.SyntaxTree, false);
-                this.containingTypeAccessibility = containingTypeAccessibility;
+                fieldLikeSymbols.Add(keyValuePair.Key, keyValuePair.Value);
             }
+        }
+    }
 
-            // This override is needed because VisitRecordDeclaration and LocalFunctionStatementSyntax are not available due to the Roslyn version.
-            public override void Visit(SyntaxNode node)
-            {
-                if (node.IsAnyKind(SyntaxKindEx.RecordClassDeclaration, SyntaxKindEx.RecordStructDeclaration))
-                {
-                    VisitBaseTypeDeclaration(node);
-                }
+    /// <summary>
+    /// Collects private or internal member symbols that could potentially be removed if they are not used.
+    /// Members that are overridden, overridable, have specific use, etc. are not removable.
+    /// </summary>
+    private sealed class CSharpRemovableSymbolWalker : SafeCSharpSyntaxWalker
+    {
+        private readonly Func<SyntaxNode, SemanticModel> getSemanticModel;
+        private readonly Accessibility containingTypeAccessibility;
 
-                if (node.IsKind(SyntaxKindEx.LocalFunctionStatement))
-                {
-                    ConditionalStore((IMethodSymbol)GetDeclaredSymbol(node), IsRemovableMethod);
-                }
+        public Dictionary<ISymbol, SyntaxNode> FieldLikeSymbols { get; } = [];
+        public HashSet<ISymbol> InternalSymbols { get; } = [];
+        public HashSet<ISymbol> PrivateSymbols { get; } = [];
 
-                base.Visit(node);
-            }
+        public CSharpRemovableSymbolWalker(Func<SyntaxTree, bool, SemanticModel> getSemanticModel, Accessibility containingTypeAccessibility)
+        {
+            this.getSemanticModel = x => getSemanticModel(x.SyntaxTree, false);
+            this.containingTypeAccessibility = containingTypeAccessibility;
+        }
 
-            public override void VisitClassDeclaration(ClassDeclarationSyntax node)
+        // This override is needed because VisitRecordDeclaration and LocalFunctionStatementSyntax are not available due to the Roslyn version.
+        public override void Visit(SyntaxNode node)
+        {
+            if (node.IsAnyKind(SyntaxKindEx.RecordClassDeclaration, SyntaxKindEx.RecordStructDeclaration))
             {
                 VisitBaseTypeDeclaration(node);
-                base.VisitClassDeclaration(node);
             }
 
-            public override void VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+            if (node.IsKind(SyntaxKindEx.LocalFunctionStatement))
             {
-                if (!IsEmptyConstructor(node)
-                    && IsPrivateOrInPrivateType(node.Modifiers))
-                {
-                    ConditionalStore((IMethodSymbol)GetDeclaredSymbol(node), IsRemovableMethod);
-                }
-
-                base.VisitConstructorDeclaration(node);
+                ConditionalStore((IMethodSymbol)GetDeclaredSymbol(node), IsRemovableMethod);
             }
 
-            public override void VisitDelegateDeclaration(DelegateDeclarationSyntax node)
-            {
-                if (IsPrivateOrInPrivateType(node.Modifiers, true))
-                {
-                    ConditionalStore(GetDeclaredSymbol(node), IsRemovableType);
-                }
-
-                base.VisitDelegateDeclaration(node);
-            }
-
-            public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
-            {
-                VisitBaseTypeDeclaration(node);
-                base.VisitEnumDeclaration(node);
-            }
-
-            public override void VisitEventDeclaration(EventDeclarationSyntax node)
-            {
-                if (IsPrivateOrInPrivateType(node.Modifiers))
-                {
-                    ConditionalStore(GetDeclaredSymbol(node), IsRemovableMember);
-                }
-
-                base.VisitEventDeclaration(node);
-            }
-
-            public override void VisitEventFieldDeclaration(EventFieldDeclarationSyntax node)
-            {
-                if (IsPrivateOrInPrivateType(node.Modifiers))
-                {
-                    StoreRemovableVariableDeclarations(node);
-                }
-
-                base.VisitEventFieldDeclaration(node);
-            }
-
-            public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
-            {
-                if (IsPrivateOrInPrivateType(node.Modifiers))
-                {
-                    StoreRemovableVariableDeclarations(node);
-                }
-
-                base.VisitFieldDeclaration(node);
-            }
-
-            public override void VisitIndexerDeclaration(IndexerDeclarationSyntax node)
-            {
-                if (IsPrivateOrInPrivateType(node.Modifiers))
-                {
-                    ConditionalStore(GetDeclaredSymbol(node), IsRemovableMember);
-                }
-
-                base.VisitIndexerDeclaration(node);
-            }
-
-            public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
-            {
-                VisitBaseTypeDeclaration(node);
-                base.VisitInterfaceDeclaration(node);
-            }
-
-            public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
-            {
-                if (IsPrivateOrInPrivateType(node.Modifiers))
-                {
-                    var symbol = (IMethodSymbol)GetDeclaredSymbol(node);
-                    ConditionalStore(symbol.PartialDefinitionPart ?? symbol, IsRemovableMethod);
-                }
-
-                base.VisitMethodDeclaration(node);
-            }
-
-            public override void VisitAccessorDeclaration(AccessorDeclarationSyntax node)
-            {
-                if (node.Modifiers.Any(SyntaxKind.PrivateKeyword))
-                {
-                    ConditionalStore(GetDeclaredSymbol(node), IsRemovable);
-                }
-
-                base.VisitAccessorDeclaration(node);
-            }
-
-            public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
-            {
-                if (IsPrivateOrInPrivateType(node.Modifiers))
-                {
-                    ConditionalStore(GetDeclaredSymbol(node), IsRemovableMember);
-                }
-
-                base.VisitPropertyDeclaration(node);
-            }
-
-            public override void VisitStructDeclaration(StructDeclarationSyntax node)
-            {
-                VisitBaseTypeDeclaration(node);
-                base.VisitStructDeclaration(node);
-            }
-
-            private void ConditionalStore<TSymbol>(TSymbol symbol, Func<TSymbol, bool> condition)
-                where TSymbol : ISymbol
-            {
-                if (condition(symbol))
-                {
-                    if (symbol.GetEffectiveAccessibility() == Accessibility.Private)
-                    {
-                        PrivateSymbols.Add(symbol);
-                    }
-                    else if (symbol is INamedTypeSymbol)
-                    {
-                        InternalSymbols.Add(symbol);
-                    }
-                }
-            }
-
-            private ISymbol GetDeclaredSymbol(SyntaxNode syntaxNode) =>
-                getSemanticModel(syntaxNode).GetDeclaredSymbol(syntaxNode);
-
-            private void StoreRemovableVariableDeclarations(BaseFieldDeclarationSyntax node)
-            {
-                foreach (var variable in node.Declaration.Variables)
-                {
-                    var symbol = GetDeclaredSymbol(variable);
-                    if (IsRemovableMember(symbol))
-                    {
-                        PrivateSymbols.Add(symbol);
-                        FieldLikeSymbols.Add(symbol, variable);
-                    }
-                }
-            }
-
-            private static bool IsEmptyConstructor(BaseMethodDeclarationSyntax constructorDeclaration) =>
-                !constructorDeclaration.HasBodyOrExpressionBody()
-                || (constructorDeclaration.Body is { } && constructorDeclaration.Body.Statements.Count == 0);
-
-            private static bool IsDeclaredInPartialClass(ISymbol methodSymbol)
-            {
-                return methodSymbol.DeclaringSyntaxReferences
-                    .Select(GetContainingTypeDeclaration)
-                    .Any(IsPartial);
-
-                static TypeDeclarationSyntax GetContainingTypeDeclaration(SyntaxReference syntaxReference) =>
-                    syntaxReference.GetSyntax().FirstAncestorOrSelf<TypeDeclarationSyntax>();
-
-                static bool IsPartial(TypeDeclarationSyntax typeDeclaration) =>
-                    typeDeclaration.Modifiers.AnyOfKind(SyntaxKind.PartialKeyword);
-            }
-
-            private static bool IsRemovableMethod(IMethodSymbol methodSymbol) =>
-                IsRemovableMember(methodSymbol)
-                && (methodSymbol.MethodKind is MethodKind.Ordinary or MethodKind.Constructor or MethodKindEx.LocalFunction)
-                && !methodSymbol.IsMainMethod()
-                && (!methodSymbol.IsEventHandler() || !IsDeclaredInPartialClass(methodSymbol)) // Event handlers could be added in XAML and no method reference will be generated in the .g.cs file.
-                && !methodSymbol.IsSerializationConstructor()
-                && !methodSymbol.IsRecordPrintMembers();
-
-            private static bool IsRemovable(ISymbol symbol) =>
-                symbol is { IsImplicitlyDeclared: false, IsVirtual: false }
-                && !HasAttributes(symbol)
-                && !symbol.IsSerializableMember()
-                && !symbol.ContainingType.IsInterface()
-                && symbol.GetInterfaceMember() == null
-                && symbol.GetOverriddenMember() == null;
-
-            private static bool HasAttributes(ISymbol symbol)
-            {
-                IEnumerable<AttributeData> attributes = symbol.GetAttributes();
-                if (symbol is IMethodSymbol { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet} method
-                    && method.AssociatedSymbol is { } property)
-                {
-                    attributes = attributes.Union(property.GetAttributes());
-                }
-                return attributes.Any(x => !x.AttributeClass.Is(KnownType.System_NonSerializedAttribute));
-            }
-
-            private static bool IsRemovableMember(ISymbol symbol) =>
-                symbol.GetEffectiveAccessibility() == Accessibility.Private
-                && IsRemovable(symbol);
-
-            private static bool IsRemovableType(ISymbol typeSymbol) =>
-                typeSymbol.GetEffectiveAccessibility() is var accessibility
-                && typeSymbol.ContainingType is { }
-                && (accessibility is Accessibility.Private or Accessibility.Internal)
-                && IsRemovable(typeSymbol);
-
-            private void VisitBaseTypeDeclaration(SyntaxNode node)
-            {
-                if (IsPrivateOrInPrivateType(((BaseTypeDeclarationSyntax)node).Modifiers, true))
-                {
-                    ConditionalStore(GetDeclaredSymbol(node), IsRemovableType);
-                }
-            }
-
-            private bool IsPrivateOrInPrivateType(SyntaxTokenList modifiers, bool checkInternal = false) =>
-                containingTypeAccessibility == Accessibility.Private
-                || (checkInternal && containingTypeAccessibility == Accessibility.Internal)
-                || !modifiers.Any(x => x.IsAnyKind(SyntaxKind.PrivateKeyword, SyntaxKind.PublicKeyword, SyntaxKind.InternalKeyword, SyntaxKind.ProtectedKeyword))
-                || modifiers.Any(SyntaxKind.PrivateKeyword);
+            base.Visit(node);
         }
+
+        public override void VisitClassDeclaration(ClassDeclarationSyntax node)
+        {
+            VisitBaseTypeDeclaration(node);
+            base.VisitClassDeclaration(node);
+        }
+
+        public override void VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+        {
+            if (!IsEmptyConstructor(node)
+                && IsPrivateOrInPrivateType(node.Modifiers))
+            {
+                ConditionalStore((IMethodSymbol)GetDeclaredSymbol(node), IsRemovableMethod);
+            }
+
+            base.VisitConstructorDeclaration(node);
+        }
+
+        public override void VisitDelegateDeclaration(DelegateDeclarationSyntax node)
+        {
+            if (IsPrivateOrInPrivateType(node.Modifiers, true))
+            {
+                ConditionalStore(GetDeclaredSymbol(node), IsRemovableType);
+            }
+
+            base.VisitDelegateDeclaration(node);
+        }
+
+        public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
+        {
+            VisitBaseTypeDeclaration(node);
+            base.VisitEnumDeclaration(node);
+        }
+
+        public override void VisitEventDeclaration(EventDeclarationSyntax node)
+        {
+            if (IsPrivateOrInPrivateType(node.Modifiers))
+            {
+                ConditionalStore(GetDeclaredSymbol(node), IsRemovableMember);
+            }
+
+            base.VisitEventDeclaration(node);
+        }
+
+        public override void VisitEventFieldDeclaration(EventFieldDeclarationSyntax node)
+        {
+            if (IsPrivateOrInPrivateType(node.Modifiers))
+            {
+                StoreRemovableVariableDeclarations(node);
+            }
+
+            base.VisitEventFieldDeclaration(node);
+        }
+
+        public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+        {
+            if (IsPrivateOrInPrivateType(node.Modifiers))
+            {
+                StoreRemovableVariableDeclarations(node);
+            }
+
+            base.VisitFieldDeclaration(node);
+        }
+
+        public override void VisitIndexerDeclaration(IndexerDeclarationSyntax node)
+        {
+            if (IsPrivateOrInPrivateType(node.Modifiers))
+            {
+                ConditionalStore(GetDeclaredSymbol(node), IsRemovableMember);
+            }
+
+            base.VisitIndexerDeclaration(node);
+        }
+
+        public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
+        {
+            VisitBaseTypeDeclaration(node);
+            base.VisitInterfaceDeclaration(node);
+        }
+
+        public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            if (IsPrivateOrInPrivateType(node.Modifiers))
+            {
+                var symbol = (IMethodSymbol)GetDeclaredSymbol(node);
+                ConditionalStore(symbol.PartialDefinitionPart ?? symbol, IsRemovableMethod);
+            }
+
+            base.VisitMethodDeclaration(node);
+        }
+
+        public override void VisitAccessorDeclaration(AccessorDeclarationSyntax node)
+        {
+            if (node.Modifiers.Any(SyntaxKind.PrivateKeyword))
+            {
+                ConditionalStore(GetDeclaredSymbol(node), IsRemovable);
+            }
+
+            base.VisitAccessorDeclaration(node);
+        }
+
+        public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        {
+            if (IsPrivateOrInPrivateType(node.Modifiers))
+            {
+                ConditionalStore(GetDeclaredSymbol(node), IsRemovableMember);
+            }
+
+            base.VisitPropertyDeclaration(node);
+        }
+
+        public override void VisitStructDeclaration(StructDeclarationSyntax node)
+        {
+            VisitBaseTypeDeclaration(node);
+            base.VisitStructDeclaration(node);
+        }
+
+        private void ConditionalStore<TSymbol>(TSymbol symbol, Func<TSymbol, bool> condition)
+            where TSymbol : ISymbol
+        {
+            if (condition(symbol))
+            {
+                if (symbol.GetEffectiveAccessibility() == Accessibility.Private)
+                {
+                    PrivateSymbols.Add(symbol);
+                }
+                else if (symbol is INamedTypeSymbol)
+                {
+                    InternalSymbols.Add(symbol);
+                }
+            }
+        }
+
+        private ISymbol GetDeclaredSymbol(SyntaxNode syntaxNode) =>
+            getSemanticModel(syntaxNode).GetDeclaredSymbol(syntaxNode);
+
+        private void StoreRemovableVariableDeclarations(BaseFieldDeclarationSyntax node)
+        {
+            foreach (var variable in node.Declaration.Variables)
+            {
+                var symbol = GetDeclaredSymbol(variable);
+                if (IsRemovableMember(symbol))
+                {
+                    PrivateSymbols.Add(symbol);
+                    FieldLikeSymbols.Add(symbol, variable);
+                }
+            }
+        }
+
+        private static bool IsEmptyConstructor(BaseMethodDeclarationSyntax constructorDeclaration) =>
+            !constructorDeclaration.HasBodyOrExpressionBody()
+            || (constructorDeclaration.Body is { } && constructorDeclaration.Body.Statements.Count == 0);
+
+        private static bool IsDeclaredInPartialClass(ISymbol methodSymbol)
+        {
+            return methodSymbol.DeclaringSyntaxReferences
+                .Select(GetContainingTypeDeclaration)
+                .Any(IsPartial);
+
+            static TypeDeclarationSyntax GetContainingTypeDeclaration(SyntaxReference syntaxReference) =>
+                syntaxReference.GetSyntax().FirstAncestorOrSelf<TypeDeclarationSyntax>();
+
+            static bool IsPartial(TypeDeclarationSyntax typeDeclaration) =>
+                typeDeclaration.Modifiers.AnyOfKind(SyntaxKind.PartialKeyword);
+        }
+
+        private static bool IsRemovableMethod(IMethodSymbol methodSymbol) =>
+            IsRemovableMember(methodSymbol)
+            && (methodSymbol.MethodKind is MethodKind.Ordinary or MethodKind.Constructor or MethodKindEx.LocalFunction)
+            && !methodSymbol.IsMainMethod()
+            && (!methodSymbol.IsEventHandler() || !IsDeclaredInPartialClass(methodSymbol)) // Event handlers could be added in XAML and no method reference will be generated in the .g.cs file.
+            && !methodSymbol.IsSerializationConstructor()
+            && !methodSymbol.IsRecordPrintMembers();
+
+        private static bool IsRemovable(ISymbol symbol) =>
+            symbol is { IsImplicitlyDeclared: false, IsVirtual: false }
+            && !HasAttributes(symbol)
+            && !symbol.IsSerializableMember()
+            && !symbol.ContainingType.IsInterface()
+            && symbol.GetInterfaceMember() is null
+            && symbol.GetOverriddenMember() is null;
+
+        private static bool HasAttributes(ISymbol symbol)
+        {
+            IEnumerable<AttributeData> attributes = symbol.GetAttributes();
+            if (symbol is IMethodSymbol { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet} method
+                && method.AssociatedSymbol is { } property)
+            {
+                attributes = attributes.Union(property.GetAttributes());
+            }
+            return attributes.Any(x => !x.AttributeClass.Is(KnownType.System_NonSerializedAttribute));
+        }
+
+        private static bool IsRemovableMember(ISymbol symbol) =>
+            symbol.GetEffectiveAccessibility() == Accessibility.Private
+            && IsRemovable(symbol);
+
+        private static bool IsRemovableType(ISymbol typeSymbol) =>
+            typeSymbol.GetEffectiveAccessibility() is var accessibility
+            && typeSymbol.ContainingType is { }
+            && (accessibility is Accessibility.Private or Accessibility.Internal)
+            && IsRemovable(typeSymbol);
+
+        private void VisitBaseTypeDeclaration(SyntaxNode node)
+        {
+            if (IsPrivateOrInPrivateType(((BaseTypeDeclarationSyntax)node).Modifiers, true))
+            {
+                ConditionalStore(GetDeclaredSymbol(node), IsRemovableType);
+            }
+        }
+
+        private bool IsPrivateOrInPrivateType(SyntaxTokenList modifiers, bool checkInternal = false) =>
+            containingTypeAccessibility == Accessibility.Private
+            || (checkInternal && containingTypeAccessibility == Accessibility.Internal)
+            || !modifiers.Any(x => x.IsAnyKind(SyntaxKind.PrivateKeyword, SyntaxKind.PublicKeyword, SyntaxKind.InternalKeyword, SyntaxKind.ProtectedKeyword))
+            || modifiers.Any(SyntaxKind.PrivateKeyword);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/UnusedPrivateMemberTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/UnusedPrivateMemberTest.cs
@@ -21,16 +21,16 @@
 using FluentAssertions.Extensions;
 using SonarAnalyzer.Rules.CSharp;
 
-namespace SonarAnalyzer.Test.Rules
-{
-    [TestClass]
-    public partial class UnusedPrivateMemberTest
-    {
-        private readonly VerifierBuilder builder = new VerifierBuilder<UnusedPrivateMember>();
+namespace SonarAnalyzer.Test.Rules;
 
-        [TestMethod]
-        public void UnusedPrivateMember_DebuggerDisplay_Attribute() =>
-            builder.AddSnippet(@"
+[TestClass]
+public partial class UnusedPrivateMemberTest
+{
+    private readonly VerifierBuilder builder = new VerifierBuilder<UnusedPrivateMember>();
+
+    [TestMethod]
+    public void UnusedPrivateMember_DebuggerDisplay_Attribute() =>
+        builder.AddSnippet(@"
 // https://github.com/SonarSource/sonar-dotnet/issues/1195
 [System.Diagnostics.DebuggerDisplay(""{field1}"", Name = ""{Property1} {Property3}"", Type = ""{Method1()}"")]
 public class MethodUsages
@@ -49,9 +49,9 @@ public class MethodUsages
     }
 }").Verify();
 
-        [TestMethod]
-        public void UnusedPrivateMember_Members_With_Attributes_Are_Not_Removable() =>
-            builder.AddSnippet(@"
+    [TestMethod]
+    public void UnusedPrivateMember_Members_With_Attributes_Are_Not_Removable() =>
+        builder.AddSnippet(@"
 using System;
 public class FieldUsages
 {
@@ -68,9 +68,9 @@ public class FieldUsages
     private class Class1 { }
 }").Verify();
 
-        [TestMethod]
-        public void UnusedPrivateMember_Assembly_Level_Attributes() =>
-            builder.AddSnippet(@"
+    [TestMethod]
+    public void UnusedPrivateMember_Assembly_Level_Attributes() =>
+        builder.AddSnippet(@"
 [assembly: System.Reflection.AssemblyCompany(Foo.Constants.AppCompany)]
 public static class Foo
 {
@@ -80,17 +80,17 @@ public static class Foo
     }
 }").Verify();
 
-        [TestMethod]
-        public void UnusedPrivateMemberWithPartialClasses() =>
-            builder.AddPaths("UnusedPrivateMember.part1.cs", "UnusedPrivateMember.part2.cs").Verify();
+    [TestMethod]
+    public void UnusedPrivateMemberWithPartialClasses() =>
+        builder.AddPaths("UnusedPrivateMember.part1.cs", "UnusedPrivateMember.part2.cs").Verify();
 
-        [TestMethod]
-        public void UnusedPrivateMember_Methods_EventHandler() =>
-            // Event handler methods are not reported because in WPF an event handler
-            // could be added through XAML and no warning will be generated if the
-            // method is removed, which could lead to serious problems that are hard
-            // to diagnose.
-            builder.AddSnippet(@"
+    [TestMethod]
+    public void UnusedPrivateMember_Methods_EventHandler() =>
+        // Event handler methods are not reported because in WPF an event handler
+        // could be added through XAML and no warning will be generated if the
+        // method is removed, which could lead to serious problems that are hard
+        // to diagnose.
+        builder.AddSnippet(@"
 using System;
 public class NewClass
 {
@@ -101,9 +101,9 @@ public partial class PartialClass
     private void Handler(object sender, EventArgs e) { } // intentional False Negative
 }").Verify();
 
-        [TestMethod]
-        public void UnusedPrivateMember_Unity3D_Ignored() =>
-            builder.AddSnippet(@"
+    [TestMethod]
+    public void UnusedPrivateMember_Unity3D_Ignored() =>
+        builder.AddSnippet(@"
 // https://github.com/SonarSource/sonar-dotnet/issues/159
 public class UnityMessages1 : UnityEngine.MonoBehaviour
 {
@@ -137,9 +137,9 @@ namespace UnityEditor
     public class AssetModificationProcessor { }
 }").Verify();
 
-        [TestMethod]
-        public void EntityFrameworkMigration_Ignored() =>
-            builder.AddSnippet(@"
+    [TestMethod]
+    public void EntityFrameworkMigration_Ignored() =>
+        builder.AddSnippet(@"
 namespace EntityFrameworkMigrations
 {
     using Microsoft.EntityFrameworkCore.Migrations;
@@ -152,80 +152,79 @@ namespace EntityFrameworkMigrations
     }
 }").AddReferences(EntityFrameworkCoreReferences("7.0.14")).Verify();
 
-        [DataTestMethod]
-        [DataRow(ProjectType.Product)]
-        [DataRow(ProjectType.Test)]
-        public void UnusedPrivateMember(ProjectType projectType) =>
-            builder.AddPaths("UnusedPrivateMember.cs").AddReferences(TestHelper.ProjectTypeReference(projectType)).Verify();
+    [DataTestMethod]
+    [DataRow(ProjectType.Product)]
+    [DataRow(ProjectType.Test)]
+    public void UnusedPrivateMember(ProjectType projectType) =>
+        builder.AddPaths("UnusedPrivateMember.cs").AddReferences(TestHelper.ProjectTypeReference(projectType)).Verify();
 
-        [TestMethod]
-        public void UnusedPrivateMember_FromCSharp7() =>
-            builder.AddPaths("UnusedPrivateMember.CSharp7.cs").WithOptions(ParseOptionsHelper.FromCSharp7).Verify();
+    [TestMethod]
+    public void UnusedPrivateMember_FromCSharp7() =>
+        builder.AddPaths("UnusedPrivateMember.CSharp7.cs").WithOptions(ParseOptionsHelper.FromCSharp7).Verify();
 
-        [TestMethod]
-        public void UnusedPrivateMember_FromCSharp8() =>
-            builder.AddPaths("UnusedPrivateMember.CSharp8.cs")
-                .WithOptions(ParseOptionsHelper.FromCSharp8)
-                .AddReferences(MetadataReferenceFacade.NetStandard21)
-                .AddReferences(MetadataReferenceFacade.MicrosoftExtensionsDependencyInjectionAbstractions)
-                .Verify();
+    [TestMethod]
+    public void UnusedPrivateMember_FromCSharp8() =>
+        builder.AddPaths("UnusedPrivateMember.CSharp8.cs")
+            .WithOptions(ParseOptionsHelper.FromCSharp8)
+            .AddReferences(MetadataReferenceFacade.NetStandard21)
+            .AddReferences(MetadataReferenceFacade.MicrosoftExtensionsDependencyInjectionAbstractions)
+            .Verify();
 
 #if NET
 
-        [TestMethod]
-        public void UnusedPrivateMember_FromCSharp9() =>
-            builder.AddPaths("UnusedPrivateMember.CSharp9.cs", "UnusedPrivateMember.CSharp9.Second.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
+    [TestMethod]
+    public void UnusedPrivateMember_FromCSharp9() =>
+        builder.AddPaths("UnusedPrivateMember.CSharp9.cs", "UnusedPrivateMember.CSharp9.Second.cs").WithOptions(ParseOptionsHelper.FromCSharp9).Verify();
 
-        [TestMethod]
-        public void UnusedPrivateMember_FromCSharp9_TopLevelStatements() =>
-            builder.AddPaths("UnusedPrivateMember.CSharp9.TopLevelStatements.cs").WithTopLevelStatements().Verify();
+    [TestMethod]
+    public void UnusedPrivateMember_FromCSharp9_TopLevelStatements() =>
+        builder.AddPaths("UnusedPrivateMember.CSharp9.TopLevelStatements.cs").WithTopLevelStatements().Verify();
 
-        [TestMethod]
-        public void UnusedPrivateMember_FromCSharp10() =>
-            builder.AddPaths("UnusedPrivateMember.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+    [TestMethod]
+    public void UnusedPrivateMember_FromCSharp10() =>
+        builder.AddPaths("UnusedPrivateMember.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
 
-        [TestMethod]
-        public void UnusedPrivateMember_FromCSharp11() =>
-            builder.AddPaths("UnusedPrivateMember.CSharp11.cs").WithOptions(ParseOptionsHelper.FromCSharp11).Verify();
+    [TestMethod]
+    public void UnusedPrivateMember_FromCSharp11() =>
+        builder.AddPaths("UnusedPrivateMember.CSharp11.cs").WithOptions(ParseOptionsHelper.FromCSharp11).Verify();
 
-        // The exception should disappear once the fix for https://github.com/dotnet/roslyn/issues/70041 gets released.
-        // If this does not happen before the official release of .NET8 and C#12, the code should be refactored to handle potential null values.
-        //
-        // Workaround to return null in ImplicitObjectCreation.TypeAsString in this particular case to avoid AD0001.
-        // Should be reverted once the fix is released
-        [TestMethod]
-        public void UnusedPrivateMember_FromCSharp12() =>
-            builder.AddPaths("UnusedPrivateMember.CSharp12.cs")
-                .WithOptions(ParseOptionsHelper.FromCSharp12)
-                .Verify();
+    // The exception should disappear once the fix for https://github.com/dotnet/roslyn/issues/70041 gets released.
+    // If this does not happen before the official release of .NET8 and C#12, the code should be refactored to handle potential null values.
+    //
+    // Workaround to return null in ImplicitObjectCreation.TypeAsString in this particular case to avoid AD0001.
+    // Should be reverted once the fix is released
+    [TestMethod]
+    public void UnusedPrivateMember_FromCSharp12() =>
+        builder.AddPaths("UnusedPrivateMember.CSharp12.cs")
+            .WithOptions(ParseOptionsHelper.FromCSharp12)
+            .Verify();
 
 #endif
 
-        [TestMethod]
-        public void UnusedPrivateMember_CodeFix() =>
-            builder.AddPaths("UnusedPrivateMember.cs")
-                .WithCodeFix<UnusedPrivateMemberCodeFix>()
-                .WithCodeFixedPaths("UnusedPrivateMember.Fixed.cs", "UnusedPrivateMember.Fixed.Batch.cs")
-                .VerifyCodeFix();
+    [TestMethod]
+    public void UnusedPrivateMember_CodeFix() =>
+        builder.AddPaths("UnusedPrivateMember.cs")
+            .WithCodeFix<UnusedPrivateMemberCodeFix>()
+            .WithCodeFixedPaths("UnusedPrivateMember.Fixed.cs", "UnusedPrivateMember.Fixed.Batch.cs")
+            .VerifyCodeFix();
 
-        [TestMethod]
-        public void UnusedPrivateMember_UsedInGeneratedFile() =>
-            builder.AddPaths("UnusedPrivateMember.CalledFromGenerated.cs", "UnusedPrivateMember.Generated.cs").Verify();
+    [TestMethod]
+    public void UnusedPrivateMember_UsedInGeneratedFile() =>
+        builder.AddPaths("UnusedPrivateMember.CalledFromGenerated.cs", "UnusedPrivateMember.Generated.cs").Verify();
 
-        [TestMethod]
-        public void UnusedPrivateMember_Performance() =>
-            // Once the NuGet packages are downloaded, the time to execute the analyzer on the given file is
-            // about ~1 sec. It was reduced from ~11 min by skipping Guids when processing ObjectCreationExpression.
-            // The threshold is set here to 30 seconds to avoid flaky builds due to slow build agents or network connections.
-            builder.AddPaths("UnusedPrivateMember.Performance.cs")
-                .AddReferences(EntityFrameworkCoreReferences("5.0.12"))   // The latest before 6.0.0 for .NET 6 that has Linq versioning collision issue
-                .Invoking(x => x.Verify())
-                .ExecutionTime().Should().BeLessOrEqualTo(30.Seconds());
+    [TestMethod]
+    public void UnusedPrivateMember_Performance() =>
+        // Once the NuGet packages are downloaded, the time to execute the analyzer on the given file is
+        // about ~1 sec. It was reduced from ~11 min by skipping Guids when processing ObjectCreationExpression.
+        // The threshold is set here to 30 seconds to avoid flaky builds due to slow build agents or network connections.
+        builder.AddPaths("UnusedPrivateMember.Performance.cs")
+            .AddReferences(EntityFrameworkCoreReferences("5.0.12"))   // The latest before 6.0.0 for .NET 6 that has Linq versioning collision issue
+            .Invoking(x => x.Verify())
+            .ExecutionTime().Should().BeLessOrEqualTo(30.Seconds());
 
-        private static ImmutableArray<MetadataReference> EntityFrameworkCoreReferences(string entityFrameworkVersion) =>
-            MetadataReferenceFacade.NetStandard
-                .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCoreSqlServer(entityFrameworkVersion))
-                .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCoreRelational(entityFrameworkVersion))
-                .ToImmutableArray();
-    }
+    private static ImmutableArray<MetadataReference> EntityFrameworkCoreReferences(string entityFrameworkVersion) =>
+        MetadataReferenceFacade.NetStandard
+            .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCoreSqlServer(entityFrameworkVersion))
+            .Concat(NuGetMetadataReference.MicrosoftEntityFrameworkCoreRelational(entityFrameworkVersion))
+            .ToImmutableArray();
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.Fixed.Batch.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.Fixed.Batch.cs
@@ -396,4 +396,10 @@ class Repro_9219
         [MyAttribute]
         private set; // Compliant
     }
+
+    public bool AttributeOnPropertyNoncompliant
+    {
+        [MyAttribute]
+        get;
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.Fixed.Batch.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.Fixed.Batch.cs
@@ -372,3 +372,28 @@ public class Repro_8532
     private string serializedField;                             // Compliant
     private string serializedReadWriteProperty { get; set; }    // Compliant
 }
+
+// https://github.com/SonarSource/sonar-dotnet/issues/9219
+class Repro_9219
+{
+    [MyAttribute]
+    public bool AttributeOnProperty
+    {
+        get;
+        private set; // Compliant
+    }
+
+    public bool AttributeOnPropertyGetter
+    {
+        [MyAttribute]
+        private get; // Compliant
+        set;
+    }
+
+    public bool AttributeOnPropertySetter
+    {
+        get;
+        [MyAttribute]
+        private set; // Compliant
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.Fixed.cs
@@ -356,3 +356,28 @@ public class Repro_8532
     private string serializedField;                             // Compliant
     private string serializedReadWriteProperty { get; set; }    // Compliant
 }
+
+// https://github.com/SonarSource/sonar-dotnet/issues/9219
+class Repro_9219
+{
+    [MyAttribute]
+    public bool AttributeOnProperty
+    {
+        get;
+        private set; // Compliant
+    }
+
+    public bool AttributeOnPropertyGetter
+    {
+        [MyAttribute]
+        private get; // Compliant
+        set;
+    }
+
+    public bool AttributeOnPropertySetter
+    {
+        get;
+        [MyAttribute]
+        private set; // Compliant
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.Fixed.cs
@@ -380,4 +380,10 @@ class Repro_9219
         [MyAttribute]
         private set; // Compliant
     }
+
+    public bool AttributeOnPropertyNoncompliant
+    {
+        [MyAttribute]
+        get;
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.cs
@@ -467,3 +467,28 @@ public class Repro_8532
     private string nonSerializedReadOnlyProperty => "";         // Noncompliant
     [NonSerialized] private string nonSerializedProperty;       // Noncompliant
 }
+
+// https://github.com/SonarSource/sonar-dotnet/issues/9219
+class Repro_9219
+{
+    [MyAttribute]
+    public bool AttributeOnProperty
+    {
+        get;
+        private set; // Compliant
+    }
+
+    public bool AttributeOnPropertyGetter
+    {
+        [MyAttribute]
+        private get; // Compliant
+        set;
+    }
+
+    public bool AttributeOnPropertySetter
+    {
+        get;
+        [MyAttribute]
+        private set; // Compliant
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.cs
@@ -491,4 +491,11 @@ class Repro_9219
         [MyAttribute]
         private set; // Compliant
     }
+
+    public bool AttributeOnPropertyNoncompliant
+    {
+        [MyAttribute]
+        get;
+        private set; // Noncompliant
+    }
 }


### PR DESCRIPTION
Fixes #9219

Reviewing per-commit might be helpful.
Definitely check `ignore whitespace`, since file-scoped namespace destroys reviewability.

Commit 1: The actual change
Commit 2: UTs
Commit 3: CaYC