### PR TITLE
Fix S2234 Bug: AD0001 is thrown due to referencing a location outside of the current compilation

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
@@ -56,9 +56,9 @@ namespace SonarAnalyzer.Rules
                                 && Language.Syntax.ArgumentList(c.Node).FirstOrDefault(x => MatchingNames(parameterSymbol, ArgumentName(x))) is { })
                             {
                                 var secondaryLocations = methodParameterLookup.MethodSymbol.DeclaringSyntaxReferences
-                                    .Select(s => Language.Syntax.NodeIdentifier(s.GetSyntax())?.GetLocation())
+                                    .Select(s => Language.Syntax.NodeIdentifier(s.GetSyntax())?.GetLocation()?.ToSecondary())
                                     .WhereNotNull();
-                                c.ReportIssue(Diagnostic.Create(Rule, PrimaryLocation(c.Node), secondaryLocations, properties: null, methodParameterLookup.MethodSymbol.Name));
+                                c.ReportIssue(Rule, PrimaryLocation(c.Node), secondaryLocations, methodParameterLookup.MethodSymbol.Name);
                                 return;
                             }
                         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParametersCorrectOrderBase.cs
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Rules
                                 && Language.Syntax.ArgumentList(c.Node).FirstOrDefault(x => MatchingNames(parameterSymbol, ArgumentName(x))) is { })
                             {
                                 var secondaryLocations = methodParameterLookup.MethodSymbol.DeclaringSyntaxReferences
-                                    .Select(s => Language.Syntax.NodeIdentifier(s.GetSyntax())?.GetLocation()?.ToSecondary())
+                                    .Select(x => Language.Syntax.NodeIdentifier(x.GetSyntax())?.ToSecondaryLocation())
                                     .WhereNotNull();
                                 c.ReportIssue(Rule, PrimaryLocation(c.Node), secondaryLocations, methodParameterLookup.MethodSymbol.Name);
                                 return;

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/ParametersCorrectOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/ParametersCorrectOrderTest.cs
@@ -93,6 +93,6 @@ public class ParametersCorrectOrderTest
                 }
             }
             """, library.ToMetadataReference()).Model.Compilation;
-        usage.WithAnalyzers([new CS.ParametersCorrectOrder()]).GetAnalyzerDiagnosticsAsync().Result.Should().ContainSingle().Which.Id.Should().Be("AD0001");    // FIXME: No, it shouldn't be AD0001
+        usage.WithAnalyzers([new CS.ParametersCorrectOrder()]).GetAnalyzerDiagnosticsAsync().Result.Should().ContainSingle().Which.Id.Should().Be("S2234", "we don't want AD0001 here");
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/ParametersCorrectOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/ParametersCorrectOrderTest.cs
@@ -75,7 +75,7 @@ public class ParametersCorrectOrderTest
             """).VerifyNoIssuesIgnoreErrors();
 
     [TestMethod]
-    public void ParametersCorrectOrder_SecondaryLocationsOutsideCurrentCompilation()
+    public async Task ParametersCorrectOrder_SecondaryLocationsOutsideCurrentCompilation()
     {
         var library = TestHelper.CompileCS("""
             public static class Library
@@ -93,6 +93,7 @@ public class ParametersCorrectOrderTest
                 }
             }
             """, library.ToMetadataReference()).Model.Compilation;
-        usage.WithAnalyzers([new CS.ParametersCorrectOrder()]).GetAnalyzerDiagnosticsAsync().Result.Should().ContainSingle().Which.Id.Should().Be("S2234", "we don't want AD0001 here");
+        var diagnostics = await usage.WithAnalyzers([new CS.ParametersCorrectOrder()]).GetAnalyzerDiagnosticsAsync();
+        diagnostics.Should().ContainSingle().Which.Id.Should().Be("S2234", "we don't want AD0001 here");
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/ParametersCorrectOrderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/ParametersCorrectOrderTest.cs
@@ -73,4 +73,26 @@ public class ParametersCorrectOrderTest
                 End Sub
             End Class
             """).VerifyNoIssuesIgnoreErrors();
+
+    [TestMethod]
+    public void ParametersCorrectOrder_SecondaryLocationsOutsideCurrentCompilation()
+    {
+        var library = TestHelper.CompileCS("""
+            public static class Library
+            {
+                public static void Method(int a, int b) { }
+            }
+            """).Model.Compilation;
+        var usage = TestHelper.CompileCS("""
+            public class Usage
+            {
+                public void Method()
+                {
+                    int a = 4, b = 2;
+                    Library.Method(b, a);
+                }
+            }
+            """, library.ToMetadataReference()).Model.Compilation;
+        usage.WithAnalyzers([new CS.ParametersCorrectOrder()]).GetAnalyzerDiagnosticsAsync().Result.Should().ContainSingle().Which.Id.Should().Be("AD0001");    // FIXME: No, it shouldn't be AD0001
+    }
 }


### PR DESCRIPTION
Fixes #8577

1st commit adds a reproducer, 2nd fixes it by using the new overloads from #9298 