### PR TITLE
Add IPropertySymbol.IsRequired() to ShimLayer

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/IPropertySymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/IPropertySymbolExtensions.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace StyleCop.Analyzers.Lightup;
+
+public static class IPropertySymbolExtensions
+{
+    private static readonly Func<IPropertySymbol, bool> IsRequiredAccessor;
+
+    static IPropertySymbolExtensions()
+    {
+        IsRequiredAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<IPropertySymbol, bool>(typeof(IPropertySymbol), nameof(IsRequired));
+    }
+
+    public static bool IsRequired(this IPropertySymbol propertySymbol) =>
+        IsRequiredAccessor(propertySymbol);
+}

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/AvoidUnderPosting.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/AvoidUnderPosting.cs
@@ -79,12 +79,10 @@ public sealed class AvoidUnderPosting : SonarDiagnosticAnalyzer
         var declaredProperties = new List<IPropertySymbol>();
         GetAllDeclaredProperties(parameterType, examinedTypes, declaredProperties);
         var invalidProperties = declaredProperties
-            .Where(x => !CanBeNull(x.Type) && !x.HasAnyAttribute(ValidationAttributes))
-            .Select(x => x.DeclaringSyntaxReferences[0].GetSyntax())
-            .Where(x => !x.GetModifiers().Any(x => x.IsKind(SyntaxKindEx.RequiredKeyword))); // ToDo: Check with IProperty.IsRequired once available
+            .Where(x => !CanBeNull(x.Type) && !x.HasAnyAttribute(ValidationAttributes) && !x.IsRequired());
         foreach (var property in invalidProperties)
         {
-            context.ReportIssue(Rule, property.GetLocation());
+            context.ReportIssue(Rule, property.GetFirstSyntaxRef().GetLocation());
         }
     }
 

--- a/analyzers/tests/SonarAnalyzer.Test/Wrappers/IPropertySymbolExtensionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Wrappers/IPropertySymbolExtensionTest.cs
@@ -31,7 +31,7 @@ public class IPropertySymbolExtensionTest
     [DataRow("")]
     public void IsRequired(string required)
     {
-        var net48Attributes = // Compiler attributes to simulate "this compiler/framework combination supports requires members"
+        var net48Attributes = // Compiler attributes to simulate "this compiler/framework combination supports required members"
 #if NETFRAMEWORK
             $$"""
             namespace System.Runtime.CompilerServices;

--- a/analyzers/tests/SonarAnalyzer.Test/Wrappers/IPropertySymbolExtensionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Wrappers/IPropertySymbolExtensionTest.cs
@@ -31,7 +31,18 @@ public class IPropertySymbolExtensionTest
     [DataRow("")]
     public void IsRequired(string required)
     {
+        var net48Attributes = // Compiler attributes to simulate "this compiler/framework combination supports requires members
+#if NETFRAMEWORK
+            $$"""
+            namespace System.Runtime.CompilerServices;
+            public class RequiredMemberAttribute : Attribute { }
+            public class CompilerFeatureRequiredAttribute(string featureName) : Attribute { }
+            """;
+#else
+            string.Empty;
+#endif
         var code = $$"""
+            {{net48Attributes}}
             public class Test
             {
                 public {{required}} int Prop { get; set; }

--- a/analyzers/tests/SonarAnalyzer.Test/Wrappers/IPropertySymbolExtensionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Wrappers/IPropertySymbolExtensionTest.cs
@@ -31,7 +31,7 @@ public class IPropertySymbolExtensionTest
     [DataRow("")]
     public void IsRequired(string required)
     {
-        var net48Attributes = // Compiler attributes to simulate "this compiler/framework combination supports requires members
+        var net48Attributes = // Compiler attributes to simulate "this compiler/framework combination supports requires members"
 #if NETFRAMEWORK
             $$"""
             namespace System.Runtime.CompilerServices;

--- a/analyzers/tests/SonarAnalyzer.Test/Wrappers/IPropertySymbolExtensionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Wrappers/IPropertySymbolExtensionTest.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using StyleCop.Analyzers.Lightup;
+
+namespace SonarAnalyzer.Test.Wrappers;
+
+[TestClass]
+public class IPropertySymbolExtensionTest
+{
+    [DataTestMethod]
+    [DataRow("required")]
+    [DataRow("")]
+    public void IsRequired(string required)
+    {
+        var code = $$"""
+            public class Test
+            {
+                public {{required}} int Prop { get; set; }
+            }
+            """;
+        var (tree, model) = TestHelper.CompileCS(code);
+        var propertyDeclaration = tree.GetRoot().DescendantNodes().OfType<PropertyDeclarationSyntax>().Single();
+        var propertySymbol = model.GetDeclaredSymbol(propertyDeclaration).Should().BeAssignableTo<IPropertySymbol>();
+        propertySymbol.Subject.IsRequired().Should().Be(propertySymbol.Subject.IsRequired);
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.Test/Wrappers/IPropertySymbolExtensionTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Wrappers/IPropertySymbolExtensionTest.cs
@@ -39,7 +39,7 @@ public class IPropertySymbolExtensionTest
             """;
         var (tree, model) = TestHelper.CompileCS(code);
         var propertyDeclaration = tree.GetRoot().DescendantNodes().OfType<PropertyDeclarationSyntax>().Single();
-        var propertySymbol = model.GetDeclaredSymbol(propertyDeclaration).Should().BeAssignableTo<IPropertySymbol>();
-        propertySymbol.Subject.IsRequired().Should().Be(propertySymbol.Subject.IsRequired);
+        var propertySymbol = model.GetDeclaredSymbol(propertyDeclaration).Should().BeAssignableTo<IPropertySymbol>().Subject;
+        propertySymbol.IsRequired().Should().Be(propertySymbol.IsRequired);
     }
 }


### PR DESCRIPTION
Follow up to #9307

Fixes ToDo in  https://github.com/SonarSource/sonar-dotnet/blob/0876a571b93c5748ea8396b9f29ba53a6e54543f/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/AvoidUnderPosting.cs#L84