### PR TITLE
Fix S6966 FP: Methods with different signatures should not trigger this rule.

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseAwaitableMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseAwaitableMethod.cs
@@ -114,7 +114,8 @@ public sealed class UseAwaitableMethod : SonarDiagnosticAnalyzer
 
     private static bool IsExcluded(IMethodSymbol methodSymbol) =>
         methodSymbol.IsAny(KnownType.Microsoft_EntityFrameworkCore_DbSet_TEntity, ExcludedMethodNamesAddAddRange) // https://github.com/SonarSource/sonar-dotnet/issues/9269
-        || methodSymbol.IsAny(KnownType.Microsoft_EntityFrameworkCore_DbContext, ExcludedMethodNamesAddAddRange); // https://github.com/SonarSource/sonar-dotnet/issues/9269
+        || methodSymbol.IsAny(KnownType.Microsoft_EntityFrameworkCore_DbContext, ExcludedMethodNamesAddAddRange)  // https://github.com/SonarSource/sonar-dotnet/issues/9269
+        || methodSymbol.Is(KnownType.MongoDB_Driver_IMongoCollectionExtensions, "Find"); // https://github.com/SonarSource/sonar-dotnet/issues/9265
 
     private static IEnumerable<IMethodSymbol> GetMethodSymbolsInScope(string methodName, WellKnownExtensionMethodContainer wellKnownExtensionMethodContainer,
         ITypeSymbol invokedType, ITypeSymbol methodContainer) =>

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -180,6 +180,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType Microsoft_VisualStudio_TestTools_UnitTesting_TestInitializeAttribute = new("Microsoft.VisualStudio.TestTools.UnitTesting.TestInitializeAttribute");
         public static readonly KnownType Microsoft_Web_XmlTransform_XmlFileInfoDocument = new("Microsoft.Web.XmlTransform.XmlFileInfoDocument");
         public static readonly KnownType Microsoft_Web_XmlTransform_XmlTransformableDocument = new("Microsoft.Web.XmlTransform.XmlTransformableDocument");
+        public static readonly KnownType MongoDB_Driver_IMongoCollectionExtensions = new("MongoDB.Driver.IMongoCollectionExtensions");
         public static readonly KnownType Mono_Data_Sqlite_SqliteCommand = new("Mono.Data.Sqlite.SqliteCommand");
         public static readonly KnownType Mono_Data_Sqlite_SqliteDataAdapter = new("Mono.Data.Sqlite.SqliteDataAdapter");
         public static readonly KnownType Mono_Unix_FileAccessPermissions = new("Mono.Unix.FileAccessPermissions");

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/UseAwaitableMethodTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/UseAwaitableMethodTest.cs
@@ -100,6 +100,6 @@ public class UseAwaitableMethodTest
         .WithOptions(ParseOptionsHelper.FromCSharp11)
         .AddReferences(NuGetMetadataReference.MongoDBDriver())
         .AddPaths("UseAwaitableMethod_MongoDBDriver.cs")
-        .Verify();
+        .VerifyNoIssues();
 #endif
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UseAwaitableMethod_MongoDBDriver.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UseAwaitableMethod_MongoDBDriver.cs
@@ -10,13 +10,12 @@ public class MongoDBDriver
     public async Task Query(IMongoCollection<Person> personCollection)
     {
         var sort = Builders<Person>.Sort.Descending(nameof(Person.Name));
-        // FP for
         // * Find https://mongodb.github.io/mongo-csharp-driver/2.8/apidocs/html/M_MongoDB_Driver_IMongoCollectionExtensions_Find__1_3.htm
         // * FindAsync https://mongodb.github.io/mongo-csharp-driver/2.8/apidocs/html/M_MongoDB_Driver_IMongoCollectionExtensions_FindAsync__1_3.htm
         // Speculative binding finds "FindAsync" but the return type IAsyncCursor<> of FindAsync is not compatible with return type IFindFluent<,> of "Find"
         // Speculative binding does overload resolution according to the C# rules, which ignore return types.
         // It seems to ignore the compiler binding error for the following "Sort" which is only defined on IFindFluent, but not in IAsyncCursor.
-        var snapshot = await personCollection.Find(s => s.Id > 10) // Noncompliant FP
+        var snapshot = await personCollection.Find(s => s.Id > 10) // Compliant https://github.com/SonarSource/sonar-dotnet/issues/9265
             .Sort(sort) // Not defined on IAsyncCursor (return type of FindAsync)
             .FirstOrDefaultAsync().ConfigureAwait(false);
     }


### PR DESCRIPTION
Fixes #9265

This implementation follows option 2 of https://github.com/SonarSource/sonar-dotnet/issues/9265#issuecomment-2126491852