### PR TITLE
ReportIssue: Replace Diagnostic.Create with secondary locations

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/SpecifyRouteAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/SpecifyRouteAttribute.cs
@@ -43,7 +43,7 @@ public sealed class SpecifyRouteAttribute() : SonarDiagnosticAnalyzer<SyntaxKind
                 {
                     return;
                 }
-                var secondaryLocations = new ConcurrentStack<Location>();
+                var secondaryLocations = new ConcurrentStack<SecondaryLocation>();
                 symbolStart.RegisterSyntaxNodeAction(nodeContext =>
                 {
                     var methodDeclaration = (MethodDeclarationSyntax)nodeContext.Node;
@@ -52,14 +52,14 @@ public sealed class SpecifyRouteAttribute() : SonarDiagnosticAnalyzer<SyntaxKind
                         && method.IsControllerActionMethod()
                         && method.GetAttributesWithInherited().Any(x => !CanBeIgnored(x.GetAttributeRouteTemplate())))
                     {
-                        secondaryLocations.Push(methodDeclaration.Identifier.GetLocation());
+                        secondaryLocations.Push(methodDeclaration.Identifier.ToSecondaryLocation());
                     }
                 }, SyntaxKind.MethodDeclaration);
                 symbolStart.RegisterSymbolEndAction(symbolEnd => ReportIssues(symbolEnd, symbolStart.Symbol, secondaryLocations));
             }, SymbolKind.NamedType);
         });
 
-    private void ReportIssues(SonarSymbolReportingContext context, ISymbol symbol, ConcurrentStack<Location> secondaryLocations)
+    private void ReportIssues(SonarSymbolReportingContext context, ISymbol symbol, ConcurrentStack<SecondaryLocation> secondaryLocations)
     {
         if (secondaryLocations.IsEmpty)
         {
@@ -70,7 +70,7 @@ public sealed class SpecifyRouteAttribute() : SonarDiagnosticAnalyzer<SyntaxKind
         {
             if (declaration.GetIdentifier() is { } identifier)
             {
-                context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, Diagnostic.Create(Rule, identifier.GetLocation(), secondaryLocations));
+                context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, Rule, identifier.GetLocation(), secondaryLocations);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CastShouldNotBeDuplicated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CastShouldNotBeDuplicated.cs
@@ -221,7 +221,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var duplicatedCastLocations = GetDuplicatedCastLocations(context, parentStatement, castType, variableExpression);
             if (duplicatedCastLocations.Any())
             {
-                context.ReportIssue(Rule, mainLocation, duplicatedCastLocations.Select(x => x.ToSecondary()), message);
+                context.ReportIssue(Rule, mainLocation, duplicatedCastLocations.ToSecondary(), message);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConsumeValueTaskCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConsumeValueTaskCorrectly.cs
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         if (syntaxNodes.Count > 1)
                         {
-                            c.ReportIssue(rule, syntaxNodes.First(), syntaxNodes.Skip(1).Select(x => x.ToSecondaryLocation()), ConsumeOnlyOnceMessage);
+                            c.ReportIssue(rule, syntaxNodes.First(), syntaxNodes.Skip(1).ToSecondaryLocations(), ConsumeOnlyOnceMessage);
                         }
                     }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeNotImplementingDispose.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeNotImplementingDispose.cs
@@ -113,7 +113,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 foreach (var location in disposeMethod.Locations)
                 {
-                    context.ReportIssue(Rule, location, disposeMethod.PartialImplementationPart?.Locations.Select(x => x.ToSecondary()) ?? []);
+                    context.ReportIssue(Rule, location, disposeMethod.PartialImplementationPart?.Locations.ToSecondary() ?? []);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeLogged.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeLogged.cs
@@ -53,7 +53,7 @@ public sealed class ExceptionsShouldBeLogged : SonarDiagnosticAnalyzer
                                 walker.LoggingInvocationsWithoutException.Any())
                             {
                                 var primaryLocation = walker.LoggingInvocationsWithoutException[0].GetLocation();
-                                var secondaryLocations = walker.LoggingInvocationsWithoutException.Skip(1).Select(x => x.ToSecondaryLocation());
+                                var secondaryLocations = walker.LoggingInvocationsWithoutException.Skip(1).ToSecondaryLocations();
                                 c.ReportIssue(Rule, primaryLocation, secondaryLocations);
                             }
                         },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeLogged.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeLogged.cs
@@ -53,8 +53,8 @@ public sealed class ExceptionsShouldBeLogged : SonarDiagnosticAnalyzer
                                 walker.LoggingInvocationsWithoutException.Any())
                             {
                                 var primaryLocation = walker.LoggingInvocationsWithoutException[0].GetLocation();
-                                var additionalLocations = walker.LoggingInvocationsWithoutException.Skip(1).Select(x => x.GetLocation());
-                                c.ReportIssue(Diagnostic.Create(Rule, primaryLocation, additionalLocations));
+                                var secondaryLocations = walker.LoggingInvocationsWithoutException.Skip(1).Select(x => x.ToSecondaryLocation());
+                                c.ReportIssue(Rule, primaryLocation, secondaryLocations);
                             }
                         },
                         SyntaxKind.CatchClause);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InheritedCollidingInterfaceMembers.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InheritedCollidingInterfaceMembers.cs
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         var membersText = GetIssueMessageText(collidingMembers, c.SemanticModel, interfaceDeclaration.SpanStart);
                         var pluralize = collidingMembers.Count > 1 ? "s" : string.Empty;
