### PR TITLE
Create rule S4347: 'SecureRandom' seeds should not be predictable (part 2)

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -223,6 +223,9 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType Org_BouncyCastle_Crypto_Generators_DsaParametersGenerator = new("Org.BouncyCastle.Crypto.Generators.DsaParametersGenerator");
         public static readonly KnownType Org_BouncyCastle_Crypto_Parameters_RsaKeyGenerationParameters = new("Org.BouncyCastle.Crypto.Parameters.RsaKeyGenerationParameters");
         public static readonly KnownType Org_BouncyCastle_Crypto_PbeParametersGenerator = new("Org.BouncyCastle.Crypto.PbeParametersGenerator");
+        public static readonly KnownType Org_BouncyCastle_Crypto_Prng_DigestRandomGenerator = new("Org.BouncyCastle.Crypto.Prng.DigestRandomGenerator");
+        public static readonly KnownType Org_BouncyCastle_Crypto_Prng_IRandomGenerator = new("Org.BouncyCastle.Crypto.Prng.IRandomGenerator");
+        public static readonly KnownType Org_BouncyCastle_Crypto_Prng_VmpcRandomGenerator = new("Org.BouncyCastle.Crypto.Prng.VmpcRandomGenerator");
         public static readonly KnownType Org_BouncyCastle_Security_SecureRandom = new("Org.BouncyCastle.Security.SecureRandom");
         public static readonly KnownType Serilog_Events_LogEventLevel = new("Serilog.Events.LogEventLevel");
         public static readonly KnownType Serilog_ILogger = new("Serilog.ILogger");

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/SecureRandomSeedsShouldNotBePredictableTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/SecureRandomSeedsShouldNotBePredictableTest.cs
@@ -204,7 +204,7 @@ public class SecureRandomSeedsShouldNotBePredictableTest
 
 #if NET
     [TestMethod]
