### PR TITLE
SonarReportingContext: Add ReportIssue with SecondaryLocation

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveClassCoupling.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveClassCoupling.cs
@@ -90,7 +90,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (dependentTypes.Count > Threshold)
                     {
-                        c.ReportIssue(Rule, typeDeclaration.Identifier, typeDeclaration.Keyword.ValueText, dependentTypes.Count, Threshold);
+                        c.ReportIssue(Rule, typeDeclaration.Identifier, typeDeclaration.Keyword.ValueText, dependentTypes.Count.ToString(), Threshold.ToString());
                     }
                 },
                 SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveInheritance.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AvoidExcessiveInheritance.cs
@@ -75,7 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         .Count();
                     if (baseTypesCount > MaximumDepth)
                     {
-                        c.ReportIssue(Rule, objectTypeInfo.Identifier, objectTypeInfo.Name, baseTypesCount, MaximumDepth);
+                        c.ReportIssue(Rule, objectTypeInfo.Identifier, objectTypeInfo.Name, baseTypesCount.ToString(), MaximumDepth.ToString());
                     }
                 },
                 SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameCondition.cs
@@ -32,11 +32,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var currentCondition = ifStatement.Condition;
                     if (ifStatement.GetPrecedingConditionsInConditionChain().FirstOrDefault(x => CSharpEquivalenceChecker.AreEquivalent(currentCondition, x)) is { } precedingCondition)
                     {
-                        c.ReportIssue(rule.CreateDiagnostic(c.Compilation,
-                            currentCondition.GetLocation(),
-                            new[] { precedingCondition.GetLocation() },
-                            properties: null,
-                            precedingCondition.GetLineNumberToReport()));
+                        c.ReportIssue(rule, currentCondition, [precedingCondition.ToSecondaryLocation()], precedingCondition.GetLineNumberToReport().ToString());
                     }
                 },
                 SyntaxKind.IfStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalStructureSameImplementation.cs
@@ -100,11 +100,7 @@ namespace SonarAnalyzer.Rules.CSharp
         }
 
         private static void ReportSyntaxNode(SonarSyntaxNodeReportingContext context, SyntaxNode node, SyntaxNode precedingNode, string errorMessageDiscriminator) =>
-            context.ReportIssue(Rule.CreateDiagnostic(context.Compilation,
-                node.GetLocation(),
-                additionalLocations: new[] { precedingNode.GetLocation() },
-                properties: null,
-                messageArgs: new object[] { precedingNode.GetLineNumberToReport(), errorMessageDiscriminator }));
+            context.ReportIssue(Rule, node, [precedingNode.ToSecondaryLocation()], precedingNode.GetLineNumberToReport().ToString(), errorMessageDiscriminator);
 
         private static bool IsApprovedStatement(StatementSyntax statement) =>
             !statement.IsAnyKind(IgnoredStatementsInSwitch);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MultilineBlocksWithoutBrace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MultilineBlocksWithoutBrace.cs
@@ -96,8 +96,7 @@ public sealed class MultilineBlocksWithoutBrace : SonarDiagnosticAnalyzer
             var lineSpan = context.Node.SyntaxTree.GetText().Lines[secondLine].Span;
             var location = Location.Create(context.Node.SyntaxTree, TextSpan.FromBounds(second.SpanStart, lineSpan.End));
             var blockSize = secondLine - StartPosition(first).Line + 1;
-            var additional = new[] { first.GetLocation() };
-            context.ReportIssue(Rule.CreateDiagnostic(context.Compilation, location, additional, properties: null, executed, execute, blockSize));
+            context.ReportIssue(Rule, location, [first.ToSecondaryLocation()], executed, execute, blockSize.ToString());
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwaggerActionReturnType.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwaggerActionReturnType.cs
@@ -71,7 +71,7 @@ public sealed class SwaggerActionReturnType : SonarDiagnosticAnalyzer
                             var methodDeclaration = (MethodDeclarationSyntax)nodeContext.Node;
                             if (InvalidMethod(methodDeclaration, nodeContext) is { } method)
                             {
-                                nodeContext.ReportIssue(Rule, methodDeclaration.Identifier, additionalLocations: method.ResponseInvocations, GetMessage(method.Symbol));
+                                nodeContext.ReportIssue(Rule, methodDeclaration.Identifier, method.ResponseInvocations.Select(x => x.ToSecondaryLocation()), GetMessage(method.Symbol));
                             }
                         }, SyntaxKind.MethodDeclaration);
                     }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
