### PR TITLE
Create rule S5344: Passwords should not be stored in plain-text or with a fast hashing algorithm (Part 2)

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PasswordsShouldBeStoredCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PasswordsShouldBeStoredCorrectly.cs
@@ -36,12 +36,13 @@ public sealed class PasswordsShouldBeStoredCorrectly : SonarDiagnosticAnalyzer
 
     protected override void Initialize(SonarAnalysisContext context)
     {
-        NetCore(context);
+        AspNetCore(context);
+        AspNetFramework(context);
         Rfc2898DeriveBytes(context);
         BouncyCastle(context);
     }
 
-    private static void NetCore(SonarAnalysisContext context)
+    private static void AspNetCore(SonarAnalysisContext context)
     {
         var propertyTracker = CSharpFacade.Instance.Tracker.PropertyAccess;
         Track(
@@ -49,14 +50,14 @@ public sealed class PasswordsShouldBeStoredCorrectly : SonarDiagnosticAnalyzer
             context,
             UseMoreIterationsMessageFormat,
             propertyTracker.MatchSetter(),
-            propertyTracker.MatchProperty(new MemberDescriptor(KnownType.Microsoft_AspNetCore_Identity_PasswordsHasherOptions, "IterationCount")),
+            propertyTracker.MatchProperty(new MemberDescriptor(KnownType.Microsoft_AspNetCore_Identity_PasswordHasherOptions, "IterationCount")),
             x => HasFewIterations(x, propertyTracker));
         Track(
             propertyTracker,
             context,
             "Identity v2 uses only 1000 iterations. Consider changing to identity V3.",
             propertyTracker.MatchSetter(),
-            propertyTracker.MatchProperty(new MemberDescriptor(KnownType.Microsoft_AspNetCore_Identity_PasswordsHasherOptions, "CompatibilityMode")),
+            propertyTracker.MatchProperty(new MemberDescriptor(KnownType.Microsoft_AspNetCore_Identity_PasswordHasherOptions, "CompatibilityMode")),
             x => propertyTracker.AssignedValue(x) is int mode && mode == 0); // PasswordHasherCompatibilityMode.IdentityV2 results to 0
 
         var argumentTracker = CSharpFacade.Instance.Tracker.Argument;
@@ -66,6 +67,16 @@ public sealed class PasswordsShouldBeStoredCorrectly : SonarDiagnosticAnalyzer
             UseMoreIterationsMessageFormat,
             argumentTracker.MatchArgument(ArgumentDescriptor.MethodInvocation(KnownType.Microsoft_AspNetCore_Cryptography_KeyDerivation_KeyDerivation, "Pbkdf2", "iterationCount", 3)),
             x => ArgumentLessThan(x, IterationCountThreshold));
+    }
+
+    private static void AspNetFramework(SonarAnalysisContext context)
+    {
+        var tracker = CSharpFacade.Instance.Tracker.ObjectCreation;
+        Track(
+            tracker,
+            context,
+            "PasswordHasher does not support state-of-the-art parameters. Use Rfc2898DeriveBytes instead.",
+            tracker.WhenDerivesFrom(KnownType.Microsoft_AspNet_Identity_PasswordHasherOptions));
     }
 
     private static void Rfc2898DeriveBytes(SonarAnalysisContext context)
@@ -109,16 +120,32 @@ public sealed class PasswordsShouldBeStoredCorrectly : SonarDiagnosticAnalyzer
             context,
             "Use a cost factor of at least 12 here.",
             tracker.Or(
-                tracker.MatchArgument(ArgumentDescriptor.MethodInvocation(KnownType.Org_BouncyCastle_Crypto_Generators_OpenBsdBCrypt, "Generate", "cost", x => x is 2 or 3)),
-                tracker.MatchArgument(ArgumentDescriptor.MethodInvocation(KnownType.Org_BouncyCastle_Crypto_Generators_BCrypt, "Generate", "cost", 2))),
+                tracker.MatchArgument(
+                    ArgumentDescriptor.MethodInvocation(KnownType.Org_BouncyCastle_Crypto_Generators_OpenBsdBCrypt, "Generate", "cost", x => x is 2 or 3)),
+                tracker.MatchArgument(
+                    ArgumentDescriptor.MethodInvocation(KnownType.Org_BouncyCastle_Crypto_Generators_BCrypt, "Generate", "cost", 2))),
             x => ArgumentLessThan(x, 12));
 
         Track(
             tracker,
             context,
             UseMoreIterationsMessageFormat,
-            tracker.MatchArgument(ArgumentDescriptor.MethodInvocation(KnownType.Org_BouncyCastle_Crypto_PbeParametersGenerator, "Init", "iterationCount", 2)),
+            tracker.MatchArgument(
+                ArgumentDescriptor.MethodInvocation(KnownType.Org_BouncyCastle_Crypto_PbeParametersGenerator, "Init", "iterationCount", 2)),
             x => ArgumentLessThan(x, IterationCountThreshold));
