### PR TITLE
SonarCompilationReportingContextBase: Add ReportIssue with SecondaryLocation

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarAnalysisContextExtensions.cs
@@ -46,23 +46,37 @@ public static class SonarAnalysisContextExtensions
     public static void RegisterCodeBlockStartAction(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<SyntaxKind>> action) =>
         context.RegisterCodeBlockStartAction(CSharpGeneratedCodeRecognizer.Instance, action);
 
-    [Obsolete("Use overload without Diagnostic.Create, or add one - the same as in the context class.")]
+    [Obsolete("Use overload without Diagnostic.Create - the same as in the context class.")]
     public static void ReportIssue(this SonarCompilationReportingContext context, Diagnostic diagnostic) =>
         context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
 
-    public static void ReportIssue(this SonarCompilationReportingContext context, DiagnosticDescriptor rule, Location location, params object[] messageArgs) =>
+    public static void ReportIssue(this SonarCompilationReportingContext context,
+                                   DiagnosticDescriptor rule,
+                                   Location primaryLocation,
+                                   IEnumerable<SecondaryLocation> secondaryLocations,
+                                   params string[] messageArgs) =>
+        context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, primaryLocation, secondaryLocations, messageArgs);
+
+    public static void ReportIssue(this SonarCompilationReportingContext context, DiagnosticDescriptor rule, Location location, params string[] messageArgs) =>
         context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, location, messageArgs);
 
-    [Obsolete("Use overload without Diagnostic.Create, or add one - the same as in the context class.")]
+    [Obsolete("Use overload without Diagnostic.Create - the same as in the context class.")]
     public static void ReportIssue(this SonarSymbolReportingContext context, Diagnostic diagnostic) =>
         context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
 
-    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params object[] messageArgs) =>
+    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params string[] messageArgs) =>
         context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, locationSyntax, messageArgs);
 
-    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxToken locationToken, params object[] messageArgs) =>
+    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxToken locationToken, params string[] messageArgs) =>
         context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, locationToken, messageArgs);
 
-    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, Location location, params object[] messageArgs) =>
+    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, Location location, params string[] messageArgs) =>
         context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, location, messageArgs);
+
+    public static void ReportIssue(this SonarSymbolReportingContext context,
+                                   DiagnosticDescriptor rule,
+                                   Location primaryLocation,
+                                   IEnumerable<SecondaryLocation> secondaryLocations,
+                                   params string[] messageArgs) =>
+        context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, primaryLocation, secondaryLocations, messageArgs);
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarAnalysisContextExtensions.cs
@@ -46,9 +46,23 @@ public static class SonarAnalysisContextExtensions
     public static void RegisterCodeBlockStartAction(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<SyntaxKind>> action) =>
         context.RegisterCodeBlockStartAction(CSharpGeneratedCodeRecognizer.Instance, action);
 
+    [Obsolete("Use overload without Diagnostic.Create, or add one - the same as in the context class.")]
     public static void ReportIssue(this SonarCompilationReportingContext context, Diagnostic diagnostic) =>
         context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
 
+    public static void ReportIssue(this SonarCompilationReportingContext context, DiagnosticDescriptor rule, Location location, params object[] messageArgs) =>
+        context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, location, messageArgs);
+
+    [Obsolete("Use overload without Diagnostic.Create, or add one - the same as in the context class.")]
     public static void ReportIssue(this SonarSymbolReportingContext context, Diagnostic diagnostic) =>
         context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
+
+    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params object[] messageArgs) =>
+        context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, locationSyntax, messageArgs);
+
+    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxToken locationToken, params object[] messageArgs) =>
+        context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, locationToken, messageArgs);
+
+    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, Location location, params object[] messageArgs) =>
+        context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, location, messageArgs);
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/BlazorQueryParameterRoutableComponent.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/BlazorQueryParameterRoutableComponent.cs
@@ -67,14 +67,14 @@ public sealed class BlazorQueryParameterRoutableComponent : SonarDiagnosticAnaly
             {
                 foreach (var location in property.Locations)
                 {
-                    c.ReportIssue(Diagnostic.Create(S6803Rule, location));
+                    c.ReportIssue(S6803Rule, location);
                 }
             }
             else if (!SupportedQueryTypes.Any(x => IsSupportedType(property.Type, x)))
             {
                 foreach (var propertyType in property.DeclaringSyntaxReferences.Select(x => ((PropertyDeclarationSyntax)x.GetSyntax()).Type))
                 {
-                    c.ReportIssue(Diagnostic.Create(S6797Rule, propertyType.GetLocation(), GetTypeName(propertyType)));
+                    c.ReportIssue(S6797Rule, propertyType.GetLocation(), GetTypeName(propertyType));
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeAbstract.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassShouldNotBeAbstract.cs
@@ -83,13 +83,13 @@ namespace SonarAnalyzer.Rules.CSharp
                 var node = declaringSyntaxReference.GetSyntax();
                 if (node is ClassDeclarationSyntax classDeclaration)
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, classDeclaration.Identifier.GetLocation(), "class", message));
+                    context.ReportIssue(Rule, classDeclaration.Identifier.GetLocation(), "class", message);
                 }
 
                 if (RecordDeclarationSyntaxWrapper.IsInstance(node))
                 {
                     var wrapper = (RecordDeclarationSyntaxWrapper)node;
-                    context.ReportIssue(Diagnostic.Create(Rule, wrapper.Identifier.GetLocation(), "record", message));
+                    context.ReportIssue(Rule, wrapper.Identifier, "record", message);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithOnlyStaticMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ClassWithOnlyStaticMember.cs
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 if (syntaxReference.GetSyntax() is ClassDeclarationSyntax classDeclarationSyntax)
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, classDeclarationSyntax.Identifier.GetLocation(), reportMessage));
+                    context.ReportIssue(Rule, classDeclarationSyntax.Identifier, reportMessage);
                 }
             }
         }