@@ -34,7 +34,7 @@ public abstract class SonarReportingContextBase<TContext> : SonarAnalysisContext
             && SonarAnalysisContext.LegacyIsRegisteredActionEnabled(diagnostic.Descriptor, diagnostic.Location?.SourceTree))
         {
             var reportingContext = CreateReportingContext(diagnostic);
-            if (!reportingContext.Compilation.IsValidLocation(diagnostic.Location))
+            if (!diagnostic.Location.IsValid(reportingContext.Compilation))
             {
                 Debug.Fail("Primary location should be part of the compilation. An AD0001 is raised if this is not the case.");
                 return;
@@ -111,8 +111,8 @@ public abstract class SonarTreeReportingContextBase<TContext> : SonarReportingCo
 
     public void ReportIssue(DiagnosticDescriptor rule, Location primaryLocation, IEnumerable<SecondaryLocation> secondaryLocations, params string[] messageArgs)
     {
-        secondaryLocations = secondaryLocations.Where(x => Compilation.IsValidLocation(x.Location)).ToArray();
-        var properties = secondaryLocations.Select((x, index) => new { x.Message, Index = index }).ToImmutableDictionary(x => x.Index.ToString(), x => x.Message);
+        secondaryLocations = secondaryLocations.Where(x => x.Location.IsValid(Compilation)).ToArray();
+        var properties = secondaryLocations.Select((x, index) => new KeyValuePair<string, string>(index.ToString(), x.Message)).ToImmutableDictionary();
         ReportIssueCore(Diagnostic.Create(rule, primaryLocation, secondaryLocations.Select(x => x.Location), properties, messageArgs));
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
@@ -103,14 +103,6 @@ public abstract class SonarTreeReportingContextBase<TContext> : SonarReportingCo
     public void ReportIssue(DiagnosticDescriptor rule, SyntaxToken locationToken, params string[] messageArgs) =>
         ReportIssue(rule, locationToken.GetLocation(), messageArgs);
 
-    [Obsolete("Use overload with IEnumrable<SecondaryLocation> instead")]
-    public void ReportIssue(DiagnosticDescriptor rule, SyntaxToken locationToken, IEnumerable<SyntaxNode> additionalLocations, params string[] messageArgs) =>
-        ReportIssueCore(Diagnostic.Create(rule, locationToken.GetLocation(), additionalLocations.Select(x => x.GetLocation()), messageArgs));
-
-    [Obsolete("Use overload with IEnumrable<SecondaryLocation> instead")]
-    public void ReportIssue(DiagnosticDescriptor rule, Location location, IEnumerable<Location> additionalLocations, ImmutableDictionary<string, string> properties, params string[] messageArgs) =>
-        ReportIssueCore(Diagnostic.Create(rule, location, additionalLocations, properties, messageArgs));
-
     public void ReportIssue(DiagnosticDescriptor rule, SyntaxToken primaryLocationToken, IEnumerable<SecondaryLocation> secondaryLocations, params string[] messageArgs) =>
         ReportIssue(rule, primaryLocationToken.GetLocation(), secondaryLocations, messageArgs);
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
@@ -94,30 +94,30 @@ public abstract class SonarTreeReportingContextBase<TContext> : SonarReportingCo
     public void ReportIssue(Diagnostic diagnostic) =>
         ReportIssueCore(diagnostic);
 
-    public void ReportIssue(DiagnosticDescriptor rule, SyntaxNode locationSyntax, params object[] messageArgs) =>
+    public void ReportIssue(DiagnosticDescriptor rule, SyntaxNode locationSyntax, params string[] messageArgs) =>
         ReportIssue(rule, locationSyntax.GetLocation(), messageArgs);
 
-    public void ReportIssue(DiagnosticDescriptor rule, SyntaxNode primaryLocationSyntax, IEnumerable<SecondaryLocation> secondaryLocations, params object[] messageArgs) =>
+    public void ReportIssue(DiagnosticDescriptor rule, SyntaxNode primaryLocationSyntax, IEnumerable<SecondaryLocation> secondaryLocations, params string[] messageArgs) =>
         ReportIssue(rule, primaryLocationSyntax.GetLocation(), secondaryLocations, messageArgs);
 
-    public void ReportIssue(DiagnosticDescriptor rule, SyntaxToken locationToken, params object[] messageArgs) =>
+    public void ReportIssue(DiagnosticDescriptor rule, SyntaxToken locationToken, params string[] messageArgs) =>
         ReportIssue(rule, locationToken.GetLocation(), messageArgs);
 
     [Obsolete("Use overload with IEnumrable<SecondaryLocation> instead")]
-    public void ReportIssue(DiagnosticDescriptor rule, SyntaxToken locationToken, IEnumerable<SyntaxNode> additionalLocations, params object[] messageArgs) =>
+    public void ReportIssue(DiagnosticDescriptor rule, SyntaxToken locationToken, IEnumerable<SyntaxNode> additionalLocations, params string[] messageArgs) =>
         ReportIssueCore(Diagnostic.Create(rule, locationToken.GetLocation(), additionalLocations.Select(x => x.GetLocation()), messageArgs));
 
     [Obsolete("Use overload with IEnumrable<SecondaryLocation> instead")]
-    public void ReportIssue(DiagnosticDescriptor rule, Location location, IEnumerable<Location> additionalLocations, ImmutableDictionary<string, string> properties, params object[] messageArgs) =>
+    public void ReportIssue(DiagnosticDescriptor rule, Location location, IEnumerable<Location> additionalLocations, ImmutableDictionary<string, string> properties, params string[] messageArgs) =>
         ReportIssueCore(Diagnostic.Create(rule, location, additionalLocations, properties, messageArgs));
 
-    public void ReportIssue(DiagnosticDescriptor rule, SyntaxToken primaryLocationToken, IEnumerable<SecondaryLocation> secondaryLocations, params object[] messageArgs) =>
+    public void ReportIssue(DiagnosticDescriptor rule, SyntaxToken primaryLocationToken, IEnumerable<SecondaryLocation> secondaryLocations, params string[] messageArgs) =>
         ReportIssue(rule, primaryLocationToken.GetLocation(), secondaryLocations, messageArgs);
 
-    public void ReportIssue(DiagnosticDescriptor rule, Location location, params object[] messageArgs) =>
+    public void ReportIssue(DiagnosticDescriptor rule, Location location, params string[] messageArgs) =>
         ReportIssueCore(Diagnostic.Create(rule, location, messageArgs));
 
-    public void ReportIssue(DiagnosticDescriptor rule, Location primaryLocation, IEnumerable<SecondaryLocation> secondaryLocations, params object[] messageArgs)
+    public void ReportIssue(DiagnosticDescriptor rule, Location primaryLocation, IEnumerable<SecondaryLocation> secondaryLocations, params string[] messageArgs)
     {
         secondaryLocations = secondaryLocations.Where(x => Compilation.IsValidLocation(x.Location)).ToArray();
         var properties = secondaryLocations.Select((x, index) => new { x.Message, Index = index }).ToImmutableDictionary(x => x.Index.ToString(), x => x.Message);

--- a/analyzers/src/SonarAnalyzer.Common/Common/SecondaryLocation.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/SecondaryLocation.cs
@@ -20,10 +20,7 @@
 
 namespace SonarAnalyzer.Common;
 
-public record SecondaryLocation(Location Location, string Message)
-{
-    public SecondaryLocation(Location location) : this(location, null) { }
-}
+public record SecondaryLocation(Location Location, string Message);
 
 public static class SecondaryLocationExtensions
 {

--- a/analyzers/src/SonarAnalyzer.Common/Common/SecondaryLocation.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/SecondaryLocation.cs
@@ -44,11 +44,4 @@ public static class SecondaryLocationExtensions
             .Select((item, index) => new { message, Index = index.ToString() })
             .ToDictionary(x => x.Index, x => message)
             .ToImmutableDictionary();
-
-    // FIXME: This does not belong in here
-    public static SecondaryLocation GetSecondaryLocation(this Diagnostic diagnostic, int index) =>
-        diagnostic.AdditionalLocations.Count <= index
-                ? throw new ArgumentOutOfRangeException(nameof(index))
-                : new SecondaryLocation(diagnostic.AdditionalLocations[index],
-                                        ((IDictionary<string, string>)diagnostic.Properties).GetValueOrDefault(index.ToString()));
 }

--- a/analyzers/src/SonarAnalyzer.Common/Common/SecondaryLocation.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/SecondaryLocation.cs
@@ -18,41 +18,37 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Common
+namespace SonarAnalyzer.Common;
+
+public record SecondaryLocation(Location Location, string Message)
 {
-    public class SecondaryLocation
-    {
-        public SecondaryLocation(Location location, string message)
-        {
-            Location = location;
-            Message = message;
-        }
+    public SecondaryLocation(Location location) : this(location, null) { }
+}
 
-        public Location Location { get; }
-        public string Message { get; }
-    }
+public static class SecondaryLocationExtensions
+{
+    [Obsolete("Use ReportIssue overload with IEnumerable<SecondaryLocation> parameter instead.")]
+    public static IEnumerable<Location> ToAdditionalLocations(this IEnumerable<SecondaryLocation> secondaryLocations) =>
+        secondaryLocations.Select(x => x.Location);
 
-    public static class SecondaryLocationHelper
-    {
-        public static IEnumerable<Location> ToAdditionalLocations(this IEnumerable<SecondaryLocation> secondaryLocations) =>
-            secondaryLocations.Select(x => x.Location);
+    [Obsolete("Use ReportIssue overload with IEnumerable<SecondaryLocation> parameter instead.")]
+    public static ImmutableDictionary<string, string> ToProperties(this IEnumerable<SecondaryLocation> secondaryLocations) =>
+        secondaryLocations
+            .Select((item, index) => new { item.Message, Index = index.ToString() })
+            .ToDictionary(x => x.Index, x => x.Message)
+            .ToImmutableDictionary();
 
-        public static ImmutableDictionary<string, string> ToProperties(this IEnumerable<SecondaryLocation> secondaryLocations) =>
-            secondaryLocations
-                .Select((item, index) => new { item.Message, Index = index.ToString() })
-                .ToDictionary(i => i.Index, i => i.Message)
-                .ToImmutableDictionary();
+    [Obsolete("Use ReportIssue overload with IEnumerable<SecondaryLocation> parameter instead.")]
+    public static ImmutableDictionary<string, string> ToProperties(this IEnumerable<Location> secondaryLocations, string message) =>
+          secondaryLocations
+            .Select((item, index) => new { message, Index = index.ToString() })
+            .ToDictionary(x => x.Index, x => message)
+            .ToImmutableDictionary();
 
-        public static ImmutableDictionary<string, string> ToProperties(this IEnumerable<Location> secondaryLocations, string message) =>
-              secondaryLocations
-                .Select((item, index) => new { message, Index = index.ToString() })
-                .ToDictionary(i => i.Index, i => message)
-                .ToImmutableDictionary();
-
-        public static SecondaryLocation GetSecondaryLocation(this Diagnostic diagnostic, int index) =>
-            diagnostic.AdditionalLocations.Count <= index
-                    ? throw new ArgumentOutOfRangeException(nameof(index))
-                    : new SecondaryLocation(diagnostic.AdditionalLocations[index],
-                                            ((IDictionary<string, string>)diagnostic.Properties).GetValueOrDefault(index.ToString()));
-    }
+    // FIXME: This does not belong in here
+    public static SecondaryLocation GetSecondaryLocation(this Diagnostic diagnostic, int index) =>
+        diagnostic.AdditionalLocations.Count <= index
+                ? throw new ArgumentOutOfRangeException(nameof(index))
+                : new SecondaryLocation(diagnostic.AdditionalLocations[index],
+                                        ((IDictionary<string, string>)diagnostic.Properties).GetValueOrDefault(index.ToString()));
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/CompilationExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/CompilationExtensions.cs
@@ -57,4 +57,7 @@ internal static class CompilationExtensions
             ? memberSymbols.Any()
             : memberSymbols.Any(memberCheck);
     }
+
+    public static bool IsValidLocation(this Compilation compilation, Location location) =>
+        location.Kind != LocationKind.SourceFile || compilation.ContainsSyntaxTree(location.SourceTree);
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/CompilationExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/CompilationExtensions.cs
@@ -57,7 +57,4 @@ internal static class CompilationExtensions
             ? memberSymbols.Any()
             : memberSymbols.Any(memberCheck);
     }
-
-    public static bool IsValidLocation(this Compilation compilation, Location location) =>
-        location.Kind != LocationKind.SourceFile || compilation.ContainsSyntaxTree(location.SourceTree);
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/DiagnosticDescriptorExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/DiagnosticDescriptorExtensions.cs
@@ -47,14 +47,12 @@ public static class DiagnosticDescriptorExtensions
         }
     }
 
+    [Obsolete("Use ReportIssue overload with DiagnosticDescriptor and IEnumerable<SecondaryLocations> parameters instead.")]
     public static Diagnostic CreateDiagnostic(this DiagnosticDescriptor descriptor,
                                               Compilation compilation,
                                               Location location,
                                               IEnumerable<Location> additionalLocations,
                                               ImmutableDictionary<string, string> properties,
                                               params object[] messageArgs) =>
-        Diagnostic.Create(descriptor, location, additionalLocations?.Where(x => IsLocationValid(x, compilation)), properties, messageArgs);
-
-    private static bool IsLocationValid(Location location, Compilation compilation) =>
-        location.Kind != LocationKind.SourceFile || compilation.ContainsSyntaxTree(location.SourceTree);
+        Diagnostic.Create(descriptor, location, additionalLocations?.Where(x => compilation.IsValidLocation(x)), properties, messageArgs);
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/DiagnosticDescriptorExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/DiagnosticDescriptorExtensions.cs
@@ -54,5 +54,5 @@ public static class DiagnosticDescriptorExtensions
                                               IEnumerable<Location> additionalLocations,
                                               ImmutableDictionary<string, string> properties,
                                               params object[] messageArgs) =>
