### PR TITLE
Fix S6964 FP: Add more attributes to the exclusions

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/AvoidUnderPosting.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/AvoidUnderPosting.cs
@@ -57,8 +57,7 @@ public sealed class AvoidUnderPosting : SonarDiagnosticAnalyzer
 
     private static void ProcessControllerMethods(SonarSyntaxNodeReportingContext context, ConcurrentDictionary<ITypeSymbol, bool> examinedTypes)
     {
-        if (context.SemanticModel.GetDeclaredSymbol(context.Node) is IMethodSymbol method
-            && method.IsControllerActionMethod())
+        if (context.SemanticModel.GetDeclaredSymbol(context.Node) is IMethodSymbol method && method.IsControllerActionMethod())
         {
             var modelParameterTypes = method.Parameters
                 .Where(x => !HasValidateNeverAttribute(x))

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/AvoidUnderPosting.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/AvoidUnderPosting.cs
@@ -96,7 +96,7 @@ public sealed class AvoidUnderPosting : SonarDiagnosticAnalyzer
         static bool IsNewtonsoftJsonPropertyRequired(IPropertySymbol property) =>
             property.GetAttributes(KnownType.Newtonsoft_Json_JsonPropertyAttribute).FirstOrDefault() is { } attribute
             && attribute.TryGetAttributeValue("Required", out string valueType)
-            && valueType == "2"; // "2" stand for Enum value: Required.Always
+            && (valueType is "1" or "2"); // "1" stands for Required.AllowNull and "2" for Required.Always
     }
 
     private static bool IgnoreType(ITypeSymbol type) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/AvoidUnderPosting.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/AvoidUnderPosting.cs
@@ -34,7 +34,10 @@ public sealed class AvoidUnderPosting : SonarDiagnosticAnalyzer
         KnownType.Microsoft_AspNetCore_Http_IFormFile,
         KnownType.Microsoft_AspNetCore_Http_IFormFileCollection);
     private static readonly ImmutableArray<KnownType> IgnoredAttributes = ImmutableArray.Create(
+        KnownType.System_Text_Json_Serialization_JsonIgnoreAttribute,
         KnownType.System_Text_Json_Serialization_JsonRequiredAttribute,
+        KnownType.Newtonsoft_Json_JsonIgnoreAttribute,
+        KnownType.Newtonsoft_Json_JsonRequiredAttribute,
         KnownType.System_ComponentModel_DataAnnotations_RangeAttribute);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
@@ -95,8 +98,8 @@ public sealed class AvoidUnderPosting : SonarDiagnosticAnalyzer
 
         static bool IsNewtonsoftJsonPropertyRequired(IPropertySymbol property) =>
             property.GetAttributes(KnownType.Newtonsoft_Json_JsonPropertyAttribute).FirstOrDefault() is { } attribute
-            && attribute.TryGetAttributeValue("Required", out string valueType)
-            && (valueType is "1" or "2"); // "1" stands for Required.AllowNull and "2" for Required.Always
+            && attribute.TryGetAttributeValue("Required", out int required)
+            && (required is 1 or 2); // Required.AllowNull = 1,   Required.Always = 2, https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_Required.htm
     }
 
     private static bool IgnoreType(ITypeSymbol type) =>