+
+        TrackSCrypt("N", 2, "Use a cost factor of at least 2 ^ 12 for N here.", 1 << 12);
+        TrackSCrypt("r", 3, "Use a memory factor of at least 8 for r here.", 8);
+        TrackSCrypt("dkLen", 5, "Use an output length of at least 32 for dkLen here.", 32);
+
+        void TrackSCrypt(string argumentName, int argumentPosition, string diagnosticMessage, int threshold) =>
+            Track(
+                tracker,
+                context,
+                diagnosticMessage,
+                tracker.MatchArgument(ArgumentDescriptor.MethodInvocation(
+                    KnownType.Org_BouncyCastle_Crypto_Generators_SCrypt, "Generate", argumentName, argumentPosition)),
+                x => ArgumentLessThan(x, threshold));
     }
 
     private static bool HasFewIterations(PropertyAccessContext context, PropertyAccessTracker<SyntaxKind> tracker) =>

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -53,6 +53,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType log4net_ILog = new("log4net.ILog");
         public static readonly KnownType log4net_LogManager = new("log4net.LogManager");
         public static readonly KnownType log4net_Util_ILogExtensions = new("log4net.Util.ILogExtensions");
+        public static readonly KnownType Microsoft_AspNet_Identity_PasswordHasherOptions = new("Microsoft.AspNet.Identity.PasswordHasherOptions");
         public static readonly KnownType Microsoft_AspNet_SignalR_Hub = new("Microsoft.AspNet.SignalR.Hub");
         public static readonly KnownType Microsoft_AspNetCore_Builder_DeveloperExceptionPageExtensions = new("Microsoft.AspNetCore.Builder.DeveloperExceptionPageExtensions");
         public static readonly KnownType Microsoft_AspNetCore_Builder_DatabaseErrorPageExtensions = new("Microsoft.AspNetCore.Builder.DatabaseErrorPageExtensions");
@@ -74,7 +75,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType Microsoft_AspNetCore_Http_IResponseCookies = new("Microsoft.AspNetCore.Http.IResponseCookies");
         public static readonly KnownType Microsoft_AspNetCore_Http_IResult = new("Microsoft.AspNetCore.Http.IResult");
         public static readonly KnownType Microsoft_AspNetCore_Http_Results = new("Microsoft.AspNetCore.Http.Results");
-        public static readonly KnownType Microsoft_AspNetCore_Identity_PasswordsHasherOptions = new("Microsoft.AspNetCore.Identity.PasswordHasherOptions");
+        public static readonly KnownType Microsoft_AspNetCore_Identity_PasswordHasherOptions = new("Microsoft.AspNetCore.Identity.PasswordHasherOptions");
         public static readonly KnownType Microsoft_AspNetCore_Mvc_AcceptVerbsAttribute = new("Microsoft.AspNetCore.Mvc.AcceptVerbsAttribute");
         public static readonly KnownType Microsoft_AspNetCore_Mvc_ApiControllerAttribute = new("Microsoft.AspNetCore.Mvc.ApiControllerAttribute");
         public static readonly KnownType Microsoft_AspNetCore_Mvc_ApiConventionMethodAttribute = new("Microsoft.AspNetCore.Mvc.ApiConventionMethodAttribute");
@@ -211,6 +212,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType Org_BouncyCastle_Asn1_X9_X962NamedCurves = new("Org.BouncyCastle.Asn1.X9.X962NamedCurves");
         public static readonly KnownType Org_BouncyCastle_Crypto_Engines_AesFastEngine = new("Org.BouncyCastle.Crypto.Engines.AesFastEngine");
         public static readonly KnownType Org_BouncyCastle_Crypto_Generators_BCrypt = new("Org.BouncyCastle.Crypto.Generators.BCrypt");