-                        var secondaryLocations = collidingMembers.SelectMany(x => x.Locations).Where(x => x.IsInSource).Select(x => x.ToSecondary());
+                        var secondaryLocations = collidingMembers.SelectMany(x => x.Locations).Where(x => x.IsInSource).ToSecondary();
                         c.ReportIssue(Rule, interfaceDeclaration.Identifier, secondaryLocations, membersText, pluralize);
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LoggingArgumentsShouldBePassedCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LoggingArgumentsShouldBePassedCorrectly.cs
@@ -81,14 +81,12 @@ public sealed class LoggingArgumentsShouldBePassedCorrectly : SonarDiagnosticAna
 
         var paramsIndex = invocationSymbol.Parameters.IndexOf(paramsParameter);
         var invalidArguments = invocation.ArgumentList.Arguments
-            .Where(x => x.GetArgumentIndex() >= paramsIndex
-                        && IsInvalidArgument(x, c.SemanticModel, knownTypes))
-            .Select(x => x.GetLocation())
+            .Where(x => x.GetArgumentIndex() >= paramsIndex && IsInvalidArgument(x, c.SemanticModel, knownTypes))
+            .Select(x => x.ToSecondaryLocation())
             .ToArray();
-
         if (invalidArguments.Length > 0)
         {
-            c.ReportIssue(Diagnostic.Create(Rule, invocation.Expression.GetLocation(), (IEnumerable<Location>)invalidArguments));
+            c.ReportIssue(Rule, invocation.Expression, invalidArguments);
         }
     }
 