@@ -89,10 +89,10 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         case ConstructorDeclarationSyntax constructorDeclaration:
                             var reportMessage = string.Format(MessageFormatConstructor, utilityClass.IsSealed ? SyntaxConstants.Private : SyntaxConstants.Protected);
-                            context.ReportIssue(Diagnostic.Create(Rule, constructorDeclaration.Identifier.GetLocation(), reportMessage));
+                            context.ReportIssue(Rule, constructorDeclaration.Identifier, reportMessage);
                             break;
                         case ClassDeclarationSyntax classDeclaration when classDeclaration.ParameterList() is { Parameters.Count: 0 }:
-                            context.ReportIssue(Diagnostic.Create(Rule, classDeclaration.Identifier.GetLocation(), MessageFormatPrimaryConstructor));
+                            context.ReportIssue(Rule, classDeclaration.Identifier, MessageFormatPrimaryConstructor);
                             break;
                         default:
                             break;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DatabasePasswordsShouldBeSecure.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DatabasePasswordsShouldBeSecure.cs
@@ -108,7 +108,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     && !HasSanitizers(connectionString.Value)
                     && connectionString.CreateLocation(webConfigPath) is { } location)
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, location));
+                    c.ReportIssue(Rule, location);
                 }
             }
         }
@@ -121,7 +121,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     if (connectionStrings[key] is { Kind: Kind.Value, Value: string value } connectionStringNode && IsVulnerable(value))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, connectionStringNode.ToLocation(appSettingsPath)));
+                        c.ReportIssue(Rule, connectionStringNode.ToLocation(appSettingsPath));
                     }
                 }
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableMemberInNonDisposableClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableMemberInNonDisposableClass.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var typeDeclarations = new CSharpRemovableDeclarationCollector(namedType, c.Compilation).TypeDeclarations;
                     foreach (var classDeclaration in typeDeclarations)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, classDeclaration.Node.Identifier.GetLocation(), message));
+                        c.ReportIssue(Rule, classDeclaration.Node.Identifier, message);
                     }
                 },
                 SymbolKind.NamedType);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableNotDisposed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableNotDisposed.cs
@@ -103,7 +103,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                         foreach (var disposable in disposableObjects.Where(x => !possiblyDisposed.Contains(x.Symbol)))
                         {
-                            c.ReportIssue(Diagnostic.Create(Rule, disposable.Node.GetLocation(), disposable.Symbol.Name));
+                            c.ReportIssue(Rule, disposable.Node, disposable.Symbol.Name);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeNotImplementingDispose.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeNotImplementingDispose.cs
@@ -113,10 +113,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 foreach (var location in disposeMethod.Locations)
                 {
-                    context.ReportIssue(Rule.CreateDiagnostic(context.Compilation,
-                        location,
-                        disposeMethod.PartialImplementationPart?.Locations ?? Enumerable.Empty<Location>(),
-                        properties: null));
+                    context.ReportIssue(Rule, location, disposeMethod.PartialImplementationPart?.Locations.Select(x => x.ToSecondary()) ?? []);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShouldBeReadonly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldShouldBeReadonly.cs
@@ -91,7 +91,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     foreach (var field in fieldCollector.NonCompliantFields)
                     {
                         var identifier = field.Node.Identifier;
-                        c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.ValueText));
+                        c.ReportIssue(Rule, identifier, identifier.ValueText);
                     }
                 },
                 SymbolKind.NamedType);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithNeutralResourcesLanguageAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithNeutralResourcesLanguageAttribute.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         {
                             if (hasResx && !HasNeutralResourcesLanguageAttribute(cc.Compilation.Assembly))
                             {
-                                cc.ReportIssue(Rule, (Location)null, cc.Compilation.AssemblyName);
+                                cc.ReportIssue(Rule, null, cc.Compilation.AssemblyName);
                             }
                         });
                 });

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithNeutralResourcesLanguageAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithNeutralResourcesLanguageAttribute.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         {
                             if (hasResx && !HasNeutralResourcesLanguageAttribute(cc.Compilation.Assembly))
                             {
-                                cc.ReportIssue(Diagnostic.Create(Rule, null, cc.Compilation.AssemblyName));
+                                cc.ReportIssue(Rule, (Location)null, cc.Compilation.AssemblyName);
                             }
                         });
                 });

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShadowsOuterStaticMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShadowsOuterStaticMember.cs
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 foreach (var identifier in namedType.DeclaringReferenceIdentifiers())
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), namedType.GetClassification()));
+                    context.ReportIssue(Rule, identifier, namedType.GetClassification());
                 }
             }
         }
