### PR TITLE
ReportIssue: Use safe overloads for secondary locations

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotTestThisWithIsOperator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotTestThisWithIsOperator.cs
@@ -123,13 +123,13 @@ namespace SonarAnalyzer.Rules.CSharp
                                                  .IsKind(SyntaxKindEx.Subpattern);
 
         private static void ReportDiagnostic(SonarSyntaxNodeReportingContext context, SyntaxNode node) =>
-            context.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
+            context.ReportIssue(Rule, node);
 
         private static void ReportDiagnostic(SonarSyntaxNodeReportingContext context, SyntaxNode node, IList<SecondaryLocation> secondaryLocations)
         {
             if (secondaryLocations.Any())
             {
-                context.ReportIssue(Diagnostic.Create(Rule, node.GetLocation(), secondaryLocations.ToAdditionalLocations(), secondaryLocations.ToProperties()));
+                context.ReportIssue(Rule, node, secondaryLocations);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeLoggedOrThrown.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeLoggedOrThrown.cs
@@ -61,7 +61,7 @@ public sealed class ExceptionsShouldBeLoggedOrThrown : SonarDiagnosticAnalyzer
                                      new(walker.LoggingInvocationWithException.GetLocation(), LoggingStatementMessage),
                                      new(throwStatement.GetLocation(), ThrownExceptionMessage)
                                  };
-                                 c.ReportIssue(Diagnostic.Create(Rule, exceptionIdentifier.GetLocation(), secondaryLocations.ToAdditionalLocations(), secondaryLocations.ToProperties()));
+                                 c.ReportIssue(Rule, exceptionIdentifier, secondaryLocations);
                              }
                          },
                          SyntaxKind.CatchClause);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionComplexity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionComplexity.cs
@@ -109,14 +109,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var complexityMetric = CSharpCyclomaticComplexityMetric.GetComplexity(nodeToCheck, onlyGlobalStatements);
             if (complexityMetric.Complexity > Maximum)
             {
-                context.ReportIssue(
-                    Diagnostic.Create(Rule,
-                                      getLocation(node),
-                                      complexityMetric.Locations.ToAdditionalLocations(),
-                                      complexityMetric.Locations.ToProperties(),
-                                      Maximum,
-                                      complexityMetric.Complexity,
-                                      declarationType));
+                context.ReportIssue(Rule, getLocation(node), complexityMetric.Locations, Maximum.ToString(), complexityMetric.Complexity.ToString(), declarationType);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeMutable.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeMutable.cs
@@ -62,17 +62,11 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     var identifiers = methodSyntax.DescendantNodes().OfType<IdentifierNameSyntax>();
 
-                    var secondaryLocations = GetAllFirstMutableFieldsUsed(c, fieldsOfClass, identifiers).Select(CreateSecondaryLocation).ToList();
-                    if (secondaryLocations.Count == 0)
+                    var secondaryLocations = GetAllFirstMutableFieldsUsed(c, fieldsOfClass, identifiers).Select(CreateSecondaryLocation).ToArray();
+                    if (secondaryLocations.Any())
                     {
-                        return;
+                        c.ReportIssue(Rule, methodSyntax.Identifier, secondaryLocations);
                     }
-
-                    c.ReportIssue(Diagnostic.Create(
-                        Rule,
-                        methodSyntax.Identifier.GetLocation(),
-                        secondaryLocations.ToAdditionalLocations(),
-                        secondaryLocations.ToProperties()));
                 },
                 SyntaxKind.MethodDeclaration);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementIDisposableCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementIDisposableCorrectly.cs
@@ -55,9 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var locations = checker.GetIssueLocations(typeDeclarationSyntax);
                     if (locations.Any())
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, declarationIdentifier.GetLocation(),
-                                                                       locations.ToAdditionalLocations(),
-                                                                       locations.ToProperties()));
+                        c.ReportIssue(Rule, declarationIdentifier, locations);
                     }
                 },
                 SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementISerializableCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementISerializableCorrectly.cs
@@ -19,7 +19,6 @@
  */
 
 using System.Runtime.Serialization;
-using System.Text;
 
 namespace SonarAnalyzer.Rules.CSharp
 {
@@ -56,9 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     implementationErrors.AddRange(CheckGetObjectData(typeDeclarationSyntax, typeSymbol, getObjectData));
                     if (implementationErrors.Any())
                     {
-                        var details = implementationErrors.Aggregate(new StringBuilder(), (sb, error) => sb.Append($"{error.Message} "), sb => sb.ToString().TrimEnd());
-                        var rule = Diagnostic.Create(Rule, typeDeclarationSyntax.Identifier.GetLocation(), implementationErrors.ToAdditionalLocations(), implementationErrors.ToProperties(), details);
-                        c.ReportIssue(rule);
+                        c.ReportIssue(Rule, typeDeclarationSyntax.Identifier, implementationErrors, implementationErrors.JoinStr(" ", x => x.Message));
                     }
                 },
                 SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