@@ -98,8 +96,8 @@ public sealed class LoggingArgumentsShouldBePassedCorrectly : SonarDiagnosticAna
         {
             var typeParameterNames = methodSymbol.TypeParameters.Select(x => x.MetadataName).ToArray();
             var positions = methodSymbol.ConstructedFrom.Parameters.Where(x => typeParameterNames.Contains(x.Type.MetadataName)).Select(x => methodSymbol.ConstructedFrom.Parameters.IndexOf(x));
-            var invalidArguments = InvalidArguments(invocation, c.SemanticModel, positions, knownTypes).Select(x => x.GetLocation());
-            c.ReportIssue(Diagnostic.Create(Rule, invocation.Expression.GetLocation(), invalidArguments));
+            var invalidArguments = InvalidArguments(invocation, c.SemanticModel, positions, knownTypes).Select(x => x.ToSecondaryLocation());
+            c.ReportIssue(Rule, invocation.Expression, invalidArguments);
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LoggingArgumentsShouldBePassedCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LoggingArgumentsShouldBePassedCorrectly.cs
@@ -82,7 +82,7 @@ public sealed class LoggingArgumentsShouldBePassedCorrectly : SonarDiagnosticAna
         var paramsIndex = invocationSymbol.Parameters.IndexOf(paramsParameter);
         var invalidArguments = invocation.ArgumentList.Arguments
             .Where(x => x.GetArgumentIndex() >= paramsIndex && IsInvalidArgument(x, c.SemanticModel, knownTypes))
-            .Select(x => x.ToSecondaryLocation())
+            .ToSecondaryLocations()
             .ToArray();
         if (invalidArguments.Length > 0)
         {
@@ -96,7 +96,7 @@ public sealed class LoggingArgumentsShouldBePassedCorrectly : SonarDiagnosticAna
         {
             var typeParameterNames = methodSymbol.TypeParameters.Select(x => x.MetadataName).ToArray();
             var positions = methodSymbol.ConstructedFrom.Parameters.Where(x => typeParameterNames.Contains(x.Type.MetadataName)).Select(x => methodSymbol.ConstructedFrom.Parameters.IndexOf(x));
-            var invalidArguments = InvalidArguments(invocation, c.SemanticModel, positions, knownTypes).Select(x => x.ToSecondaryLocation());
+            var invalidArguments = InvalidArguments(invocation, c.SemanticModel, positions, knownTypes).ToSecondaryLocations();
             c.ReportIssue(Rule, invocation.Expression, invalidArguments);
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/LoggingTemplatePlaceHoldersShouldBeInOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/LoggingTemplatePlaceHoldersShouldBeInOrder.cs
@@ -45,8 +45,7 @@ public sealed class LoggingTemplatePlaceHoldersShouldBeInOrder : IMessageTemplat
             {
                 var templateStart = templateArgument.Expression.GetLocation().SourceSpan.Start;
                 var primaryLocation = Location.Create(context.Tree, new(templateStart + placeholder.Start, placeholder.Length));
-                var secondaryLocation = outOfOrderArgument.GetLocation();
-                context.ReportIssue(Diagnostic.Create(Rule, primaryLocation, [secondaryLocation], placeholder.Name, outOfOrderArgument.ToString()));
+                context.ReportIssue(Rule, primaryLocation, [outOfOrderArgument.ToSecondaryLocation()], placeholder.Name, outOfOrderArgument.ToString());
                 return; // only raise on the first out-of-order placeholder to make the rule less noisy
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/NamedPlaceholdersShouldBeUnique.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/NamedPlaceholdersShouldBeUnique.cs
@@ -40,7 +40,7 @@ public sealed class NamedPlaceholdersShouldBeUnique : IMessageTemplateCheck
         {
             var templateStart = templateArgument.Expression.GetLocation().SourceSpan.Start;
             var locations = group.Select(x => Location.Create(context.Tree, new(templateStart + x.Start, x.Length)));
-            context.ReportIssue(Diagnostic.Create(Rule, locations.First(), locations.Skip(1), group.First().Name));
+            context.ReportIssue(Rule, locations.First(), locations.Skip(1).Select(x => x.ToSecondary()), group.First().Name);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/NamedPlaceholdersShouldBeUnique.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/NamedPlaceholdersShouldBeUnique.cs
@@ -40,7 +40,7 @@ public sealed class NamedPlaceholdersShouldBeUnique : IMessageTemplateCheck
         {
             var templateStart = templateArgument.Expression.GetLocation().SourceSpan.Start;
             var locations = group.Select(x => Location.Create(context.Tree, new(templateStart + x.Start, x.Length)));
-            context.ReportIssue(Rule, locations.First(), locations.Skip(1).Select(x => x.ToSecondary()), group.First().Name);
+            context.ReportIssue(Rule, locations.First(), locations.Skip(1).ToSecondary(), group.First().Name);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/UsePascalCaseForNamedPlaceHolders.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/UsePascalCaseForNamedPlaceHolders.cs
@@ -36,11 +36,10 @@ public sealed class UsePascalCaseForNamedPlaceHolders : IMessageTemplateCheck
         var nonPascalCasePlaceholders = placeholders.Where(x => char.IsLower(x.Name[0])).ToArray();
         if (nonPascalCasePlaceholders.Length > 0)
         {
-            var secondaryLocations = nonPascalCasePlaceholders.Select(GetLocation);
-            context.ReportIssue(Diagnostic.Create(Rule, templateArgument.GetLocation(), secondaryLocations));
+            context.ReportIssue(Rule, templateArgument, nonPascalCasePlaceholders.Select(CreateLocation));
         }
 
-        Location GetLocation(Placeholder placeholder) =>
-            Location.Create(context.Tree, new(templateArgument.Expression.GetLocation().SourceSpan.Start + placeholder.Start, placeholder.Length));
+        SecondaryLocation CreateLocation(Placeholder placeholder) =>
+            Location.Create(context.Tree, new(templateArgument.Expression.GetLocation().SourceSpan.Start + placeholder.Start, placeholder.Length)).ToSecondary();
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnEmptyCollectionInsteadOfNull.cs
@@ -63,7 +63,7 @@ public sealed class ReturnEmptyCollectionInsteadOfNull : SonarDiagnosticAnalyzer
         {
             if (nullOrDefaultLiterals.Count > 0 && IsReturningCollection(context))
             {
-                context.ReportIssue(Rule, nullOrDefaultLiterals[0], nullOrDefaultLiterals.Skip(1).Select(x => x.ToSecondary()));
+                context.ReportIssue(Rule, nullOrDefaultLiterals[0], nullOrDefaultLiterals.Skip(1).ToSecondary());
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwaggerActionReturnType.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwaggerActionReturnType.cs
@@ -71,7 +71,7 @@ public sealed class SwaggerActionReturnType : SonarDiagnosticAnalyzer
                             var methodDeclaration = (MethodDeclarationSyntax)nodeContext.Node;
                             if (InvalidMethod(methodDeclaration, nodeContext) is { } method)
                             {
-                                nodeContext.ReportIssue(Rule, methodDeclaration.Identifier, method.ResponseInvocations.Select(x => x.ToSecondaryLocation()), GetMessage(method.Symbol));
+                                nodeContext.ReportIssue(Rule, methodDeclaration.Identifier, method.ResponseInvocations.ToSecondaryLocations(), GetMessage(method.Symbol));
                             }
                         }, SyntaxKind.MethodDeclaration);
                     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyLoggingCalls.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyLoggingCalls.cs
@@ -110,8 +110,8 @@ public sealed class TooManyLoggingCalls : ParametrizedDiagnosticAnalyzer
                 if (invocations.Count > threshold)
                 {
                     var primaryLocation = invocations[0].GetLocation();
-                    var secondaryLocations = invocations.Skip(1).Select(x => x.GetLocation());
-                    context.ReportIssue(Diagnostic.Create(Rule, primaryLocation, secondaryLocations, group.Key, invocations.Count, threshold));
+                    var secondaryLocations = invocations.Skip(1).Select(x => x.ToSecondaryLocation());
+                    context.ReportIssue(Rule, primaryLocation, secondaryLocations, group.Key, invocations.Count.ToString(), threshold.ToString());
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyLoggingCalls.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyLoggingCalls.cs
@@ -110,7 +110,7 @@ public sealed class TooManyLoggingCalls : ParametrizedDiagnosticAnalyzer
                 if (invocations.Count > threshold)
                 {
                     var primaryLocation = invocations[0].GetLocation();
-                    var secondaryLocations = invocations.Skip(1).Select(x => x.ToSecondaryLocation());
+                    var secondaryLocations = invocations.Skip(1).ToSecondaryLocations();
                     context.ReportIssue(Rule, primaryLocation, secondaryLocations, group.Key, invocations.Count.ToString(), threshold.ToString());
                 }
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/XXE/XmlReaderSettingsValidator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/XXE/XmlReaderSettingsValidator.cs
@@ -50,9 +50,9 @@ namespace SonarAnalyzer.Rules.XXE
         /// <param name="settings">The symbol of the XmlReaderSettings node received as parameter. This is used to check
         /// if certain properties (ProhibitDtd, DtdProcessing or XmlUrlResolver) were modified for the given symbol.</param>
         /// <returns>The list of unsafe assignment locations.</returns>
-        public IList<Location> GetUnsafeAssignmentLocations(InvocationExpressionSyntax invocation, ISymbol settings)
+        public IList<SecondaryLocation> GetUnsafeAssignmentLocations(InvocationExpressionSyntax invocation, ISymbol settings, string message)
         {
-            var unsafeAssignmentLocations = new List<Location>();
+            var unsafeAssignmentLocations = new List<SecondaryLocation>();
             // By default ProhibitDtd is 'true' and DtdProcessing is 'ignore'
             var unsafeDtdProcessing = false;
             var unsafeResolver = isXmlResolverSafeByDefault;
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules.XXE
                     unsafeDtdProcessing = IsXmlResolverDtdProcessingUnsafe(assignment, semanticModel);
                     if (unsafeDtdProcessing)
                     {
-                        unsafeAssignmentLocations.Add(assignment.GetLocation());
+                        unsafeAssignmentLocations.Add(assignment.ToSecondaryLocation(message));
                     }
                 }
                 else if (name == "XmlResolver")
@@ -81,12 +81,12 @@ namespace SonarAnalyzer.Rules.XXE
                     unsafeResolver = IsXmlResolverAssignmentUnsafe(assignment, semanticModel);
                     if (unsafeResolver)
                     {
-                        unsafeAssignmentLocations.Add(assignment.GetLocation());
+                        unsafeAssignmentLocations.Add(assignment.ToSecondaryLocation(message));
                     }
                 }
             }
 
-            return unsafeDtdProcessing && unsafeResolver ? unsafeAssignmentLocations : new List<Location>();
+            return unsafeDtdProcessing && unsafeResolver ? unsafeAssignmentLocations : [];
         }
 
         private static bool IsMemberAccessOnSymbol(ExpressionSyntax expression, ISymbol symbol, SemanticModel semanticModel) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
@@ -29,7 +29,7 @@ namespace SonarAnalyzer.Rules.CSharp
     {
         private const string DiagnosticId = "S2755";
         private const string MessageFormat = "Disable access to external entities in XML parsing.";
-        private const string SecondaryMessageFormat = "This value enables external entities in XML parsing.";
+        private const string SecondaryMessage = "This value enables external entities in XML parsing.";
 
         private static readonly DiagnosticDescriptor Rule =
             DescriptorFactory.Create(DiagnosticId, MessageFormat);
@@ -99,9 +99,9 @@ namespace SonarAnalyzer.Rules.CSharp
             }
 
             var xmlReaderSettingsValidator = new XmlReaderSettingsValidator(context.SemanticModel, versionProvider.GetDotNetFrameworkVersion(context.Compilation));
-            if (xmlReaderSettingsValidator.GetUnsafeAssignmentLocations(invocation, settings) is { } secondaryLocations && secondaryLocations.Any())
+            if (xmlReaderSettingsValidator.GetUnsafeAssignmentLocations(invocation, settings, SecondaryMessage) is { } secondaryLocations && secondaryLocations.Any())
             {
-                context.ReportIssue(Rule, invocation, secondaryLocations.Select(x => x.ToSecondary(SecondaryMessageFormat)));
+                context.ReportIssue(Rule, invocation, secondaryLocations);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/EnumerableExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/EnumerableExtensions.cs
@@ -164,5 +164,14 @@ namespace SonarAnalyzer.Helpers
                 { Count: 1 } single => single[0],
                 _ => string.Empty,
             };
+
+        public static IEnumerable<SecondaryLocation> ToSecondary(this IEnumerable<Location> locations, string message = null) =>
+            locations.Select(x => x.ToSecondary(message));
+
+        public static IEnumerable<SecondaryLocation> ToSecondaryLocations(this IEnumerable<SyntaxNode> nodes, string message = null) =>
+            nodes.Select(x => x.ToSecondaryLocation(message));
+
+        public static IEnumerable<SecondaryLocation> ToSecondaryLocations(this IEnumerable<SyntaxToken> nodes, string message = null) =>
+            nodes.Select(x => x.ToSecondaryLocation(message));
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AspNet/RouteTemplateShouldNotStartWithSlashBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AspNet/RouteTemplateShouldNotStartWithSlashBase.cs
@@ -75,7 +75,7 @@ public abstract class RouteTemplateShouldNotStartWithSlashBase<TSyntaxKind>() : 
             ? MessageOnlyActions
             : MessageActionsAndController;
 
-        var secondaryLocations = actions.SelectMany(x => x.RouteParameters.Keys).Select(x => x.ToSecondary());
+        var secondaryLocations = actions.SelectMany(x => x.RouteParameters.Keys.ToSecondary());
         foreach (var identifier in controllerSymbol.DeclaringSyntaxReferences.Select(x => Language.Syntax.NodeIdentifier(x.GetSyntax())).WhereNotNull())
         {
             context.ReportIssue(Language.GeneratedCodeRecognizer, Rule, identifier.GetLocation(), secondaryLocations, issueMessage);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AspNet/RouteTemplateShouldNotStartWithSlashBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AspNet/RouteTemplateShouldNotStartWithSlashBase.cs
@@ -75,12 +75,10 @@ public abstract class RouteTemplateShouldNotStartWithSlashBase<TSyntaxKind>() : 
             ? MessageOnlyActions
             : MessageActionsAndController;
 
-        var secondaryLocations = actions.SelectMany(x => x.RouteParameters.Keys);
-        foreach (var classDeclaration in controllerSymbol.DeclaringSyntaxReferences.Select(x => x.GetSyntax()))
+        var secondaryLocations = actions.SelectMany(x => x.RouteParameters.Keys).Select(x => x.ToSecondary());
+        foreach (var identifier in controllerSymbol.DeclaringSyntaxReferences.Select(x => Language.Syntax.NodeIdentifier(x.GetSyntax())).WhereNotNull())
         {
-            context.ReportIssue(
-                Language.GeneratedCodeRecognizer,
-                Diagnostic.Create(Rule, Language.Syntax.NodeIdentifier(classDeclaration)?.GetLocation(), secondaryLocations, issueMessage));
+            context.ReportIssue(Language.GeneratedCodeRecognizer, Rule, identifier.GetLocation(), secondaryLocations, issueMessage);
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CertificateValidationCheckBase.cs
@@ -151,7 +151,7 @@ namespace SonarAnalyzer.Rules
             if (!locations.IsEmpty)
             {
                 // Report both, assignment as well as all implementation occurrences
-                c.Context.ReportIssue(Rule, primaryLocation, locations.Select(x => x.ToSecondary(SecondaryMessage)));
+                c.Context.ReportIssue(Rule, primaryLocation, locations.ToSecondary(SecondaryMessage));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CommentsShouldNotBeEmptyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CommentsShouldNotBeEmptyBase.cs
@@ -63,8 +63,8 @@ public abstract class CommentsShouldNotBeEmptyBase<TSyntaxKind> : SonarDiagnosti
         foreach (var partition in partitions.Where(trivia => trivia.Any() && trivia.All(x => string.IsNullOrWhiteSpace(GetCommentText(x)))))
         {
             var location = partition.First().GetLocation();
-            var secondary = partition.Skip(1).Select(x => x.GetLocation());
-            context.ReportIssue(Diagnostic.Create(Rule, location, secondary));
+            var secondary = partition.Skip(1).Select(x => x.GetLocation().ToSecondary());
+            context.ReportIssue(Rule, location, secondary);
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/StringLiteralShouldNotBeDuplicatedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/StringLiteralShouldNotBeDuplicatedBase.cs
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules
             {
                 var duplicates = item.ToList();
                 var firstToken = duplicates[0];
-                context.ReportIssue(rule, firstToken, duplicates.Skip(1).Select(x => x.ToSecondaryLocation()), ExtractStringContent(firstToken), duplicates.Count.ToString());
+                context.ReportIssue(rule, firstToken, duplicates.Skip(1).ToSecondaryLocations(), ExtractStringContent(firstToken), duplicates.Count.ToString());
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseWhereBeforeOrderByBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseWhereBeforeOrderByBase.cs
@@ -38,14 +38,11 @@ public abstract class UseWhereBeforeOrderByBase<TSyntaxKind, TInvocation> : Sona
                 && Language.Syntax.TryGetOperands(invocation, out var left, out var right)
                 && LeftHasCorrectName(left, out var orderByMethodDescription)
                 && MethodIsLinqExtension(left, c.SemanticModel)
-                && MethodIsLinqExtension(right, c.SemanticModel))
+                && MethodIsLinqExtension(right, c.SemanticModel)
+                && Language.Syntax.NodeIdentifier(right) is { } rightIdentifier
+                && Language.Syntax.NodeIdentifier(left) is { } leftIdentifier)
             {
-                var diagnostic = Diagnostic.Create(
-                    Rule,
-                    Language.Syntax.NodeIdentifier(right)?.GetLocation(),
-                    new[] { Language.Syntax.NodeIdentifier(left)?.GetLocation() },
-                    orderByMethodDescription);
-                c.ReportIssue(diagnostic);
+                c.ReportIssue(Rule, rightIdentifier.GetLocation(), [leftIdentifier.ToSecondaryLocation()], orderByMethodDescription);
             }
         },
         Language.SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/ConditionEvaluatesToConstantBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/ConditionEvaluatesToConstantBase.cs
@@ -112,7 +112,7 @@ public abstract class ConditionEvaluatesToConstantBase : SymbolicRuleCheck
         var secondaryLocations = SecondaryLocations(block, conditionValue, syntax.Span.End);
         if (secondaryLocations.Any())
         {
-            ReportIssue(Rule2583, syntax, secondaryLocations.Select(x => x.ToSecondary()), issueMessage, S2583MessageSuffix);
+            ReportIssue(Rule2583, syntax, secondaryLocations, issueMessage, S2583MessageSuffix);
         }
         else
         {
@@ -120,9 +120,9 @@ public abstract class ConditionEvaluatesToConstantBase : SymbolicRuleCheck
         }
     }
 
-    private List<Location> SecondaryLocations(BasicBlock block, bool conditionValue, int spanStart)
+    private List<SecondaryLocation> SecondaryLocations(BasicBlock block, bool conditionValue, int spanStart)
     {
-        List<Location> locations = new();
+        List<SecondaryLocation> locations = new();
         var unreachable = UnreachableOperations(block, conditionValue);
         var currentStart = spanStart;
 
@@ -143,7 +143,7 @@ public abstract class ConditionEvaluatesToConstantBase : SymbolicRuleCheck
             {
                 var firstNode = nodes.OrderBy(x => x.SpanStart).First();
                 var lastNode = nodes.OrderBy(x => x.Span.End).Last();
-                locations.Add(firstNode.CreateLocation(lastNode));
+                locations.Add(firstNode.CreateLocation(lastNode).ToSecondary());
                 return true;
             }
             return false;

--- a/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/RestrictDeserializedTypesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/SymbolicExecution/Roslyn/RuleChecks/RestrictDeserializedTypesBase.cs
@@ -78,7 +78,7 @@ public abstract class RestrictDeserializedTypesBase : SymbolicRuleCheck
         else if (UnsafeDeserialization(state, operation) is { } invocation)
         {
             var methodDeclaration = UnsafeMethodDeclaration(state, invocation.Instance);
-            var additionalLocations = methodDeclaration is null ? [] : new[] { GetIdentifier(methodDeclaration).GetLocation().ToSecondary(SecondaryMessage) };
+            var additionalLocations = methodDeclaration is null ? [] : new[] { GetIdentifier(methodDeclaration).ToSecondaryLocation(SecondaryMessage) };
             ReportIssue(operation, additionalLocations, RestrictTypesMessage);
         }
         return state;

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Analyzers/DummyAnalyzerWithLocation.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Analyzers/DummyAnalyzerWithLocation.cs
@@ -44,7 +44,7 @@ public class DummyAnalyzerWithLocation : SonarDiagnosticAnalyzer
         if (context.Node is InvocationExpressionSyntax invocation
             && invocation.Expression is IdentifierNameSyntax { Identifier.ValueText: "RaiseHere" } identifier)
         {
-            context.ReportIssue(Diagnostic.Create(rule, identifier.GetLocation(), invocation.ArgumentList.Arguments.Select(arg => arg.GetLocation())));
+            context.ReportIssue(rule, identifier.GetLocation(), invocation.ArgumentList.Arguments.Select(arg => arg.ToSecondaryLocation()));
         }
     }
 }


### PR DESCRIPTION
Follow up of https://github.com/SonarSource/sonar-dotnet/pull/9298 to prevent AD0001s like in #9323 

This PR replaces usage of `Diagnostic.Create` overloads that
* Did not use the safe `DiagnosticDescriptorExtensions.CreateDiagnostic` (replaced in #9346)
* Used secondary locations parameter