@@ -83,7 +83,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && member.FirstDeclaringReferenceIdentifier() is { } identifier
                 && identifier.GetLocation() is { Kind: LocationKind.SourceFile } location)
             {
-                context.ReportIssue(Diagnostic.Create(Rule, location, member.GetClassification()));
+                context.ReportIssue(Rule, location, member.GetClassification());
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldNotHaveConflictingTransparencyAttributes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldNotHaveConflictingTransparencyAttributes.cs
@@ -75,18 +75,15 @@ namespace SonarAnalyzer.Rules.CSharp
                                                                       .GetAttributes(KnownType.System_Security_SecurityCriticalAttribute)
                                                                       .FirstOrDefault();
 
-            if (assemblySecurityCriticalAttribute != null)
+            if (assemblySecurityCriticalAttribute is not null)
             {
-                var assemblySecurityLocation = assemblySecurityCriticalAttribute.ApplicationSyntaxReference.GetSyntax().GetLocation();
+                var assemblySecurityLocation = assemblySecurityCriticalAttribute.ApplicationSyntaxReference.GetSyntax().ToSecondaryLocation();
 
                 // All parts declaring the 'SecuritySafeCriticalAttribute' are incorrect since the assembly
                 // itself is marked as 'SecurityCritical'.
                 foreach (var item in nodesWithSecuritySafeCritical)
                 {
-                    compilationContext.ReportIssue(Rule.CreateDiagnostic(compilationContext.Compilation,
-                        item.Value.GetLocation(),
-                        additionalLocations: new[] { assemblySecurityLocation },
-                        properties: null));
+                    compilationContext.ReportIssue(Rule, item.Value.GetLocation(), [assemblySecurityLocation]);
                 }
             }
             else
@@ -94,14 +91,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 foreach (var item in nodesWithSecuritySafeCritical)
                 {
                     var current = item.Key.Parent;
-                    while (current != null)
+                    while (current is not null)
                     {
                         if (nodesWithSecurityCritical.ContainsKey(current))
                         {
-                            compilationContext.ReportIssue(Rule.CreateDiagnostic(compilationContext.Compilation,
-                                item.Value.GetLocation(),
-                                additionalLocations: new[] { nodesWithSecurityCritical[current].GetLocation() },
-                                properties: null));
+                            compilationContext.ReportIssue(Rule, item.Value.GetLocation(), [nodesWithSecurityCritical[current].ToSecondaryLocation()]);
                             break;
                         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverloadOptionalParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverloadOptionalParameter.cs
@@ -61,14 +61,15 @@ namespace SonarAnalyzer.Rules.CSharp
             var defaultCanBeUsed = IsMoreParameterAvailableInConflicting(hidingInfo) || !MethodsUsingSameParameterNames(hidingInfo);
             var isOtherFile = syntax.SyntaxTree.FilePath != hidingMethodSyntax.SyntaxTree.FilePath;
 
-            c.ReportIssue(Diagnostic.Create(Rule, syntax.GetLocation(),
+            c.ReportIssue(Rule,
+                syntax,
                 hidingMethodSyntax.GetLocation().GetMappedLineSpan().StartLinePosition.Line + 1,
                 isOtherFile
                     ? $" in file '{new FileInfo(hidingMethodSyntax.SyntaxTree.FilePath).Name}'"
                     : string.Empty,
                 defaultCanBeUsed
                     ? "can only be used with named arguments"
-                    : "can't be used"));
+                    : "can't be used");
         }
 
         private static List<ParameterHidingMethodInfo> GetParameterHidingInfo(IMethodSymbol methodSymbol) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverloadOptionalParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverloadOptionalParameter.cs
@@ -61,9 +61,10 @@ namespace SonarAnalyzer.Rules.CSharp
             var defaultCanBeUsed = IsMoreParameterAvailableInConflicting(hidingInfo) || !MethodsUsingSameParameterNames(hidingInfo);
             var isOtherFile = syntax.SyntaxTree.FilePath != hidingMethodSyntax.SyntaxTree.FilePath;
 
-            c.ReportIssue(Rule,
+            c.ReportIssue(
+                Rule,
                 syntax,
-                hidingMethodSyntax.GetLocation().GetMappedLineSpan().StartLinePosition.Line + 1,
+                (hidingMethodSyntax.GetLocation().GetMappedLineSpan().StartLinePosition.Line + 1).ToString(),
                 isOtherFile
                     ? $" in file '{new FileInfo(hidingMethodSyntax.SyntaxTree.FilePath).Name}'"
                     : string.Empty,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     .Select(x => x.GetSyntax())
                     .OfType<MethodDeclarationSyntax>())
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation(), MakeThisMethodPrivateMessage));
+                    c.ReportIssue(Rule, methodDeclaration.Identifier, MakeThisMethodPrivateMessage);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NotAssignedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NotAssignedPrivateMember.cs
@@ -82,7 +82,7 @@ namespace SonarAnalyzer.Rules.CSharp
                             ? property.Identifier.GetLocation()
                             : field.Identifier.GetLocation();
 
-                        c.ReportIssue(Diagnostic.Create(Rule, location, memberType, candidateMember.Symbol.Name));
+                        c.ReportIssue(Rule, location, memberType, candidateMember.Symbol.Name);
                     }
                 },
                 SymbolKind.NamedType);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SetLocaleForDataTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SetLocaleForDataTypes.cs