@@ -101,7 +101,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var xmlReaderSettingsValidator = new XmlReaderSettingsValidator(context.SemanticModel, versionProvider.GetDotNetFrameworkVersion(context.Compilation));
             if (xmlReaderSettingsValidator.GetUnsafeAssignmentLocations(invocation, settings) is { } secondaryLocations && secondaryLocations.Any())
             {
-                context.ReportIssue(Diagnostic.Create(Rule, invocation.GetLocation(), secondaryLocations, secondaryLocations.ToProperties(SecondaryMessageFormat)));
+                context.ReportIssue(Rule, invocation, secondaryLocations.Select(x => x.ToSecondary(SecondaryMessageFormat)));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
@@ -111,6 +111,8 @@ public abstract class SonarTreeReportingContextBase<TContext> : SonarReportingCo
 
     public void ReportIssue(DiagnosticDescriptor rule, Location primaryLocation, IEnumerable<SecondaryLocation> secondaryLocations, params string[] messageArgs)
     {
+        _ = rule ?? throw new ArgumentNullException(nameof(rule));
+        _ = secondaryLocations ?? throw new ArgumentNullException(nameof(secondaryLocations));
         secondaryLocations = secondaryLocations.Where(x => x.Location.IsValid(Compilation)).ToArray();
         var properties = secondaryLocations.Select((x, index) => new KeyValuePair<string, string>(index.ToString(), x.Message)).ToImmutableDictionary();
         ReportIssueCore(Diagnostic.Create(rule, primaryLocation, secondaryLocations.Select(x => x.Location), properties, messageArgs));

--- a/analyzers/src/SonarAnalyzer.Common/Common/SecondaryLocation.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Common/SecondaryLocation.cs
@@ -34,11 +34,4 @@ public static class SecondaryLocationExtensions
             .Select((item, index) => new { item.Message, Index = index.ToString() })
             .ToDictionary(x => x.Index, x => x.Message)
             .ToImmutableDictionary();
-
-    [Obsolete("Use ReportIssue overload with IEnumerable<SecondaryLocation> parameter instead.")]
-    public static ImmutableDictionary<string, string> ToProperties(this IEnumerable<Location> secondaryLocations, string message) =>
-          secondaryLocations
-            .Select((item, index) => new { message, Index = index.ToString() })
-            .ToDictionary(x => x.Index, x => message)
-            .ToImmutableDictionary();
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CognitiveComplexityBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CognitiveComplexityBase.cs
@@ -62,12 +62,7 @@ namespace SonarAnalyzer.Rules
 
             if (metric.Complexity > Threshold)
             {
-                context.ReportIssue(
-                    Diagnostic.Create(rule,
-                                      getLocationToReport(syntax),
-                                      metric.Locations.ToAdditionalLocations(),
-                                      metric.Locations.ToProperties(),
-                                      new object[] { declarationType, metric.Complexity, threshold }));
+                context.ReportIssue(rule, getLocationToReport(syntax), metric.Locations, declarationType, metric.Complexity.ToString(), threshold.ToString());
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MethodOverloadsShouldBeGroupedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MethodOverloadsShouldBeGroupedBase.cs
@@ -47,12 +47,7 @@ namespace SonarAnalyzer.Rules
                 {
                     var firstName = misplacedOverload.First().NameSyntax;
                     var secondaryLocations = misplacedOverload.Skip(1).Select(x => new SecondaryLocation(x.NameSyntax.GetLocation(), "Non-adjacent overload")).ToList();
-                    c.ReportIssue(Diagnostic.Create(
-                        descriptor: Rule,
-                        location: firstName.GetLocation(),
-                        additionalLocations: secondaryLocations.ToAdditionalLocations(),
-                        properties: secondaryLocations.ToProperties(),
-                        messageArgs: firstName.ValueText));
+                    c.ReportIssue(Rule, firstName, secondaryLocations, firstName.ValueText);
                 }
             },
             SyntaxKinds);

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/CalculationsShouldNotOverflowBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/CalculationsShouldNotOverflowBase.cs
@@ -38,19 +38,19 @@ public abstract class CalculationsShouldNotOverflowBase : SymbolicRuleCheck
         {
             if (number.Max < bounds.Min)
             {
-                ReportIssue(operation, MessageGuaranteed, MessageUnderflow, bounds.Min);
+                ReportIssue(operation, MessageGuaranteed, MessageUnderflow, bounds.Min.ToString());
             }
             else if (number.Min > bounds.Max)
             {
-                ReportIssue(operation, MessageGuaranteed, MessageOverflow, bounds.Max);
+                ReportIssue(operation, MessageGuaranteed, MessageOverflow, bounds.Max.ToString());
             }
             else if (number.Max > bounds.Max)
             {
-                ReportIssue(operation, MessageLikely, MessageOverflow, bounds.Max);
+                ReportIssue(operation, MessageLikely, MessageOverflow, bounds.Max.ToString());
             }
             else if (number.Min < bounds.Min)
             {
-                ReportIssue(operation, MessageLikely, MessageUnderflow, bounds.Min);
+                ReportIssue(operation, MessageLikely, MessageUnderflow, bounds.Min.ToString());
             }
         }
         return context.State;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/ConditionEvaluatesToConstantBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/ConditionEvaluatesToConstantBase.cs
@@ -112,11 +112,11 @@ public abstract class ConditionEvaluatesToConstantBase : SymbolicRuleCheck
         var secondaryLocations = SecondaryLocations(block, conditionValue, syntax.Span.End);
         if (secondaryLocations.Any())
         {
-            ReportIssue(Rule2583, syntax, secondaryLocations, properties: null, issueMessage, S2583MessageSuffix);
+            ReportIssue(Rule2583, syntax, secondaryLocations.Select(x => x.ToSecondary()), issueMessage, S2583MessageSuffix);
         }
         else
         {
-            ReportIssue(Rule2589, syntax, additionalLocations: null, properties: null, issueMessage, string.Empty);
+            ReportIssue(Rule2589, syntax, [], issueMessage, string.Empty);
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/PublicMethodArgumentsShouldBeCheckedForNullBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/PublicMethodArgumentsShouldBeCheckedForNullBase.cs
@@ -43,7 +43,7 @@ public abstract class PublicMethodArgumentsShouldBeCheckedForNullBase : Symbolic
             var message = IsInConstructorInitializer(candidate.Syntax)
                 ? "Refactor this constructor to avoid using members of parameter '{0}' because it could be {1}."
                 : "Refactor this method to add validation of parameter '{0}' before using it.";
-            ReportIssue(candidate, string.Format(message, candidate.Syntax, NullName), context);
+            ReportIssue(candidate, string.Format(message, candidate.Syntax, NullName));
         }
 
         return context.State;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/RestrictDeserializedTypesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/RestrictDeserializedTypesBase.cs
@@ -78,10 +78,8 @@ public abstract class RestrictDeserializedTypesBase : SymbolicRuleCheck
         else if (UnsafeDeserialization(state, operation) is { } invocation)
         {
             var methodDeclaration = UnsafeMethodDeclaration(state, invocation.Instance);
-            var additionalLocations = methodDeclaration is not null
-                ? new[] { GetIdentifier(methodDeclaration).GetLocation() }
-                : Array.Empty<Location>();
-            ReportIssue(operation, additionalLocations, additionalLocations.ToProperties(SecondaryMessage), RestrictTypesMessage);
+            var additionalLocations = methodDeclaration is null ? [] : new[] { GetIdentifier(methodDeclaration).GetLocation().ToSecondary(SecondaryMessage) };
+            ReportIssue(operation, additionalLocations, RestrictTypesMessage);
         }
         return state;
     }

