### PR TITLE
DiagnosticDescriptorExtensions: Replace SonarTreeReportingContextBase usages of CreateDiagnostic

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Common/Walkers/ParameterValidationInMethodWalker.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Common/Walkers/ParameterValidationInMethodWalker.cs
@@ -31,11 +31,11 @@ namespace SonarAnalyzer.Common.Walkers
             };
 
         private readonly SemanticModel semanticModel;
-        private readonly List<Location> argumentExceptionLocations = new();
+        private readonly List<SecondaryLocation> argumentExceptionLocations = new();
 
         protected bool keepWalking = true;
 
-        public IEnumerable<Location> ArgumentExceptionLocations => argumentExceptionLocations;
+        public IEnumerable<SecondaryLocation> ArgumentExceptionLocations => argumentExceptionLocations;
 
         public ParameterValidationInMethodWalker(SemanticModel semanticModel) =>
             this.semanticModel = semanticModel;
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Common.Walkers
                 && semanticModel.GetTypeInfo(node.Expression) is var typeInfo
                 && typeInfo.Type.DerivesFrom(KnownType.System_ArgumentException))
             {
-                argumentExceptionLocations.Add(node.Expression.GetLocation());
+                argumentExceptionLocations.Add(node.Expression.ToSecondaryLocation());
             }
 
             // there is no need to visit children
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.Common.Walkers
             if (node.IsMemberAccessOnKnownType("ThrowIfNull", KnownType.System_ArgumentNullException, semanticModel))
             {
                 // "ThrowIfNull" returns void so it cannot be an argument. We can stop.
-                argumentExceptionLocations.Add(node.GetLocation());
+                argumentExceptionLocations.Add(node.ToSecondaryLocation());
             }
             else
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BinaryOperationWithIdenticalExpressions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BinaryOperationWithIdenticalExpressions.cs
@@ -73,16 +73,10 @@ namespace SonarAnalyzer.Rules.CSharp
             var methodSymbol = context.SemanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
 
             var operands = GetOperands(invocation, methodSymbol);
-            if (operands != null &&
-                CSharpEquivalenceChecker.AreEquivalent(RemoveParentheses(operands.Item1), RemoveParentheses(operands.Item2)))
+            if (operands is not null && CSharpEquivalenceChecker.AreEquivalent(RemoveParentheses(operands.Item1), RemoveParentheses(operands.Item2)))
             {
                 var message = string.Format(EqualsMessage, operands.Item2);
-                var diagnostic = Rule.CreateDiagnostic(context.Compilation,
-                    operands.Item1.GetLocation(),
-                    additionalLocations: new[] { operands.Item2.GetLocation() },
-                    properties: null,
-                    messageArgs: message);
-                context.ReportIssue(diagnostic);
+                context.ReportIssue(Rule, operands.Item1.GetLocation(), [operands.Item2.ToSecondaryLocation()], message);
             }
         }
 
@@ -118,12 +112,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (CSharpEquivalenceChecker.AreEquivalent(left.RemoveParentheses(), right.RemoveParentheses()))
             {
                 var message = string.Format(OperatorMessageFormat, operatorToken);
-                context.ReportIssue(Rule.CreateDiagnostic(context.Compilation,
-                    right.GetLocation(),
-                    additionalLocations:
-                    new[] { left.GetLocation() },
-                    properties: null,
-                    messageArgs: message));
+                context.ReportIssue(Rule, right, [left.ToSecondaryLocation()], message);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CastShouldNotBeDuplicated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CastShouldNotBeDuplicated.cs
@@ -219,10 +219,9 @@ namespace SonarAnalyzer.Rules.CSharp
                                                         string message)
         {
             var duplicatedCastLocations = GetDuplicatedCastLocations(context, parentStatement, castType, variableExpression);
-
             if (duplicatedCastLocations.Any())
             {
-                context.ReportIssue(Rule.CreateDiagnostic(context.Compilation, mainLocation, duplicatedCastLocations, properties: null, message));
+                context.ReportIssue(Rule, mainLocation, duplicatedCastLocations.Select(x => x.ToSecondary()), message);
             }
         }
 
@@ -239,7 +238,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 var duplicatedCastLocations = GetDuplicatedCastLocations(context, parentStatement, castType, variableExpression);
                 foreach (var castLocation in duplicatedCastLocations)
                 {
-                    context.ReportIssue(Rule.CreateDiagnostic(context.Compilation, castLocation, new[] { patternLocation }, properties: null, message));
+                    context.ReportIssue(Rule, castLocation, [patternLocation.ToSecondary()], message);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsLogFailures.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CloudNative/AzureFunctionsLogFailures.cs
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     walker.SafeVisit(catchClause.Filter?.FilterExpression);
                     if (!walker.HasValidLoggerCall)
                     {
-                        c.ReportIssue(Rule.CreateDiagnostic(c.Compilation, catchClause.CatchKeyword.GetLocation(), walker.InvalidLoggerInvocationLocations, properties: null));
+                        c.ReportIssue(Rule, catchClause.CatchKeyword.GetLocation(), walker.InvalidLoggerInvocationLocations);
                     }
                 }
             },