@@ -89,7 +89,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 if (invalidCreation.Key.GetSymbolType() is { } type)
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, invalidCreation.Value.GetLocation(), type.Name));
+                    c.ReportIssue(Rule, invalidCreation.Value.GetLocation(), type.Name);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 // Method invocation is noncompliant when there is at least 1 invocation of the method, and no invocation is using the return value. The case of 0 invocation is handled by S1144.
                 if (matchingInvocations.Any() && !matchingInvocations.Any(IsReturnValueUsed))
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, declaredPrivateMethodWithReturn.Node.ReturnType.GetLocation()));
+                    context.ReportIssue(Rule, declaredPrivateMethodWithReturn.Node.ReturnType);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfMissingContractAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/WcfMissingContractAttribute.cs
@@ -75,7 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var classOrInterface = namedType.IsClass() ? "class" : "interface";
                     message = string.Format(message, classOrInterface);
 
-                    c.ReportIssue(Diagnostic.Create(Rule, declarationSyntax.Identifier.GetLocation(), attributeToAdd, message));
+                    c.ReportIssue(Rule, declarationSyntax.Identifier, attributeToAdd, message);
                 },
                 SymbolKind.NamedType);
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
@@ -126,11 +126,26 @@ public abstract class SonarCompilationReportingContextBase<TContext> : SonarRepo
 {
     protected SonarCompilationReportingContextBase(SonarAnalysisContext analysisContext, TContext context) : base(analysisContext, context) { }
 
+    [Obsolete("Use overload without Diagnostic.Create, or add one")]
     public void ReportIssue(GeneratedCodeRecognizer generatedCodeRecognizer, Diagnostic diagnostic)
     {
         if (ShouldAnalyzeTree(diagnostic.Location.SourceTree, generatedCodeRecognizer))
         {
             ReportIssueCore(diagnostic);
+        }
+    }
+
+    public void ReportIssue(GeneratedCodeRecognizer generatedCodeRecognizer, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params object[] messageArgs) =>
+        ReportIssue(generatedCodeRecognizer, rule, locationSyntax.GetLocation(), messageArgs);
+
+    public void ReportIssue(GeneratedCodeRecognizer generatedCodeRecognizer, DiagnosticDescriptor rule, SyntaxToken locationToken, params object[] messageArgs) =>
+        ReportIssue(generatedCodeRecognizer, rule, locationToken.GetLocation(), messageArgs);
+
+    public void ReportIssue(GeneratedCodeRecognizer generatedCodeRecognizer, DiagnosticDescriptor rule, Location location, params object[] messageArgs)
+    {
+        if (ShouldAnalyzeTree(location.SourceTree, generatedCodeRecognizer))
+        {
+            ReportIssueCore(Diagnostic.Create(rule, location, messageArgs));
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
@@ -135,15 +135,15 @@ public abstract class SonarCompilationReportingContextBase<TContext> : SonarRepo
         }
     }
 
-    public void ReportIssue(GeneratedCodeRecognizer generatedCodeRecognizer, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params object[] messageArgs) =>
+    public void ReportIssue(GeneratedCodeRecognizer generatedCodeRecognizer, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params string[] messageArgs) =>
         ReportIssue(generatedCodeRecognizer, rule, locationSyntax.GetLocation(), messageArgs);
 
-    public void ReportIssue(GeneratedCodeRecognizer generatedCodeRecognizer, DiagnosticDescriptor rule, SyntaxToken locationToken, params object[] messageArgs) =>
+    public void ReportIssue(GeneratedCodeRecognizer generatedCodeRecognizer, DiagnosticDescriptor rule, SyntaxToken locationToken, params string[] messageArgs) =>
         ReportIssue(generatedCodeRecognizer, rule, locationToken.GetLocation(), messageArgs);
 
-    public void ReportIssue(GeneratedCodeRecognizer generatedCodeRecognizer, DiagnosticDescriptor rule, Location location, params object[] messageArgs)
+    public void ReportIssue(GeneratedCodeRecognizer generatedCodeRecognizer, DiagnosticDescriptor rule, Location location, params string[] messageArgs)
     {
-        if (ShouldAnalyzeTree(location.SourceTree, generatedCodeRecognizer))
+        if (ShouldAnalyzeTree(location?.SourceTree, generatedCodeRecognizer))
         {
             ReportIssueCore(Diagnostic.Create(rule, location, messageArgs));
         }
@@ -157,7 +157,7 @@ public abstract class SonarCompilationReportingContextBase<TContext> : SonarRepo
     {
         _ = rule ?? throw new ArgumentNullException(nameof(rule));
         _ = secondaryLocations ?? throw new ArgumentNullException(nameof(secondaryLocations));
-        if (ShouldAnalyzeTree(primaryLocation.SourceTree, generatedCodeRecognizer))
+        if (ShouldAnalyzeTree(primaryLocation?.SourceTree, generatedCodeRecognizer))
         {
             secondaryLocations = secondaryLocations.Where(x => x.Location.IsValid(Compilation)).ToArray();
             var properties = secondaryLocations.Select((x, index) => new KeyValuePair<string, string>(index.ToString(), x.Message)).ToImmutableDictionary();

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/DiagnosticDescriptorExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/DiagnosticDescriptorExtensions.cs
@@ -46,13 +46,4 @@ public static class DiagnosticDescriptorExtensions
             return false;
         }
     }
-
-    [Obsolete("Use ReportIssue overload with DiagnosticDescriptor and IEnumerable<SecondaryLocations> parameters instead.")]
-    public static Diagnostic CreateDiagnostic(this DiagnosticDescriptor descriptor,
-                                              Compilation compilation,
-                                              Location location,
-                                              IEnumerable<Location> additionalLocations,
-                                              ImmutableDictionary<string, string> properties,
-                                              params object[] messageArgs) =>
-        Diagnostic.Create(descriptor, location, additionalLocations?.Where(x => x.IsValid(compilation)), properties, messageArgs);
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DisablingRequestValidationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DisablingRequestValidationBase.cs
@@ -68,9 +68,9 @@ namespace SonarAnalyzer.Rules
                 && a.ConstructorArguments[0].Value is bool enableValidationValue
                 && !enableValidationValue
                 && a.AttributeClass.Is(KnownType.System_Web_Mvc_ValidateInputAttribute));
-            if (attributeWithFalseParameter != null)
+            if (attributeWithFalseParameter is not null)
             {
-                context.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(rule, attributeWithFalseParameter.ApplicationSyntaxReference.GetSyntax().GetLocation()));
+                context.ReportIssue(Language.GeneratedCodeRecognizer, rule, attributeWithFalseParameter.ApplicationSyntaxReference.GetSyntax());
             }
         }
 