--- a/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarSyntaxTreeReportingContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarSyntaxTreeReportingContextTest.cs
@@ -19,6 +19,7 @@
  */
 
 using System.Threading.Channels;
+using NSubstitute;
 using SonarAnalyzer.AnalysisContext;
 
 namespace SonarAnalyzer.Test.AnalysisContext;
@@ -71,5 +72,16 @@ public class SonarSyntaxTreeReportingContextTest
         lastDiagnostic.Should().NotBeNull();
         lastDiagnostic.Id.Should().Be("Sxxxx");
         lastDiagnostic.AdditionalLocations.Should().BeEmpty("This secondary location is outside the compilation");
+    }
+
+    [TestMethod]
+    public void ReportIssue_NullArguments_Throws()
+    {
+        var compilation = TestHelper.CompileCS("// Nothing to see here").Model.Compilation;
+        var sut = new SonarSyntaxTreeReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), default, compilation);
+        var rule = AnalysisScaffolding.CreateDescriptor("Sxxxx", DiagnosticDescriptorFactory.MainSourceScopeTag);
+
+        sut.Invoking(x => x.ReportIssue(null, primaryLocation: null,  secondaryLocations: [])).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("rule");
+        sut.Invoking(x => x.ReportIssue(rule, primaryLocation: null,  secondaryLocations: null)).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("secondaryLocations");
     }
 }


### PR DESCRIPTION
Follow up of #9323 to prevent AD0001s with secondary locations raised on a referenced projects.

This PR:
* Replaces old usages with secondary locations with the new, safe API*
* Updates SE `ReportIssue` to the same principle

*Except one that will follow in a later PR