@@ -86,10 +86,10 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             private readonly SemanticModel model;
             private readonly CancellationToken cancel;
-            private List<Location> invalidInvocations;
+            private List<SecondaryLocation> invalidInvocations;
 
             public bool HasValidLoggerCall { get; private set; }
-            public IEnumerable<Location> InvalidLoggerInvocationLocations => invalidInvocations;
+            public IEnumerable<SecondaryLocation> InvalidLoggerInvocationLocations => invalidInvocations ?? [];
 
             public LoggerCallWalker(SemanticModel model, CancellationToken cancel)
             {
@@ -118,7 +118,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     else
                     {
                         invalidInvocations ??= new();
-                        invalidInvocations.Add(node.GetLocation());
+                        invalidInvocations.Add(node.ToSecondaryLocation());
                     }
                 }
                 base.VisitInvocationExpression(node);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsShouldStartOnNewLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsShouldStartOnNewLine.cs
@@ -39,10 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 if (TryGetPreviousTokenInSameLine(ifKeyword, out var previousTokenInSameLine) &&
                     previousTokenInSameLine.IsKind(SyntaxKind.CloseBraceToken))
                 {
-                    c.ReportIssue(rule.CreateDiagnostic(c.Compilation,
-                        ifKeyword.GetLocation(),
-                        additionalLocations: new[] { previousTokenInSameLine.GetLocation() },
-                        properties: null));
+                    c.ReportIssue(rule, ifKeyword, [previousTokenInSameLine.GetLocation().ToSecondary()]);
                 }
             },
             SyntaxKind.IfStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsShouldStartOnNewLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsShouldStartOnNewLine.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 if (TryGetPreviousTokenInSameLine(ifKeyword, out var previousTokenInSameLine) &&
                     previousTokenInSameLine.IsKind(SyntaxKind.CloseBraceToken))
                 {
-                    c.ReportIssue(rule, ifKeyword, [previousTokenInSameLine.GetLocation().ToSecondary()]);
+                    c.ReportIssue(rule, ifKeyword, [previousTokenInSameLine.ToSecondaryLocation()]);
                 }
             },
             SyntaxKind.IfStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConsumeValueTaskCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConsumeValueTaskCorrectly.cs
@@ -55,17 +55,13 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         if (syntaxNodes.Count > 1)
                         {
-                            c.ReportIssue(rule.CreateDiagnostic(c.Compilation,
-                                syntaxNodes.First().GetLocation(),
-                                additionalLocations: syntaxNodes.Skip(1).Select(node => node.GetLocation()).ToArray(),
-                                properties: null,
-                                messageArgs: ConsumeOnlyOnceMessage));
+                            c.ReportIssue(rule, syntaxNodes.First(), syntaxNodes.Skip(1).Select(x => x.ToSecondaryLocation()), ConsumeOnlyOnceMessage);
                         }
                     }
 
                     foreach (var node in walker.ConsumedButNotCompleted)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, node.GetLocation(), messageArgs: ConsumeOnlyIfCompletedMessage   ));
+                        c.ReportIssue(rule, node, ConsumeOnlyIfCompletedMessage);
                     }
                 },
                 // when visiting a method or another member with logic inside, lambdas and local functions will be visited as well

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotMarkEnumsWithFlags.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotMarkEnumsWithFlags.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         .ToList();
 
                     var invalidMembers = membersWithValues.Where(tuple => !IsValidFlagValue(tuple.Value, allValues))
-                        .Select(tuple => tuple.Member.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax().ToSecondaryLocation())
+                        .Select(tuple => tuple.Member.GetFirstSyntaxRef()?.ToSecondaryLocation())
                         .WhereNotNull()
                         .ToList();
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotMarkEnumsWithFlags.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotMarkEnumsWithFlags.cs
@@ -58,16 +58,13 @@ namespace SonarAnalyzer.Rules.CSharp
                         .ToList();
 
                     var invalidMembers = membersWithValues.Where(tuple => !IsValidFlagValue(tuple.Value, allValues))
-                        .Select(tuple => tuple.Member.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax().GetLocation())
+                        .Select(tuple => tuple.Member.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax().ToSecondaryLocation())
                         .WhereNotNull()
                         .ToList();
 
                     if (invalidMembers.Count > 0)
                     {
-                        c.ReportIssue(Rule.CreateDiagnostic(c.Compilation,
-                            enumDeclaration.Identifier.GetLocation(),
-                            additionalLocations: invalidMembers,
-                            properties: null));
+                        c.ReportIssue(Rule, enumDeclaration.Identifier, invalidMembers);
                     }
                 }, SyntaxKind.EnumDeclaration);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseCollectionInItsOwnMethodCalls.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseCollectionInItsOwnMethodCalls.cs