-        Diagnostic.Create(descriptor, location, additionalLocations?.Where(x => compilation.IsValidLocation(x)), properties, messageArgs);
+        Diagnostic.Create(descriptor, location, additionalLocations?.Where(x => x.IsValid(compilation)), properties, messageArgs);
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/LocationExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/LocationExtensions.cs
@@ -44,4 +44,7 @@ public static class LocationExtensions
 
     public static int EndLine(this Location location) =>
         location.GetLineSpan().EndLinePosition.Line;
+
+    public static SecondaryLocation ToSecondary(this Location location, string message = null) =>
+        new(location, message);
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/LocationExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/LocationExtensions.cs
@@ -45,6 +45,9 @@ public static class LocationExtensions
     public static int EndLine(this Location location) =>
         location.GetLineSpan().EndLinePosition.Line;
 
+    public static bool IsValid(this Location location, Compilation compilation) =>
+        location.Kind != LocationKind.SourceFile || compilation.ContainsSyntaxTree(location.SourceTree);
+
     public static SecondaryLocation ToSecondary(this Location location, string message = null) =>
         new(location, message);
 }

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxTokenExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/SyntaxTokenExtensions.cs
@@ -24,4 +24,7 @@ public static class SyntaxTokenExtensions
 {
     public static int Line(this SyntaxToken token) =>
         token.GetLocation().StartLine();
+
+    public static SecondaryLocation ToSecondaryLocation(this SyntaxToken token, string message = null) =>
+        new(token.GetLocation(), message);
 }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/SyntaxNodeExtensions.cs
