### PR TITLE
ReportIssue: Remove obsolete overloads from SonarAnalysisContextExtensions

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/SonarAnalysisContextExtensions.cs
@@ -46,37 +46,19 @@ public static class SonarAnalysisContextExtensions
     public static void RegisterCodeBlockStartAction(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<SyntaxKind>> action) =>
         context.RegisterCodeBlockStartAction(CSharpGeneratedCodeRecognizer.Instance, action);
 
-    [Obsolete("Use another overload of ReportIssue, without calling Diagnostic.Create")]
-    public static void ReportIssue(this SonarCompilationReportingContext context, Diagnostic diagnostic) =>
-        context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
-
-    public static void ReportIssue(this SonarCompilationReportingContext context,
-                                   DiagnosticDescriptor rule,
-                                   Location primaryLocation,
-                                   IEnumerable<SecondaryLocation> secondaryLocations,
-                                   params string[] messageArgs) =>
-        context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, primaryLocation, secondaryLocations, messageArgs);
-
-    public static void ReportIssue(this SonarCompilationReportingContext context, DiagnosticDescriptor rule, Location location, params string[] messageArgs) =>
-        context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, location, messageArgs);
-
-    [Obsolete("Use another overload of ReportIssue, without calling Diagnostic.Create")]
-    public static void ReportIssue(this SonarSymbolReportingContext context, Diagnostic diagnostic) =>
-        context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnostic);
-
-    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params string[] messageArgs) =>
+    public static void ReportIssue<TContext>(this SonarCompilationReportingContextBase<TContext> context, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params string[] messageArgs) =>
         context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, locationSyntax, messageArgs);
 
-    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxToken locationToken, params string[] messageArgs) =>
+    public static void ReportIssue<TContext>(this SonarCompilationReportingContextBase<TContext> context, DiagnosticDescriptor rule, SyntaxToken locationToken, params string[] messageArgs) =>
         context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, locationToken, messageArgs);
 
-    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, Location location, params string[] messageArgs) =>
+    public static void ReportIssue<TContext>(this SonarCompilationReportingContextBase<TContext> context, DiagnosticDescriptor rule, Location location, params string[] messageArgs) =>
         context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, location, messageArgs);
 
-    public static void ReportIssue(this SonarSymbolReportingContext context,
-                                   DiagnosticDescriptor rule,
-                                   Location primaryLocation,
-                                   IEnumerable<SecondaryLocation> secondaryLocations,
-                                   params string[] messageArgs) =>
+    public static void ReportIssue<TContext>(this SonarCompilationReportingContextBase<TContext> context,
+                                             DiagnosticDescriptor rule,
+                                             Location primaryLocation,
+                                             IEnumerable<SecondaryLocation> secondaryLocations,
+                                             params string[] messageArgs) =>
         context.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, rule, primaryLocation, secondaryLocations, messageArgs);
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/UseAspNetModelBinding.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/UseAspNetModelBinding.cs
@@ -77,7 +77,7 @@ public sealed class UseAspNetModelBinding : SonarDiagnosticAnalyzer<SyntaxKind>
             {
                 foreach (var candidate in candidates.Where(x => !(hasActionFiltersOverrides && x.OriginatesFromParameter)))
                 {
-                    symbolEnd.ReportIssue(Diagnostic.Create(Rule, candidate.Location, candidate.Message));
+                    symbolEnd.ReportIssue(Rule, candidate.Location, candidate.Message);
                 }
             });
         }, SymbolKind.NamedType);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithNeutralResourcesLanguageAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MarkAssemblyWithNeutralResourcesLanguageAttribute.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         {
                             if (hasResx && !HasNeutralResourcesLanguageAttribute(cc.Compilation.Assembly))
                             {
-                                cc.ReportIssue(Rule, null, cc.Compilation.AssemblyName);
+                                cc.ReportIssue(Rule, (Location)null, cc.Compilation.AssemblyName);
                             }
                         });
                 });

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UninvokedEventDeclaration.cs
@@ -60,11 +60,10 @@ namespace SonarAnalyzer.Rules.CSharp
             var usedSymbols = GetInvokedEventSymbols(removableDeclarationCollector)
                 .Concat(GetPossiblyCopiedSymbols(removableDeclarationCollector))
                 .ToHashSet();