@@ -54,15 +54,9 @@ namespace SonarAnalyzer.Rules.CSharp
                     }
 
                     var operands = GetOperandsToCheckIfTrackedMethod(invocation, c.SemanticModel);
-                    if (operands != null &&
-                        CSharpEquivalenceChecker.AreEquivalent(operands.Left, operands.Right))
+                    if (operands is not null && CSharpEquivalenceChecker.AreEquivalent(operands.Left, operands.Right))
                     {
-                        c.ReportIssue(rule.CreateDiagnostic(c.Compilation,
-                            operands.Left.GetLocation(),
-                            new[] { operands.Right.GetLocation() },
-                            properties: null,
-                            operands.Right.ToString(),
-                            operands.ErrorMessage));
+                        c.ReportIssue(rule, operands.Left, [operands.Right.ToSecondaryLocation()], operands.Right.ToString(), operands.ErrorMessage);
                     }
                 }, SyntaxKind.InvocationExpression);
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopIncrementSign.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopIncrementSign.cs
@@ -91,20 +91,12 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (incrementorData.Operation == ArithmeticOperation.Addition &&
                         condition == Condition.Greater)
                     {
-                        c.ReportIssue(rule.CreateDiagnostic(c.Compilation,
-                            forNode.Incrementors.First().GetLocation(),
-                            new[] { forNode.Condition.GetLocation() },
-                            properties: null,
-                            incrementorData.IdentifierName, "inc"));
+                        c.ReportIssue(rule, forNode.Incrementors.First(), [forNode.Condition.ToSecondaryLocation()], incrementorData.IdentifierName, "inc");
                     }
                     else if (incrementorData.Operation == ArithmeticOperation.Substraction &&
                              condition == Condition.Less)
                     {
-                        c.ReportIssue(rule.CreateDiagnostic(c.Compilation,
-                            forNode.Incrementors.First().GetLocation(),
-                            new[] { forNode.Condition.GetLocation() },
-                            properties: null,
-                            incrementorData.IdentifierName, "dec"));
+                        c.ReportIssue(rule, forNode.Incrementors.First(), [forNode.Condition.ToSecondaryLocation()], incrementorData.IdentifierName, "dec");
                     }
                 },
                 SyntaxKind.ForStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/LooseFilePermissions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/LooseFilePermissions.cs
@@ -49,14 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 var invocationLocation = invocation.GetLocation();
                 var secondaryLocation = objectCreation.Expression.GetLocation();
-                if (invocationLocation.StartLine() == secondaryLocation.StartLine())
-                {
-                    context.ReportIssue(Rule, invocationLocation);
-                }
-                else
-                {
-                    context.ReportIssue(Rule, invocationLocation, [secondaryLocation.ToSecondary()]);
-                }
+                context.ReportIssue(Rule, invocationLocation, invocationLocation.StartLine() == secondaryLocation.StartLine() ? [] : [secondaryLocation.ToSecondary()]);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/IfCollapsible.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/IfCollapsible.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     var ifStatement = (IfStatementSyntax)c.Node;
 
-                    if (ifStatement.Else != null)
+                    if (ifStatement.Else is not null)
                     {
                         return;
                     }
@@ -41,10 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var parentIfStatement = GetParentIfStatement(ifStatement);
                     if (parentIfStatement is { Else: null })
                     {
-                        c.ReportIssue(Rule.CreateDiagnostic(c.Compilation,
-                            ifStatement.IfKeyword.GetLocation(),
-                            additionalLocations: new[] { parentIfStatement.IfKeyword.GetLocation() },
-                            properties: null));
+                        c.ReportIssue(Rule, ifStatement.IfKeyword, [parentIfStatement.IfKeyword.ToSecondaryLocation()]);
                     }
                 },
                 SyntaxKind.IfStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/IndentSingleLineFollowingConditional.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/IndentSingleLineFollowingConditional.cs
@@ -129,13 +129,8 @@ namespace SonarAnalyzer.Rules.CSharp
             conditionallyExecutedNode is BlockSyntax ||
             VisualIndentComparer.IsSecondIndentLonger(controlNode, conditionallyExecutedNode);
 
