### PR TITLE
Fix S6966 FP: EntityFrameworks DbContext/DBSet Add/AddRange methods are preferred over their Async counterpart

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseAwaitableMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseAwaitableMethod.cs
@@ -27,7 +27,7 @@ public sealed class UseAwaitableMethod : SonarDiagnosticAnalyzer
 {
     private const string DiagnosticId = "S6966";
     private const string MessageFormat = "Await {0} instead.";
-    private static readonly string[] MethodNamesAddAddRange = ["Add", "AddRange"];
+    private static readonly string[] ExcludedMethodNamesAddAddRange = ["Add", "AddRange"];
 
     private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
@@ -113,8 +113,8 @@ public sealed class UseAwaitableMethod : SonarDiagnosticAnalyzer
     }
 
     private static bool IsExcluded(IMethodSymbol methodSymbol) =>
-        methodSymbol.IsAny(KnownType.Microsoft_EntityFrameworkCore_DbSet_TEntity, MethodNamesAddAddRange) // https://github.com/SonarSource/sonar-dotnet/issues/9269
-        || methodSymbol.IsAny(KnownType.Microsoft_EntityFrameworkCore_DbContext, MethodNamesAddAddRange); // https://github.com/SonarSource/sonar-dotnet/issues/9269
+        methodSymbol.IsAny(KnownType.Microsoft_EntityFrameworkCore_DbSet_TEntity, ExcludedMethodNamesAddAddRange) // https://github.com/SonarSource/sonar-dotnet/issues/9269
+        || methodSymbol.IsAny(KnownType.Microsoft_EntityFrameworkCore_DbContext, ExcludedMethodNamesAddAddRange); // https://github.com/SonarSource/sonar-dotnet/issues/9269
 
     private static IEnumerable<IMethodSymbol> GetMethodSymbolsInScope(string methodName, WellKnownExtensionMethodContainer wellKnownExtensionMethodContainer,
         ITypeSymbol invokedType, ITypeSymbol methodContainer) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseAwaitableMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseAwaitableMethod.cs
@@ -27,6 +27,7 @@ public sealed class UseAwaitableMethod : SonarDiagnosticAnalyzer
 {
     private const string DiagnosticId = "S6966";
     private const string MessageFormat = "Await {0} instead.";
+    private static readonly string[] MethodNamesAddAddRange = ["Add", "AddRange"];
 
     private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
@@ -112,7 +113,8 @@ public sealed class UseAwaitableMethod : SonarDiagnosticAnalyzer
     }
 
     private static bool IsExcluded(IMethodSymbol methodSymbol) =>