@@ -99,7 +99,7 @@ namespace SonarAnalyzer.Rules
                 if (pages.GetAttributeIfBoolValueIs("validateRequest", false) is { } validateRequest
                     && validateRequest.CreateLocation(webConfigPath) is { } location)
                 {
-                    context.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(rule, location));
+                    context.ReportIssue(Language.GeneratedCodeRecognizer, rule, location);
                 }
             }
         }
@@ -113,7 +113,7 @@ namespace SonarAnalyzer.Rules
                     && value < MinimumAcceptedRequestValidationModeValue
                     && requestValidationMode.CreateLocation(webConfigPath) is { } location)
                 {
-                    context.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(rule, location));
+                    context.ReportIssue(Language.GeneratedCodeRecognizer, rule, location);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -152,13 +152,13 @@ namespace SonarAnalyzer.Rules
             {
                 if (!element.HasElements && IssueMessage(element.Name.LocalName, element.Value) is { } elementMessage && element.CreateLocation(path) is { } elementLocation)
                 {
-                    context.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(rule, elementLocation, elementMessage));
+                    context.ReportIssue(Language.GeneratedCodeRecognizer, rule, elementLocation, elementMessage);
                 }
                 foreach (var attribute in element.Attributes())
                 {
                     if (IssueMessage(attribute.Name.LocalName, attribute.Value) is { } attributeMessage && attribute.CreateLocation(path) is { } attributeLocation)
                     {
-                        context.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(rule, attributeLocation, attributeMessage));
+                        context.ReportIssue(Language.GeneratedCodeRecognizer, rule, attributeLocation, attributeMessage);
                     }
                 }
             }
@@ -292,7 +292,7 @@ namespace SonarAnalyzer.Rules
             {
                 if (value.Value is string str && analyzer.IssueMessage(key, str) is { } valueMessage)
                 {
-                    context.ReportIssue(analyzer.Language.GeneratedCodeRecognizer, Diagnostic.Create(analyzer.rule, value.ToLocation(path), valueMessage));
+                    context.ReportIssue(analyzer.Language.GeneratedCodeRecognizer, analyzer.rule, value.ToLocation(path), valueMessage);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
@@ -160,7 +160,7 @@ namespace SonarAnalyzer.Rules
                     && IsVulnerable(maxRequestLength.Value, FileUploadSizeLimit / OneKilobyte)
                     && maxRequestLength.CreateLocation(webConfigPath) is { } location)
                 {
-                    c.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(rule, location));
+                    c.ReportIssue(Language.GeneratedCodeRecognizer, rule, location);
                 }
             }
             foreach (var requestLimit in doc.XPathSelectElements("configuration/system.webServer/security/requestFiltering/requestLimits"))