-        private static void ReportIssue(SonarSyntaxNodeReportingContext context, Location primaryLocation,
-            SyntaxNode secondaryLocationNode, string conditionLabelText) =>
-               context.ReportIssue(Rule.CreateDiagnostic(context.Compilation,
-                   primaryLocation,
-                   new[] { GetFirstLineOfNode(secondaryLocationNode) },
-                   properties: null,
-                   conditionLabelText));
+        private static void ReportIssue(SonarSyntaxNodeReportingContext context, Location primaryLocation, SyntaxNode secondaryLocationNode, string conditionLabelText) =>
+               context.ReportIssue(Rule, primaryLocation, [GetFirstLineOfNode(secondaryLocationNode).ToSecondary()], conditionLabelText);
 
         private static Location GetFirstLineOfNode(SyntaxNode node)
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InheritedCollidingInterfaceMembers.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InheritedCollidingInterfaceMembers.cs
@@ -53,16 +53,8 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         var membersText = GetIssueMessageText(collidingMembers, c.SemanticModel, interfaceDeclaration.SpanStart);
                         var pluralize = collidingMembers.Count > 1 ? "s" : string.Empty;
-
-                        var secondaryLocations = collidingMembers.SelectMany(x => x.Locations)
-                                                                 .Where(x => x.IsInSource);
-
-                        c.ReportIssue(Rule.CreateDiagnostic(c.Compilation,
-                            interfaceDeclaration.Identifier.GetLocation(),
-                            secondaryLocations,
-                            properties: null,
-                            membersText,
-                            pluralize));
+                        var secondaryLocations = collidingMembers.SelectMany(x => x.Locations).Where(x => x.IsInSource).Select(x => x.ToSecondary());
+                        c.ReportIssue(Rule, interfaceDeclaration.Identifier, secondaryLocations, membersText, pluralize);
                     }
                 },
                 SyntaxKind.InterfaceDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LoopsAndLinq.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LoopsAndLinq.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var forEachStatementSyntax = (ForEachStatementSyntax)c.Node;
                     if (CanBeSimplifiedUsingWhere(forEachStatementSyntax.Statement, out var ifConditionLocation))
                     {
-                        c.ReportIssue(Rule.CreateDiagnostic(c.Compilation, forEachStatementSyntax.Expression.GetLocation(), new[] { ifConditionLocation }, properties: null, WhereMessageFormat));
+                        c.ReportIssue(Rule, forEachStatementSyntax.Expression, [ifConditionLocation], WhereMessageFormat);
                     }
                     else
                     {
@@ -47,11 +47,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 },
                 SyntaxKind.ForEachStatement);
 
-        private static bool CanBeSimplifiedUsingWhere(SyntaxNode statement, out Location ifConditionLocation)
+        private static bool CanBeSimplifiedUsingWhere(SyntaxNode statement, out SecondaryLocation ifConditionLocation)
         {
             if (GetIfStatement(statement) is { } ifStatementSyntax && CanIfStatementBeMoved(ifStatementSyntax))
             {
-                ifConditionLocation = ifStatementSyntax.Condition.GetLocation();
+                ifConditionLocation = ifStatementSyntax.Condition.ToSecondaryLocation();
                 return true;
             }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterNamesShouldNotDuplicateMethodNames.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterNamesShouldNotDuplicateMethodNames.cs
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 var parameterName = parameter.ToString();
                 if (string.Equals(parameterName, methodName, StringComparison.OrdinalIgnoreCase))
                 {
-                    context.ReportIssue(rule.CreateDiagnostic(context.Compilation, parameter.GetLocation(), new[] { identifier.GetLocation() }, properties: null, parameterName));
+                    context.ReportIssue(rule, parameter, [identifier.ToSecondaryLocation()], parameterName);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterValidationInAsyncShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterValidationInAsyncShouldBeWrapped.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     walker.SafeVisit(method);
                     if (walker.ArgumentExceptionLocations.Any())
                     {
-                        c.ReportIssue(Rule.CreateDiagnostic(c.Compilation, method.Identifier.GetLocation(), walker.ArgumentExceptionLocations, properties: null));
+                        c.ReportIssue(Rule, method.Identifier, walker.ArgumentExceptionLocations);
                     }
                 },
                 SyntaxKind.MethodDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterValidationInYieldShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ParameterValidationInYieldShouldBeWrapped.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (walker.HasYieldStatement &&
                         walker.ArgumentExceptionLocations.Any())
                     {
-                        c.ReportIssue(Rule.CreateDiagnostic(c.Compilation, methodDeclaration.Identifier.GetLocation(), additionalLocations: walker.ArgumentExceptionLocations, properties: null));
+                        c.ReportIssue(Rule, methodDeclaration.Identifier, walker.ArgumentExceptionLocations);
                     }
                 },
                 SyntaxKind.MethodDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyNamesShouldNotMatchGetMethods.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyNamesShouldNotMatchGetMethods.cs
@@ -45,12 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         var propertyIdentifier = collidingMembers.Item1;
                         var methodIdentifier = collidingMembers.Item2;