+        public static readonly KnownType Org_BouncyCastle_Crypto_Generators_SCrypt = new("Org.BouncyCastle.Crypto.Generators.SCrypt");
         public static readonly KnownType Org_BouncyCastle_Crypto_Generators_DHParametersGenerator = new("Org.BouncyCastle.Crypto.Generators.DHParametersGenerator");
         public static readonly KnownType Org_BouncyCastle_Crypto_Generators_OpenBsdBCrypt = new("Org.BouncyCastle.Crypto.Generators.OpenBsdBCrypt");
         public static readonly KnownType Org_BouncyCastle_Crypto_Generators_DsaParametersGenerator = new("Org.BouncyCastle.Crypto.Generators.DsaParametersGenerator");

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/PasswordsShouldBeStoredCorrectlyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/PasswordsShouldBeStoredCorrectlyTest.cs
@@ -80,7 +80,7 @@ public class PasswordsShouldBeStoredCorrectlyTest
                 {
                     const int ITERATIONS = 100_000;
 
-                    void Method(int iterations, byte[] bs)
+                    void Method(int iterations, byte[] bs, HashAlgorithmName han)
                     {
                         new Rfc2898DeriveBytes("password", bs);                             // Noncompliant
                         new Rfc2898DeriveBytes("password", 42);                             // Noncompliant
@@ -90,19 +90,35 @@ public class PasswordsShouldBeStoredCorrectlyTest
                     //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                         new Rfc2898DeriveBytes("password", bs, 42);                         // Noncompliant
                         new Rfc2898DeriveBytes("password", 42, 42);                         // Noncompliant
-                        new Rfc2898DeriveBytes(bs, bs, 42, HashAlgorithmName.MD5);          // Noncompliant {{Use at least 100,000 iterations here.}}
+                        new Rfc2898DeriveBytes(bs, bs, 42, han);                            // Noncompliant {{Use at least 100,000 iterations here.}}
                     //                                 ^^
-                        new Rfc2898DeriveBytes("password", bs, 42, HashAlgorithmName.MD5);  // Noncompliant
-                        new Rfc2898DeriveBytes("password", 42, 42, HashAlgorithmName.MD5);  // Noncompliant
+                        new Rfc2898DeriveBytes("password", bs, 42, han);                    // Noncompliant
+                        new Rfc2898DeriveBytes("password", 42, 42, han);                    // Noncompliant
                         new Rfc2898DeriveBytes(bs, bs, ITERATIONS);                         // Noncompliant
                         new Rfc2898DeriveBytes("", bs, ITERATIONS);                         // Noncompliant
                         new Rfc2898DeriveBytes("", 42, ITERATIONS);                         // Noncompliant
                     //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-                        new Rfc2898DeriveBytes(bs, bs, iterations, HashAlgorithmName.SHA1); // Compliant
-                        new Rfc2898DeriveBytes(bs, bs, ITERATIONS, HashAlgorithmName.SHA1); // Compliant
-                        new Rfc2898DeriveBytes("", bs, ITERATIONS, HashAlgorithmName.SHA1); // Compliant
-                        new Rfc2898DeriveBytes("", 42, ITERATIONS, HashAlgorithmName.SHA1); // Compliant
+                        new Rfc2898DeriveBytes(bs, bs, iterations, han);                    // Compliant
+                        new Rfc2898DeriveBytes(bs, bs, ITERATIONS, han);                    // Compliant
+                        new Rfc2898DeriveBytes("", bs, ITERATIONS, han);                    // Compliant
+                        new Rfc2898DeriveBytes("", 42, ITERATIONS, han);                    // Compliant
+
+                        var x = new Rfc2898DeriveBytes(bs, bs, ITERATIONS, han);
+                        x.IterationCount = 1;                                               // Noncompliant {{Use at least 100,000 iterations here.}}
+                    //  ^^^^^^^^^^^^^^^^
+
+                        new Rfc2898DeriveBytes(bs, bs, ITERATIONS, han)
+                        {
+                            IterationCount = 42                                             // Noncompliant {{Use at least 100,000 iterations here.}}
+                    //      ^^^^^^^^^^^^^^
+                        };
+                    }
+
+                    void MakeItUnsafe(Rfc2898DeriveBytes password)
+                    {
+                        password.IterationCount = 1;                                        // Noncompliant {{Use at least 100,000 iterations here.}}
+                    //  ^^^^^^^^^^^^^^^^^^^^^^^
                     }
                 }
                 """)

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/PasswordsShouldBeStoredCorrectlyTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/PasswordsShouldBeStoredCorrectlyTest.cs
@@ -108,6 +108,8 @@ public class PasswordsShouldBeStoredCorrectlyTest
                         x.IterationCount = 1;                                               // Noncompliant {{Use at least 100,000 iterations here.}}
                     //  ^^^^^^^^^^^^^^^^
 
+                        x.IterationCount = 100_042;                                         // Compliant
+
                         new Rfc2898DeriveBytes(bs, bs, ITERATIONS, han)
                         {
                             IterationCount = 42                                             // Noncompliant {{Use at least 100,000 iterations here.}}

--- a/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/NuGetMetadataReference.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/NuGetMetadataReference.cs
@@ -71,6 +71,7 @@ public static class NuGetMetadataReference
     public static References MicrosoftAspNetCoreRouting(string packageVersion) => Create("Microsoft.AspNetCore.Routing", packageVersion);
     public static References MicrosoftAspNetCoreMvcRazorRuntime(string packageVersion = "2.2.0") => Create("Microsoft.AspNetCore.Razor.Runtime", packageVersion);
     public static References MicrosoftAspNetCoreRoutingAbstractions(string packageVersion) => Create("Microsoft.AspNetCore.Routing.Abstractions", packageVersion);
+    public static References MicrosoftAspNetIdentity(string packageVersion = "3.0.0-rc1-final") => Create("Microsoft.AspNet.Identity", packageVersion);
     public static References MicrosoftAspNetMvc(string packageVersion) => Create("Microsoft.AspNet.Mvc", packageVersion);
     public static References MicrosoftAspNetCoreAppRef(string packageVersion) => Create("Microsoft.AspNetCore.App.Ref", packageVersion);
     public static References MicrosoftAspNetSignalRCore(string packageVersion = "2.4.1") => Create("Microsoft.AspNet.SignalR.Core", packageVersion);

--- a/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/NuGetMetadataReference.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/NuGetMetadataReference.cs
@@ -71,6 +71,7 @@ public static class NuGetMetadataReference
     public static References MicrosoftAspNetCoreRouting(string packageVersion) => Create("Microsoft.AspNetCore.Routing", packageVersion);
     public static References MicrosoftAspNetCoreMvcRazorRuntime(string packageVersion = "2.2.0") => Create("Microsoft.AspNetCore.Razor.Runtime", packageVersion);
     public static References MicrosoftAspNetCoreRoutingAbstractions(string packageVersion) => Create("Microsoft.AspNetCore.Routing.Abstractions", packageVersion);
+    // There is no package version of Microsoft.AspNet.Identity that is NOT a pre-release.
     public static References MicrosoftAspNetIdentity(string packageVersion = "3.0.0-rc1-final") => Create("Microsoft.AspNet.Identity", packageVersion);
     public static References MicrosoftAspNetMvc(string packageVersion) => Create("Microsoft.AspNet.Mvc", packageVersion);
     public static References MicrosoftAspNetCoreAppRef(string packageVersion) => Create("Microsoft.AspNetCore.App.Ref", packageVersion);


### PR DESCRIPTION
Part of #8998

Whatever is checked, is implemented in this PR:

- [ ]  `PasswordHasherOptions`.IterationCount < 100K (Core)
- [ ] `PasswordHasherOptions`.CompatibilityMode == IdentityV2 (Core)
- [ ] `KeyDerivation`.Pbkdf2.iterationCount < 100K (Core)
- [ ] `Rfc2898DeriveBytes.`Pbkdf2.iterations < 100K (Core)
- [x] `PasswordHasher` instantiated (FRM)
- [ ] `Rfc2898DeriveBytes`.iterations < 100K (cross-platform)
- [ ] `Rfc2898DeriveBytes`.hashAlgorithm does not exist (cross-platform)
- [ ] (`OpenBsdCrypt`/`BCrypt`).Generate.cost < 12 (BouncyCastle)
- [ ] `PbeParametersGenerator`.Init.iterationCount < 100K (BouncyCastle)
- [x] `SCrypt`.Generate N < 2^12, r < 8, or dklen < 32 (BouncyCastle)