### PR TITLE
Fix T0010 FP: Allow delegate type parameter name

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/LambdaParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/LambdaParameterName.cs
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Reflection.Metadata;
-
 namespace SonarAnalyzer.Rules.CSharp.Styling;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/LambdaParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/LambdaParameterName.cs
@@ -44,7 +44,7 @@ public sealed class LambdaParameterName : StylingAnalyzer
             TypeKind: TypeKind.Delegate,
             DelegateInvokeMethod.Parameters: { Length: 1 } parameters
         } delegateType
-    && !IsFuncOrAction(delegateType)
+        && !IsFuncOrAction(delegateType)
         && parameters[0] is { Name: { } parameterName }
         && parameterName == lambda.Parameter.Identifier.ValueText;
 

--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/LambdaParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/Rules/LambdaParameterName.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System.Reflection.Metadata;
+
 namespace SonarAnalyzer.Rules.CSharp.Styling;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -28,15 +30,28 @@ public sealed class LambdaParameterName : StylingAnalyzer
     protected override void Initialize(SonarAnalysisContext context) =>
         context.RegisterNodeAction(c =>
             {
-                var parameter = ((SimpleLambdaExpressionSyntax)c.Node).Parameter;
-                if (parameter.Identifier.ValueText is not ("x" or "_")
-                    && c.Node.Parent.FirstAncestorOrSelf<LambdaExpressionSyntax>() is null
-                    && !IsSonarContextAction(c))
+                if (c.Node is SimpleLambdaExpressionSyntax { Parameter: { Identifier.ValueText: not ("x" or "_") } parameter, Parent: { } parent } lambda
+                    && parent.FirstAncestorOrSelf<LambdaExpressionSyntax>() is null
+                    && !IsSonarContextAction(c)
+                    && !MatchesDelegateParameterName(c.SemanticModel, lambda))
                 {
                     c.ReportIssue(Rule, parameter);
                 }
             },
             SyntaxKind.SimpleLambdaExpression);
+
+    private static bool MatchesDelegateParameterName(SemanticModel model, SimpleLambdaExpressionSyntax lambda) =>
+        model.GetTypeInfo(lambda).ConvertedType is INamedTypeSymbol
+        {
+            TypeKind: TypeKind.Delegate,
+            DelegateInvokeMethod.Parameters: { Length: 1 } parameters
+        } delegateType
+    && !IsFuncOrAction(delegateType)
+        && parameters[0] is { Name: { } parameterName }
+        && parameterName == lambda.Parameter.Identifier.ValueText;
+
+    private static bool IsFuncOrAction(INamedTypeSymbol delegateType) =>
+        delegateType.IsAny(KnownType.System_Func_T_TResult, KnownType.System_Action_T);
 
     private static bool IsSonarContextAction(SonarSyntaxNodeReportingContext context) =>
         context.SemanticModel.GetSymbolInfo(context.Node).Symbol is IMethodSymbol lambda