-                        c.ReportIssue(Rule.CreateDiagnostic(c.Compilation,
-                            propertyIdentifier.GetLocation(),
-                            new[] { methodIdentifier.GetLocation() },
-                            properties: null,
-                            propertyIdentifier.ValueText,
-                            methodIdentifier.ValueText));
+                        c.ReportIssue(Rule, propertyIdentifier, [methodIdentifier.ToSecondaryLocation()], propertyIdentifier.ValueText, methodIdentifier.ValueText);
                     }
                 },
                 SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
@@ -63,7 +63,7 @@ public sealed class ReturnEmptyCollectionInsteadOfNull : SonarDiagnosticAnalyzer
         {
             if (nullOrDefaultLiterals.Count > 0 && IsReturningCollection(context))
             {
-                context.ReportIssue(Rule.CreateDiagnostic(context.Compilation, nullOrDefaultLiterals[0], additionalLocations: nullOrDefaultLiterals.Skip(1), properties: null));
+                context.ReportIssue(Rule, nullOrDefaultLiterals[0], nullOrDefaultLiterals.Skip(1).Select(x => x.ToSecondary()));
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SelfAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SelfAssignment.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     foreach (var assigment in expression.MapAssignmentArguments().Where(x => CSharpEquivalenceChecker.AreEquivalent(x.Left, x.Right)))
                     {
-                        c.ReportIssue(Rule.CreateDiagnostic(c.Compilation, assigment.Left.GetLocation(), additionalLocations: new[] { assigment.Right.GetLocation() }, properties: null));
+                        c.ReportIssue(Rule, assigment.Left, [assigment.Right.ToSecondaryLocation()]);
                     }
                 },
                 SyntaxKind.SimpleAssignmentExpression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldWrittenFrom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldWrittenFrom.cs
@@ -88,8 +88,8 @@ namespace SonarAnalyzer.Rules
                             var firstPosition = fieldWithLocations.Value.Select(x => x.SourceSpan.Start).Min();
                             var location = fieldWithLocations.Value.First(x => x.SourceSpan.Start == firstPosition);
                             var message = GetDiagnosticMessageArgument(cbc.CodeBlock, cbc.OwningSymbol, fieldWithLocations.Key);
-                            var secondaryLocations = fieldWithLocations.Key.DeclaringSyntaxReferences.Select(x => x.GetSyntax().GetLocation());
-                            c.ReportIssue(Rule.CreateDiagnostic(c.SemanticModel.Compilation, location, secondaryLocations, properties: null, message));
+                            var secondaryLocations = fieldWithLocations.Key.DeclaringSyntaxReferences.Select(x => x.GetSyntax().ToSecondaryLocation());
+                            c.ReportIssue(Rule, location, secondaryLocations, message);
                         }
                     });
                 });

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SymbolicExecution/SymbolicExecutionRunner.cs
@@ -149,7 +149,7 @@ public class SymbolicExecutionRunner : SymbolicExecutionRunnerBase
     {
         foreach (var analyzerContext in analyzerContexts.Where(x => x.SupportsPartialResults == supportsPartialResults))
         {
-            foreach (var diagnostic in analyzerContext.GetDiagnostics(context.Compilation))
+            foreach (var diagnostic in analyzerContext.GetDiagnostics())
             {
                 context.ReportIssue(diagnostic);
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeMemberVisibility.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeMemberVisibility.cs
@@ -49,12 +49,12 @@ namespace SonarAnalyzer.Rules.CSharp
                     var secondaryLocations = GetInvalidMemberLocations(c.SemanticModel, typeDeclaration);
                     if (secondaryLocations.Any())
                     {
-                        c.ReportIssue(Rule.CreateDiagnostic(c.Compilation, typeDeclaration.Identifier.GetLocation(), additionalLocations: secondaryLocations, properties: null));
+                        c.ReportIssue(Rule, typeDeclaration.Identifier, secondaryLocations);
                     }
                 },
                 TypeKinds);
 
-        private static Location[] GetInvalidMemberLocations(SemanticModel semanticModel, BaseTypeDeclarationSyntax type)
+        private static SecondaryLocation[] GetInvalidMemberLocations(SemanticModel semanticModel, BaseTypeDeclarationSyntax type)
         {
             var parentType = GetParentType(type);
             if (parentType is null && type.Modifiers.AnyOfKind(SyntaxKind.InternalKeyword))
@@ -65,11 +65,11 @@ namespace SonarAnalyzer.Rules.CSharp
                                        && !x.Modifiers().AnyOfKind(SyntaxKind.OverrideKeyword) // Overridden member need to keep the visibility of the base declaration
                                        && !x.IsAnyKind(SyntaxKind.OperatorDeclaration, SyntaxKind.ConversionOperatorDeclaration) // Operators must be public
                                        && !IsInterfaceImplementation(semanticModel, x))
-                           .Select(x => x.Modifiers().Single(modifier => modifier.IsKind(SyntaxKind.PublicKeyword)).GetLocation())
+                           .Select(x => x.Modifiers().Single(modifier => modifier.IsKind(SyntaxKind.PublicKeyword)).ToSecondaryLocation())
                            .ToArray();
             }
 