-    public void SecureRandomSeedsShouldNotBePredictable_CS_IRandomGenerator_CustomImplementation() =>
+    public void SecureRandomSeedsShouldNotBePredictable_CS_IRandomGenerator_Inheritance() =>
         builder
             .AddSnippet($$$"""
                 using System;

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/SecureRandomSeedsShouldNotBePredictableTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/SecureRandomSeedsShouldNotBePredictableTest.cs
@@ -129,26 +129,109 @@ public class SecureRandomSeedsShouldNotBePredictableTest
     [DataRow("bs[42] *= b")]
     [DataTestMethod]
     public void SecureRandomSeedsShouldNotBePredictable_CS_ArrayEdited(string messWithArray) =>
-    builder
-        .AddSnippet($$$"""
-            using System;
-            using System.Text;
-            using Org.BouncyCastle.Security;
-            class Testcases
-            {
-                void Method(byte b)
+        builder
+            .AddSnippet($$$"""
+                using System;
+                using System.Text;
+                using Org.BouncyCastle.Security;
+                class Testcases
                 {
-                    var bs = new byte[42];
+                    void Method(byte b)
+                    {
+                        var bs = new byte[42];
 
-                    var sr = SecureRandom.GetInstance("SHA256PRNG", false);
-                    sr.SetSeed(bs);
-                    sr.Next();                  // Noncompliant
+                        var sr = SecureRandom.GetInstance("SHA256PRNG", false);
+                        sr.SetSeed(bs);
+                        sr.Next();                  // Noncompliant
 
-                    {{{messWithArray}}};
-                    sr.SetSeed(bs);
-                    sr.Next();                  // Compliant
+                        {{{messWithArray}}};
+                        sr.SetSeed(bs);
+                        sr.Next();                  // Compliant
+                    }
                 }
-            }
-            """)
-        .Verify();
+                """)
+            .Verify();
+
+    [DataRow("DigestRandomGenerator(digest)")]
+    [DataRow("VmpcRandomGenerator()")]
+    [DataTestMethod]
+    public void SecureRandomSeedsShouldNotBePredictable_CS_IRandomGenerator(string generator) =>
+        builder
+            .AddSnippet($$$"""
+                using System.Text;
+                using Org.BouncyCastle.Security;
+                using Org.BouncyCastle.Crypto.Prng;
+                using Org.BouncyCastle.Crypto.Digests;
+
+                class Testcases
+                {
+                    const int SEED = 42;
+
+                    void Method(byte[] bs, Sha256Digest digest, long seed)
+                    {
+                        IRandomGenerator rng = new {{{generator}}};
+                        rng.NextBytes(bs);    // Noncompliant {{Set an unpredictable seed before generating random values.}}
+                    //  ^^^^^^^^^^^^^^^^^
+
+                        rng.AddSeedMaterial(SEED);
+                        rng.NextBytes(bs, 0, 42); // Noncompliant
+                    //  ^^^^^^^^^^^^^^^^^^^^^^^^
+
+                        rng.AddSeedMaterial(new byte[3]);
+                        rng.NextBytes(bs);  // Noncompliant
+
+                        rng.AddSeedMaterial(Encoding.UTF8.GetBytes("exploding whale"));
+                        rng.NextBytes(bs);  // Noncompliant
+
+                        rng.AddSeedMaterial(42);
+                        rng.NextBytes(bs);  // Noncompliant
+
+                        rng.AddSeedMaterial(bs);
+                        rng.NextBytes(bs);  // Compliant, bs is unknown
+
+                        rng.AddSeedMaterial(42);
+                        rng.NextBytes(bs);  // Compliant, seed is already unpredictable
+
+                        rng = new {{{generator}}};
+                        rng.NextBytes(bs); // Noncompliant
+
+                        rng.AddSeedMaterial(seed);
+                        rng.NextBytes(bs); // Compliant
+                    }
+                }
+                """)
+            .Verify();
+
+#if NET
+    [TestMethod]
+    public void SecureRandomSeedsShouldNotBePredictable_CS_IRandomGenerator_CustomImplementation() =>
+        builder
+            .AddSnippet($$$"""
+                using System;
+                using Org.BouncyCastle.Security;
+                using Org.BouncyCastle.Crypto.Prng;
+                using Org.BouncyCastle.Crypto.Digests;
+
+                class Testcases
+                {
+                    void IRandomGenerator(byte[] bs)
+                    {
+                        var notRelevant = new MyGen();
+                        notRelevant.NextBytes(bs); // Compliant, we only track "Digest" and "Vmpc".
+                    }
+                }
+
+                class MyGen : IRandomGenerator
+                {
+                    public void AddSeedMaterial(byte[] seed) { }
+                    public void AddSeedMaterial(ReadOnlySpan<byte> seed) { }
+                    public void AddSeedMaterial(long seed) { }
+                    public void NextBytes(byte[] bytes) { }
+                    public void NextBytes(byte[] bytes, int start, int len) { }
+                    public void NextBytes(Span<byte> bytes) { }
+                }
+
+                """)
+            .VerifyNoIssues();
+#endif
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/SecureRandomSeedsShouldNotBePredictable.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/SecureRandomSeedsShouldNotBePredictable.cs
@@ -256,6 +256,14 @@ class Testcases
 
         sr = SecureRandom.GetInstance("SHA256PRNG", false);
         sr.Next(); // Noncompliant
+        var ss = new byte[3];
+        ss[0] = b;
+        ss.Initialize();
+        sr.SetSeed(ss);
+        sr.Next(); // Noncompliant, Initialize is predictable
+
+        sr = SecureRandom.GetInstance("SHA256PRNG", false);
+        sr.Next(); // Noncompliant
         sr.SetSeed(xs.Cast<byte>().ToArray());
         sr.Next(); // Compliant FN, array is predictable
     }


### PR DESCRIPTION
Part of https://github.com/SonarSource/sonar-dotnet/issues/8992

Implementing Scenario 2

Also, added support for `Array.Initialize`, which re-sets an array to predictable.