### PR TITLE
Improve S6967: Filter out CancellationToken parameters

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/CallModelStateIsValid.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/CallModelStateIsValid.cs
@@ -66,7 +66,7 @@ public sealed class CallModelStateIsValid : SonarDiagnosticAnalyzer
     {
         if (codeBlockContext.CodeBlock is MethodDeclarationSyntax methodDeclaration
             && codeBlockContext.OwningSymbol is IMethodSymbol methodSymbol
-            && methodSymbol.Parameters.Length > 0
+            && methodSymbol.Parameters.Any(x => !x.Type.Is(KnownType.System_Threading_CancellationToken))
             && methodSymbol.IsControllerActionMethod()
             && !HasActionFilterAttribute(methodSymbol))
         {

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -542,6 +542,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType System_Text_RegularExpressions_Regex = new("System.Text.RegularExpressions.Regex");
         public static readonly KnownType System_Text_RegularExpressions_RegexOptions = new("System.Text.RegularExpressions.RegexOptions");
         public static readonly KnownType System_Text_StringBuilder = new("System.Text.StringBuilder");
+        public static readonly KnownType System_Threading_CancellationToken = new("System.Threading.CancellationToken");
         public static readonly KnownType System_Threading_CancellationTokenSource = new("System.Threading.CancellationTokenSource");
         public static readonly KnownType System_Threading_Monitor = new("System.Threading.Monitor");
         public static readonly KnownType System_Threading_Mutex = new("System.Threading.Mutex");

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/AspNet/CallModelStateIsValid.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/AspNet/CallModelStateIsValid.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
@@ -90,6 +92,9 @@ public class NonCompliantController : ControllerBase
 
     [HttpGet("/[controller]/list")]
     public string[] List() => null;                                             // Compliant
+
+    [HttpGet("/[controller]/listasync")]
+    public Task<string[]> ListAsync(CancellationToken token) => null;           // Compliant
 }
 
 [ApiController]


### PR DESCRIPTION
Improves #9095 
[Fixes FPs](https://peach.aws-prd.sonarsource.com/issues?projects=bitwarden-core&resolved=false&rules=csharpsquid%3AS6967&open=AY8vOYQHr4ooVA6A4nO1) where the controller action only has a [CancellationToken parameter](https://andrewlock.net/using-cancellationtokens-in-asp-net-core-mvc-controllers/).