-            return Array.Empty<Location>();
+            return [];
         }
 
         private static bool IsInterfaceImplementation(SemanticModel semanticModel, MemberDeclarationSyntax declaration) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericWithRefParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericWithRefParameters.cs
@@ -50,8 +50,8 @@ namespace SonarAnalyzer.Rules.CSharp
 
                 if (refObjectParameters.Count > 0)
                 {
-                    var parameterLocations = refObjectParameters.Select(p => p.Locations.FirstOrDefault()).WhereNotNull();
-                    c.ReportIssue(rule.CreateDiagnostic(c.Compilation, methodDeclaration.Identifier.GetLocation(), additionalLocations: parameterLocations, properties: null));
+                    var parameterLocations = refObjectParameters.Select(p => p.Locations.FirstOrDefault()?.ToSecondary()).WhereNotNull();
+                    c.ReportIssue(rule, methodDeclaration.Identifier, parameterLocations);
                 }
 
             },

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ConditionEvaluatesToConstant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ConditionEvaluatesToConstant.cs
@@ -203,7 +203,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
                 var unreachableLocations = GetUnreachableLocations(constantNode, constantValue).ToList();
                 var constantText = constantValue.ToString().ToLowerInvariant();
                 return unreachableLocations.Count > 0
-                    ? S2583.CreateDiagnostic(compilation, constantNode.GetLocation(), unreachableLocations, properties: null, string.Format(S2583MessageFormatBool, constantText))
+                    ? Diagnostic.Create(S2583, constantNode.GetLocation(), unreachableLocations, properties: null, string.Format(S2583MessageFormatBool, constantText))
                     : Diagnostic.Create(S2589, constantNode.GetLocation(), messageArgs: string.Format(S2589MessageFormatBool, constantText));
             }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ConditionEvaluatesToConstant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ConditionEvaluatesToConstant.cs
@@ -117,7 +117,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
             public bool SupportsPartialResults => false;
 
-            public IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation)
+            public IEnumerable<Diagnostic> GetDiagnostics()
             {
                 // Do not raise issue in generator functions (See #1295)
                 if (hasYieldStatement)
@@ -129,11 +129,11 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
                     .Union(conditionTrue
                         .Except(conditionFalse)
                         .Where(x => !IsMuted(x) && !IsInsideCatchOrFinallyBlock(x) && !IsConditionOfLoopWithBreak(x))
-                        .Select(x => GetNodeDiagnostics(compilation, x, true)))
+                        .Select(x => GetNodeDiagnostics(x, true)))
                     .Union(conditionFalse
                         .Except(conditionTrue)
                         .Where(x => !IsMuted(x) && !IsInsideCatchOrFinallyBlock(x))
-                        .Select(x => GetNodeDiagnostics(compilation, x, false)))
+                        .Select(x => GetNodeDiagnostics(x, false)))
                     .Union(isNull
                         .Except(isUnknown)
                         .Except(isNotNull)
@@ -198,7 +198,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
             private static bool IsLoopBreakingStatement(SyntaxNode syntaxNode) =>
                 syntaxNode.IsAnyKind(LoopBreakingStatements);
 
-            private static Diagnostic GetNodeDiagnostics(Compilation compilation, SyntaxNode constantNode, bool constantValue)
+            private static Diagnostic GetNodeDiagnostics(SyntaxNode constantNode, bool constantValue)
             {
                 var unreachableLocations = GetUnreachableLocations(constantNode, constantValue).ToList();
                 var constantText = constantValue.ToString().ToLowerInvariant();

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyCollectionsShouldNotBeEnumerated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyCollectionsShouldNotBeEnumerated.cs
@@ -87,7 +87,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
             public bool SupportsPartialResults => false;
 
-            public IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation) =>
+            public IEnumerable<Diagnostic> GetDiagnostics() =>
                 emptyCollections.Except(nonEmptyCollections).Select(node => Diagnostic.Create(S4158, node.GetLocation()));
 
             public void Dispose()

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyNullableValueAccess.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/EmptyNullableValueAccess.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
                 nullableValueCheck.ValuePropertyAccessed += AddIdentifier;
             }
 
-            public IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation) =>
+            public IEnumerable<Diagnostic> GetDiagnostics() =>
                 nullIdentifiers.Select(x => Diagnostic.Create(S3655, x.Parent.GetLocation(), x.Identifier.ValueText));
 
             private void AddIdentifier(object sender, MemberAccessedEventArgs args) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InvalidCastToInterfaceSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InvalidCastToInterfaceSymbolicExecution.cs
@@ -97,7 +97,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
             }
 
             // Nothing to return since the issues are raised during analysis.