-
-            removableEventFields
-                .Where(x => !usedSymbols.Contains(x.Symbol))
-                .ToList()
-                .ForEach(x => context.ReportIssue(Diagnostic.Create(Rule, GetLocation(x.Node), x.Symbol.Name)));
+            foreach (var field in removableEventFields.Where(x => !usedSymbols.Contains(x.Symbol)))
+            {
+                context.ReportIssue(Rule, GetLocation(field.Node), field.Symbol.Name);
+            }
 
             Location GetLocation(SyntaxNode node) =>
                 node is VariableDeclaratorSyntax variableDeclarator

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarAnalysisContextExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Extensions/SonarAnalysisContextExtensions.cs
@@ -46,15 +46,12 @@ public static class SonarAnalysisContextExtensions
     public static void RegisterCodeBlockStartAction(this SonarAnalysisContext context, Action<SonarCodeBlockStartAnalysisContext<SyntaxKind>> action) =>
         context.RegisterCodeBlockStartAction(VisualBasicGeneratedCodeRecognizer.Instance, action);
 
-    public static void ReportIssue(this SonarCompilationReportingContext context, DiagnosticDescriptor rule, Location location, params string[] messageArgs) =>
-        context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, rule, location, messageArgs);
-
-    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params string[] messageArgs) =>
+    public static void ReportIssue<TContext>(this SonarCompilationReportingContextBase<TContext> context, DiagnosticDescriptor rule, SyntaxNode locationSyntax, params string[] messageArgs) =>
         context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, rule, locationSyntax, messageArgs);
 
-    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, SyntaxToken locationToken, params string[] messageArgs) =>
+    public static void ReportIssue<TContext>(this SonarCompilationReportingContextBase<TContext> context, DiagnosticDescriptor rule, SyntaxToken locationToken, params string[] messageArgs) =>
         context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, rule, locationToken, messageArgs);
 
-    public static void ReportIssue(this SonarSymbolReportingContext context, DiagnosticDescriptor rule, Location location, params string[] messageArgs) =>
+    public static void ReportIssue<TContext>(this SonarCompilationReportingContextBase<TContext> context, DiagnosticDescriptor rule, Location location, params string[] messageArgs) =>
         context.ReportIssue(VisualBasicGeneratedCodeRecognizer.Instance, rule, location, messageArgs);
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionExplicitOn.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionExplicitOn.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 {
                     if (!c.Compilation.VB().Options.OptionExplicit)
                     {
-                        c.ReportIssue(Rule, null, string.Format(AssemblyMessageFormat, c.Compilation.AssemblyName));
+                        c.ReportIssue(Rule, (Location)null, string.Format(AssemblyMessageFormat, c.Compilation.AssemblyName));
                     }
                 }));
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionStrictOn.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OptionStrictOn.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 {
                     if (c.Compilation.VB().Options.OptionStrict != OptionStrict.On)
                     {
-                        c.ReportIssue(Rule, null, string.Format(AssemblyMessageFormat, c.Compilation.AssemblyName));
+                        c.ReportIssue(Rule, (Location)null, string.Format(AssemblyMessageFormat, c.Compilation.AssemblyName));
                     }
                 }));
         }


### PR DESCRIPTION
Follow up of #9298 effort

This PR: 
* Removes two obsolete `SonarAnalysisContextExtensions` extensions
* Deduplicates extensions to extend a base class, instead of duplicating extensions for `SonarCompilationReportingContext` and `SonarSymbolReportingContext` separately