@@ -53,6 +53,9 @@ internal static class SyntaxNodeExtensions
         return root.SyntaxTree.FilePath;
     }
 
-    internal static TSyntaxKind Kind<TSyntaxKind>(this SyntaxNode node) where TSyntaxKind : struct, Enum => // internal to not be confused with e.g. CSharp.SyntaxNode.Kind()
-        node == null ? default : (TSyntaxKind)Enum.ToObject(typeof(TSyntaxKind), node.RawKind);
+    public static TSyntaxKind Kind<TSyntaxKind>(this SyntaxNode node) where TSyntaxKind : struct, Enum => // internal to not be confused with e.g. CSharp.SyntaxNode.Kind()
+        node is null ? default : (TSyntaxKind)Enum.ToObject(typeof(TSyntaxKind), node.RawKind);
+
+    public static SecondaryLocation ToSecondaryLocation(this SyntaxNode node, string message = null) =>
+        new(node.GetLocation(), message);
 }

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/SyntaxNodeExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/SyntaxNodeExtensions.cs
@@ -53,7 +53,7 @@ internal static class SyntaxNodeExtensions
         return root.SyntaxTree.FilePath;
     }
 
-    public static TSyntaxKind Kind<TSyntaxKind>(this SyntaxNode node) where TSyntaxKind : struct, Enum => // internal to not be confused with e.g. CSharp.SyntaxNode.Kind()
+    public static TSyntaxKind Kind<TSyntaxKind>(this SyntaxNode node) where TSyntaxKind : struct, Enum =>
         node is null ? default : (TSyntaxKind)Enum.ToObject(typeof(TSyntaxKind), node.RawKind);
 
     public static SecondaryLocation ToSecondaryLocation(this SyntaxNode node, string message = null) =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