-            public IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation) => Enumerable.Empty<Diagnostic>();
+            public IEnumerable<Diagnostic> GetDiagnostics() => Enumerable.Empty<Diagnostic>();
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/NullPointerDereference.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/NullPointerDereference.cs
@@ -206,7 +206,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
             public bool SupportsPartialResults => true;
 
-            public IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation) =>
+            public IEnumerable<Diagnostic> GetDiagnostics() =>
                 nullIdentifiers.Select(nullIdentifier => Diagnostic.Create(S2259, nullIdentifier.GetLocation(), nullIdentifier.Identifier.ValueText));
 
             public void Dispose() => nullPointerCheck.MemberAccessed -= MemberAccessedHandler;

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ObjectsShouldNotBeDisposedMoreThanOnce.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/ObjectsShouldNotBeDisposedMoreThanOnce.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
             public bool SupportsPartialResults => true;
 
-            public IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation) =>
+            public IEnumerable<Diagnostic> GetDiagnostics() =>
                 nodesToReport.Select(item => Diagnostic.Create(S3966, item.Key.GetLocation(), item.Value));
 
             public void Dispose()

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/PublicMethodArgumentsShouldBeCheckedForNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/PublicMethodArgumentsShouldBeCheckedForNull.cs
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
                 nullPointerCheck.MemberAccessing += MemberAccessingHandler;
             }
 
-            public IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation) =>
+            public IEnumerable<Diagnostic> GetDiagnostics() =>
                 identifiers.Select(identifier => Diagnostic.Create(S3900, identifier.GetLocation(), GetMessage(identifier)));
 
             public void Dispose()

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/RestrictDeserializedTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/RestrictDeserializedTypes.cs
@@ -46,7 +46,7 @@ internal sealed class RestrictDeserializedTypes : ISymbolicExecutionAnalyzer
         public bool SupportsPartialResults => true;
 
         public IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation) =>
-            locations.Select(location => Diagnostic.Create(S5773, location.Primary, location.SecondaryLocations, properties: null, location.Message));
+            locations.Select(location => Diagnostic.Create(S5773, location.Primary, location.SecondaryLocations, location.Message));
 
         public void Dispose()
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/RestrictDeserializedTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/RestrictDeserializedTypes.cs
@@ -45,7 +45,7 @@ internal sealed class RestrictDeserializedTypes : ISymbolicExecutionAnalyzer
 
         public bool SupportsPartialResults => true;
 
-        public IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation) =>
+        public IEnumerable<Diagnostic> GetDiagnostics() =>
             locations.Select(location => Diagnostic.Create(S5773, location.Primary, location.SecondaryLocations, location.Message));
 
         public void Dispose()

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/RestrictDeserializedTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/RestrictDeserializedTypes.cs
@@ -46,7 +46,7 @@ internal sealed class RestrictDeserializedTypes : ISymbolicExecutionAnalyzer
         public bool SupportsPartialResults => true;
 
         public IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation) =>
-            locations.Select(location => S5773.CreateDiagnostic(compilation, location.Primary, location.SecondaryLocations, properties: null, location.Message));
+            locations.Select(location => Diagnostic.Create(S5773, location.Primary, location.SecondaryLocations, properties: null, location.Message));
 
         public void Dispose()
         {

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/DefaultAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/DefaultAnalysisContext.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar
 
         public bool SupportsPartialResults => false;
 
-        public IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation) =>
+        public IEnumerable<Diagnostic> GetDiagnostics() =>
             locations.Distinct().Select(CreateDiagnostic);
 
         public void AddLocation(T location) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ISymbolicExecutionAnalysisContext.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/ISymbolicExecutionAnalysisContext.cs
@@ -30,6 +30,6 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar
         // of steps was reached or an exception was thrown during analysis.
         bool SupportsPartialResults { get; }
 
-        IEnumerable<Diagnostic> GetDiagnostics(Compilation compilation);
+        IEnumerable<Diagnostic> GetDiagnostics();
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotOverwriteCollectionElementsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotOverwriteCollectionElementsBase.cs
@@ -68,9 +68,9 @@ namespace SonarAnalyzer.Rules
                 .TakeWhile(IsSameCollection(collectionIdentifier))
                 .FirstOrDefault(IsSameIndexOrKey(indexOrKey));
 