@@ -169,7 +169,7 @@ namespace SonarAnalyzer.Rules
                     && IsVulnerable(maxAllowedContentLength.Value, FileUploadSizeLimit)
                     && maxAllowedContentLength.CreateLocation(webConfigPath) is { } location)
                 {
-                    c.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(rule, location));
+                    c.ReportIssue(Language.GeneratedCodeRecognizer, rule, location);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
@@ -122,7 +122,7 @@ namespace SonarAnalyzer.Rules
                 context.ReportIssue(
                     Language.GeneratedCodeRecognizer,
                     rule,
-                    invalidAttributes.MainAttribute,
+                    invalidAttributes.MainAttribute.GetLocation(),
                     invalidAttributes.SecondaryAttribute is null ? [] : [invalidAttributes.SecondaryAttribute.ToSecondaryLocation()]);
             }
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/RequestsWithExcessiveLengthBase.cs
@@ -99,7 +99,7 @@ namespace SonarAnalyzer.Rules
             if (IsDisableRequestSizeLimit(AttributeName(attribute))
                 && attribute.IsKnownType(KnownType.Microsoft_AspNetCore_Mvc_DisableRequestSizeLimitAttribute, context.SemanticModel))
             {
-                context.ReportIssue(Diagnostic.Create(rule, attribute.GetLocation()));
+                context.ReportIssue(rule, attribute);
                 return;
             }
 
@@ -121,12 +121,9 @@ namespace SonarAnalyzer.Rules
             {
                 context.ReportIssue(
                     Language.GeneratedCodeRecognizer,
-                    invalidAttributes.SecondaryAttribute != null
-                        ? rule.CreateDiagnostic(context.Compilation,
-                            invalidAttributes.MainAttribute.GetLocation(),
-                            new List<Location> { invalidAttributes.SecondaryAttribute.GetLocation() },
-                            properties: null)
-                        : Diagnostic.Create(rule, invalidAttributes.MainAttribute.GetLocation()));
+                    rule,
+                    invalidAttributes.MainAttribute,
+                    invalidAttributes.SecondaryAttribute is null ? [] : [invalidAttributes.SecondaryAttribute.ToSecondaryLocation()]);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ImplementSerializationMethodsCorrectlyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ImplementSerializationMethodsCorrectlyBase.cs
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules
                         && issues.Any()
                         && GetIdentifierLocation(methodSymbol) is { } location)
                     {
-                        c.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(rule, location, issues.ToSentence()));
+                        c.ReportIssue(Language.GeneratedCodeRecognizer, rule, location, issues.ToSentence());
                     }
                 },
                 SymbolKind.Method);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MarkAssemblyWithAttributeBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MarkAssemblyWithAttributeBase.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules
                     {
                         if (!cc.Compilation.Assembly.HasAttribute(AttributeToFind) && !cc.Compilation.Assembly.HasAttribute(KnownType.Microsoft_AspNetCore_Razor_Hosting_RazorCompiledItemAttribute))
                         {
-                            cc.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(rule, null, cc.Compilation.AssemblyName));
+                            cc.ReportIssue(Language.GeneratedCodeRecognizer, rule, (Location)null, cc.Compilation.AssemblyName);
                         }
                     })
                 );

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertiesAccessCorrectFieldBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertiesAccessCorrectFieldBase.cs
@@ -119,9 +119,9 @@ namespace SonarAnalyzer.Rules
             if (!expectedFieldIsUsed || !actualFields.Any())
             {
                 var locationAndAccessorType = GetLocationAndAccessor(actualFields, methodSymbol);
-                if (locationAndAccessorType.Item1 != null)
+                if (locationAndAccessorType.Item1 is not null)
                 {
-                    context.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(Rule, locationAndAccessorType.Item1, locationAndAccessorType.Item2, expectedField.Name));
+                    context.ReportIssue(Language.GeneratedCodeRecognizer, Rule, locationAndAccessorType.Item1, locationAndAccessorType.Item2, expectedField.Name);
                 }
             }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ProvideDeserializationMethodsForOptionalFieldsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ProvideDeserializationMethodsForOptionalFieldsBase.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules
                         return;
                     }
 
-                    c.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(SupportedDiagnostics[0], GetNamedTypeIdentifierLocation(declaringSyntax), errorMessage));
+                    c.ReportIssue(Language.GeneratedCodeRecognizer, SupportedDiagnostics[0], GetNamedTypeIdentifierLocation(declaringSyntax), errorMessage);
                 },
                 SymbolKind.NamedType);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PureAttributeOnVoidMethodBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PureAttributeOnVoidMethodBase.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules
                 {
                     if (InvalidPureDataAttributeUsage((IMethodSymbol)c.Symbol) is { } pureAttribute)
                     {
-                        c.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(Rule, pureAttribute.ApplicationSyntaxReference.GetSyntax().GetLocation()));
+                        c.ReportIssue(Language.GeneratedCodeRecognizer, Rule, pureAttribute.ApplicationSyntaxReference.GetSyntax());
                     }
                 },
                 SymbolKind.Method);

--- a/analyzers/src/SonarAnalyzer.Common/Trackers/MethodDeclarationTracker.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Trackers/MethodDeclarationTracker.cs
@@ -49,14 +49,14 @@ namespace SonarAnalyzer.Helpers.Trackers
                 {
                     if (c.Symbol.IsTopLevelMain())
                     {
-                        c.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(input.Rule, Location.Create(declaration.SyntaxTree, TextSpan.FromBounds(0, 0))));
+                        c.ReportIssue(Language.GeneratedCodeRecognizer, input.Rule, Location.Create(declaration.SyntaxTree, TextSpan.FromBounds(0, 0)));
                     }
                     else
                     {
                         var methodIdentifier = GetMethodIdentifier(declaration.GetSyntax());
                         if (methodIdentifier.HasValue)
                         {
-                            c.ReportIssue(Language.GeneratedCodeRecognizer, Diagnostic.Create(input.Rule, methodIdentifier.Value.GetLocation()));
+                            c.ReportIssue(Language.GeneratedCodeRecognizer, input.Rule, methodIdentifier.Value);
                         }
                     }
                 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarAnalysisContextExtensions.cs
