### PR TITLE
UTs: run on dotnet 8.0.5

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/Metrics/CSharpExecutableLinesMetricTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Metrics/CSharpExecutableLinesMetricTest.cs
@@ -893,14 +893,14 @@ class Program
 @page "/razor"
 @using TestCases
 
-<p>Current count: @currentCount</p>     <!-- +1 -->
+<p>Current count: @currentCount</p>     <!-- Not counted -->
 
-@currentCount                           <!-- +1 -->
+@currentCount                           <!-- Not counted -->
 
 @code {
     private int currentCount = 0;
 }
-""", RazorFile, 4, 6);
+""", RazorFile);
 
         [TestMethod]
         public void GetLineNumbers_Razor_MethodReferenceAndCall() =>
@@ -927,13 +927,13 @@ class Program
         [TestMethod]
         public void GetLineNumbers_Razor_PropertyReference() =>
             AssertLineNumbersOfExecutableLinesRazor("""
-@IncrementAmount <!-- +1 -->
+@IncrementAmount <!-- Not counted -->
 
 @code {
     [Parameter]
     public int IncrementAmount { get; set; } = 1;
 }
-""", RazorFile, 1);
+""", RazorFile);
 
         [TestMethod]
         public void GetLineNumbers_Razor_Html() =>

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/Utilities/MetricsAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/Utilities/MetricsAnalyzerTest.cs
@@ -69,14 +69,14 @@ namespace SonarAnalyzer.Test.Rules
                     var metrics = messages.Single(x => x.FilePath.EndsWith(RazorFileName));
 
                     metrics.ClassCount.Should().Be(1);
-                    metrics.CodeLine.Should().BeEquivalentTo(new[] { 3, 5, 8, 10, 13, 15, 16, 17, 19, 22, 23, 24, 26, 28, 29, 32, 33, 34, 36, 37, 39, 40, 43 });
+                    metrics.CodeLine.Should().BeEquivalentTo(new[] { 2, 1, 3, 5, 8, 10, 13, 15, 16, 17, 19, 22, 23, 24, 26, 28, 29, 32, 33, 34, 36, 37, 39, 40, 43 });
                     metrics.CognitiveComplexity.Should().Be(3);
                     metrics.Complexity.Should().Be(4);
-                    metrics.ExecutableLines.Should().BeEquivalentTo(new[] { 3, 5, 13, 15, 17, 24, 28, 29, 32, 36, 39, 43 });
+                    metrics.ExecutableLines.Should().BeEquivalentTo(new[] { 13, 15, 28, 29, 32, 36 });
                     metrics.FunctionCount.Should().Be(1);
                     metrics.NoSonarComment.Should().BeEmpty();
                     metrics.NonBlankComment.Should().BeEquivalentTo(new[] { 7, 8, 10, 15, 21, 22, 23, 28, 29, 32, 33, 36, 37, 38 });
-                    metrics.StatementCount.Should().Be(13);
+                    metrics.StatementCount.Should().Be(6);
                 });
 
         [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/Utilities/MetricsAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/Utilities/MetricsAnalyzerTest.cs
@@ -69,7 +69,7 @@ namespace SonarAnalyzer.Test.Rules
                     var metrics = messages.Single(x => x.FilePath.EndsWith(RazorFileName));
 
                     metrics.ClassCount.Should().Be(1);
-                    metrics.CodeLine.Should().BeEquivalentTo(new[] { 2, 1, 3, 5, 8, 10, 13, 15, 16, 17, 19, 22, 23, 24, 26, 28, 29, 32, 33, 34, 36, 37, 39, 40, 43 });
+                    metrics.CodeLine.Should().BeEquivalentTo(new[] { 1, 2, 3, 5, 8, 10, 13, 15, 16, 17, 19, 22, 23, 24, 26, 28, 29, 32, 33, 34, 36, 37, 39, 40, 43 });
                     metrics.CognitiveComplexity.Should().Be(3);
                     metrics.Complexity.Should().Be(4);
                     metrics.ExecutableLines.Should().BeEquivalentTo(new[] { 13, 15, 28, 29, 32, 36 });

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/Utilities/SymbolReferenceAnalyzerTest.cs
@@ -244,11 +244,11 @@ namespace SonarAnalyzer.Test.Rules
 
                         orderedSymbols[1].FilePath.Should().EndWith("RazorComponent.razor");        // RazorComponent.razor
                         // https://github.com/SonarSource/sonar-dotnet/issues/8417
-                        // Net8 SDK: Declaration (1,0) - (1,17) Reference (1,6) - (1,23) <- Overlapping
+                        // before dotnet 8.0.5  SDK: Declaration (1,0) - (1,17) Reference (1,6) - (1,23) <- Overlapping
                         // Declaration of TSomeVeryLongName is placed starting at index 0 (ignoring "@typeparam ")
                         // Reference "where TSomeVeryLongName" is placed starting at index 6 (ignoring "@typeparam TSomeVeryLongName ")
                         VerifyReferences(orderedSymbols[1].Reference, 1, 1, 1);
-                        orderedSymbols[1].Reference.Single().Reference.Single().Should().BeEquivalentTo(new TextRange { StartLine = 1, EndLine = 1, StartOffset = 6, EndOffset = 23 });
+                        orderedSymbols[1].Reference.Single().Reference.Single().Should().BeEquivalentTo(new TextRange { StartLine = 1, EndLine = 1, StartOffset = 35, EndOffset = 52 });
                     });
 
         [DataTestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/Utilities/MetricsAnalyzer/Razor.razor
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/Utilities/MetricsAnalyzer/Razor.razor
@@ -37,7 +37,7 @@
 {                                                  // code line
     // comment
     @:Name: @i                                     // code line, FN: comment 
-}                                                  <!-- FN: comment,code line -->
+}                                                  <!-- code line, FN: comment -->
 
 <Component>
     @currentCount                                  <!-- FN: comment -->

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/Utilities/MetricsAnalyzer/Razor.razor
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/Utilities/MetricsAnalyzer/Razor.razor
@@ -1,8 +1,8 @@
-@page "/razor"                                     // FN: line of code, comment (location mapping issue)
-@namespace RazorNamespace                          // FN: line of code, comment (location mapping issue)
-<p>Current count: @currentCount</p>                <!-- code line, FN: comment -->
+@page "/razor"
+@namespace RazorNamespace
+<p>Current count: @currentCount</p>                <!-- FN: comment -->
 
-@currentCount                                      <!-- code line, FN: comment -->
+@currentCount                                      <!-- FN: comment -->
 
 @code {                                            // FN: line of code (location mapping issue)
     private int currentCount = 0;                  // code line
@@ -14,14 +14,14 @@
 
 @for (var i = 0; i < 5; i++)                       // code line
 {                                                  <!-- code line, FN: comment -->
-    <text>Value: @i</text>                         <!-- code line, FN: comment -->
+    <text>Value: @i</text>                         <!-- FN: comment -->
     <text>test</text>
 }                                                  <!-- code line, FN: comment -->
 
 @{                                                 // FN: code line (location mapping issue)
     void RenderName(string name)                   // code line
     {                                              // code line
-        <p>Name: <strong>@name</strong></p>        <!-- code line, FN: comment -->
+        <p>Name: <strong>@name</strong></p>        <!-- FN: comment -->
         <p>Name: <strong>Hardcoded</strong></p>
     }                                              <!-- code line, FN: comment -->
 
@@ -37,10 +37,10 @@
 {                                                  // code line
     // comment
     @:Name: @i                                     // code line, FN: comment 
-}                                                  <!-- code line, FN: comment -->
+}                                                  <!-- FN: comment,code line -->
 
 <Component>
-    @currentCount                                  <!-- code line, FN: comment -->
+    @currentCount                                  <!-- FN: comment -->
 </Component>
 
 <!-- FN: comment -->

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Common/SourceGeneratorProviderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Common/SourceGeneratorProviderTest.cs
@@ -26,12 +26,12 @@ namespace SonarAnalyzer.TestFramework.Test.Common;
 public class SourceGeneratorProviderTest
 {
     private static AnalyzerFileReference RazorSourceGenerator =>
-        SourceGeneratorProvider.SourceGenerators.Single(x => x.FullPath.EndsWith("Microsoft.CodeAnalysis.Razor.Compiler.SourceGenerators.dll"));
+        SourceGeneratorProvider.SourceGenerators.Single(x => x.FullPath.EndsWith("Microsoft.CodeAnalysis.Razor.Compiler.dll"));
 
     [TestMethod]
     public void SourceGenerators_ContainsRazorSourceGenerator() =>
         SourceGeneratorProvider.SourceGenerators.Should()
-            .Contain(x => x.FullPath.EndsWith(Path.Combine("Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.CodeAnalysis.Razor.Compiler.SourceGenerators.dll")));
+            .Contain(x => x.FullPath.EndsWith(Path.Combine("Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.CodeAnalysis.Razor.Compiler.dll")));
 
     [TestMethod]
     public void RazorSourceGenerator_ExistsLocally() =>
@@ -39,7 +39,7 @@ public class SourceGeneratorProviderTest
 
     [TestMethod]
     public void RazorSourceGenerator_LoadsCorrectAssembly() =>
-        RazorSourceGenerator.GetAssembly().GetName().Name.Should().Be("Microsoft.CodeAnalysis.Razor.Compiler.SourceGenerators");
+        RazorSourceGenerator.GetAssembly().GetName().Name.Should().Be("Microsoft.CodeAnalysis.Razor.Compiler");
 
     [TestMethod]
     public void LatestSdkFolder_ReturnsAssemblyMajor()

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/Dummy.SecondaryLocation.razor
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/Dummy.SecondaryLocation.razor
@@ -1,7 +1,7 @@
 
 <p>The solution to all problems is: @(RaiseHere(21))</p> @* wrong location *@
-@*                      ^^^^^^^^^ *@
-@*                                ^^ Secondary@-1 *@
+@*                                    ^^^^^^^^^ *@
+@*                                              ^^ Secondary@-1 *@
 
 @code
 {

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/Dummy.SecondaryLocation.razor
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/Dummy.SecondaryLocation.razor
@@ -1,5 +1,5 @@
 
-<p>The solution to all problems is: @(RaiseHere(21))</p> @* wrong location *@
+<p>The solution to all problems is: @(RaiseHere(21))</p>
 @*                                    ^^^^^^^^^ *@
 @*                                              ^^ Secondary@-1 *@
 

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/DummyExpressions.razor
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/DummyExpressions.razor
@@ -1,8 +1,8 @@
 ﻿<p>Explicit expression: @(RaiseHere())</p> @* Noncompliant, wrong location*@
-@*                      ^^^^^^^^^ *@
+@*                        ^^^^^^^^^ *@
 
 <p>Implicit expression: @RaiseHere()</p> @* Noncompliant, wrong location *@
-@*                      ^^^^^^^^^ *@
+@*                       ^^^^^^^^^ *@
 
 <p>Multi-statement block: @{ var result = RaiseHere(); }</p>
 @*                                        ^^^^^^^^^ *@
@@ -17,7 +17,7 @@
 @*                 ^^^^^^^^^ *@
 
 <p>Lambda expression: @((Func<int>)(() => RaiseHere()))()</p> @* Noncompliant, wrong location *@
-@*                                         ^^^^^^^^^ *@
+@*                                        ^^^^^^^^^ *@
 
 <p>Nested multi-statement block: @{ var result2 = RaiseHere(); var result3 = RaiseHere(); }</p>
 @*                                                ^^^^^^^^^ *@
@@ -25,7 +25,7 @@
 
 <p>Nested control structures: @if(RaiseHere() == 42) { <text>@(RaiseHere() + 1)</text> }</p> @* second issue has wrong location *@
 @*                                ^^^^^^^^^ *@
-@*                       ^^^^^^^^^@-1 *@
+@*                                                             ^^^^^^^^^@-1 *@
 
 @code
 {

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/DummyExpressions.razor
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/DummyExpressions.razor
@@ -1,7 +1,7 @@
-﻿<p>Explicit expression: @(RaiseHere())</p> @* Noncompliant, wrong location*@
+﻿<p>Explicit expression: @(RaiseHere())</p> @* Noncompliant *@
 @*                        ^^^^^^^^^ *@
 
-<p>Implicit expression: @RaiseHere()</p> @* Noncompliant, wrong location *@
+<p>Implicit expression: @RaiseHere()</p> @* Noncompliant *@
 @*                       ^^^^^^^^^ *@
 
 <p>Multi-statement block: @{ var result = RaiseHere(); }</p>
@@ -16,7 +16,7 @@
 <p>Code blocks: @{ RaiseHere(); }</p>
 @*                 ^^^^^^^^^ *@
 
-<p>Lambda expression: @((Func<int>)(() => RaiseHere()))()</p> @* Noncompliant, wrong location *@
+<p>Lambda expression: @((Func<int>)(() => RaiseHere()))()</p> @* Noncompliant *@
 @*                                        ^^^^^^^^^ *@
 
 <p>Nested multi-statement block: @{ var result2 = RaiseHere(); var result3 = RaiseHere(); }</p>

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/DummyExpressions.razor
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/TestCases/DummyExpressions.razor
@@ -23,7 +23,7 @@
 @*                                                ^^^^^^^^^ *@
 @*                                                                           ^^^^^^^^^@-1 *@
 
-<p>Nested control structures: @if(RaiseHere() == 42) { <text>@(RaiseHere() + 1)</text> }</p> @* second issue has wrong location *@
+<p>Nested control structures: @if(RaiseHere() == 42) { <text>@(RaiseHere() + 1)</text> }</p>
 @*                                ^^^^^^^^^ *@
 @*                                                             ^^^^^^^^^@-1 *@
 

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/SourceGeneratorProvider.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/SourceGeneratorProvider.cs
@@ -26,7 +26,7 @@ namespace SonarAnalyzer.TestFramework.Common;
 public static class SourceGeneratorProvider
 {
     private static readonly string RazorSourceGeneratorPath =
-        Path.Combine(LatestSdkFolder(), "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.CodeAnalysis.Razor.Compiler.SourceGenerators.dll");
+        Path.Combine(LatestSdkFolder(), "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.CodeAnalysis.Razor.Compiler.dll");
 
     public static AnalyzerFileReference[] SourceGenerators { get; } =
     [

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -248,6 +248,12 @@ stages:
             FrameworkMoniker: 'net8.0'
 
       steps:
+      - task: UseDotNet@2
+        displayName: Use .NET
+        inputs:
+          packageType: 'sdk'
+          version: 8.0.300
+
       - task: DownloadPipelineArtifact@2
         displayName: 'Download binaries to test'
         inputs:


### PR DESCRIPTION
dotnet 8.0.5 introduced breaking changes when generating code for Razor files.

This PR updates our pipeline to:
- run UTs on 8.0.5
- describe the new behavior

Fixes: https://github.com/SonarSource/sonar-dotnet/issues/9291