-            if (previousSet != null)
+            if (previousSet is not null)
             {
-                context.ReportIssue(Rule.CreateDiagnostic(context.Compilation, context.Node.GetLocation(), additionalLocations: new[] { previousSet.GetLocation() }, properties: null));
+                context.ReportIssue(Rule, context.Node, [previousSet.ToSecondaryLocation()]);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MethodsShouldNotHaveIdenticalImplementationsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MethodsShouldNotHaveIdenticalImplementationsBase.cs
@@ -55,11 +55,7 @@ namespace SonarAnalyzer.Rules
                         foreach (var duplicate in duplicates)
                         {
                             methodsToHandle.Remove(duplicate);
-                            c.ReportIssue(SupportedDiagnostics[0].CreateDiagnostic(c.Compilation,
-                                GetMethodIdentifier(duplicate).GetLocation(),
-                                additionalLocations: new[] { GetMethodIdentifier(method).GetLocation() },
-                                properties: null,
-                                messageArgs: GetMethodIdentifier(method).ValueText));
+                            c.ReportIssue(SupportedDiagnostics[0], GetMethodIdentifier(duplicate), [GetMethodIdentifier(method).ToSecondaryLocation()], GetMethodIdentifier(method).ValueText);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.Common/Rules/RedundantParenthesesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/RedundantParenthesesBase.cs
@@ -50,12 +50,9 @@ namespace SonarAnalyzer.Rules
                             .Reverse()
                             .Skip(1)
                             .First(); // There are always at least two parenthesized expressions
-
                         var location = GetOpenParenToken(expression).CreateLocation(GetOpenParenToken(innermostExpression));
-
-                        var secondaryLocation = GetCloseParenToken(innermostExpression).CreateLocation(GetCloseParenToken(expression));
-
-                        c.ReportIssue(SupportedDiagnostics[0].CreateDiagnostic(c.Compilation, location, additionalLocations: new[] { secondaryLocation }, properties: null));
+                        var secondaryLocation = GetCloseParenToken(innermostExpression).CreateLocation(GetCloseParenToken(expression)).ToSecondary();
+                        c.ReportIssue(SupportedDiagnostics[0], location, [secondaryLocation]);
                     }
                 },
                 ParenthesizedExpressionSyntaxKind);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IfCollapsible.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IfCollapsible.cs
@@ -50,10 +50,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                         return;
                     }
 
-                    c.ReportIssue(rule.CreateDiagnostic(c.Compilation,
-                        multilineIfBlock.IfStatement.IfKeyword.GetLocation(),
-                        new[] { parentMultilineIfBlock.IfStatement.IfKeyword.GetLocation() },
-                        properties: null));
+                    c.ReportIssue(rule, multilineIfBlock.IfStatement.IfKeyword, [parentMultilineIfBlock.IfStatement.IfKeyword.ToSecondaryLocation()]);
                 },
                 SyntaxKind.MultiLineIfBlock);
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LooseFilePermissions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LooseFilePermissions.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 var invocationLocation = invocation.GetLocation();
                 var secondaryLocation = objectCreation.GetLocation();
 
-                if( invocationLocation.StartLine() == secondaryLocation.StartLine())
+                if (invocationLocation.StartLine() == secondaryLocation.StartLine())
                 {
                     context.ReportIssue(Rule, invocationLocation);
                 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LooseFilePermissions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LooseFilePermissions.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Microsoft.CodeAnalysis;
+
 namespace SonarAnalyzer.Rules.VisualBasic
 {
     [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
@@ -34,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             var node = context.Node;
             if (IsFileAccessPermissions(node, context.SemanticModel) && !node.IsPartOfBinaryNegationOrCondition())
             {
-                context.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
+                context.ReportIssue(Rule, node);
             }
         }
 
@@ -47,11 +49,14 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 var invocationLocation = invocation.GetLocation();
                 var secondaryLocation = objectCreation.GetLocation();
 
-                var diagnostic = invocationLocation.StartLine() == secondaryLocation.StartLine()
-                    ? Diagnostic.Create(Rule, invocationLocation)
-                    : Rule.CreateDiagnostic(context.Compilation, invocationLocation, additionalLocations: new[] {secondaryLocation}, properties: null);
-
-                context.ReportIssue(diagnostic);
+                if( invocationLocation.StartLine() == secondaryLocation.StartLine())
+                {
+                    context.ReportIssue(Rule, invocationLocation);
+                }
+                else
+                {
+                    context.ReportIssue(Rule, invocationLocation, [secondaryLocation.ToSecondary()]);
+                }
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LooseFilePermissions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LooseFilePermissions.cs
@@ -48,15 +48,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             {
                 var invocationLocation = invocation.GetLocation();
                 var secondaryLocation = objectCreation.GetLocation();
-
-                if (invocationLocation.StartLine() == secondaryLocation.StartLine())
-                {
-                    context.ReportIssue(Rule, invocationLocation);
-                }
-                else
-                {
-                    context.ReportIssue(Rule, invocationLocation, [secondaryLocation.ToSecondary()]);
-                }
+                context.ReportIssue(Rule, invocationLocation, invocationLocation.StartLine() == secondaryLocation.StartLine() ? [] : [secondaryLocation.ToSecondary()]);
             }
         }
 


### PR DESCRIPTION
Follow up of #9174

Old SE rules are replaced without the secondary location check. It is simply too difficult to add it there, and it is not really needed, because SE reports only on locations within the analyzed method.