@@ -46,9 +46,15 @@ public static class SonarAnalysisContextExtensions
     public static void RegisterCodeBlockStartAction(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<SyntaxKind>> action) =>
         context.RegisterCodeBlockStartAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-    public static void ReportIssue(this SonarCompilationReportingContext context, Diagnostic diagnostic) =>
-        context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic);
+    public static void ReportIssue(this SonarCompilationReportingContext context, DiagnosticDescriptor rule, Location location, params object[] messageArgs) =>
+        context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, rule, location, messageArgs);
 
-    public static void ReportIssue(this SonarSymbolReportingContext context, Diagnostic diagnostic) =>
-        context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, diagnostic);
+    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params object[] messageArgs) =>
+        context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, rule, locationSyntax, messageArgs);
+
+    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxToken locationToken, params object[] messageArgs) =>
+        context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, rule, locationToken, messageArgs);
+
+    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, Location location, params object[] messageArgs) =>
+        context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, rule, location, messageArgs);
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarAnalysisContextExtensions.cs
@@ -46,15 +46,15 @@ public static class SonarAnalysisContextExtensions
     public static void RegisterCodeBlockStartAction(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<SyntaxKind>> action) =>
         context.RegisterCodeBlockStartAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-    public static void ReportIssue(this SonarCompilationReportingContext context, DiagnosticDescriptor rule, Location location, params object[] messageArgs) =>
+    public static void ReportIssue(this SonarCompilationReportingContext context, DiagnosticDescriptor rule, Location location, params string[] messageArgs) =>
         context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, rule, location, messageArgs);
 
-    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params object[] messageArgs) =>
+    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params string[] messageArgs) =>
         context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, rule, locationSyntax, messageArgs);
 
-    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxToken locationToken, params object[] messageArgs) =>
+    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxToken locationToken, params string[] messageArgs) =>
         context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, rule, locationToken, messageArgs);
 
-    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, Location location, params object[] messageArgs) =>
+    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, Location location, params string[] messageArgs) =>
         context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, rule, location, messageArgs);
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionExplicitOn.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionExplicitOn.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var statement = (OptionStatementSyntax)c.Node;
                     if (statement.NameKeyword.IsKind(SyntaxKind.ExplicitKeyword) && statement.ValueKeyword.IsKind(SyntaxKind.OffKeyword))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, statement.GetLocation(), StatementMessage));
+                        c.ReportIssue(Rule, statement, StatementMessage);
                     }
                 },
                 SyntaxKind.OptionStatement);
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 {
                     if (!c.Compilation.VB().Options.OptionExplicit)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, null, string.Format(AssemblyMessageFormat, c.Compilation.AssemblyName)));
+                        c.ReportIssue(Rule, null, string.Format(AssemblyMessageFormat, c.Compilation.AssemblyName));
                     }
                 }));
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionStrictOn.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionStrictOn.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 var statement = (OptionStatementSyntax)c.Node;
                 if (statement.NameKeyword.IsKind(SyntaxKind.StrictKeyword) && !statement.ValueKeyword.IsKind(SyntaxKind.OnKeyword))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, statement.GetLocation(), StatementMessage));
+                    c.ReportIssue(Rule, statement, StatementMessage);
                 }
             },
             SyntaxKind.OptionStatement);
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 {
                     if (c.Compilation.VB().Options.OptionStrict != OptionStrict.On)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, null, string.Format(AssemblyMessageFormat, c.Compilation.AssemblyName)));
+                        c.ReportIssue(Rule, null, string.Format(AssemblyMessageFormat, c.Compilation.AssemblyName));
                     }
                 }));
         }

--- a/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextBaseTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextBaseTest.cs
@@ -261,6 +261,18 @@ public partial class SonarAnalysisContextBaseTest
            .WithMessage("File 'SonarLint.xml' has been added as an AdditionalFile but could not be read and parsed.");
     }
 
+    [TestMethod]
+    public void ReportIssue_Null_Throws()
+    {
+        var compilation = TestHelper.CompileCS("// Nothing to see here").Model.Compilation;
+        var sut = CreateSut(ProjectType.Product, false);
+        var rule = AnalysisScaffolding.CreateDescriptor("Sxxxx", DiagnosticDescriptorFactory.MainSourceScopeTag);
+        var recognizer = CSharpGeneratedCodeRecognizer.Instance;
+
+        sut.Invoking(x => x.ReportIssue(recognizer, null, primaryLocation: null, secondaryLocations: [])).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("rule");
+        sut.Invoking(x => x.ReportIssue(recognizer, rule, primaryLocation: null, secondaryLocations: null)).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("secondaryLocations");
+    }
+
     private static void CheckSonarLintXmlDefaultValues(SonarLintXmlReader sut)
     {
         sut.AnalyzeRazorCode(LanguageNames.CSharp).Should().BeTrue();

--- a/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextBaseTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextBaseTest.cs
@@ -273,6 +273,25 @@ public partial class SonarAnalysisContextBaseTest
         sut.Invoking(x => x.ReportIssue(recognizer, rule, primaryLocation: null, secondaryLocations: null)).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("secondaryLocations");
     }
 
