### PR TITLE
Fix T0010 FP: Allow "_" discard like parameter name

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/LambdaParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/LambdaParameterName.cs
@@ -29,7 +29,7 @@ public sealed class LambdaParameterName : StylingAnalyzer
         context.RegisterNodeAction(c =>
             {
                 var parameter = ((SimpleLambdaExpressionSyntax)c.Node).Parameter;
-                if (parameter.Identifier.ValueText != "x"
+                if (parameter.Identifier.ValueText is not ("x" or "_")
                     && c.Node.Parent.FirstAncestorOrSelf<LambdaExpressionSyntax>() is null
                     && !IsSonarContextAction(c))
                 {

--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/LambdaParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/LambdaParameterName.cs
@@ -23,7 +23,7 @@ namespace SonarAnalyzer.Rules.CSharp.Styling;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class LambdaParameterName : StylingAnalyzer
 {
-    public LambdaParameterName() : base("T0010", "Use 'x' for the lambda parameter name.") { }
+    public LambdaParameterName() : base("T0010", "Use 'x' or '_' for the lambda parameter name.") { }
 
     protected override void Initialize(SonarAnalysisContext context) =>
         context.RegisterNodeAction(c =>

--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/LambdaParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/LambdaParameterName.cs
@@ -23,7 +23,7 @@ namespace SonarAnalyzer.Rules.CSharp.Styling;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class LambdaParameterName : StylingAnalyzer
 {
-    public LambdaParameterName() : base("T0010", "Use 'x' or '_' for the lambda parameter name.") { }
+    public LambdaParameterName() : base("T0010", "Use 'x' for the lambda parameter name.") { }
 
     protected override void Initialize(SonarAnalysisContext context) =>
         context.RegisterNodeAction(c =>

--- a/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/LambdaParameterName.cs
+++ b/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/LambdaParameterName.cs
@@ -8,7 +8,7 @@ public class Sample
         Method(x => 42);
         Method(x => { });
 
-        Method(item => 42);     // Noncompliant {{Use 'x' or '_' for the lambda parameter name.}}
+        Method(item => 42);     // Noncompliant {{Use 'x' for the lambda parameter name.}}
         Method(item => { });    // Noncompliant
         //     ^^^^
 

--- a/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/LambdaParameterName.cs
+++ b/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/LambdaParameterName.cs
@@ -16,7 +16,7 @@ public class Sample
         Method(b => 42);        // Noncompliant
         Method(y => 42);        // Noncompliant
         Method(z => 42);        // Noncompliant
-        Method(_ => 42);        // Noncompliant, it's not a discard, it's a parameter named "_"
+        Method(_ => 42);        // Compliant
         Method(node => 42);     // Noncompliant
         Method(dataGridViewCellContextMenuStripNeededEventArgs => 42);     // Noncompliant
 
@@ -31,6 +31,7 @@ public class Sample
         Method(() => 42);
         Method(() => { });
         Method((a, b) => 42);
+        Method((_, _) => 42);
         Method((a, b) => { });
     }
 

--- a/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/LambdaParameterName.cs
+++ b/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/LambdaParameterName.cs
@@ -8,7 +8,7 @@ public class Sample
         Method(x => 42);
         Method(x => { });
 
-        Method(item => 42);     // Noncompliant {{Use 'x' for the lambda parameter name.}}
+        Method(item => 42);     // Noncompliant {{Use 'x' or '_' for the lambda parameter name.}}
         Method(item => { });    // Noncompliant
         //     ^^^^
 


### PR DESCRIPTION
` _ => 42` should be allowed, because `_` is more descriptive than `x` in this case and signals: "I do not care about the parameter." Rational: In `(_, _) => 42` `_` is a real discard, while in `_ => 42` it isn't only for back compatibility reasons.

See e.g. here:
https://sonarcloud.io/project/issues?resolved=false&pullRequest=8950&id=sonaranalyzer-dotnet&open=AY9NLK1CHaBGYjI6fPmk

`_` is a better name than `x` in such a case.