-        methodSymbol.IsAny(KnownType.Microsoft_EntityFrameworkCore_DbSet_TEntity, "Add", "AddRange");
+        methodSymbol.IsAny(KnownType.Microsoft_EntityFrameworkCore_DbSet_TEntity, MethodNamesAddAddRange) // https://github.com/SonarSource/sonar-dotnet/issues/9269
+        || methodSymbol.IsAny(KnownType.Microsoft_EntityFrameworkCore_DbContext, MethodNamesAddAddRange); // https://github.com/SonarSource/sonar-dotnet/issues/9269
 
     private static IEnumerable<IMethodSymbol> GetMethodSymbolsInScope(string methodName, WellKnownExtensionMethodContainer wellKnownExtensionMethodContainer,
         ITypeSymbol invokedType, ITypeSymbol methodContainer) =>

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UseAwaitableMethod_EF.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UseAwaitableMethod_EF.cs
@@ -11,32 +11,32 @@ public class EntityFramework
     public async Task Query()
     {
         DbSet<object> dbSet = default;
-        dbSet.Add(null);      // Compliant https://github.com/SonarSource/sonar-dotnet/issues/9269
-        dbSet.AddRange(null); // Compliant https://github.com/SonarSource/sonar-dotnet/issues/9269
-        dbSet.All(x => true); // Noncompliant
-        dbSet.Any(x => true); // Noncompliant
-        dbSet.Average(x => 1); // Noncompliant
-        dbSet.Contains(null); // Noncompliant
-        dbSet.Count(); // Noncompliant
-        dbSet.ElementAt(1); // Compliant: EF 8.0 only
+        dbSet.Add(null);             // Compliant https://github.com/SonarSource/sonar-dotnet/issues/9269
+        dbSet.AddRange(null);        // Compliant https://github.com/SonarSource/sonar-dotnet/issues/9269
+        dbSet.All(x => true);        // Noncompliant
+        dbSet.Any(x => true);        // Noncompliant
+        dbSet.Average(x => 1);       // Noncompliant
+        dbSet.Contains(null);        // Noncompliant
+        dbSet.Count();               // Noncompliant
+        dbSet.ElementAt(1);          // Compliant: EF 8.0 only
         dbSet.ElementAtOrDefault(1); // Compliant: EF 8.0 only
-        dbSet.ExecuteDelete(); // Noncompliant
+        dbSet.ExecuteDelete();       // Noncompliant
         dbSet.ExecuteUpdate(x => x.SetProperty(x => x.ToString(), x => string.Empty)); // Noncompliant
-        dbSet.Find(null); // Noncompliant
-        dbSet.First(); // Noncompliant
-        dbSet.FirstOrDefault(); // Noncompliant
-        dbSet.Last(); // Noncompliant
-        dbSet.LastOrDefault(); // Noncompliant
-        dbSet.Load(); // Noncompliant
-        dbSet.LongCount(); // Noncompliant
-        dbSet.Max(); // Noncompliant
-        dbSet.Min(); // Noncompliant
-        dbSet.Single(); // Noncompliant
-        dbSet.SingleOrDefault(); // Noncompliant
-        dbSet.Sum(x => 0); // Noncompliant
-        dbSet.ToArray(); // Noncompliant
-        dbSet.ToDictionary(x => 0); // Noncompliant
-        dbSet.ToList(); // Noncompliant
+        dbSet.Find(null);            // Noncompliant
+        dbSet.First();               // Noncompliant
+        dbSet.FirstOrDefault();      // Noncompliant
+        dbSet.Last();                // Noncompliant
+        dbSet.LastOrDefault();       // Noncompliant
+        dbSet.Load();                // Noncompliant
+        dbSet.LongCount();           // Noncompliant
+        dbSet.Max();                 // Noncompliant
+        dbSet.Min();                 // Noncompliant
+        dbSet.Single();              // Noncompliant
+        dbSet.SingleOrDefault();     // Noncompliant
+        dbSet.Sum(x => 0);           // Noncompliant
+        dbSet.ToArray();             // Noncompliant
+        dbSet.ToDictionary(x => 0);  // Noncompliant
+        dbSet.ToList();              // Noncompliant
     }
 
     public async Task NotIQueryable(IEnumerable<object> enumerable)

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UseAwaitableMethod_EF.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UseAwaitableMethod_EF.cs
@@ -48,8 +48,8 @@ public class EnitityFramework
 
     public async Task Context(DbContext dbContext)
     {
-        dbContext.Add(null);            // Noncompliant FP https://github.com/SonarSource/sonar-dotnet/issues/9269
-        dbContext.AddRange(null);       // Noncompliant FP https://github.com/SonarSource/sonar-dotnet/issues/9269
+        dbContext.Add(null);            // Compliant https://github.com/SonarSource/sonar-dotnet/issues/9269
+        dbContext.AddRange(null);       // Compliant https://github.com/SonarSource/sonar-dotnet/issues/9269
         dbContext.Dispose();            // Noncompliant
         dbContext.Find<object>();       // Noncompliant
         dbContext.Find(typeof(object)); // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UseAwaitableMethod_EF.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UseAwaitableMethod_EF.cs
@@ -11,8 +11,8 @@ public class EnitityFramework
     public async Task Query()
     {
         DbSet<object> dbSet = default;
-        dbSet.Add(null);      // Noncompliant FP https://github.com/SonarSource/sonar-dotnet/issues/9269
-        dbSet.AddRange(null); // Noncompliant FP https://github.com/SonarSource/sonar-dotnet/issues/9269
+        dbSet.Add(null);      // Compliant https://github.com/SonarSource/sonar-dotnet/issues/9269
+        dbSet.AddRange(null); // Compliant https://github.com/SonarSource/sonar-dotnet/issues/9269
         dbSet.All(x => true); // Noncompliant
         dbSet.Any(x => true); // Noncompliant
         dbSet.Average(x => 1); // Noncompliant

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UseAwaitableMethod_EF.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UseAwaitableMethod_EF.cs
@@ -6,7 +6,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 
-public class EnitityFramework
+public class EntityFramework
 {
     public async Task Query()
     {


### PR DESCRIPTION
Fixes #9269