+    [TestMethod]
+    public void ReportIssue_NullLocation_UsesEmpty()
+    {
+        Diagnostic lastDiagnostic = null;
+        var compilation = TestHelper.CompileCS("// Nothing to see here").Model.Compilation;
+        var compilationContext = new CompilationAnalysisContext(compilation, AnalysisScaffolding.CreateOptions(), x => lastDiagnostic = x, _ => true, default);
+        var sut = new SonarCompilationReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), compilationContext);
+        var rule = AnalysisScaffolding.CreateDescriptor("Sxxxx", DiagnosticDescriptorFactory.MainSourceScopeTag);
+        var recognizer = CSharpGeneratedCodeRecognizer.Instance;
+
+        sut.ReportIssue(recognizer, rule, location: null);
+        lastDiagnostic.Should().NotBeNull();
+        lastDiagnostic.Location.Should().Be(Location.None);
+
+        sut.ReportIssue(recognizer, rule, primaryLocation: null, secondaryLocations: []);
+        lastDiagnostic.Should().NotBeNull();
+        lastDiagnostic.Location.Should().Be(Location.None);
+    }
+
     private static void CheckSonarLintXmlDefaultValues(SonarLintXmlReader sut)
     {
         sut.AnalyzeRazorCode(LanguageNames.CSharp).Should().BeTrue();

--- a/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextTest.cs
@@ -279,11 +279,7 @@ public partial class SonarAnalysisContextTest
         symbol.Locations.Returns([location]);
         var symbolContext = new SymbolAnalysisContext(symbol, context.Model.Compilation, context.Options, _ => wasReported = true, _ => true, default);
         var sut = new SonarSymbolReportingContext(new SonarAnalysisContext(context, DummyMainDescriptor), symbolContext);
-        var diagnostic = Substitute.For<Diagnostic>();
-        diagnostic.Id.Returns("Sxxx");
-        diagnostic.Location.Returns(location);
-        diagnostic.Descriptor.Returns(DummyMainDescriptor[0]);
-        sut.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
+        sut.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, DummyMainDescriptor[0], location);
 
         wasReported.Should().Be(expected);
     }

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/SonarAnalysisContextExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/SonarAnalysisContextExtensionsTest.cs
@@ -45,7 +45,7 @@ public class SonarAnalysisContextExtensions
         var wasReported = false;
         var symbolContext = new SymbolAnalysisContext(Substitute.For<ISymbol>(), model.Compilation, AnalysisScaffolding.CreateOptions(), _ => wasReported = true, _ => true, default);
         var context = new SonarSymbolReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), symbolContext);
-        ExtensionsCS.ReportIssue(context, Diagnostic.Create(DummyMainDescriptor, tree.GetRoot().GetLocation()));
+        ExtensionsCS.ReportIssue(context, DummyMainDescriptor, tree.GetRoot());
 
         wasReported.Should().Be(expected);
     }

--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/SonarAnalysisContextExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/SonarAnalysisContextExtensionsTest.cs
@@ -63,8 +63,16 @@ public class SonarAnalysisContextExtensions
         var wasReported = false;
         var symbolContext = new SymbolAnalysisContext(Substitute.For<ISymbol>(), model.Compilation, AnalysisScaffolding.CreateOptions(), _ => wasReported = true, _ => true, default);
         var context = new SonarSymbolReportingContext(AnalysisScaffolding.CreateSonarAnalysisContext(), symbolContext);
-        ExtensionsVB.ReportIssue(context, Diagnostic.Create(DummyMainDescriptor, tree.GetRoot().GetLocation()));
 
+        ExtensionsVB.ReportIssue(context, DummyMainDescriptor, tree.GetRoot());
+        wasReported.Should().Be(expected);
+
+        wasReported = false;
+        ExtensionsVB.ReportIssue(context, DummyMainDescriptor, tree.GetRoot().GetFirstToken());
+        wasReported.Should().Be(expected);
+
+        wasReported = false;
+        ExtensionsVB.ReportIssue(context, DummyMainDescriptor, tree.GetRoot().GetLocation());
         wasReported.Should().Be(expected);
     }
 }


### PR DESCRIPTION
Follow up of #9298

This PR prepares `ReportIssue` overloads for symbol-context and compilation-context reporting.
It also removes deprecated `DiagnosticDescriptorExtensions.CreateDiagnostic`, as it is not used anymore.

There's a certain duplication now in `SonarCompilationReportingContextBase` vs `SonarTreeReportingContextBase`.  I'm tempted to push the `ReportIssue` methods in the base class and solve the `if(ShouldAnalyzeTree)` question somehow in a common way (or abstract)