--- a/analyzers/src/SonarAnalyzer.Common/Extensions/ISymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Extensions/ISymbolExtensions.cs
@@ -24,6 +24,9 @@ namespace SonarAnalyzer.Extensions;
 
 public static class ISymbolExtensions
 {
+    public static bool HasAnyAttribute(this ISymbol symbol, ImmutableArray<KnownType> types) =>
+        symbol.GetAttributes(types).Any();
+
     public static bool HasAttribute(this ISymbol symbol, KnownType type) =>
         symbol.GetAttributes(type).Any();
 

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -212,6 +212,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType NUnit_Framework_TestCaseSourceAttribute = new("NUnit.Framework.TestCaseSourceAttribute");
         public static readonly KnownType NUnit_Framework_TestFixtureAttribute = new("NUnit.Framework.TestFixtureAttribute");
         public static readonly KnownType NUnit_Framework_TheoryAttribute = new("NUnit.Framework.TheoryAttribute");
+        public static readonly KnownType Newtonsoft_Json_JsonPropertyAttribute = new("Newtonsoft.Json.JsonPropertyAttribute");
         public static readonly KnownType Org_BouncyCastle_Asn1_Nist_NistNamedCurves = new("Org.BouncyCastle.Asn1.Nist.NistNamedCurves");
         public static readonly KnownType Org_BouncyCastle_Asn1_Sec_SecNamedCurves = new("Org.BouncyCastle.Asn1.Sec.SecNamedCurves");
         public static readonly KnownType Org_BouncyCastle_Asn1_TeleTrust_TeleTrusTNamedCurves = new("Org.BouncyCastle.Asn1.TeleTrust.TeleTrusTNamedCurves");
@@ -321,6 +322,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType System_ComponentModel_Composition_PartCreationPolicyAttribute = new("System.ComponentModel.Composition.PartCreationPolicyAttribute");
         public static readonly KnownType System_ComponentModel_DataAnnotations_KeyAttribute = new("System.ComponentModel.DataAnnotations.KeyAttribute");
         public static readonly KnownType System_ComponentModel_DataAnnotations_RegularExpressionAttribute = new("System.ComponentModel.DataAnnotations.RegularExpressionAttribute");
+        public static readonly KnownType System_ComponentModel_DataAnnotations_RangeAttribute = new("System.ComponentModel.DataAnnotations.RangeAttribute");
         public static readonly KnownType System_ComponentModel_DataAnnotations_IValidatableObject = new("System.ComponentModel.DataAnnotations.IValidatableObject");
         public static readonly KnownType System_ComponentModel_DataAnnotations_RequiredAttribute = new("System.ComponentModel.DataAnnotations.RequiredAttribute");
         public static readonly KnownType System_ComponentModel_DataAnnotations_ValidationAttribute = new("System.ComponentModel.DataAnnotations.ValidationAttribute");
@@ -561,7 +563,6 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType System_StringComparison = new("System.StringComparison");
         public static readonly KnownType System_SystemException = new("System.SystemException");
         public static readonly KnownType System_Text_Encoding = new("System.Text.Encoding");
-        public static readonly KnownType System_Text_Json_Serialization_JsonPropertyAttribute = new("System.Text.Json.Serialization.JsonPropertyAttribute");
         public static readonly KnownType System_Text_Json_Serialization_JsonRequiredAttribute = new("System.Text.Json.Serialization.JsonRequiredAttribute");
         public static readonly KnownType System_Text_RegularExpressions_Regex = new("System.Text.RegularExpressions.Regex");
         public static readonly KnownType System_Text_RegularExpressions_RegexOptions = new("System.Text.RegularExpressions.RegexOptions");

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -202,6 +202,9 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType NLog_LogFactory = new("NLog.LogFactory");
         public static readonly KnownType NLog_LogManager = new("NLog.LogManager");
         public static readonly KnownType NLog_Logger = new("NLog.Logger");
+        public static readonly KnownType Newtonsoft_Json_JsonPropertyAttribute = new("Newtonsoft.Json.JsonPropertyAttribute");
+        public static readonly KnownType Newtonsoft_Json_JsonRequiredAttribute = new("Newtonsoft.Json.JsonRequiredAttribute");
+        public static readonly KnownType Newtonsoft_Json_JsonIgnoreAttribute = new("Newtonsoft.Json.JsonIgnoreAttribute");
         public static readonly KnownType NUnit_Framework_Assert = new("NUnit.Framework.Assert");
         public static readonly KnownType NUnit_Framework_AssertionException = new("NUnit.Framework.AssertionException");
         public static readonly KnownType NUnit_Framework_ExpectedExceptionAttribute = new("NUnit.Framework.ExpectedExceptionAttribute");
@@ -212,7 +215,6 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType NUnit_Framework_TestCaseSourceAttribute = new("NUnit.Framework.TestCaseSourceAttribute");
         public static readonly KnownType NUnit_Framework_TestFixtureAttribute = new("NUnit.Framework.TestFixtureAttribute");
         public static readonly KnownType NUnit_Framework_TheoryAttribute = new("NUnit.Framework.TheoryAttribute");
-        public static readonly KnownType Newtonsoft_Json_JsonPropertyAttribute = new("Newtonsoft.Json.JsonPropertyAttribute");
         public static readonly KnownType Org_BouncyCastle_Asn1_Nist_NistNamedCurves = new("Org.BouncyCastle.Asn1.Nist.NistNamedCurves");
         public static readonly KnownType Org_BouncyCastle_Asn1_Sec_SecNamedCurves = new("Org.BouncyCastle.Asn1.Sec.SecNamedCurves");
         public static readonly KnownType Org_BouncyCastle_Asn1_TeleTrust_TeleTrusTNamedCurves = new("Org.BouncyCastle.Asn1.TeleTrust.TeleTrusTNamedCurves");
@@ -563,6 +565,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType System_StringComparison = new("System.StringComparison");
         public static readonly KnownType System_SystemException = new("System.SystemException");
         public static readonly KnownType System_Text_Encoding = new("System.Text.Encoding");
+        public static readonly KnownType System_Text_Json_Serialization_JsonIgnoreAttribute = new("System.Text.Json.Serialization.JsonIgnoreAttribute");
         public static readonly KnownType System_Text_Json_Serialization_JsonRequiredAttribute = new("System.Text.Json.Serialization.JsonRequiredAttribute");
         public static readonly KnownType System_Text_RegularExpressions_Regex = new("System.Text.RegularExpressions.Regex");
         public static readonly KnownType System_Text_RegularExpressions_RegexOptions = new("System.Text.RegularExpressions.RegexOptions");

--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -561,6 +561,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType System_StringComparison = new("System.StringComparison");
         public static readonly KnownType System_SystemException = new("System.SystemException");
         public static readonly KnownType System_Text_Encoding = new("System.Text.Encoding");
+        public static readonly KnownType System_Text_Json_Serialization_JsonPropertyAttribute = new("System.Text.Json.Serialization.JsonPropertyAttribute");
         public static readonly KnownType System_Text_Json_Serialization_JsonRequiredAttribute = new("System.Text.Json.Serialization.JsonRequiredAttribute");
         public static readonly KnownType System_Text_RegularExpressions_Regex = new("System.Text.RegularExpressions.Regex");
         public static readonly KnownType System_Text_RegularExpressions_RegexOptions = new("System.Text.RegularExpressions.RegexOptions");

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/AspNet/AvoidUnderPostingTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/AspNet/AvoidUnderPostingTest.cs
@@ -35,7 +35,7 @@ public class AvoidUnderPostingTest
 
     private readonly VerifierBuilder builder = new VerifierBuilder<AvoidUnderPosting>()
             .WithBasePath("AspNet")
-            .AddReferences([..AspNetReferences, .. NuGetMetadataReference.SystemTextJson("7.0.4")]);
+            .AddReferences([..AspNetReferences, .. NuGetMetadataReference.SystemTextJson("7.0.4"), ..NuGetMetadataReference.NewtonsoftJson("13.0.3")]);
 
     [TestMethod]
     public void AvoidUnderPosting_CSharp() =>

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/AspNet/AvoidUnderPosting.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/AspNet/AvoidUnderPosting.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -17,8 +18,9 @@ namespace Basics
 //                 ^^^^^^^^^^^^^
         public int? NullableValueProperty { get; set; }
         [Required] public int RequiredValueProperty { get; set; }                   // Noncompliant, RequiredAttribute has no effect on value types
-        [Range(0, 10)] public int ValuePropertyWithRangeValidation { get; set; }    // Noncompliant
+        [Range(0, 10)] public int ValuePropertyWithRangeValidation { get; set; }    // Compliant
         [Required] public int? RequiredNullableValueProperty { get; set; }
+        [JsonProperty(Required = Required.Always)] public int JsonRequiredValueProperty { get; set; }
         public int PropertyWithPrivateSetter { get; private set; }
         protected int ProtectedProperty { get; set; }
         internal int InternalProperty { get; set; }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/AspNet/AvoidUnderPosting.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/AspNet/AvoidUnderPosting.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -20,8 +21,16 @@ namespace Basics
         [Required] public int RequiredValueProperty { get; set; }                   // Noncompliant, RequiredAttribute has no effect on value types
         [Range(0, 10)] public int ValuePropertyWithRangeValidation { get; set; }    // Compliant
         [Required] public int? RequiredNullableValueProperty { get; set; }
-        [JsonProperty(Required = Required.Always)] public int JsonRequiredValuePropertyAlways { get; set; }         // Compliant
-        [JsonProperty(Required = Required.AllowNull)] public int JsonRequiredValuePropertyAllowNull { get; set; }   // Compliant
+        [JsonProperty(Required = Required.Always)] public int JsonRequiredValuePropertyAlways { get; set; }              // Compliant
+        [JsonProperty(Required = Required.AllowNull)] public int JsonRequiredValuePropertyAllowNull { get; set; }        // Compliant
+        [JsonProperty(Required = Required.DisallowNull)] public int JsonRequiredValuePropertyDisallowNull { get; set; }  // Noncompliant
+        [JsonProperty] public int JsonRequiredValuePropertyDefault { get; set; }                                         // Noncompliant
+        [Newtonsoft.Json.JsonIgnore] public int JsonIgnoredProperty { get; set; }                                        // Compliant
+        [Newtonsoft.Json.JsonRequired] public int JsonRequiredNewtonsoftValueProperty { get; set; }                      // Compliant
+        [System.Text.Json.Serialization.JsonRequired] public int JsonRequiredValueProperty { get; set; }                 // Compliant
+        [System.Text.Json.Serialization.JsonIgnore] public int JsonIgnoreValueProperty { get; set; }                     // Compliant
+        [JsonProperty(Required = Required.AllowNull)] [FromQuery] public int PropertyWithMultipleAttributesCompliant { get; set; }   // Compliant
+        [Required] [FromQuery] public int PropertyWithMultipleAttributesNonCompliant { get; set; }   // Noncompliant
         public int PropertyWithPrivateSetter { get; private set; }
         protected int ProtectedProperty { get; set; }
         internal int InternalProperty { get; set; }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/AspNet/AvoidUnderPosting.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/AspNet/AvoidUnderPosting.cs
@@ -20,7 +20,8 @@ namespace Basics
         [Required] public int RequiredValueProperty { get; set; }                   // Noncompliant, RequiredAttribute has no effect on value types
         [Range(0, 10)] public int ValuePropertyWithRangeValidation { get; set; }    // Compliant
         [Required] public int? RequiredNullableValueProperty { get; set; }
-        [JsonProperty(Required = Required.Always)] public int JsonRequiredValueProperty { get; set; }
+        [JsonProperty(Required = Required.Always)] public int JsonRequiredValuePropertyAlways { get; set; }         // Compliant
+        [JsonProperty(Required = Required.AllowNull)] public int JsonRequiredValuePropertyAllowNull { get; set; }   // Compliant
         public int PropertyWithPrivateSetter { get; private set; }
         protected int ProtectedProperty { get; set; }
         internal int InternalProperty { get; set; }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/NuGetMetadataReference.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/NuGetMetadataReference.cs
@@ -139,9 +139,9 @@ public static class NuGetMetadataReference
     public static References NHibernate(string packageVersion = "5.2.2") => Create("NHibernate", packageVersion);
     public static References NpgsqlEntityFrameworkCorePostgreSQL(string packageVersion) => Create("Npgsql.EntityFrameworkCore.PostgreSQL", packageVersion);
     public static References NSubstitute(string packageVersion) => Create("NSubstitute", packageVersion);
+    public static References NewtonsoftJson(string packageVersion) => Create("Newtonsoft.Json", packageVersion);
     public static References NUnit(string packageVersion) => Create("NUnit", packageVersion);
     public static References NUnitLite(string packageVersion) => Create("NUnitLite", packageVersion);
-    public static References NewtonsoftJson(string packageVersion) => Create("Newtonsoft.Json", packageVersion);
     public static References OracleEntityFrameworkCore(string packageVersion) => Create("Oracle.EntityFrameworkCore", packageVersion);
     public static References PetaPocoCompiled(string packageVersion = "6.0.353") => Create("PetaPoco.Compiled", packageVersion);
     public static References RhinoMocks(string packageVersion) => Create("RhinoMocks", packageVersion);

--- a/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/NuGetMetadataReference.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/MetadataReferences/NuGetMetadataReference.cs
@@ -141,6 +141,7 @@ public static class NuGetMetadataReference
     public static References NSubstitute(string packageVersion) => Create("NSubstitute", packageVersion);
     public static References NUnit(string packageVersion) => Create("NUnit", packageVersion);
     public static References NUnitLite(string packageVersion) => Create("NUnitLite", packageVersion);
+    public static References NewtonsoftJson(string packageVersion) => Create("Newtonsoft.Json", packageVersion);
     public static References OracleEntityFrameworkCore(string packageVersion) => Create("Oracle.EntityFrameworkCore", packageVersion);
     public static References PetaPocoCompiled(string packageVersion = "6.0.353") => Create("PetaPoco.Compiled", packageVersion);
     public static References RhinoMocks(string packageVersion) => Create("RhinoMocks", packageVersion);


### PR DESCRIPTION
Fixes #9337 

With this PR I'm excluding properties annotated with:
-  `JsonProperty(Required = Required.Always)`
-  `JsonProperty(Required = Required.AllowNull)`
-  `Newtonsoft.Json.JsonIgnore`
- `Newtonsoft.Json.JsonRequired`
- `System.Text.Json.Serialization.JsonRequired`
- `System.Text.Json.Serialization.JsonIgnore`
- `Range`