--- a/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/LambdaParameterName.cs
+++ b/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/LambdaParameterName.cs
@@ -107,15 +107,16 @@ public class CustomDelegates
     {
         ParameterNamedI delegate1 = i => { }; // Compliant "i" matches the parameter name of the delegate
         ParameterNamedI delegate2 = j => { }; // Noncompliant
+        ParameterNamedI delegate3 = x => { }; // Compliant
 
-        ParameterNamedTest delegate3 = test => { };     // Compliant
-        ParameterNamedTest delegate4 = someTest => { }; // Noncompliant
-        ParameterNamedTest delegate5 = testSome => { }; // Noncompliant
+        ParameterNamedTest delegate4 = test => { };     // Compliant
+        ParameterNamedTest delegate5 = someTest => { }; // Noncompliant
+        ParameterNamedTest delegate6 = testSome => { }; // Noncompliant
 
-        ParameterNamedRegistrationContext delegate6 = registrationContext => { }; // Compliant
-        ParameterNamedRegistrationContext delegate7 = registrationcontext => { }; // Noncompliant
-        ParameterNamedRegistrationContext delegate8 = registration => { };        // Noncompliant
-        ParameterNamedRegistrationContext delegate9 = context => { };             // Noncompliant
+        ParameterNamedRegistrationContext delegate7 = registrationContext => { }; // Compliant
+        ParameterNamedRegistrationContext delegate8 = registrationcontext => { }; // Noncompliant
+        ParameterNamedRegistrationContext delegate9 = registration => { };        // Noncompliant
+        ParameterNamedRegistrationContext delegate10 = context => { };             // Noncompliant
 
         Func<int, int> function = arg => 0;  // Noncompliant, the delegate parameter is named "arg" (https://learn.microsoft.com/en-us/dotnet/api/system.func-2) but we do not allow that for Func<T, TResult>
         Action<int> action = obj => { };     // Noncompliant, the delegate parameter is named "obj" (https://learn.microsoft.com/en-us/dotnet/api/system.action-1) but we do not allow that for Func<T, TResult>

--- a/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/LambdaParameterName.cs
+++ b/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/LambdaParameterName.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 public class Sample
@@ -94,4 +95,30 @@ public class RuleRegistration
     public class SometingAnalysisContext { }
     public class SometingReportingContext { }
     public class SonarSometingContext { }
+}
+
+public class CustomDelegates
+{
+    public delegate void ParameterNamedI(int i);
+    public delegate void ParameterNamedTest(int test);
+    public delegate void ParameterNamedRegistrationContext(int registrationContext);
+
+    public void Test()
+    {
+        ParameterNamedI delegate1 = i => { }; // Compliant "i" matches the parameter name of the delegate
+        ParameterNamedI delegate2 = j => { }; // Noncompliant
+
+        ParameterNamedTest delegate3 = test => { };     // Compliant
+        ParameterNamedTest delegate4 = someTest => { }; // Noncompliant
+        ParameterNamedTest delegate5 = testSome => { }; // Noncompliant
+
+        ParameterNamedRegistrationContext delegate6 = registrationContext => { }; // Compliant
+        ParameterNamedRegistrationContext delegate7 = registrationcontext => { }; // Noncompliant
+        ParameterNamedRegistrationContext delegate8 = registration => { };        // Noncompliant
+        ParameterNamedRegistrationContext delegate9 = context => { };             // Noncompliant
+
+        Func<int, int> function = arg => 0;  // Noncompliant, the delegate parameter is named "arg" (https://learn.microsoft.com/en-us/dotnet/api/system.func-2) but we do not allow that for Func<T, TResult>
+        Action<int> action = obj => { };     // Noncompliant, the delegate parameter is named "obj" (https://learn.microsoft.com/en-us/dotnet/api/system.action-1) but we do not allow that for Func<T, TResult>
+        new List<int>().Exists(obj => true); // Compliant. List.Exists uses System.Predicate<T> instead of System.Func<T, bool>
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/LambdaParameterName.cs
+++ b/analyzers/tests/SonarAnalyzer.CSharp.Styling.Test/TestCases/LambdaParameterName.cs
@@ -74,34 +74,34 @@ public class RuleRegistration
         RegisterSonarWhateverAnalysisContext(context => { });
         RegisterSonarWhateverAnalysisContext(whateverContext => { });
         RegisterSonarWhateverReportingContext(c => { });
-        RegisterSonarSometing(c => { });                // Noncompliant, wrong suffix
-        RegisterSometingAnalysisContext(c => { });      // Noncompliant, wrong prefix
-        RegisterSometingReportingContext(c => { });     // Noncompliant, wrong prefix
-        RegisterSonarSometingContext(c => { });         // Noncompliant, wrong suffix
+        RegisterSonarSomething(c => { });                // Noncompliant, wrong suffix
+        RegisterSomethingAnalysisContext(c => { });      // Noncompliant, wrong prefix
+        RegisterSomethingReportingContext(c => { });     // Noncompliant, wrong prefix
+        RegisterSonarSomethingContext(c => { });         // Noncompliant, wrong suffix
     }
 
     protected void RegisterSonarWhateverAnalysisContext(Action<SonarWhateverAnalysisContext> action) { }
     protected void RegisterSonarWhateverReportingContext(Action<SonarWhateverReportingContext> action) { }
-    protected void RegisterSonarSometing(Action<SonarSometing> action) { }
-    protected void RegisterSometingAnalysisContext(Action<SometingAnalysisContext> action) { }
-    protected void RegisterSometingReportingContext(Action<SometingReportingContext> action) { }
-    protected void RegisterSonarSometingContext(Action<SonarSometingContext> action) { }
+    protected void RegisterSonarSomething(Action<SonarSomething> action) { }
+    protected void RegisterSomethingAnalysisContext(Action<SomethingAnalysisContext> action) { }
+    protected void RegisterSomethingReportingContext(Action<SomethingReportingContext> action) { }
+    protected void RegisterSonarSomethingContext(Action<SonarSomethingContext> action) { }
 
     // Well-known expected classes patterns
     public class SonarWhateverAnalysisContext { }
     public class SonarWhateverReportingContext { }
     // Unexpected types
-    public class SonarSometing { }
-    public class SometingAnalysisContext { }
-    public class SometingReportingContext { }
-    public class SonarSometingContext { }
+    public class SonarSomething { }
+    public class SomethingAnalysisContext { }
+    public class SomethingReportingContext { }
+    public class SonarSomethingContext { }
 }
 
 public class CustomDelegates
 {
     public delegate void ParameterNamedI(int i);
     public delegate void ParameterNamedTest(int test);
-    public delegate void ParameterNamedRegistrationContext(int registrationContext);
+    public delegate void ParameterNamedCamelCasing(int camelCasing);
 
     public void Test()
     {
@@ -113,13 +113,13 @@ public class CustomDelegates
         ParameterNamedTest delegate5 = someTest => { }; // Noncompliant
         ParameterNamedTest delegate6 = testSome => { }; // Noncompliant
 
-        ParameterNamedRegistrationContext delegate7 = registrationContext => { }; // Compliant
-        ParameterNamedRegistrationContext delegate8 = registrationcontext => { }; // Noncompliant
-        ParameterNamedRegistrationContext delegate9 = registration => { };        // Noncompliant
-        ParameterNamedRegistrationContext delegate10 = context => { };             // Noncompliant
+        ParameterNamedCamelCasing delegate7 = camelCasing => { }; // Compliant
+        ParameterNamedCamelCasing delegate8 = camelcasing => { }; // Noncompliant
+        ParameterNamedCamelCasing delegate9 = camel => { };     // Noncompliant
+        ParameterNamedCamelCasing delegate10 = casing => { };    // Noncompliant
 
         Func<int, int> function = arg => 0;  // Noncompliant, the delegate parameter is named "arg" (https://learn.microsoft.com/en-us/dotnet/api/system.func-2) but we do not allow that for Func<T, TResult>
-        Action<int> action = obj => { };     // Noncompliant, the delegate parameter is named "obj" (https://learn.microsoft.com/en-us/dotnet/api/system.action-1) but we do not allow that for Func<T, TResult>
+        Action<int> action = obj => { };     // Noncompliant, the delegate parameter is named "obj" (https://learn.microsoft.com/en-us/dotnet/api/system.action-1) but we do not allow that for Action<T>
         new List<int>().Exists(obj => true); // Compliant. List.Exists uses System.Predicate<T> instead of System.Func<T, bool>
     }
 }


### PR DESCRIPTION
Fixes
```cs
public delegate void SomeDelegate(int someParameterName);

public void Use(SomeDelegate action) { }

public void Test()
{
    Use(x => { }); // Compliant
    Use(someParameterName => { }); // FP
}
```