@@ -151,7 +151,7 @@ namespace SonarAnalyzer.Rules
             if (!locations.IsEmpty)
             {
                 // Report both, assignment as well as all implementation occurrences
-                c.Context.ReportIssue(Rule.CreateDiagnostic(c.Context.Compilation, primaryLocation, locations, locations.ToProperties(SecondaryMessage)));
+                c.Context.ReportIssue(Rule, primaryLocation, locations.Select(x => x.ToSecondary(SecondaryMessage)));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -103,24 +103,24 @@ namespace SonarAnalyzer.Rules
             var input = new TrackerInput(context, configuration, rule);
 
             var oc = Language.Tracker.ObjectCreation;
-            oc.Track(input, new object[] { MessageHardcodedPassword },
+            oc.Track(input, [MessageHardcodedPassword],
                 oc.MatchConstructor(KnownType.System_Net_NetworkCredential),
                 oc.ArgumentAtIndexIs(1, KnownType.System_String),
                 oc.ArgumentAtIndexIsConst(1));
 
-            oc.Track(input, new object[] { MessageHardcodedPassword },
+            oc.Track(input, [MessageHardcodedPassword],
                oc.MatchConstructor(KnownType.System_Security_Cryptography_PasswordDeriveBytes),
                oc.ArgumentAtIndexIs(0, KnownType.System_String),
                oc.ArgumentAtIndexIsConst(0));
 
             var pa = Language.Tracker.PropertyAccess;
-            pa.Track(input, new object[] { MessageHardcodedPassword },
+            pa.Track(input, [MessageHardcodedPassword],
                pa.MatchSetter(),
                pa.AssignedValueIsConstant(),
                pa.MatchProperty(new MemberDescriptor(KnownType.System_Net_NetworkCredential, "Password")));
 
             var inv = Language.Tracker.Invocation;
-            inv.Track(input, new object[] { MessageHardcodedPassword },
+            inv.Track(input, [MessageHardcodedPassword],
                 inv.MatchMethod(new MemberDescriptor(KnownType.System_Security_SecureString, nameof(SecureString.AppendChar))),
                 inv.ArgumentAtIndexIs(0, IsSecureStringAppendCharFromConstant));
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/StringLiteralShouldNotBeDuplicatedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/StringLiteralShouldNotBeDuplicatedBase.cs
@@ -79,12 +79,7 @@ namespace SonarAnalyzer.Rules
             {
                 var duplicates = item.ToList();
                 var firstToken = duplicates[0];
-                context.ReportIssue(rule.CreateDiagnostic(context.Compilation,
-                    firstToken.GetLocation(),
-                    duplicates.Skip(1).Select(x => x.GetLocation()),
-                    properties: null,
-                    ExtractStringContent(firstToken),
-                    duplicates.Count));
+                context.ReportIssue(rule, firstToken, duplicates.Skip(1).Select(x => x.ToSecondaryLocation()), ExtractStringContent(firstToken), duplicates.Count.ToString());
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/SyntaxTrackerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/SyntaxTrackerBase.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Helpers
         public void Track(TrackerInput input, params Condition[] conditions) =>
             Track(input, [], conditions);
 
-        public void Track(TrackerInput input, object[] diagnosticMessageArgs, params Condition[] conditions)
+        public void Track(TrackerInput input, string[] diagnosticMessageArgs, params Condition[] conditions)
         {
             input.Context.RegisterCompilationStartAction(c =>
               {
@@ -47,11 +47,7 @@ namespace SonarAnalyzer.Helpers
                     && trackingContext.PrimaryLocation is not null
                     && trackingContext.PrimaryLocation != Location.None)
                 {
-                    c.ReportIssue(input.Rule,
-                        trackingContext.PrimaryLocation,
-                        trackingContext.SecondaryLocations.ToAdditionalLocations(),
-                        trackingContext.SecondaryLocations.ToProperties(),
-                        diagnosticMessageArgs);
+                    c.ReportIssue(input.Rule, trackingContext.PrimaryLocation, trackingContext.SecondaryLocations, diagnosticMessageArgs);
                 }
             }
         }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/CompilationIssues.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Verification/IssueValidation/CompilationIssues.cs
@@ -70,7 +70,8 @@ internal sealed class CompilationIssues : IEnumerable<IssueLocation>
             ret.Add(primary);
             for (var i = 0; i < diagnostic.AdditionalLocations.Count; i++)
             {
-                ret.Add(new IssueLocation(primary, diagnostic.GetSecondaryLocation(i)));
+                var secondaryMessage = diagnostic.Properties.TryGetValue(i.ToString(), out var message) ? message : null;
+                ret.Add(new IssueLocation(primary, new SecondaryLocation(diagnostic.AdditionalLocations[i], secondaryMessage)));
             }
         }
         return ret;


### PR DESCRIPTION
Prerequisite for #9174 

Review per commit shows the logical changes.
The purpose of this PR is to prepare everything that will be needed by all other rules. Migration of other rules (mainly monotounus removals of `DiagnosticDescriptorExtensions.CreateDiagnostic` will be in upcoming PRs)

The goals are:
* Make `ReportIssue` contract clear about `SecondaryLocation` boundary
* Hide the workaround with immutable dictionary of parameters
* Make reporting of secondary issues with messages super easy
* Fix bug where `ToProperties` does not respect `SecondaryLocation.Message`, but uses additional argument instead

I've changed `params object[]` to `params string[]` so we don't risk accidentally sending a collection of secondary locations (with a wrong type) to the params value.