### PR TITLE
Replace calls to obsolete SonarTreeReportingContextBase.ReportIssue overload

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/ApiControllersShouldNotDeriveDirectlyFromController.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/ApiControllersShouldNotDeriveDirectlyFromController.cs
@@ -95,7 +95,7 @@ public sealed class ApiControllersShouldNotDeriveDirectlyFromController : SonarD
 
         foreach (var location in reportLocations)
         {
-            context.ReportIssue(CSharpFacade.Instance.GeneratedCodeRecognizer, Diagnostic.Create(Rule, location));
+            context.ReportIssue(CSharpFacade.Instance.GeneratedCodeRecognizer, Rule, location);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CheckArgumentException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CheckArgumentException.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (objectCreation.ArgumentList == null || objectCreation.ArgumentList.Arguments.Count == 0)
             {
-                analysisContext.ReportIssue(Diagnostic.Create(Rule, objectCreation.Expression.GetLocation(), ParameterLessConstructorMessage));
+                analysisContext.ReportIssue(Rule, objectCreation.Expression, ParameterLessConstructorMessage);
                 return;
             }
 
@@ -75,7 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 var message = constructorMessageArgument.HasValue && methodArgumentNames.Contains(TakeOnlyBeforeDot(constructorMessageArgument))
                     ? ConstructorParametersInverted
                     : string.Format(InvalidParameterName, constructorParameterArgument.Value);
-                analysisContext.ReportIssue(Diagnostic.Create(Rule, objectCreation.Expression.GetLocation(), message));
+                analysisContext.ReportIssue(Rule, objectCreation.Expression, message);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentedOutCode.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentedOutCode.cs
@@ -62,7 +62,7 @@ public sealed class CommentedOutCode : SonarDiagnosticAnalyzer
                 && !trivium.ToFullString().TrimStart().StartsWith("///", StringComparison.Ordinal)
                 && IsCode(trivium.ToString().Substring(CommentMarkLength)))
             {
-                context.ReportIssue(Rule, trivium);
+                context.ReportIssue(Rule, trivium.GetLocation());
                 shouldReport = false;
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentedOutCode.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CommentedOutCode.cs
@@ -62,7 +62,7 @@ public sealed class CommentedOutCode : SonarDiagnosticAnalyzer
                 && !trivium.ToFullString().TrimStart().StartsWith("///", StringComparison.Ordinal)
                 && IsCode(trivium.ToString().Substring(CommentMarkLength)))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, trivium.GetLocation()));
+                context.ReportIssue(Rule, trivium);
                 shouldReport = false;
             }
         }
@@ -81,7 +81,7 @@ public sealed class CommentedOutCode : SonarDiagnosticAnalyzer
                 var lineSpan = context.Tree.GetText().Lines[lineNumber].Span;
                 var commentLineSpan = lineSpan.Intersection(trivia.GetLocation().SourceSpan);
                 var location = Location.Create(context.Tree, commentLineSpan ?? lineSpan);
-                context.ReportIssue(Diagnostic.Create(Rule, location));
+                context.ReportIssue(Rule, location);
                 return;
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ComparableInterfaceImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ComparableInterfaceImplementation.cs
@@ -76,11 +76,11 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (membersToOverride.Any())
                     {
-                        c.ReportIssue(Diagnostic.Create(
+                        c.ReportIssue(
                             Rule,
-                            classDeclaration.Identifier.GetLocation(),
+                            classDeclaration.Identifier,
                             string.Join(" or ", implementedComparableInterfaces),
-                            membersToOverride.JoinAnd()));
+                            membersToOverride.JoinAnd());
                     }
                 },
                 SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CompareNaN.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CompareNaN.cs
@@ -51,9 +51,9 @@ namespace SonarAnalyzer.Rules.CSharp
                             : MessageFormatComparison;
 
                         c.ReportIssue(
-                            Diagnostic.Create(Rule,
-                            binaryExpressionSyntax.GetLocation(),
-                            string.Format(messageFormat, KnownTypeAliasMap[floatingPointType])));
+                            Rule,
+                            binaryExpressionSyntax,
+                            string.Format(messageFormat, KnownTypeAliasMap[floatingPointType]));
                     }
                 },
                 SyntaxKind.GreaterThanExpression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConditionalsWithSameCondition.cs
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 if (CSharpEquivalenceChecker.AreEquivalent(currentExpression, previousExpression)
                     && !ContainsPossibleUpdate(previousStatement, currentExpression, context.SemanticModel))
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, currentExpression.GetLocation(), previousExpression.GetLineNumberToReport()));
+                    context.ReportIssue(Rule, currentExpression, previousExpression.GetLineNumberToReport().ToString());
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorArgumentValueShouldExist.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorArgumentValueShouldExist.cs
@@ -53,8 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             var attributeSyntax =
                 (AttributeSyntax)constructorArgumentAttribute.ApplicationSyntaxReference.GetSyntax();
-            c.ReportIssue(Diagnostic.Create(rule,
-                attributeSyntax.ArgumentList.Arguments[0].GetLocation()));
+            c.ReportIssue(rule, attributeSyntax.ArgumentList.Arguments[0]);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorOverridableCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ConstructorOverridableCall.cs
@@ -60,8 +60,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 IsMethodOverridable(methodSymbol) &&
                 enclosingSymbol.IsInType(methodSymbol.ContainingType))
             {
-                context.ReportIssue(Diagnostic.Create(rule, invocationExpression.Expression.GetLocation(),
-                    methodSymbol.Name));
+                context.ReportIssue(rule, invocationExpression.Expression, methodSymbol.Name);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ControlCharacterInString.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ControlCharacterInString.cs
@@ -113,7 +113,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 if (EscapedControlCharacters.TryGetValue(text[charPos], out var escapeSequence))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation(), displayPosIncrement + charPos, escapeSequence));
+                    c.ReportIssue(Rule, c.Node, (displayPosIncrement + charPos).ToString(), escapeSequence);
                     return;
                 }
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CryptographicKeyShouldNotBeTooShort.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CryptographicKeyShouldNotBeTooShort.cs
@@ -111,7 +111,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         // https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.rsacryptoserviceprovider.keysize
                         if (containingType.IsAny(KnownType.System_Security_Cryptography_DSACryptoServiceProvider, KnownType.System_Security_Cryptography_RSACryptoServiceProvider))
                         {
-                            c.ReportIssue(Diagnostic.Create(Rule, assignment.GetLocation(), MinimalCommonKeyLength, CipherName(containingType), UselessAssignmentInfo));
+                            c.ReportIssue(Rule, assignment, MinimalCommonKeyLength.ToString(), CipherName(containingType), UselessAssignmentInfo);
                         }
                         else
                         {
@@ -132,7 +132,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (containingType.IsAny(SystemSecurityCryptographyDsaRsa) && IsInvalidCommonKeyLength(c, firstParam))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, invocation.GetLocation(), MinimalCommonKeyLength, CipherName(containingType), string.Empty));
+                c.ReportIssue(Rule, invocation, MinimalCommonKeyLength.ToString(), CipherName(containingType), string.Empty);
             }
             else
             {
@@ -173,7 +173,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var match = namedEllipticCurve.SafeMatch(curveName);
             if (match.Success && int.TryParse(match.Groups["KeyLength"].Value, out var keyLength) && keyLength < MinimalEllipticCurveKeyLength)
             {
-                c.ReportIssue(Diagnostic.Create(Rule, syntaxElement.GetLocation(), MinimalEllipticCurveKeyLength, "EC", string.Empty));
+                c.ReportIssue(Rule, syntaxElement, MinimalEllipticCurveKeyLength.ToString(), "EC", string.Empty);
             }
         }
 
@@ -184,7 +184,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (containingType.Is(KnownType.System_Security_Cryptography_DSACryptoServiceProvider)
                 || (containingType.Is(KnownType.System_Security_Cryptography_RSACryptoServiceProvider) && HasDefaultSize(c, objectCreation.ArgumentList)))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, objectCreation.Expression.GetLocation(), MinimalCommonKeyLength, CipherName(containingType), string.Empty));
+                c.ReportIssue(Rule, objectCreation.Expression, MinimalCommonKeyLength.ToString(), CipherName(containingType), string.Empty);
             }
             else
             {
@@ -204,7 +204,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             if (containingType.DerivesFromAny(SystemSecurityCryptographyDsaRsa) && keyLengthSyntax != null && IsInvalidCommonKeyLength(c, keyLengthSyntax))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, syntaxElement.GetLocation(), MinimalCommonKeyLength, CipherName(containingType), string.Empty));
+                c.ReportIssue(Rule, syntaxElement, MinimalCommonKeyLength.ToString(), CipherName(containingType), string.Empty);
             }
         }
 
@@ -216,7 +216,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && IsInvalidCommonKeyLength(c, firstParam))
             {
                 var cipherAlgorithmName = containingType.Is(KnownType.Org_BouncyCastle_Crypto_Generators_DHParametersGenerator) ? "DH" : "DSA";
-                c.ReportIssue(Diagnostic.Create(Rule, invocation.GetLocation(), MinimalCommonKeyLength, cipherAlgorithmName, string.Empty));
+                c.ReportIssue(Rule, invocation, MinimalCommonKeyLength.ToString(), cipherAlgorithmName, string.Empty);
             }
         }
 
@@ -226,7 +226,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && containingType.Is(KnownType.Org_BouncyCastle_Crypto_Parameters_RsaKeyGenerationParameters)
                 && IsInvalidCommonKeyLength(c, keyLengthParam))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, objectCreation.Expression.GetLocation(), MinimalCommonKeyLength, "RSA", string.Empty));
+                c.ReportIssue(Rule, objectCreation.Expression, MinimalCommonKeyLength.ToString(), "RSA", string.Empty);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeadStores.cs
@@ -135,7 +135,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 }
 
                 protected void ReportIssue(Location location, ISymbol symbol) =>
-                    owner.context.ReportIssue(Diagnostic.Create(Rule, location, symbol.Name));
+                    owner.context.ReportIssue(Rule, location, symbol.Name);
 
                 protected bool IsSymbolRelevant(ISymbol symbol) =>
                     symbol != null && !owner.capturedVariables.Contains(symbol);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DebugAssertHasNoSideEffects.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DebugAssertHasNoSideEffects.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (IsDebugAssert(c, invokedMethodSyntax)
                         && ContainsCallsWithSideEffects(invokedMethodSyntax))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, invokedMethodSyntax.ArgumentList.GetLocation()));
+                        c.ReportIssue(rule, invokedMethodSyntax.ArgumentList);
                     }
                 },
                 SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DeclareEventHandlersCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DeclareEventHandlersCorrectly.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && eventHandlerType.DelegateInvokeMethod is { } methodSymbol
                 && !IsCorrectEventHandlerSignature(methodSymbol))
             {
-                analysisContext.ReportIssue(Diagnostic.Create(Rule, typeSyntax.GetLocation()));
+                analysisContext.ReportIssue(Rule, typeSyntax);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DefaultSectionShouldBeFirstOrLast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DefaultSectionShouldBeFirstOrLast.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
                             .Labels
                             .First(label => label.IsKind(SyntaxKind.DefaultSwitchLabel))
                             .GetLocation();
-                        c.ReportIssue(Diagnostic.Create(rule, defaultLabelLocation));
+                        c.ReportIssue(rule, defaultLabelLocation);
                     }
                 },
                 SyntaxKind.SwitchStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DelegateSubtraction.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DelegateSubtraction.cs
@@ -39,7 +39,7 @@ public sealed class DelegateSubtraction : SonarDiagnosticAnalyzer
                 var assignment = (AssignmentExpressionSyntax)c.Node;
                 if (!ExpressionIsSimple(assignment.Right) && IsDelegateSubtraction(assignment, c.SemanticModel))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, assignment.GetLocation()));
+                    c.ReportIssue(Rule, assignment);
                 }
             },
             SyntaxKind.SubtractAssignmentExpression);
@@ -52,7 +52,7 @@ public sealed class DelegateSubtraction : SonarDiagnosticAnalyzer
                     && !BinaryIsValidSubstraction(binary)
                     && IsDelegateSubtraction(binary, c.SemanticModel))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, binary.GetLocation()));
+                    c.ReportIssue(Rule, binary);
                 }
             },
             SyntaxKind.SubtractExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableReturnedFromUsing.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableReturnedFromUsing.cs
@@ -96,7 +96,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (returnedSymbols.Any())
             {
-                c.ReportIssue(Diagnostic.Create(rule, usingKeyword.GetLocation(), returnedSymbols.Select(s => $"'{s.Name}'").OrderBy(s => s).JoinAnd()));
+                c.ReportIssue(rule, usingKeyword, returnedSymbols.Select(s => $"'{s.Name}'").OrderBy(s => s).JoinAnd());
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableTypesNeedFinalizers.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposableTypesNeedFinalizers.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     && HasNativeHandleFields(declaration, c.SemanticModel)
                     && !HasFinalizer(declaration))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, declaration.Identifier.GetLocation()));
+                    c.ReportIssue(Rule, declaration.Identifier);
                 }
             },
             SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeFromDispose.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DisposeFromDispose.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     && FieldDeclaredInType(c.SemanticModel, invocation, invocationTarget)
                     && !FieldDisposedInDispose(c.SemanticModel, invocationTarget))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, name.GetLocation()));
+                    c.ReportIssue(Rule, name);
                 }
             },
             SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCatchNullReferenceException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCatchNullReferenceException.cs
@@ -38,13 +38,13 @@ namespace SonarAnalyzer.Rules.CSharp
                     var catchClause = (CatchClauseSyntax)c.Node;
                     if (IsCatchingNullReferenceException(catchClause.Declaration, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, catchClause.Declaration.Type.GetLocation()));
+                        c.ReportIssue(rule, catchClause.Declaration.Type);
                         return;
                     }
 
                     if (HasIsNullReferenceExceptionFilter(catchClause.Filter, c.SemanticModel, out var locationToReportOn))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, locationToReportOn));
+                        c.ReportIssue(rule, locationToReportOn);
                     }
                 },
                 SyntaxKind.CatchClause);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCatchSystemException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCatchSystemException.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && IsSystemException(catchClause.Declaration, c.SemanticModel)
                         && !IsThrowTheLastStatementInTheBlock(catchClause.Block))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, GetLocation(catchClause)));
+                        c.ReportIssue(Rule, GetLocation(catchClause));
                     }
                 },
                 SyntaxKind.CatchClause);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCopyArraysInProperties.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotCopyArraysInProperties.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     foreach (var location in walker.Locations)
                     {
-                        c.ReportIssue(Diagnostic.Create(s2365, location, property.Identifier.Text));
+                        c.ReportIssue(s2365, location, property.Identifier.Text);
                     }
                 },
                 SyntaxKind.PropertyDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotExposeListT.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotExposeListT.cs
@@ -104,7 +104,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             if (typeSyntax != null && typeSyntax.IsKnownType(KnownType.System_Collections_Generic_List_T, context.SemanticModel))
             {
-                context.ReportIssue(Rule, typeSyntax, messageArgs: memberType);
+                context.ReportIssue(Rule, typeSyntax, memberType);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotExposeListT.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotExposeListT.cs
@@ -104,7 +104,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             if (typeSyntax != null && typeSyntax.IsKnownType(KnownType.System_Collections_Generic_List_T, context.SemanticModel))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, typeSyntax.GetLocation(), messageArgs: memberType));
+                context.ReportIssue(Rule, typeSyntax, messageArgs: memberType);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotInstantiateSharedClasses.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotInstantiateSharedClasses.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (createdType != null &&
                         createdType.GetAttributes(KnownType.System_ComponentModel_Composition_PartCreationPolicyAttribute).Any(IsShared))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, creationSyntax.GetLocation()));
+                        c.ReportIssue(rule, creationSyntax);
                     }
                 },
                 SyntaxKind.ObjectCreationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotLockOnSharedResource.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotLockOnSharedResource.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         IsLockOnStringLiteral(lockStatement.Expression) ||
                         IsLockOnForbiddenKnownType(lockStatement.Expression, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, lockStatement.Expression.GetLocation()));
+                        c.ReportIssue(rule, lockStatement.Expression);
                     }
                 },
                 SyntaxKind.LockStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotNestTernaryOperators.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotNestTernaryOperators.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         .OfType<ConditionalExpressionSyntax>()
                         .Any())
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                        c.ReportIssue(Rule, c.Node);
                     }
                 },
                 SyntaxKind.ConditionalExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotNestTypesInArguments.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotNestTypesInArguments.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     foreach (var argument in argumentTypeSymbols)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, argument.GetLocation()));
+                        c.ReportIssue(Rule, argument);
                     }
                 },
                 SyntaxKind.MethodDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotOverloadOperatorEqual.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotOverloadOperatorEqual.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
                && analysisContext.SemanticModel.GetDeclaredSymbol(classDeclaration) is { } namedTypeSymbol
                && !namedTypeSymbol.ImplementsAny(InterfacesRelyingOnOperatorEqualOverload))
             {
-                analysisContext.ReportIssue(Diagnostic.Create(Rule, declaration.OperatorToken.GetLocation()));
+                analysisContext.ReportIssue(Rule, declaration.OperatorToken);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotThrowFromDestructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotThrowFromDestructors.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 {
                     if (c.Node.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>() is DestructorDeclarationSyntax)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation()));
+                        c.ReportIssue(rule, c.Node);
                     }
                 },
                 SyntaxKind.ThrowStatement,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseLiteralBoolInAssertions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseLiteralBoolInAssertions.cs
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && IsTrackedMethod(methodSymbol)
                         && !IsWorkingWithNullableType(methodSymbol, invocation.ArgumentList.Arguments, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, invocation.GetLocation()));
+                        c.ReportIssue(Rule, invocation);
                     }
                 },
                 SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseOutRefParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotUseOutRefParameters.cs
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(Rule, modifier.GetLocation(), modifier.ValueText));
+                    c.ReportIssue(Rule, modifier, modifier.ValueText);
                 },
                 SyntaxKind.Parameter);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotWriteToStandardOutput.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DoNotWriteToStandardOutput.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         !c.Node.IsInDebugBlock() &&
                         !CSharpDebugOnlyCodeHelper.IsCallerInConditionalDebug(methodCall, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, methodCall.Expression.GetLocation()));
+                        c.ReportIssue(Rule, methodCall.Expression);
                     }
                 },
                 SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DontMixIncrementOrDecrementWithOtherOperators.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DontMixIncrementOrDecrementWithOtherOperators.cs
@@ -51,8 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (operatorToken != null &&
                         c.Node.Ancestors().FirstOrDefault(node => node.IsAnyKind(arithmeticOperator)) is BinaryExpressionSyntax)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, operatorToken.Value.GetLocation(),
-                            operatorToken.Value.IsKind(SyntaxKind.PlusPlusToken) ? "increment" : "decrement"));
+                        c.ReportIssue(rule, operatorToken.Value, operatorToken.Value.IsKind(SyntaxKind.PlusPlusToken) ? "increment" : "decrement");
                     }
                 },
                 SyntaxKind.PreDecrementExpression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/DontUseTraceSwitchLevels.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/DontUseTraceSwitchLevels.cs
@@ -47,7 +47,7 @@ public sealed class DontUseTraceSwitchLevels : SonarDiagnosticAnalyzer
                     && methodSymbol.ContainingType.Is(KnownType.System_Diagnostics_Trace)
                     && UsesTraceSwitchAsCondition(c.SemanticModel, methodSymbol, invocation) is { } traceSwitchProperty)
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, traceSwitchProperty.GetLocation(), invocation.GetName()));
+                    c.ReportIssue(Rule, traceSwitchProperty, invocation.GetName());
                 }
             },
             SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyMethod.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && body.IsEmpty()
                 && !ShouldBeExcluded(context, context.Node, context.Node.GetModifiers()))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, ReportingToken(context.Node).GetLocation()));
+                context.ReportIssue(Rule, ReportingToken(context.Node));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyNamespace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyNamespace.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var namespaceDeclaration = (BaseNamespaceDeclarationSyntaxWrapper)c.Node;
                     if (!namespaceDeclaration.Members.Any())
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, namespaceDeclaration.SyntaxNode.GetLocation()));
+                        c.ReportIssue(Rule, namespaceDeclaration.SyntaxNode);
                     }
                 },
                 SyntaxKind.NamespaceDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EmptyStatement.cs
@@ -31,6 +31,6 @@ namespace SonarAnalyzer.Rules.CSharp
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         protected override void Initialize(SonarAnalysisContext context) =>
-            context.RegisterNodeAction(c => c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation())), SyntaxKind.EmptyStatement);
+            context.RegisterNodeAction(c => c.ReportIssue(Rule, c.Node), SyntaxKind.EmptyStatement);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumStorageNeedsToBeInt32.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumStorageNeedsToBeInt32.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (enumDeclaration != null &&
                         !IsDefaultOrLarger(enumBaseType, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, enumDeclaration.Identifier.GetLocation()));
+                        c.ReportIssue(rule, enumDeclaration.Identifier);
                     }
                 },
                 SyntaxKind.EnumDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumerableSumInUnchecked.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumerableSumInUnchecked.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         c.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol &&
                         IsSumOnInteger(methodSymbol))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, memberAccess.Name.GetLocation()));
+                        c.ReportIssue(rule, memberAccess.Name);
                     }
                 },
                 SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumsShouldNotBeNamedReserved.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EnumsShouldNotBeNamedReserved.cs
@@ -39,7 +39,7 @@ public sealed class EnumsShouldNotBeNamedReserved : SonarDiagnosticAnalyzer
                         .SplitCamelCaseToWords()
                         .Any(w => w == "RESERVED"))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, enumMemberDeclaration.GetLocation()));
+                    c.ReportIssue(Rule, enumMemberDeclaration);
                 }
             },
             SyntaxKind.EnumMemberDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnFloatingPoint.cs
@@ -61,7 +61,7 @@ public sealed class EqualityOnFloatingPoint : SonarDiagnosticAnalyzer
             && IsIndirectInequality(context.SemanticModel, binaryExpression, left, right) is var isInequality
             && (isEquality || isInequality))
         {
-            context.ReportIssue(Diagnostic.Create(Rule, binaryExpression.GetLocation(), MessageEqualityPart(isEquality), "a range"));
+            context.ReportIssue(Rule, binaryExpression, MessageEqualityPart(isEquality), "a range");
         }
     }
 
@@ -81,7 +81,7 @@ public sealed class EqualityOnFloatingPoint : SonarDiagnosticAnalyzer
                 ?? ProposedMessageForIdentifier(context, equals.Right)
                 ?? ProposedMessageForIdentifier(context, equals.Left)
                 ?? "a range";
-            context.ReportIssue(Diagnostic.Create(Rule, equals.OperatorToken.GetLocation(), messageEqualityPart, proposed));
+            context.ReportIssue(Rule, equals.OperatorToken, messageEqualityPart, proposed);
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnModulus.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EqualityOnModulus.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (CheckExpression(equalsExpression.Left, equalsExpression.Right, c.SemanticModel, out var constantValue)
                 || CheckExpression(equalsExpression.Right, equalsExpression.Left, c.SemanticModel, out constantValue))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, equalsExpression.GetLocation(), constantValue < 0 ? "negative" : "positive"));
+                c.ReportIssue(Rule, equalsExpression, constantValue < 0 ? "negative" : "positive");
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EquatableClassShouldBeSealed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EquatableClassShouldBeSealed.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && !classDeclaration.Identifier.IsMissing
                         && HasAnyInvalidIEquatableEqualsMethod(classSymbol))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, classDeclaration.Identifier.GetLocation(), classDeclaration.Identifier));
+                        c.ReportIssue(Rule, classDeclaration.Identifier, classDeclaration.Identifier.ValueText);
                     }
                 },
                 SyntaxKind.ClassDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/EventHandlerDelegateShouldHaveProperArguments.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/EventHandlerDelegateShouldHaveProperArguments.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         .IsNullLiteral();
                     if (isSecondParameterNull)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, invocation.GetLocation(), NullEventArgsMessage));
+                        c.ReportIssue(rule, invocation, NullEventArgsMessage);
                     }
 
                     var eventSymbol = GetEventSymbol(invocation.Expression, c.SemanticModel);
@@ -77,11 +77,11 @@ namespace SonarAnalyzer.Rules.CSharp
                         .IsNullLiteral();
                     if (isFirstParameterNull && !eventSymbol.IsStatic)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, invocation.GetLocation(), NullSenderMessage));
+                        c.ReportIssue(rule, invocation, NullSenderMessage);
                     }
                     else if (!isFirstParameterNull && eventSymbol.IsStatic)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, invocation.GetLocation(), NonNullSenderMessage));
+                        c.ReportIssue(rule, invocation, NonNullSenderMessage);
                     }
                 },
                 SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionRethrow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionRethrow.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         var thrown = c.SemanticModel.GetSymbolInfo(@throw.Expression).Symbol as ILocalSymbol;
                         if (Equals(thrown, exceptionIdentifier))
                         {
-                            c.ReportIssue(Diagnostic.Create(rule, @throw.GetLocation()));
+                            c.ReportIssue(rule, @throw);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionShouldNotBeThrownFromUnexpectedMethods.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionShouldNotBeThrownFromUnexpectedMethods.cs
@@ -129,7 +129,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     x => x.SyntaxNode,
                     x => x.Expression) is { } throwExpressionLocation)
             {
-                analysisContext.ReportIssue(Diagnostic.Create(Rule, throwExpressionLocation, "expression"));
+                analysisContext.ReportIssue(Rule, throwExpressionLocation, "expression");
             }
             else if (GetLocationToReport(
                         node.DescendantNodes()
@@ -138,7 +138,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         x => x,
                         x => x.Expression) is { } throwStatementLocation)
             {
-                analysisContext.ReportIssue(Diagnostic.Create(Rule, throwStatementLocation, "statement"));
+                analysisContext.ReportIssue(Rule, throwStatementLocation, "statement");
             }
 
             // `throwNodes` is an enumeration of either throw expressions or throw statements

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsNeedStandardConstructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsNeedStandardConstructors.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     classSymbol.DerivesFrom(KnownType.System_Exception) &&
                     !HasStandardConstructors(classSymbol))
                 {
-                    c.ReportIssue(Diagnostic.Create(rule, classDeclaration.Identifier.GetLocation()));
+                    c.ReportIssue(rule, classDeclaration.Identifier);
                 }
             },
             SyntaxKind.ClassDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExceptionsShouldBeUsed.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     && c.SemanticModel.GetSymbolInfo(objectCreation.Type).Symbol is INamedTypeSymbol createdObjectType
                     && createdObjectType.DerivesFrom(KnownType.System_Exception))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, objectCreation.GetLocation()));
+                    c.ReportIssue(Rule, objectCreation);
                 }
             },
             SyntaxKind.ObjectCreationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ExtensionMethodShouldBeInSeparateNamespace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ExtensionMethodShouldBeInSeparateNamespace.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && methodSymbol.ContainingNamespace.Equals(methodSymbol.Parameters[0].Type.ContainingNamespace)
                         && !methodSymbol.Parameters[0].Type.HasAttribute(KnownType.System_CodeDom_Compiler_GeneratedCodeAttribute))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation()));
+                        c.ReportIssue(Rule, methodDeclaration.Identifier);
                     }
                 },
                 SyntaxKind.MethodDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldsShouldBeEncapsulatedInProperties.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldsShouldBeEncapsulatedInProperties.cs
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (symbol.GetEffectiveAccessibility() == Accessibility.Public)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, firstVariable.GetLocation()));
+                        c.ReportIssue(Rule, firstVariable);
                     }
                 },
                 SyntaxKind.FieldDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FileShouldEndWithEmptyNewLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FileShouldEndWithEmptyNewLine.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var isFileEndingWithNewLine = lastToken.TrailingTrivia.LastOrDefault().IsKind(SyntaxKind.EndOfLineTrivia);
                     if (!isFileEndingWithNewLine)
                     {
-                        stac.ReportIssue(Diagnostic.Create(Rule, lastToken.GetLocation(), Path.GetFileName(stac.Tree.FilePath)));
+                        stac.ReportIssue(Rule, lastToken, Path.GetFileName(stac.Tree.FilePath));
                     }
                 });
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FinalizerShouldNotBeEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FinalizerShouldNotBeEmpty.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (destructorDeclaration.Body?.Statements.Count == 0
                         && destructorDeclaration.ExpressionBody() == null)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, destructorDeclaration.GetLocation()));
+                        c.ReportIssue(Rule, destructorDeclaration);
                     }
                 },
                 SyntaxKind.DestructorDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopConditionAlwaysFalse.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopConditionAlwaysFalse.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var forNode = (ForStatementSyntax)c.Node;
                     if (forNode.Condition != null && (IsAlwaysFalseCondition(forNode.Condition) || IsConditionFalseAtInitialization(forNode)))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, forNode.Condition.GetLocation()));
+                        c.ReportIssue(Rule, forNode.Condition);
                     }
                 },
                 SyntaxKind.ForStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopCounterChanged.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopCounterChanged.cs
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                         if (symbol != null && loopCounters.Contains(symbol))
                         {
-                            c.ReportIssue(Diagnostic.Create(Rule, affectedExpression.GetLocation(), symbol.Name));
+                            c.ReportIssue(Rule, affectedExpression, symbol.Name);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopCounterCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopCounterCondition.cs
@@ -56,13 +56,13 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (conditionSymbols.Any())
                     {
                         var conditionVariables = conditionSymbols.Select(s => $"'{s.Name}'").OrderBy(s => s).JoinAnd();
-                        c.ReportIssue(Diagnostic.Create(Rule, forNode.Condition.GetLocation(),
-                            string.Format(CultureInfo.InvariantCulture, MessageFormatNotEmpty, conditionVariables, incrementedVariables)));
+                        c.ReportIssue(Rule, forNode.Condition,
+                            string.Format(CultureInfo.InvariantCulture, MessageFormatNotEmpty, conditionVariables, incrementedVariables));
                     }
                     else
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, forNode.ForKeyword.GetLocation(),
-                            string.Format(CultureInfo.InvariantCulture, MessageFormatEmpty, incrementedVariables)));
+                        c.ReportIssue(Rule, forNode.ForKeyword,
+                            string.Format(CultureInfo.InvariantCulture, MessageFormatEmpty, incrementedVariables));
                     }
                 },
                 SyntaxKind.ForStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopCounterCondition.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForLoopCounterCondition.cs
@@ -56,13 +56,11 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (conditionSymbols.Any())
                     {
                         var conditionVariables = conditionSymbols.Select(s => $"'{s.Name}'").OrderBy(s => s).JoinAnd();
-                        c.ReportIssue(Rule, forNode.Condition,
-                            string.Format(CultureInfo.InvariantCulture, MessageFormatNotEmpty, conditionVariables, incrementedVariables));
+                        c.ReportIssue(Rule, forNode.Condition, string.Format(CultureInfo.InvariantCulture, MessageFormatNotEmpty, conditionVariables, incrementedVariables));
                     }
                     else
                     {
-                        c.ReportIssue(Rule, forNode.ForKeyword,
-                            string.Format(CultureInfo.InvariantCulture, MessageFormatEmpty, incrementedVariables));
+                        c.ReportIssue(Rule, forNode.ForKeyword, string.Format(CultureInfo.InvariantCulture, MessageFormatEmpty, incrementedVariables));
                     }
                 },
                 SyntaxKind.ForStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ForeachLoopExplicitConversion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ForeachLoopExplicitConversion.cs
@@ -47,11 +47,11 @@ namespace SonarAnalyzer.Rules.CSharp
                     }
 
                     c.ReportIssue(
-                        Diagnostic.Create(Rule,
-                            foreachStatement.Type.GetLocation(),
-                            foreachStatement.Identifier.ValueText,
-                            foreachInfo.ElementType.ToMinimalDisplayString(c.SemanticModel, foreachStatement.Type.SpanStart),
-                            foreachStatement.Type.ToString()));
+                        Rule,
+                        foreachStatement.Type,
+                        foreachStatement.Identifier.ValueText,
+                        foreachInfo.ElementType.ToMinimalDisplayString(c.SemanticModel, foreachStatement.Type.SpanStart),
+                        foreachStatement.Type.ToString());
                 },
                 SyntaxKind.ForEachStatement);
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FrameworkTypeNaming.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FrameworkTypeNaming.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(Rule, classDeclaration.Identifier.GetLocation(), baseTypeName));
+                    c.ReportIssue(Rule, classDeclaration.Identifier, baseTypeName);
                 },
                 SyntaxKind.ClassDeclaration);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionNestingDepth.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionNestingDepth.cs
@@ -30,7 +30,7 @@ namespace SonarAnalyzer.Rules.CSharp
         protected override void Initialize(SonarParametrizedAnalysisContext context) =>
             context.RegisterNodeAction(c =>
             {
-                var walker = new NestingDepthWalker(Maximum, token => c.ReportIssue(Diagnostic.Create(rule, token.GetLocation(), Maximum)));
+                var walker = new NestingDepthWalker(Maximum, token => c.ReportIssue(rule, token, Maximum.ToString()));
                 walker.SafeVisit(c.Node);
             },
             SyntaxKind.MethodDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericLoggerInjectionShouldMatchEnclosingType.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericLoggerInjectionShouldMatchEnclosingType.cs
@@ -40,7 +40,7 @@ public sealed class GenericLoggerInjectionShouldMatchEnclosingType : SonarDiagno
                     var constructor = (ConstructorDeclarationSyntax)c.Node;
                     foreach (var invalidType in InvalidTypeParameters(constructor, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, invalidType.GetLocation()));
+                        c.ReportIssue(Rule, invalidType);
                     }
                 },
                 SyntaxKind.ConstructorDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericReadonlyFieldPropertyAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericReadonlyFieldPropertyAssignment.cs
@@ -85,7 +85,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && !IsInsideConstructorDeclaration(expression, fieldSymbol.ContainingType, semanticModel)
                 && semanticModel.GetSymbolInfo(expression).Symbol is IPropertySymbol propertySymbol)
             {
-                context.ReportIssue(Diagnostic.Create(Rule, expression.GetLocation(), fieldSymbol.Name, propertySymbol.Name));
+                context.ReportIssue(Rule, expression, fieldSymbol.Name, propertySymbol.Name);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterEmptinessChecking.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterEmptinessChecking.cs
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         var expressionToReportOn = leftIsNull ? equalsExpression.Left : equalsExpression.Right;
 
-                        c.ReportIssue(Diagnostic.Create(Rule, expressionToReportOn.GetLocation(), typeInfo.Name));
+                        c.ReportIssue(Rule, expressionToReportOn, typeInfo.Name);
                     }
                 },
                 SyntaxKind.EqualsExpression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterInOut.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterInOut.cs
@@ -181,13 +181,13 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (variance == VarianceKind.In)
             {
-                context.ReportIssue(Diagnostic.Create(Rule, location, "in", typeParameter.Name, "contravariant"));
+                context.ReportIssue(Rule, location, "in", typeParameter.Name, "contravariant");
                 return;
             }
 
             if (variance == VarianceKind.Out)
             {
-                context.ReportIssue(Diagnostic.Create(Rule, location, "out", typeParameter.Name, "covariant"));
+                context.ReportIssue(Rule, location, "out", typeParameter.Name, "covariant");
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParameterUnused.cs
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var usedTypeParameters = GetUsedTypeParameters(c, symbol.DeclaringSyntaxReferences.Select(x => x.GetSyntax()), typeParameterNames).ToHashSet();
             foreach (var typeParameter in typeParameterNames.Where(x => !usedTypeParameters.Contains(x)))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, info.Parameters.Parameters.First(x => x.Identifier.Text == typeParameter).GetLocation(), typeParameter, info.ContainerName));
+                c.ReportIssue(Rule, info.Parameters.Parameters.First(x => x.Identifier.Text == typeParameter), typeParameter, info.ContainerName);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParametersRequired.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GenericTypeParametersRequired.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (typeParameters.Except(typeParametersInArguments).Any())
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation()));
+                        c.ReportIssue(Rule, methodDeclaration.Identifier);
                     }
                 },
                 SyntaxKind.MethodDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeEqualsOverride.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GetHashCodeEqualsOverride.cs
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                             var firstPosition = locations.Select(loc => loc.SourceSpan.Start).Min();
                             var location = locations.First(loc => loc.SourceSpan.Start == firstPosition);
-                            c.ReportIssue(Diagnostic.Create(Rule, location, methodSymbol.Name));
+                            c.ReportIssue(Rule, location, methodSymbol.Name);
                         });
                 });
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/GuardConditionOnEqualsOverride.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/GuardConditionOnEqualsOverride.cs
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (!invokedMethod.ContainingType.Is(KnownType.System_Object)
                 && GetHashCodeEqualsOverride.IsEqualsCallInGuardCondition(invocation, invokedMethod))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, invocation.GetLocation()));
+                context.ReportIssue(Rule, invocation);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/ClearTextProtocolsAreSensitive.cs
@@ -144,11 +144,11 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (!IsServerSafe(objectCreation, context.SemanticModel) && ObjectInitializationTracker.ShouldBeReported(objectCreation, context.SemanticModel, false))
             {
-                context.ReportIssue(Diagnostic.Create(EnableSslRule, objectCreation.Expression.GetLocation()));
+                context.ReportIssue(EnableSslRule, objectCreation.Expression);
             }
             else if (objectCreation.TypeAsString(context.SemanticModel) is { } typeAsString && TelnetRegexForIdentifier.SafeIsMatch(typeAsString))
             {
-                context.ReportIssue(Diagnostic.Create(DefaultRule, objectCreation.Expression.GetLocation(), TelnetKey, RecommendedProtocols[TelnetKey]));
+                context.ReportIssue(DefaultRule, objectCreation.Expression, TelnetKey, RecommendedProtocols[TelnetKey]);
             }
         }
 
@@ -157,7 +157,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var invocation = (InvocationExpressionSyntax)context.Node;
             if (TelnetRegexForIdentifier.SafeIsMatch(invocation.Expression.ToString()))
             {
-                context.ReportIssue(Diagnostic.Create(DefaultRule, invocation.GetLocation(), TelnetKey, RecommendedProtocols[TelnetKey]));
+                context.ReportIssue(DefaultRule, invocation, TelnetKey, RecommendedProtocols[TelnetKey]);
             }
         }
 
@@ -169,7 +169,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && assignment.Right.FindConstantValue(context.SemanticModel) is bool enableSslValue
                 && !enableSslValue)
             {
-                context.ReportIssue(Diagnostic.Create(EnableSslRule, assignment.GetLocation()));
+                context.ReportIssue(EnableSslRule, assignment);
             }
         }
 
@@ -177,7 +177,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             if (GetUnsafeProtocol(c.Node, c.SemanticModel) is { } unsafeProtocol)
             {
-                c.ReportIssue(Diagnostic.Create(DefaultRule, c.Node.GetLocation(), unsafeProtocol, RecommendedProtocols[unsafeProtocol]));
+                c.ReportIssue(DefaultRule, c.Node, unsafeProtocol, RecommendedProtocols[unsafeProtocol]);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DisablingCsrfProtection.cs
@@ -67,6 +67,6 @@ namespace SonarAnalyzer.Rules.CSharp
         }
 
         private static void ReportDiagnostic(SonarSyntaxNodeReportingContext context) =>
-            context.ReportIssue(Diagnostic.Create(Rule, context.Node.GetLocation()));
+            context.ReportIssue(Rule, context.Node);
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotUseRandom.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/DoNotUseRandom.cs
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                 && c.SemanticModel.GetSymbolInfo(objectCreationSyntax).Symbol is IMethodSymbol methodSymbol
                                 && methodSymbol.ContainingType.Is(KnownType.System_Random))
                             {
-                                c.ReportIssue(Diagnostic.Create(Rule, objectCreationSyntax.GetLocation()));
+                                c.ReportIssue(Rule, objectCreationSyntax);
                             }
                         },
                         SyntaxKind.ObjectCreationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/InsecureDeserialization.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/InsecureDeserialization.cs
@@ -86,7 +86,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
 
             static void ReportIssue(SonarSyntaxNodeReportingContext context, ConstructorInfo constructor) =>
-                context.ReportIssue(Diagnostic.Create(Rule, constructor.GetReportLocation()));
+                context.ReportIssue(Rule, constructor.GetReportLocation());
         }
 
         private static bool OnDeserializationHasConditions(TypeDeclarationSyntax typeDeclaration, SemanticModel semanticModel) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/PermissiveCors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/PermissiveCors.cs
@@ -101,7 +101,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (attribute.IsKnownType(KnownType.System_Web_Http_Cors_EnableCorsAttribute, context.SemanticModel)
                 && IsStar(attribute.ArgumentList.Arguments[0].Expression, context.SemanticModel))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, attribute.GetLocation()));
+                context.ReportIssue(Rule, attribute);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/UnsafeCodeBlocks.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/Hotspots/UnsafeCodeBlocks.cs
@@ -71,7 +71,7 @@ public sealed class UnsafeCodeBlocks : HotspotDiagnosticAnalyzer
     {
         if (IsEnabled(context.Options))
         {
-            context.ReportIssue(Diagnostic.Create(Rule, token.GetLocation()));
+            context.ReportIssue(Rule, token);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementSerializationMethodsCorrectly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ImplementSerializationMethodsCorrectly.cs
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             foreach (var attribute in attributes)
             {
-                context.ReportIssue(Diagnostic.Create(AttributeNotConsideredRule, attribute.GetLocation(), memberType));
+                context.ReportIssue(AttributeNotConsideredRule, attribute, memberType);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.SonarCfg.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.SonarCfg.cs
@@ -108,7 +108,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var lastJumpLocation = reportOnOptions.Max(b => b.JumpNode.SpanStart);
                     var reportOn = reportOnOptions.First(b => b.JumpNode.SpanStart == lastJumpLocation);
 
-                    context.ReportIssue(Diagnostic.Create(Rule, reportOn.JumpNode.GetLocation(), declarationType));
+                    context.ReportIssue(Rule, reportOn.JumpNode, declarationType);
                 }
             }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InfiniteRecursion.cs
@@ -118,7 +118,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
 
             public void ReportIssue() =>
-                analysisContext.ReportIssue(Diagnostic.Create(Rule, issueLocation, messageArg));
+                analysisContext.ReportIssue(Rule, issueLocation, messageArg);
         }
 
         private interface IChecker

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InitializeStaticFieldsInline.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InitializeStaticFieldsInline.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         if ((hasIfOrSwitch && assignedFieldCount <= 1)
                             || (!hasIfOrSwitch && assignedFieldCount > 0))
                         {
-                            c.ReportIssue(Diagnostic.Create(Rule, constructor.Identifier.GetLocation()));
+                            c.ReportIssue(Rule, constructor.Identifier);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfaceMethodsShouldBeCallableByChildTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfaceMethodsShouldBeCallableByChildTypes.cs
@@ -75,10 +75,10 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 var identifierName = getIdentifierName(memberDeclaration);
 
-                analysisContext.ReportIssue(Diagnostic.Create(Rule,
-                                                                             identifierName.GetLocation(),
-                                                                             declaration.Identifier.ValueText,
-                                                                             string.Concat(explicitInterfaceSpecifier.Name, ".", identifierName.ValueText)));
+                analysisContext.ReportIssue(Rule,
+                                            identifierName,
+                                            declaration.Identifier.ValueText,
+                                            string.Concat(explicitInterfaceSpecifier.Name, ".", identifierName.ValueText));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfaceMethodsShouldBeCallableByChildTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfaceMethodsShouldBeCallableByChildTypes.cs
@@ -75,10 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 var identifierName = getIdentifierName(memberDeclaration);
 
-                analysisContext.ReportIssue(Rule,
-                                            identifierName,
-                                            declaration.Identifier.ValueText,
-                                            string.Concat(explicitInterfaceSpecifier.Name, ".", identifierName.ValueText));
+                analysisContext.ReportIssue(Rule, identifierName, declaration.Identifier.ValueText, string.Concat(explicitInterfaceSpecifier.Name, ".", identifierName.ValueText));
             }
         }
 
@@ -86,7 +83,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             var symbol = semanticModel.GetDeclaredSymbol(declaration);
 
-            return symbol is {IsSealed: false}
+            return symbol is { IsSealed: false }
                    && symbol.IsPubliclyAccessible();
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfacesShouldNotBeEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InterfacesShouldNotBeEmpty.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && !IsSpecializedGeneric(interfaceSymbol)
                         && !HasEnhancingAttribute(interfaceSymbol))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, interfaceDeclaration.Identifier.GetLocation()));
+                        c.ReportIssue(Rule, interfaceDeclaration.Identifier);
                     }
                 },
                 SyntaxKind.InterfaceDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/InvocationResolvesToOverrideWithParams.cs
@@ -58,7 +58,7 @@ public sealed class InvocationResolvesToOverrideWithParams : SonarDiagnosticAnal
             && argumentTypes.All(x => x is not IErrorTypeSymbol)
             && OtherOverloadsOf(method).FirstOrDefault(IsPossibleMatch) is { } otherMethod)
         {
-            context.ReportIssue(Diagnostic.Create(Rule, node.GetLocation(), otherMethod.ToMinimalDisplayString(context.SemanticModel, node.SpanStart)));
+            context.ReportIssue(Rule, node, otherMethod.ToMinimalDisplayString(context.SemanticModel, node.SpanStart));
         }
 
         bool IsPossibleMatch(IMethodSymbol method) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/IssueSuppression.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/IssueSuppression.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (identifier != null)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation()));
+                        c.ReportIssue(Rule, identifier);
                     }
                 },
                 SyntaxKind.Attribute);
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             foreach (var pragmaWarning in pragmaWarnings)
             {
-                c.ReportIssue(Diagnostic.Create(Rule, pragmaWarning.CreateLocation(pragmaWarning.DisableOrRestoreKeyword)));
+                c.ReportIssue(Rule, pragmaWarning.CreateLocation(pragmaWarning.DisableOrRestoreKeyword));
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/JSInvokableMethodsShouldBePublic.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/JSInvokableMethodsShouldBePublic.cs
@@ -45,7 +45,7 @@ public sealed class JSInvokableMethodsShouldBePublic : SonarDiagnosticAnalyzer
         if (!method.Modifiers.AnyOfKind(SyntaxKind.PublicKeyword)
             && method.AttributeLists.SelectMany(x => x.Attributes).Any(x => x.IsKnownType(KnownType.Microsoft_JSInterop_JSInvokable, context.SemanticModel)))
         {
-            context.ReportIssue(Diagnostic.Create(Rule, method.Identifier.GetLocation()));
+            context.ReportIssue(Rule, method.Identifier);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LiteralSuffixUpperCase.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LiteralSuffixUpperCase.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (text[text.Length - 1] == 'l' && !ShouldIgnore(text))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, Location.Create(literal.SyntaxTree, new TextSpan(literal.Span.End - 1, 1))));
+                        c.ReportIssue(Rule, Location.Create(literal.SyntaxTree, new TextSpan(literal.Span.End - 1, 1)));
                     }
                 },
                 SyntaxKind.NumericLiteralExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LiteralsShouldNotBePassedAsLocalizedParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LiteralsShouldNotBePassedAsLocalizedParameters.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 var firstArgument = invocationSyntax.ArgumentList.Arguments.FirstOrDefault();
                 if (IsStringLiteral(firstArgument?.Expression, context.SemanticModel))
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, firstArgument.GetLocation()));
+                    context.ReportIssue(Rule, firstArgument);
                 }
                 return;
             }
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             foreach (var nonCompliantParameter in nonCompliantParameters)
             {
-                context.ReportIssue(Diagnostic.Create(Rule, nonCompliantParameter.syntax.GetLocation()));
+                context.ReportIssue(Rule, nonCompliantParameter.syntax);
             }
         }
 
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     && IsLocalizable(propertySymbol)
                     && IsStringLiteral(assignmentMapping.Right, context.SemanticModel))
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, assignmentMapping.Right.GetLocation()));
+                    context.ReportIssue(Rule, assignmentMapping.Right);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LockedFieldShouldBeReadonly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LockedFieldShouldBeReadonly.cs
@@ -40,22 +40,22 @@ public sealed class LockedFieldShouldBeReadonly : SonarDiagnosticAnalyzer
         var expression = ((LockStatementSyntax)context.Node).Expression?.RemoveParentheses();
         if (IsCreation(expression))
         {
-            context.ReportIssue(Diagnostic.Create(LockedFieldRule, expression.GetLocation(), "a new instance because is a no-op"));
+            context.ReportIssue(LockedFieldRule, expression, "a new instance because is a no-op");
         }
         else
         {
             var lazySymbol = new Lazy<ISymbol>(() => context.SemanticModel.GetSymbolInfo(expression).Symbol);
             if (IsOfTypeString(expression, lazySymbol))
             {
-                context.ReportIssue(Diagnostic.Create(LockedFieldRule, expression.GetLocation(), "strings as they can be interned"));
+                context.ReportIssue(LockedFieldRule, expression, "strings as they can be interned");
             }
             else if (expression is IdentifierNameSyntax && lazySymbol.Value is ILocalSymbol localSymbol)
             {
-                context.ReportIssue(Diagnostic.Create(LocalVariableRule, expression.GetLocation(), $"local variable '{localSymbol.Name}'"));
+                context.ReportIssue(LocalVariableRule, expression, $"local variable '{localSymbol.Name}'");
             }
             else if (FieldWritable(expression, lazySymbol) is { } field)
             {
-                context.ReportIssue(Diagnostic.Create(LockedFieldRule, expression.GetLocation(), $"writable field '{field.Name}'"));
+                context.ReportIssue(LockedFieldRule, expression, $"writable field '{field.Name}'");
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LoggerFieldsShouldBePrivateStaticReadonly.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LoggerFieldsShouldBePrivateStaticReadonly.cs
@@ -66,7 +66,7 @@ public sealed class LoggerFieldsShouldBePrivateStaticReadonly : SonarDiagnosticA
                 {
                     foreach (var invalid in InvalidFields((FieldDeclarationSyntax)c.Node, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, invalid.GetLocation(), invalid.ValueText));
+                        c.ReportIssue(Rule, invalid, invalid.ValueText);
                     }
                 },
                 SyntaxKind.FieldDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LoggerMembersNamesShouldComply.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LoggerMembersNamesShouldComply.cs
@@ -88,7 +88,7 @@ public sealed class LoggerMembersNamesShouldComply : ParametrizedDiagnosticAnaly
                             && c.SemanticModel.GetDeclaredSymbol(memberData.Member).GetSymbolType() is { } type
                             && type.DerivesOrImplementsAny(Loggers))
                         {
-                            c.ReportIssue(Diagnostic.Create(Rule, memberData.Location, memberData.MemberType, memberData.Name, Format));
+                            c.ReportIssue(Rule, memberData.Location, memberData.MemberType, memberData.Name, Format);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LoggersShouldBeNamedForEnclosingType.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LoggersShouldBeNamedForEnclosingType.cs
@@ -65,7 +65,7 @@ public sealed class LoggersShouldBeNamedForEnclosingType : SonarDiagnosticAnalyz
             && IsValidMethod(method)
             && !MatchesEnclosingType(argument, enclosingType, context.SemanticModel))
         {
-            context.ReportIssue(Diagnostic.Create(Rule, argument.GetLocation()));
+            context.ReportIssue(Rule, argument);
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LoopsAndLinq.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LoopsAndLinq.cs
@@ -128,9 +128,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && accessedProperties.First().Value is var stats
                 && (stats.IsInVarDeclarator || stats.Count > 1))
             {
-                c.ReportIssue(Rule,
-                              forEachStatementSyntax.Expression,
-                              string.Format(SelectMessageFormat, forEachStatementSyntax.Identifier.ValueText, accessedProperties.Single().Key.Name));
+                c.ReportIssue(Rule, forEachStatementSyntax.Expression, string.Format(SelectMessageFormat, forEachStatementSyntax.Identifier.ValueText, accessedProperties.Single().Key.Name));
             }
 
             static IEnumerable<IdentifierNameSyntax> GetStatementIdentifiers(ForEachStatementSyntax forEachStatementSyntax) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LoopsAndLinq.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LoopsAndLinq.cs
@@ -128,10 +128,9 @@ namespace SonarAnalyzer.Rules.CSharp
                 && accessedProperties.First().Value is var stats
                 && (stats.IsInVarDeclarator || stats.Count > 1))
             {
-                var diagnostic = Diagnostic.Create(Rule,
-                                                   forEachStatementSyntax.Expression.GetLocation(),
-                                                   string.Format(SelectMessageFormat, forEachStatementSyntax.Identifier.ValueText, accessedProperties.Single().Key.Name));
-                c.ReportIssue(diagnostic);
+                c.ReportIssue(Rule,
+                              forEachStatementSyntax.Expression,
+                              string.Format(SelectMessageFormat, forEachStatementSyntax.Identifier.ValueText, accessedProperties.Single().Key.Name));
             }
 
             static IEnumerable<IdentifierNameSyntax> GetStatementIdentifiers(ForEachStatementSyntax forEachStatementSyntax) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/LossOfFractionInDivision.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/LossOfFractionInDivision.cs
@@ -46,8 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         || DivisionIsArgumentAndTypeIsNonIntegral(division, c.SemanticModel, out divisionResultType)
                         || DivisionIsInReturnAndTypeIsNonIntegral(division, c.SemanticModel, out divisionResultType))
                     {
-                        var diagnostic = Diagnostic.Create(Rule, division.GetLocation(), divisionResultType.ToMinimalDisplayString(c.SemanticModel, division.SpanStart));
-                        c.ReportIssue(diagnostic);
+                        c.ReportIssue(Rule, division, divisionResultType.ToMinimalDisplayString(c.SemanticModel, division.SpanStart));
                     }
                 },
                 SyntaxKind.DivideExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MagicNumberShouldNotBeUsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MagicNumberShouldNotBeUsed.cs
@@ -51,8 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (!IsExceptionToTheRule(literalExpression))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, literalExpression.GetLocation(),
-                            literalExpression.Token.ValueText));
+                        c.ReportIssue(Rule, literalExpression, literalExpression.Token.ValueText);
                     }
                 },
                 SyntaxKind.NumericLiteralExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializedToDefault.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializedToDefault.cs
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (propertySymbol != null
                 && IsDefaultValueInitializer(propertyDeclaration.Initializer, propertySymbol.Type))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, propertyDeclaration.Initializer.GetLocation(), propertySymbol.Name));
+                context.ReportIssue(Rule, propertyDeclaration.Initializer, propertySymbol.Name);
             }
         }
 
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                 if (IsDefaultValueInitializer(eventDeclaration.Initializer, eventSymbol.Type))
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, eventDeclaration.Initializer.GetLocation(), eventSymbol.Name));
+                    context.ReportIssue(Rule, eventDeclaration.Initializer, eventSymbol.Name);
                     return;
                 }
             }
@@ -87,7 +87,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 if (context.SemanticModel.GetDeclaredSymbol(variableDeclarator) is IFieldSymbol {IsConst: false} fieldSymbol
                     && IsDefaultValueInitializer(variableDeclarator.Initializer, fieldSymbol.Type))
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, variableDeclarator.Initializer.GetLocation(), fieldSymbol.Name));
+                    context.ReportIssue(Rule, variableDeclarator.Initializer, fieldSymbol.Name);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializerRedundant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberInitializerRedundant.cs
@@ -91,7 +91,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     x is { Node.Initializer.ThisOrBaseKeyword.RawKind: (int)SyntaxKind.ThisKeyword }
                     || IsSymbolFirstSetInCfg(kvp.Key, x.Node, x.Model, c.Cancel)))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, kvp.Value.GetLocation(), InstanceMemberMessage));
+                    c.ReportIssue(Rule, kvp.Value, InstanceMemberMessage);
                 }
             }
         }
@@ -118,7 +118,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 // all module initializers are executed when the type is created, so it is enough if ANY initializes the member
                 if (initializerDeclarations.Any(x => IsSymbolFirstSetInCfg(memberSymbol, x.Node, x.Model, c.Cancel)))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, initializedMembers[memberSymbol].GetLocation(), StaticMemberMessage));
+                    c.ReportIssue(Rule, initializedMembers[memberSymbol], StaticMemberMessage);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberOverrideCallsBaseMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberOverrideCallsBaseMember.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var method = (MethodDeclarationSyntax)c.Node;
                     if (IsMethodCandidate(method, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, method.GetLocation(), method.Identifier.ValueText, "method"));
+                        c.ReportIssue(Rule, method, method.Identifier.ValueText, "method");
                     }
                 },
                 SyntaxKind.MethodDeclaration);
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var property = (PropertyDeclarationSyntax)c.Node;
                     if (IsPropertyCandidate(property, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, property.GetLocation(), property.Identifier.ValueText, "property"));
+                        c.ReportIssue(Rule, property, property.Identifier.ValueText, "property");
                     }
                 },
                 SyntaxKind.PropertyDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldBeStatic.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MemberShouldBeStatic.cs
@@ -106,7 +106,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 return;
             }
             var identifier = getIdentifier(declaration);
-            context.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.Text, memberKind));
+            context.ReportIssue(Rule, identifier, identifier.Text, memberKind);
 
             bool IsStaticVirtualAbstractOrOverride() =>
                 methodOrPropertySymbol.IsStatic || methodOrPropertySymbol.IsVirtual || methodOrPropertySymbol.IsAbstract || methodOrPropertySymbol.IsOverride;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/MessageTemplatesShouldBeCorrect.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MessageTemplates/MessageTemplatesShouldBeCorrect.cs
@@ -49,7 +49,7 @@ public sealed class MessageTemplatesShouldBeCorrect : SonarDiagnosticAnalyzer
                         foreach (var error in errors)
                         {
                             var location = Location.Create(c.Tree, new(templateStart + error.Start, error.Length));
-                            c.ReportIssue(Diagnostic.Create(Rule, location, error.Message));
+                            c.ReportIssue(Rule, location, error.Message);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideAddsParams.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideAddsParams.cs
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (paramsKeyword != default
                         && IsNotSemanticallyParams(lastParameter, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, paramsKeyword.GetLocation()));
+                        c.ReportIssue(Rule, paramsKeyword);
                     }
                 },
                 SyntaxKind.MethodDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideChangedDefaultValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideChangedDefaultValue.cs
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
             {
                 if (overridingParameter.HasExplicitDefaultValue)
                 {
-                    context.ReportIssue(Diagnostic.Create(rule, parameterSyntax.Default.GetLocation(), "Remove", MessageRemoveExplicit));
+                    context.ReportIssue(rule, parameterSyntax.Default, "Remove", MessageRemoveExplicit);
                 }
 
                 return;
@@ -79,14 +79,14 @@ namespace SonarAnalyzer.Rules.CSharp
             if (overridingParameter.HasExplicitDefaultValue &&
                 !overriddenParameter.HasExplicitDefaultValue)
             {
-                context.ReportIssue(Diagnostic.Create(rule, parameterSyntax.Default.GetLocation(), "Remove", MessageRemove));
+                context.ReportIssue(rule, parameterSyntax.Default, "Remove", MessageRemove);
                 return;
             }
 
             if (!overridingParameter.HasExplicitDefaultValue &&
                 overriddenParameter.HasExplicitDefaultValue)
             {
-                context.ReportIssue(Diagnostic.Create(rule, parameterSyntax.Identifier.GetLocation(), "Add", MessageAdd));
+                context.ReportIssue(rule, parameterSyntax.Identifier, "Add", MessageAdd);
                 return;
             }
 
@@ -94,7 +94,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 overriddenParameter.HasExplicitDefaultValue &&
                 !Equals(overridingParameter.ExplicitDefaultValue, overriddenParameter.ExplicitDefaultValue))
             {
-                context.ReportIssue(Diagnostic.Create(rule, parameterSyntax.Default.Value.GetLocation(), "Use", MessageUseSame));
+                context.ReportIssue(rule, parameterSyntax.Default.Value, "Use", MessageUseSame);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideNoParams.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodOverrideNoParams.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && methodSymbol.OverriddenMethod.Parameters.Any(p => p.IsParams)
                         && !method.ParameterList.Parameters.Last().Modifiers.Any(SyntaxKind.ParamsKeyword))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, method.ParameterList.Parameters.Last().GetLocation()));
+                        c.ReportIssue(Rule, method.ParameterList.Parameters.Last());
                     }
                 },
                 SyntaxKind.MethodDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterMissingOptional.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterMissingOptional.cs
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var optionalAttribute = attributes.FirstOrDefault(a => a.Symbol.IsInType(KnownType.System_Runtime_InteropServices_OptionalAttribute));
                     if (optionalAttribute == null)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, defaultParameterValueAttribute.SyntaxNode.GetLocation()));
+                        c.ReportIssue(Rule, defaultParameterValueAttribute.SyntaxNode);
                     }
                 },
                 SyntaxKind.Parameter);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodShouldBeNamedAccordingToSynchronicity.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodShouldBeNamedAccordingToSynchronicity.cs
@@ -69,11 +69,11 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (hasAsyncSuffix && !hasAsyncReturnType)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation(), RemoveAsyncSuffixMessage));
+                        c.ReportIssue(Rule, methodDeclaration.Identifier, RemoveAsyncSuffixMessage);
                     }
                     else if (!hasAsyncSuffix && hasAsyncReturnType)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation(), AddAsyncSuffixMessage));
+                        c.ReportIssue(Rule, methodDeclaration.Identifier, AddAsyncSuffixMessage);
                     }
                 },
                 SyntaxKind.MethodDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodShouldNotOnlyReturnConstant.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodShouldNotOnlyReturnConstant.cs
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && methodSymbol.GetInterfaceMember() == null
                         && methodSymbol.GetOverriddenMember() == null)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation()));
+                        c.ReportIssue(Rule, methodDeclaration.Identifier);
                     }
                 },
                 SyntaxKind.MethodDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveTooManyLines.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodsShouldNotHaveTooManyLines.cs
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         if (linesCount > Max)
                         {
                             var modifierPrefix = wrapper.Modifiers.Any(SyntaxKind.StaticKeyword) ? "This static" : "This";
-                            c.ReportIssue(Diagnostic.Create(LocalFunctionRule, wrapper.Identifier.GetLocation(), modifierPrefix, linesCount, Max, MethodKeyword));
+                            c.ReportIssue(LocalFunctionRule, wrapper.Identifier, modifierPrefix, linesCount.ToString(), Max.ToString(), MethodKeyword);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MutableFieldsShouldNotBe.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MutableFieldsShouldNotBe.cs
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.Rules
                         && CollectInvalidFieldVariables(fieldDeclaration, assignmentsImmutability, c.SemanticModel).ToList() is { Count: > 0 } incorrectFieldVariables)
                     {
                         var pluralizeSuffix = incorrectFieldVariables.Count > 1 ? "s" : string.Empty;
-                        c.ReportIssue(Diagnostic.Create(rule, fieldDeclaration.Declaration.Type.GetLocation(), pluralizeSuffix, incorrectFieldVariables.ToSentence(quoteWords: true)));
+                        c.ReportIssue(rule, fieldDeclaration.Declaration.Type, pluralizeSuffix, incorrectFieldVariables.ToSentence(quoteWords: true));
                     }
                 }
             },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NativeMethodsShouldBeWrapped.cs
@@ -91,7 +91,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 .ForEach(Report);
 
             void Report(IMethodSymbol externMethod) =>
-                c.ReportIssue(Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation(), string.Format(MakeThisWrapperLessTrivialMessage, externMethod.Name)));
+                c.ReportIssue(Rule, methodDeclaration.Identifier, string.Format(MakeThisWrapperLessTrivialMessage, externMethod.Name));
 
             bool ParametersMatchContainingMethodDeclaration(InvocationExpressionSyntax invocation) =>
                 invocation.ArgumentList.Arguments.All(IsDeclaredParameterOrLiteral);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NestedCodeBlock.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NestedCodeBlock.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var block = (BlockSyntax)c.Node;
                     if (block.Parent.IsAnyKind(SyntaxKind.Block, SyntaxKind.GlobalStatement))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, block.OpenBraceToken.GetLocation()));
+                        c.ReportIssue(Rule, block.OpenBraceToken);
                     }
                 },
                 SyntaxKind.Block);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NoExceptionsInFinally.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NoExceptionsInFinally.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
 
             public override void VisitThrowStatement(ThrowStatementSyntax node) =>
-                context.ReportIssue(Diagnostic.Create(rule, node.GetLocation()));
+                context.ReportIssue(rule, node);
 
             public override void VisitFinallyClause(FinallyClauseSyntax node)
             {

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NonAsyncTaskShouldNotReturnNull.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NonAsyncTaskShouldNotReturnNull.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         !enclosingMember.IsKind(SyntaxKind.VariableDeclaration) &&
                         IsInvalidEnclosingSymbolContext(enclosingMember, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, nullLiteral.GetLocation()));
+                        c.ReportIssue(rule, nullLiteral);
                     }
                 },
                 SyntaxKind.NullLiteralExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NonDerivedPrivateClassesShouldBeSealed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NonDerivedPrivateClassesShouldBeSealed.cs
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && !IsPossiblyDerived(declaration, model, symbols, out var modifier, out var inheritanceScope))
                     {
                         var type = declaration.IsKind(SyntaxKind.ClassDeclaration) ? "classes" : "record classes";
-                        c.ReportIssue(Diagnostic.Create(Rule, declaration.Identifier.GetLocation(), modifier, type, inheritanceScope));
+                        c.ReportIssue(Rule, declaration.Identifier, modifier, type, inheritanceScope);
                     }
                 }
             });

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NonFlagsEnumInBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NonFlagsEnumInBitwiseOperation.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var message = string.Format(messageFormat, friendlyTypeName);
 
             var op = operatorSelector((T)context.Node);
-            context.ReportIssue(Diagnostic.Create(Rule, op.GetLocation(), message));
+            context.ReportIssue(Rule, op, message);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/NumberPatternShouldBeRegular.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (HasIrregularPattern(literal.Token.Text))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, literal.GetLocation()));
+                        c.ReportIssue(rule, literal);
                     }
                 },
                 SyntaxKind.NumericLiteralExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ObjectCreatedDropped.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ObjectCreatedDropped.cs
@@ -36,7 +36,7 @@ public sealed class ObjectCreatedDropped : SonarDiagnosticAnalyzer
                 var creation = (ObjectCreationExpressionSyntax)c.Node;
                 if (creation.Parent is ExpressionStatementSyntax)
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, creation.GetLocation(), creation.Type));
+                    c.ReportIssue(Rule, creation, creation.Type.ToString());
                 }
             },
             SyntaxKind.ObjectCreationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ObjectShouldBeInitializedCorrectlyBase.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ObjectShouldBeInitializedCorrectlyBase.cs
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules
                             var objectCreation = ObjectCreationFactory.Create(c.Node);
                             if (ObjectInitializationTracker.ShouldBeReported(objectCreation, c.SemanticModel, isDefaultConstructorSafe ))
                             {
-                                c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], objectCreation.Expression.GetLocation()));
+                                c.ReportIssue(SupportedDiagnostics[0], objectCreation.Expression);
                             }
                         },
                         SyntaxKind.ObjectCreationExpression, SyntaxKindEx.ImplicitObjectCreationExpression);
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules
                             var assignment = (AssignmentExpressionSyntax)c.Node;
                             if (ObjectInitializationTracker.ShouldBeReported(assignment, c.SemanticModel))
                             {
-                                c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], assignment.GetLocation()));
+                                c.ReportIssue(SupportedDiagnostics[0], assignment);
                             }
                         },
                         SyntaxKind.SimpleAssignmentExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OperatorOverloadsShouldHaveNamedAlternatives.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OperatorOverloadsShouldHaveNamedAlternatives.cs
@@ -107,8 +107,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 if (operatorName != null &&
                     !HasAlternativeMethod(operatorSymbol, out var operatorAlternativeMethodName))
                 {
-                    c.ReportIssue(Diagnostic.Create(rule, operatorDeclaration.OperatorToken.GetLocation(),
-                        operatorAlternativeMethodName, operatorName));
+                    c.ReportIssue(rule, operatorDeclaration.OperatorToken, operatorAlternativeMethodName, operatorName);
                 }
             },
             SyntaxKind.OperatorDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OperatorsShouldBeOverloadedConsistently.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OperatorsShouldBeOverloadedConsistently.cs
@@ -59,8 +59,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 var missingMethods = FindMissingMethods(classSymbol).ToList();
                 if (missingMethods.Count > 0)
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, classDeclaration.Identifier.GetLocation(),
-                        missingMethods.ToSentence(quoteWords: true)));
+                    c.ReportIssue(Rule, classDeclaration.Identifier, missingMethods.ToSentence(quoteWords: true));
                 }
             },
             // This rule is not applicable for records, as for records it is not possible to override the == operator.

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameterWithDefaultValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalParameterWithDefaultValue.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var defaultValueAttribute = attributes.FirstOrDefault(a => a.Symbol.IsInType(KnownType.System_ComponentModel_DefaultValueAttribute));
                     if (defaultValueAttribute != null)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, defaultValueAttribute.SyntaxNode.GetLocation()));
+                        c.ReportIssue(Rule, defaultValueAttribute.SyntaxNode);
                     }
                 },
                 SyntaxKind.Parameter);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalRefOutParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OptionalRefOutParameter.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (optionalAttribute != null)
                     {
                         var refKind = parameter.Modifiers.Any(SyntaxKind.OutKeyword) ? "out" : "ref";
-                        c.ReportIssue(Diagnostic.Create(Rule, optionalAttribute.SyntaxNode.GetLocation(), refKind));
+                        c.ReportIssue(Rule, optionalAttribute.SyntaxNode, refKind);
                     }
                 },
                 SyntaxKind.Parameter);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OrderByRepeated.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OrderByRepeated.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         IsMethodOrderByExtension(outerInvocation, c.SemanticModel) &&
                         IsOrderByOrThenBy(innerInvocation, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, memberAccess.Name.GetLocation()));
+                        c.ReportIssue(rule, memberAccess.Name);
                     }
 
                     static bool IsOrderByOrThenBy(InvocationExpressionSyntax invocation, SemanticModel semanticModel) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/OverrideGetHashCodeOnOverridingEquals.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/OverrideGetHashCodeOnOverridingEquals.cs
@@ -52,8 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(rule, declaration.Identifier.GetLocation(),
-                        declaration.Keyword.ValueText, overridenMethods[0], GetMissingMethodName(overridenMethods[0])));
+                    c.ReportIssue(rule, declaration.Identifier, declaration.Keyword.ValueText, overridenMethods[0], GetMissingMethodName(overridenMethods[0]));
                 },
                 SyntaxKind.ClassDeclaration,
                 SyntaxKind.StructDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PInvokesShouldNotBeVisible.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PInvokesShouldNotBeVisible.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         methodSymbol.IsPubliclyAccessible() &&
                         methodSymbol.HasAttribute(KnownType.System_Runtime_InteropServices_DllImportAttribute))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, methodDeclaration.Identifier.GetLocation()));
+                        c.ReportIssue(rule, methodDeclaration.Identifier);
                     }
                 },
                 SyntaxKind.MethodDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PartialMethodNoImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PartialMethodNoImplementation.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && context.SemanticModel.GetDeclaredSymbol(declaration) is { } methodSymbol
                 && methodSymbol.PartialImplementationPart == null)
             {
-                context.ReportIssue(Diagnostic.Create(Rule, partialKeyword.GetLocation(), "this", string.Empty));
+                context.ReportIssue(Rule, partialKeyword, "this", string.Empty);
             }
         }
 
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && methodSymbol.PartialImplementationPart == null
                 && PartialMethodsWithoutAccessModifier(methodSymbol).Any())
             {
-                context.ReportIssue(Diagnostic.Create(Rule, statement.GetLocation(), "the", MessageAdditional));
+                context.ReportIssue(Rule, statement, "the", MessageAdditional);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PointersShouldBePrivate.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PointersShouldBePrivate.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && accessibility != Accessibility.Internal
                         && !variableSymbol.IsReadOnly)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, variable.GetLocation(), variableSymbol.Name));
+                        c.ReportIssue(Rule, variable, variableSymbol.Name);
                     }
                 }
             },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PreferJaggedArraysOverMultidimensional.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PreferJaggedArraysOverMultidimensional.cs
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (IsMultiDimensionalArray(typeSymbol))
             {
-                context.ReportIssue(Diagnostic.Create(rule, getLocation(syntax)));
+                context.ReportIssue(rule, getLocation(syntax));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PrivateFieldUsedAsLocalVariable.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PrivateFieldUsedAsLocalVariable.cs
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     foreach (var fieldSymbol in privateFields.Keys.Where(collector.IsRemovableField))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, privateFields[fieldSymbol].GetLocation(), fieldSymbol.Name));
+                        c.ReportIssue(Rule, privateFields[fieldSymbol], fieldSymbol.Name);
                     }
                 },
                 SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PrivateStaticMethodUsedOnlyByNestedClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PrivateStaticMethodUsedOnlyByNestedClass.cs
@@ -59,7 +59,7 @@ public sealed class PrivateStaticMethodUsedOnlyByNestedClass : SonarDiagnosticAn
                         if (typeToMoveInto != outerType)
                         {
                             var nestedTypeName = typeToMoveInto.Identifier.ValueText;
-                            c.ReportIssue(Diagnostic.Create(Rule, reference.Method.Identifier.GetLocation(), nestedTypeName));
+                            c.ReportIssue(Rule, reference.Method.Identifier, nestedTypeName);
                         }
                     }
                 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertiesShouldBePreferred.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertiesShouldBePreferred.cs
@@ -48,10 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     foreach (var candidate in propertyCandidates)
                     {
-                        c.ReportIssue(
-                            Rule,
-                            candidate.Locations.FirstOrDefault(),
-                            messageArgs: candidate.Name);
+                        c.ReportIssue(Rule, candidate.Locations.FirstOrDefault(), candidate.Name);
                     }
                 },
                 SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertiesShouldBePreferred.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertiesShouldBePreferred.cs
@@ -48,10 +48,10 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     foreach (var candidate in propertyCandidates)
                     {
-                        c.ReportIssue(Diagnostic.Create(
+                        c.ReportIssue(
                             Rule,
                             candidate.Locations.FirstOrDefault(),
-                            messageArgs: candidate.Name));
+                            messageArgs: candidate.Name);
                     }
                 },
                 SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyToAutoProperty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PropertyToAutoProperty.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && getterField.IsStatic == propertySymbol.IsStatic
                         && getterField.Type.Equals(propertySymbol.Type))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, propertyDeclaration.Identifier.GetLocation()));
+                        c.ReportIssue(Rule, propertyDeclaration.Identifier);
                     }
                 },
                 SyntaxKind.PropertyDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/PureAttributeOnVoidMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/PureAttributeOnVoidMethod.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && localFunction.AttributeLists.SelectMany(x => x.Attributes).Any(IsPureAttribute)
                         && InvalidPureDataAttributeUsage((IMethodSymbol)c.SemanticModel.GetDeclaredSymbol(c.Node)) is { } pureAttribute)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, pureAttribute.ApplicationSyntaxReference.GetSyntax().GetLocation()));
+                        c.ReportIssue(Rule, pureAttribute.ApplicationSyntaxReference.GetSyntax());
                     }
                 },
                 SyntaxKindEx.LocalFunctionStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundancyInConstructorDestructorDeclaration.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundancyInConstructorDestructorDeclaration.cs
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (typeDeclaration.ParameterList() is { Parameters.Count: 0 } parameterList
                 && !IsStructWithInitializedFieldOrProperty(typeDeclaration, context.SemanticModel))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, parameterList.GetLocation(), "primary constructor"));
+                context.ReportIssue(Rule, parameterList, "primary constructor");
             }
         }
 
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (destructorDeclaration.Body is { Statements.Count: 0 })
             {
-                context.ReportIssue(Diagnostic.Create(Rule, destructorDeclaration.GetLocation(), "destructor"));
+                context.ReportIssue(Rule, destructorDeclaration, "destructor");
             }
         }
 
@@ -71,7 +71,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (IsConstructorRedundant(constructorDeclaration, context.SemanticModel))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, constructorDeclaration.GetLocation(), "constructor"));
+                context.ReportIssue(Rule, constructorDeclaration, "constructor");
                 return;
             }
 
@@ -79,7 +79,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (initializer != null
                 && IsInitializerRedundant(initializer))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, initializer.GetLocation(), "'base()' call"));
+                context.ReportIssue(Rule, initializer, "'base()' call");
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantArgument.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantArgument.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         foreach (var argumentMapping in methodParameterLookup.GetAllArgumentParameterMappings().Reverse().Where(x => ArgumentHasDefaultValue(x, c.SemanticModel)))
                         {
-                            c.ReportIssue(Diagnostic.Create(Rule, argumentMapping.Node.GetLocation(), argumentMapping.Symbol.Name));
+                            c.ReportIssue(Rule, argumentMapping.Node, argumentMapping.Symbol.Name);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantCast.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantCast.cs
@@ -106,7 +106,7 @@ public sealed class RedundantCast : SonarDiagnosticAnalyzer
     }
 
     private static void ReportIssue(SonarSyntaxNodeReportingContext context, ExpressionSyntax expression, ITypeSymbol castType, Location location) =>
-        context.ReportIssue(Diagnostic.Create(Rule, location, castType.ToMinimalDisplayString(context.SemanticModel, expression.SpanStart)));
+        context.ReportIssue(Rule, location, castType.ToMinimalDisplayString(context.SemanticModel, expression.SpanStart));
 
     /// If the invocation one of the <see cref="CastIEnumerableMethods"/> extensions, returns the method symbol.
     private static IMethodSymbol GetEnumerableExtensionSymbol(InvocationExpressionSyntax invocation, SemanticModel semanticModel) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantConditionalAroundAssignment.cs
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (c.SemanticModel.GetSymbolInfo(assignment.Left).Symbol is not IPropertySymbol)
             {
-                c.ReportIssue(Diagnostic.Create(Rule, condition.GetLocation()));
+                c.ReportIssue(Rule, condition);
             }
         }
 
@@ -85,7 +85,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     && CSharpEquivalenceChecker.AreEquivalent(expression, ((ConstantPatternSyntaxWrapper)constantPattern).Expression))
                     || (condition.IsKind(SyntaxKindEx.DiscardPattern) && switchExpression.Arms.Count == 1))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, condition.GetLocation()));
+                    c.ReportIssue(Rule, condition);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantJumpStatement.cs
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             foreach (var jumpBlock in removableJumps)
             {
-                context.ReportIssue(Diagnostic.Create(Rule, jumpBlock.JumpNode.GetLocation()));
+                context.ReportIssue(Rule, jumpBlock.JumpNode);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantModifier.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantModifier.cs
@@ -199,7 +199,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && context.SemanticModel.GetDeclaredSymbol(typeDeclaration) is { DeclaringSyntaxReferences.Length: <= 1 })
             {
                 var keyword = typeDeclaration.Modifiers.First(m => m.IsKind(SyntaxKind.PartialKeyword));
-                context.ReportIssue(Rule, keyword.GetLocation(), "partial", "gratuitous");
+                context.ReportIssue(Rule, keyword, "partial", "gratuitous");
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantModifier.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantModifier.cs
@@ -186,7 +186,7 @@ namespace SonarAnalyzer.Rules.CSharp
         }
 
         private static void ReportOnUnsafeBlock(SonarSyntaxNodeReportingContext context, Location issueLocation) =>
-            context.ReportIssue(Diagnostic.Create(Rule, issueLocation, "unsafe", "redundant"));
+            context.ReportIssue(Rule, issueLocation, "unsafe", "redundant");
 
         private static SyntaxToken FindUnsafeKeyword(MemberDeclarationSyntax memberDeclaration) =>
             Modifiers(memberDeclaration).FirstOrDefault(x => x.IsKind(SyntaxKind.UnsafeKeyword));
@@ -199,7 +199,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && context.SemanticModel.GetDeclaredSymbol(typeDeclaration) is { DeclaringSyntaxReferences.Length: <= 1 })
             {
                 var keyword = typeDeclaration.Modifiers.First(m => m.IsKind(SyntaxKind.PartialKeyword));
-                context.ReportIssue(Diagnostic.Create(Rule, keyword.GetLocation(), "partial", "gratuitous"));
+                context.ReportIssue(Rule, keyword.GetLocation(), "partial", "gratuitous");
             }
         }
 
@@ -221,7 +221,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && context.ContainingSymbol.ContainingType is { IsSealed: true })
             {
                 var keyword = modifiers.First(m => m.IsKind(SyntaxKind.SealedKeyword));
-                context.ReportIssue(Diagnostic.Create(Rule, keyword.GetLocation(), "sealed", "redundant"));
+                context.ReportIssue(Rule, keyword, "sealed", "redundant");
             }
         }
 
@@ -324,7 +324,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 if (isSimplyRedundant || !currentContextHasIntegralOperation)
                 {
                     var keywordToReport = isThisNodeChecked ? "checked" : "unchecked";
-                    context.ReportIssue(Diagnostic.Create(Rule, tokenToReport.GetLocation(), keywordToReport, "redundant"));
+                    context.ReportIssue(Rule, tokenToReport, keywordToReport, "redundant");
                 }
                 isCurrentContextChecked = originalIsCurrentContextChecked;
                 currentContextHasIntegralOperation = originalContextHasIntegralOperation || (currentContextHasIntegralOperation && isSimplyRedundant);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
@@ -101,11 +101,11 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (IsNotNullPattern(left) && IsAffirmativePatternMatch(right))
             {
-                context.ReportIssue(Diagnostic.Create(RuleForPatternSyntax, left.GetLocation()));
+                context.ReportIssue(RuleForPatternSyntax, left);
             }
             else if (IsNotNullPattern(right) && IsAffirmativePatternMatch(left))
             {
-                context.ReportIssue(Diagnostic.Create(RuleForPatternSyntax, right.GetLocation()));
+                context.ReportIssue(RuleForPatternSyntax, right.GetLocation());
             }
 
             static bool IsNotNullPattern(SyntaxNode node) =>
@@ -133,11 +133,11 @@ namespace SonarAnalyzer.Rules.CSharp
                 var rightPattern = (PatternSyntaxWrapper)right;
                 if (leftPattern.IsNull() && IsNegativePatternMatch(rightPattern))
                 {
-                    context.ReportIssue(Diagnostic.Create(RuleForPatternSyntax, left.GetLocation()));
+                    context.ReportIssue(RuleForPatternSyntax, left);
                 }
                 else if (rightPattern.IsNull() && IsNegativePatternMatch(leftPattern))
                 {
-                    context.ReportIssue(Diagnostic.Create(RuleForPatternSyntax, right.GetLocation()));
+                    context.ReportIssue(RuleForPatternSyntax, right);
                 }
             }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullCheck.cs
@@ -105,7 +105,7 @@ namespace SonarAnalyzer.Rules.CSharp
             }
             else if (IsNotNullPattern(right) && IsAffirmativePatternMatch(left))
             {
-                context.ReportIssue(RuleForPatternSyntax, right.GetLocation());
+                context.ReportIssue(RuleForPatternSyntax, right);
             }
 
             static bool IsNotNullPattern(SyntaxNode node) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullableTypeComparison.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantNullableTypeComparison.cs
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (typeSymbol != null &&
                 typeSymbol.OriginalDefinition.Is(KnownType.System_Nullable_T))
             {
-                context.ReportIssue(Diagnostic.Create(rule, location));
+                context.ReportIssue(rule, location);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantParenthesesObjectsCreation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantParenthesesObjectsCreation.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var argumentList = (AttributeArgumentListSyntax)c.Node;
                     if (!argumentList.Arguments.Any())
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, argumentList.GetLocation()));
+                        c.ReportIssue(rule, argumentList);
                     }
                 },
                 SyntaxKind.AttributeArgumentList);
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         objectCreation.Initializer != null &&
                         !argumentList.Arguments.Any())
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, argumentList.GetLocation()));
+                        c.ReportIssue(rule, argumentList);
                     }
                 },
                 SyntaxKind.ObjectCreationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantPropertyNamesInAnonymousClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantPropertyNamesInAnonymousClass.cs
@@ -40,8 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     foreach (var initializer in GetRedundantInitializers(anonymousObjectCreation.Initializers))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, initializer.NameEquals.GetLocation(),
-                            initializer.NameEquals.Name.Identifier.ValueText));
+                        c.ReportIssue(rule, initializer.NameEquals, initializer.NameEquals.Name.Identifier.ValueText);
                     }
                 },
                 SyntaxKind.AnonymousObjectCreationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToArrayCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToArrayCall.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (memberAccess is not null)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, memberAccess.Name.GetLocation(), memberAccess.Name.Identifier.ValueText));
+                        c.ReportIssue(Rule, memberAccess.Name, memberAccess.Name.Identifier.ValueText);
                     }
                 },
                 SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToStringCall.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RedundantToStringCall.cs
@@ -90,7 +90,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (methodSymbol.IsInType(KnownType.System_String))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, location, MessageCallOnString));
+                        c.ReportIssue(rule, location, MessageCallOnString);
                         return;
                     }
 
@@ -111,7 +111,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (parameterLookup.TryGetSymbol(stringFormatArgument, out var argParameter) &&
                         argParameter.Name.StartsWith("arg", StringComparison.Ordinal))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, location, MessageCompiler));
+                        c.ReportIssue(rule, location, MessageCompiler);
                     }
                 },
                 SyntaxKind.InvocationExpression);
@@ -157,7 +157,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var stringParameterIndex = (checkedSideIndex + 1) % 2;
             if (!DoesCollidingAdditionExist(subExpressionType, stringParameterIndex))
             {
-                context.ReportIssue(Diagnostic.Create(rule, location, MessageCompiler));
+                context.ReportIssue(rule, location, MessageCompiler);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualityCheckWhenEqualsExists.cs
@@ -74,7 +74,7 @@ namespace SonarAnalyzer.Rules.CSharp
                             if (MightOverrideEquals(typeLeft, allInterfacesWithImplementationsOverriddenEquals) ||
                                 MightOverrideEquals(typeRight, allInterfacesWithImplementationsOverriddenEquals))
                             {
-                                c.ReportIssue(Diagnostic.Create(Rule, binary.OperatorToken.GetLocation()));
+                                c.ReportIssue(Rule, binary.OperatorToken);
                             }
                         },
                         SyntaxKind.EqualsExpression,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualsOnValueType.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReferenceEqualsOnValueType.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         methodSymbol.Name == ReferenceEqualsName &&
                         AnyArgumentIsValueType(invocation.ArgumentList, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, invocation.Expression.GetLocation()));
+                        c.ReportIssue(rule, invocation.Expression);
                     }
                 },
                 SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RequireAttributeUsageAttribute.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RequireAttributeUsageAttribute.cs
@@ -44,8 +44,7 @@ public sealed class RequireAttributeUsageAttribute : SonarDiagnosticAnalyzer
                     ? " to improve readability, even though it inherits it from its base type"
                     : string.Empty;
 
-                c.ReportIssue(Diagnostic.Create(Rule, classDeclaration.Identifier.GetLocation(),
-                    classSymbol.Name, additionalText));
+                c.ReportIssue(Rule, classDeclaration.Identifier, classSymbol.Name, additionalText);
             }
         },
         SyntaxKind.ClassDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnValueIgnored.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ReturnValueIgnored.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && invokedMethodSymbol.Parameters.All(p => p.RefKind == RefKind.None)
                 && IsSideEffectFreeOrPure(invokedMethodSymbol))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, expression.GetLocation(), invokedMethodSymbol.Name));
+                context.ReportIssue(Rule, expression, invokedMethodSymbol.Name);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/RightCurlyBraceStartsLine.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/RightCurlyBraceStartsLine.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
                             !IsOnSameLineAsOpenBrace(closeBraceToken) &&
                             !IsInitializer(closeBraceToken.Parent)))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, closeBraceToken.GetLocation()));
+                        c.ReportIssue(rule, closeBraceToken);
                     }
                 });
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SerializationConstructorsShouldBeSecured.cs
@@ -74,7 +74,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (isConstructorMissingAttributes)
             {
-                c.ReportIssue(Diagnostic.Create(rule, reportLocation));
+                c.ReportIssue(rule, reportLocation);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyIFormatProviderOrCultureInfo.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyIFormatProviderOrCultureInfo.cs
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         CanPotentiallyRaise(methodSymbol) &&
                         CSharpOverloadHelper.HasOverloadWithType(invocation, c.SemanticModel, formatAndCultureType))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, invocation.GetLocation(), invocation.Expression));
+                        c.ReportIssue(rule, invocation, invocation.Expression.ToString());
                     }
                 }, SyntaxKind.InvocationExpression);
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyStringComparison.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SpecifyStringComparison.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         IsInvalidCall(invocation.Expression, c.SemanticModel) &&
                         CSharpOverloadHelper.HasOverloadWithType(invocation, c.SemanticModel, stringComparisonType))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, invocation.GetLocation(), invocation.Expression));
+                        c.ReportIssue(rule, invocation, invocation.Expression.ToString());
                     }
                 }, SyntaxKind.InvocationExpression);
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SqlKeywordsDelimitedBySpace.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SqlKeywordsDelimitedBySpace.cs
@@ -164,7 +164,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && IsInvalidCombination(firstStringText.Last(), secondStringText.First()))
                     {
                         var word = secondStringText.Split(' ').FirstOrDefault();
-                        context.ReportIssue(Diagnostic.Create(Rule, secondString.Node.GetLocation(), word));
+                        context.ReportIssue(Rule, secondString.Node, word);
                     }
                 }
             }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInGenericClass.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInGenericClass.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             if (!HasGenericType(context, root, typeParameterNames))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, location));
+                context.ReportIssue(Rule, location);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInitializerOrder.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StaticFieldInitializerOrder.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                 .Select(x => new IdentifierTypeDeclarationMapping(x, GetTypeDeclaration(x)))
                                 .Any(x => x.TypeDeclaration is not null && (x.TypeDeclaration != typeDeclaration || x.Field.DeclaringSyntaxReferences.First().Span.Start > variable.SpanStart)))
                         {
-                            c.ReportIssue(Diagnostic.Create(Rule, variable.Initializer.GetLocation()));
+                            c.ReportIssue(Rule, variable.Initializer);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StreamReadStatement.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StreamReadStatement.cs
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && (method.ContainingType.Is(KnownType.System_IO_Stream)
                             || (method.IsOverride && method.ContainingType.DerivesOrImplements(KnownType.System_IO_Stream))))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, expression.GetLocation(), method.Name));
+                        c.ReportIssue(Rule, expression, method.Name);
                     }
                 },
                 SyntaxKind.ExpressionStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringFormatValidator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringFormatValidator.cs
@@ -111,12 +111,12 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (BugRelatedFailures.Contains(failure.Failure))
             {
-                analysisContext.ReportIssue(Diagnostic.Create(BugRule, invocation.Expression.GetLocation(), failure.ToString()));
+                analysisContext.ReportIssue(BugRule, invocation.Expression, failure.ToString());
             }
 
             if (CodeSmellRelatedFailures.Contains(failure.Failure))
             {
-                analysisContext.ReportIssue(Diagnostic.Create(CodeSmellRule, invocation.Expression.GetLocation(), failure.ToString()));
+                analysisContext.ReportIssue(CodeSmellRule, invocation.Expression, failure.ToString());
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOffsetMethods.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOffsetMethods.cs
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         var memberAccess = (MemberAccessExpressionSyntax)invocationExpression.Expression;
 
-                        analysisContext.ReportIssue(Diagnostic.Create(rule, invocationExpression.GetLocation(), memberAccess.Name));
+                        analysisContext.ReportIssue(rule, invocationExpression, memberAccess.Name.ToString());
                     }
                 },
                 SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOperationWithoutCulture.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 CommonCultureSpecificMethodNames.Contains(calledMethod.Name) &&
                 !calledMethod.Parameters.Any(param => param.Type.IsAny(StringCultureSpecifierNames)))
             {
-                context.ReportIssue(Diagnostic.Create(rule, memberAccess.Name.GetLocation(), MessageDefineLocale));
+                context.ReportIssue(rule, memberAccess.Name, MessageDefineLocale);
                 return;
             }
 
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 calledMethod.Parameters.Any(param => param.Type.SpecialType == SpecialType.System_String) &&
                 !calledMethod.Parameters.Any(param => param.Type.IsAny(StringCultureSpecifierNames)))
             {
-                context.ReportIssue(Diagnostic.Create(rule, memberAccess.Name.GetLocation(), MessageDefineLocale));
+                context.ReportIssue(rule, memberAccess.Name, MessageDefineLocale);
                 return;
             }
 
@@ -80,14 +80,14 @@ namespace SonarAnalyzer.Rules.CSharp
                 calledMethod.Name == ToStringMethodName &&
                 calledMethod.Parameters.Length == 0)
             {
-                context.ReportIssue(Diagnostic.Create(rule, memberAccess.Name.GetLocation(), MessageDefineLocale));
+                context.ReportIssue(rule, memberAccess.Name, MessageDefineLocale);
                 return;
             }
 
             if (calledMethod.IsInType(KnownType.System_String) &&
                 calledMethod.Name == CompareToMethodName)
             {
-                context.ReportIssue(Diagnostic.Create(rule, memberAccess.Name.GetLocation(), MessageChangeCompareTo));
+                context.ReportIssue(rule, memberAccess.Name, MessageChangeCompareTo);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOrIntegralTypesForIndexers.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/StringOrIntegralTypesForIndexers.cs
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     return;
                 }
 
-                c.ReportIssue(Diagnostic.Create(Rule, parameter.Type.GetLocation()));
+                c.ReportIssue(Rule, parameter.Type);
             },
             SyntaxKind.IndexerDeclaration);
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SuppressFinalizeUseless.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SuppressFinalizeUseless.cs
@@ -63,7 +63,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (!hasFinalizer)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, invocation.GetLocation()));
+                        c.ReportIssue(rule, invocation);
                     }
                 },
                 SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchCaseFallsThroughToDefault.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchCaseFallsThroughToDefault.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     foreach (var label in section.Labels.Where(label => !label.IsKind(SyntaxKind.DefaultSwitchLabel)))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, label.GetLocation()));
+                        c.ReportIssue(rule, label);
                     }
                 },
                 SyntaxKind.SwitchSection);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchCasesMinimumThree.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchCasesMinimumThree.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var switchNode = (SwitchStatementSyntax)c.Node;
                     if (!HasAtLeastThreeLabels(switchNode))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, switchNode.SwitchKeyword.GetLocation(), SwitchStatementMessage));
+                        c.ReportIssue(rule, switchNode.SwitchKeyword, SwitchStatementMessage);
                     }
                 },
                 SyntaxKind.SwitchStatement);
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     };
                     if (message != string.Empty)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, switchNode.SwitchKeyword.GetLocation(), message));
+                        c.ReportIssue(rule, switchNode.SwitchKeyword, message);
                     }
                 },
                 SyntaxKindEx.SwitchExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchDefaultClauseEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchDefaultClauseEmpty.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (section.Statements[0].IsKind(SyntaxKind.BreakStatement) &&
                         !HasAnyComment(section))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, section.GetLocation()));
+                        c.ReportIssue(rule, section);
                     }
                 },
                 SyntaxKind.SwitchSection);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
@@ -44,8 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var statementsCount = switchSection.Statements.SelectMany(GetSubStatements).Count();
                     if (statementsCount > Threshold)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, switchSection.Labels.First().GetLocation(),
-                            "switch section", statementsCount, Threshold, "method"));
+                        c.ReportIssue(rule, switchSection.Labels.First(), "switch section", statementsCount.ToString(), Threshold.ToString(), "method");
                     }
                 },
                 SyntaxKind.SwitchSection);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchShouldNotBeNested.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/SwitchShouldNotBeNested.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     var switchStatement = (SwitchStatementSyntax)c.Node;
                     if (switchStatement.Parent?.FirstAncestorOrSelf<SwitchStatementSyntax>() != null)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, switchStatement.SwitchKeyword.GetLocation()));
+                        c.ReportIssue(rule, switchStatement.SwitchKeyword);
                     }
                 },
                 SyntaxKind.SwitchStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TaskConfigureAwait.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TaskConfigureAwait.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && c.SemanticModel.GetTypeInfo(expression).Type is { } type
                         && type.DerivesFrom(KnownType.System_Threading_Tasks_Task))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, expression.GetLocation()));
+                        c.ReportIssue(rule, expression);
                     }
                 },
                 SyntaxKind.AwaitExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestClassShouldHaveTestMethod.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestClassShouldHaveTestMethod.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && IsViolatingRule(typeSymbol)
                         && !IsExceptionToTheRule(typeSymbol))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, typeDeclaration.Identifier.GetLocation(), typeDeclaration.GetDeclarationTypeName()));
+                        c.ReportIssue(Rule, typeDeclaration.Identifier, typeDeclaration.GetDeclarationTypeName());
                     }
                 },
                 SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldContainAssertion.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldContainAssertion.cs
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && !IsTestIgnored(methodSymbol)
                         && !ContainsAssertion(c.Node, c.SemanticModel, new HashSet<IMethodSymbol>(), 0))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation()));
+                        c.ReportIssue(Rule, methodDeclaration.Identifier);
                     }
                 },
                 SyntaxKind.MethodDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldHaveCorrectSignature.cs
@@ -104,7 +104,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 var message = validator(c.Node, methodSymbol);
                 if (message != null)
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, methodSymbol.Locations.First(), message));
+                    c.ReportIssue(Rule, methodSymbol.Locations.First(), message);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldNotBeIgnored.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TestMethodShouldNotBeIgnored.cs
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (attributes.Any(IsTestOrTestClassAttribute)
                         && !attributes.Any(IsWorkItemAttribute))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, attribute.GetLocation()));
+                        c.ReportIssue(Rule, attribute);
                     }
                 },
                 SyntaxKind.Attribute);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThisShouldNotBeExposedFromConstructors.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThisShouldNotBeExposedFromConstructors.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                 !IsClassMember(invocation.Expression) &&
                                 c.SemanticModel.GetSymbolInfo(invocation.Expression).Symbol is IMethodSymbol)
                             {
-                                c.ReportIssue(Diagnostic.Create(rule, thisExpression.GetLocation()));
+                                c.ReportIssue(rule, thisExpression);
                             }
                         },
                         SyntaxKind.InvocationExpression);
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules.CSharp
                                 !IsClassMember(assignment.Left) &&
                                 c.SemanticModel.GetSymbolInfo(assignment.Left).Symbol is IPropertySymbol)
                             {
-                                c.ReportIssue(Diagnostic.Create(rule, right.GetLocation()));
+                                c.ReportIssue(rule, right);
                             }
                         },
                         SyntaxKind.SimpleAssignmentExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadStaticNonStaticField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadStaticNonStaticField.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && !fieldDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword)
                         && fieldDeclaration.AttributeLists.GetAttributes(KnownType.System_ThreadStaticAttribute, c.SemanticModel).FirstOrDefault() is { } threadStaticAttribute)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, threadStaticAttribute.Name.GetLocation()));
+                        c.ReportIssue(Rule, threadStaticAttribute.Name);
                     }
                 },
                 SyntaxKind.FieldDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadStaticWithInitializer.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ThreadStaticWithInitializer.cs
@@ -45,8 +45,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     foreach (var variableDeclaratorSyntax in fieldDeclaration.Declaration.Variables.Where(variableDeclaratorSyntax => variableDeclaratorSyntax.Initializer != null))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, variableDeclaratorSyntax.Initializer.GetLocation(),
-                            variableDeclaratorSyntax.Identifier.ValueText));
+                        c.ReportIssue(Rule, variableDeclaratorSyntax.Initializer, variableDeclaratorSyntax.Identifier.ValueText);
                     }
                 },
                 SyntaxKind.FieldDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyGenericParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyGenericParameters.cs
@@ -52,11 +52,11 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(Rule,
-                                                    typeDeclaration.Identifier.GetLocation(),
-                                                    typeDeclaration.Identifier.ValueText,
-                                                    typeDeclaration.GetDeclarationTypeName(),
-                                                    MaxNumberOfGenericParametersInClass));
+                    c.ReportIssue(Rule,
+                                  typeDeclaration.Identifier,
+                                  typeDeclaration.Identifier.ValueText,
+                                  typeDeclaration.GetDeclarationTypeName(),
+                                  MaxNumberOfGenericParametersInClass.ToString());
                 },
                 SyntaxKind.ClassDeclaration,
                 SyntaxKind.StructDeclaration,
@@ -74,11 +74,11 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(Rule,
-                                                    methodDeclaration.Identifier.GetLocation(),
-                                                    new[] { EnclosingTypeName(c.Node), methodDeclaration.Identifier.ValueText }.JoinNonEmpty("."),
-                                                    "method",
-                                                    MaxNumberOfGenericParametersInMethod));
+                    c.ReportIssue(Rule,
+                                  methodDeclaration.Identifier,
+                                  new[] { EnclosingTypeName(c.Node), methodDeclaration.Identifier.ValueText }.JoinNonEmpty("."),
+                                  "method",
+                                  MaxNumberOfGenericParametersInMethod.ToString());
                 },
                 SyntaxKind.MethodDeclaration,
                 SyntaxKindEx.LocalFunctionStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyGenericParameters.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TooManyGenericParameters.cs
@@ -52,11 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    c.ReportIssue(Rule,
-                                  typeDeclaration.Identifier,
-                                  typeDeclaration.Identifier.ValueText,
-                                  typeDeclaration.GetDeclarationTypeName(),
-                                  MaxNumberOfGenericParametersInClass.ToString());
+                    c.ReportIssue(Rule, typeDeclaration.Identifier, typeDeclaration.Identifier.ValueText, typeDeclaration.GetDeclarationTypeName(), MaxNumberOfGenericParametersInClass.ToString());
                 },
                 SyntaxKind.ClassDeclaration,
                 SyntaxKind.StructDeclaration,
@@ -74,11 +70,12 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    c.ReportIssue(Rule,
-                                  methodDeclaration.Identifier,
-                                  new[] { EnclosingTypeName(c.Node), methodDeclaration.Identifier.ValueText }.JoinNonEmpty("."),
-                                  "method",
-                                  MaxNumberOfGenericParametersInMethod.ToString());
+                    c.ReportIssue(
+                        Rule,
+                        methodDeclaration.Identifier,
+                        new[] { EnclosingTypeName(c.Node), methodDeclaration.Identifier.ValueText }.JoinNonEmpty("."),
+                        "method",
+                        MaxNumberOfGenericParametersInMethod.ToString());
                 },
                 SyntaxKind.MethodDeclaration,
                 SyntaxKindEx.LocalFunctionStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TrackNotImplementedException.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
         {
             if (c.SemanticModel.GetTypeInfo(newExceptionExpression).Type.Is(KnownType.System_NotImplementedException))
             {
-                c.ReportIssue(Diagnostic.Create(rule, throwExpression.GetLocation()));
+                c.ReportIssue(rule, throwExpression);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TryStatementsWithIdenticalCatchShouldBeMerged.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TryStatementsWithIdenticalCatchShouldBeMerged.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                 if (mergeableTry != null)
                 {
-                    c.ReportIssue(Diagnostic.Create(rule, tryStatement.GetLocation(), messageArgs: mergeableTry.GetLineNumberToReport()));
+                    c.ReportIssue(rule, tryStatement, messageArgs: mergeableTry.GetLineNumberToReport().ToString());
                 }
 
                 bool SameCatches(IReadOnlyCollection<CatchClauseSyntax> other) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeExaminationOnSystemType.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeExaminationOnSystemType.cs
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 ? MessageIsInstanceOfTypeWithGetType
                 : MessageIsInstanceOfType;
 
-            context.ReportIssue(Diagnostic.Create(Rule, argument.GetLocation(), message));
+            context.ReportIssue(Rule, argument, message);
         }
 
         private static void CheckGetTypeCallOnType(SonarSyntaxNodeReportingContext context, InvocationExpressionSyntax invocation, IMethodSymbol invokedMethod)
@@ -85,7 +85,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 return;
             }
 
-            context.ReportIssue(Diagnostic.Create(Rule, memberCall.OperatorToken.CreateLocation(invocation), MessageGetType));
+            context.ReportIssue(Rule, memberCall.OperatorToken, MessageGetType);
         }
 
         private static bool IsException(MemberAccessExpressionSyntax memberAccess, SemanticModel semanticModel) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeExaminationOnSystemType.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeExaminationOnSystemType.cs
@@ -85,7 +85,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 return;
             }
 
-            context.ReportIssue(Rule, memberCall.OperatorToken, MessageGetType);
+            context.ReportIssue(Rule, memberCall.OperatorToken.CreateLocation(invocation), MessageGetType);
         }
 
         private static bool IsException(MemberAccessExpressionSyntax memberAccess, SemanticModel semanticModel) =>

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypeNamesShouldNotMatchNamespaces.cs
@@ -52,7 +52,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     && FrameworkNamespaces.Contains(identifier.ValueText)
                     && c.SemanticModel.GetDeclaredSymbol(c.Node)?.DeclaredAccessibility == Accessibility.Public)
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.ValueText));
+                    c.ReportIssue(Rule, identifier, identifier.ValueText);
                 }
             },
             SyntaxKind.ClassDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/TypesShouldNotExtendOutdatedBaseTypes.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/TypesShouldNotExtendOutdatedBaseTypes.cs
@@ -51,8 +51,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 if (!classDeclaration.Identifier.IsMissing
                     && classSymbol.BaseType.IsAny(OutdatedTypes))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, classDeclaration.Identifier.GetLocation(),
-                        messageArgs: classSymbol.BaseType.ToDisplayString()));
+                    c.ReportIssue(Rule, classDeclaration.Identifier, messageArgs: classSymbol.BaseType.ToDisplayString());
                 }
             },
             // The rule is not applicable for records as at the current moment all the outdated types are classes and records cannot inherit classes.

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
@@ -170,7 +170,8 @@ public sealed class UnchangedLocalVariablesShouldBeConst : SonarDiagnosticAnalyz
             && initializer.DescendantNodesAndSelf().Any(x => x.IsKind(SyntaxKind.Interpolation));
 
     private static void Report(SonarSyntaxNodeReportingContext c, VariableDeclaratorSyntax declaratorSyntax) =>
-        c.ReportIssue(Rule,
+        c.ReportIssue(
+            Rule,
             declaratorSyntax.Identifier,
             declaratorSyntax.Identifier.ValueText,
             AddionalMessageHints(c.SemanticModel, declaratorSyntax));

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnchangedLocalVariablesShouldBeConst.cs
@@ -170,10 +170,10 @@ public sealed class UnchangedLocalVariablesShouldBeConst : SonarDiagnosticAnalyz
             && initializer.DescendantNodesAndSelf().Any(x => x.IsKind(SyntaxKind.Interpolation));
 
     private static void Report(SonarSyntaxNodeReportingContext c, VariableDeclaratorSyntax declaratorSyntax) =>
-        c.ReportIssue(Diagnostic.Create(Rule,
-            declaratorSyntax.Identifier.GetLocation(),
+        c.ReportIssue(Rule,
+            declaratorSyntax.Identifier,
             declaratorSyntax.Identifier.ValueText,
-            AddionalMessageHints(c.SemanticModel, declaratorSyntax)));
+            AddionalMessageHints(c.SemanticModel, declaratorSyntax));
 
     private static string AddionalMessageHints(SemanticModel semanticModel, VariableDeclaratorSyntax declaratorSyntax) =>
         declaratorSyntax is { Parent: VariableDeclarationSyntax { Type: { IsVar: true } typeSyntax } }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryBitwiseOperation.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryBitwiseOperation.cs
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 var location = assignment.Parent is StatementSyntax
                     ? assignment.Parent.GetLocation()
                     : assignment.OperatorToken.CreateLocation(assignment.Right);
-                context.ReportIssue(Diagnostic.Create(Rule, location));
+                context.ReportIssue(Rule, location);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryMathematicalComparison.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryMathematicalComparison.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.CSharp
                && range.IsOutOfRange(constant))
             {
                 var typeName = typeSymbolOfOther.ToMinimalDisplayString(context.SemanticModel, other.GetLocation().SourceSpan.Start);
-                context.ReportIssue(Diagnostic.Create(MathComparisonRule, other.Parent.GetLocation(), typeName));
+                context.ReportIssue(MathComparisonRule, other.Parent, typeName);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryUsings.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnnecessaryUsings.cs
@@ -94,7 +94,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 if (context.SemanticModel.GetSymbolInfo(usingDirective.Name).Symbol is INamespaceSymbol namespaceSymbol
                     && !necessaryNamespaces.Any(usedNamespace => usedNamespace.IsSameNamespace(namespaceSymbol)))
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, usingDirective.GetLocation()));
+                    context.ReportIssue(Rule, usingDirective);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
@@ -92,7 +92,7 @@ namespace SonarAnalyzer.Rules.CSharp
             // Method invocation is noncompliant when there is at least 1 invocation of the method, and no invocation is using the return value. The case of 0 invocation is handled by S1144.
             if (matchingInvocations.Any() && !matchingInvocations.Any(IsReturnValueUsed))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, localFunctionSyntax.ReturnType.GetLocation()));
+                context.ReportIssue(Rule, localFunctionSyntax.ReturnType);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseConstantLoggingTemplate.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseConstantLoggingTemplate.cs
@@ -94,7 +94,7 @@ public sealed class UseConstantLoggingTemplate : SonarDiagnosticAnalyzer
                 && ArgumentValue(invocation, method, messageParameter) is { } argumentValue
                 && InvalidSyntaxNode(argumentValue, c.SemanticModel) is { } invalidNode)
             {
-                c.ReportIssue(Rule, invalidNode.GetLocation(), Messages[invalidNode.Kind()]);
+                c.ReportIssue(Rule, invalidNode, Messages[invalidNode.Kind()]);
             }
         },
         SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseConstantsWhereAppropriate.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseConstantsWhereAppropriate.cs
@@ -75,8 +75,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(rule,
-                        firstVariableWithInitialization.Identifier.GetLocation()));
+                    c.ReportIssue(rule, firstVariableWithInitialization.Identifier);
                 },
                 SyntaxKind.FieldDeclaration);
         }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseCurlyBraces.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseCurlyBraces.cs
@@ -97,7 +97,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
                     if (!checkedKind.Validator(c.Node))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, checkedKind.IssueReportLocation(c.Node), checkedKind.Value));
+                        c.ReportIssue(rule, checkedKind.IssueReportLocation(c.Node), checkedKind.Value);
                     }
                 },
                 CheckedKinds.Select(e => e.Kind).ToArray());

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericEventHandlerInstances.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseGenericEventHandlerInstances.cs
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 eventSymbol.GetInterfaceMember() == null &&
                 (eventSymbol.Type as INamedTypeSymbol)?.ConstructedFrom.IsAny(allowedTypes) == false)
             {
-                analysisContext.ReportIssue(Diagnostic.Create(rule, getLocationToReportOn()));
+                analysisContext.ReportIssue(rule, getLocationToReportOn());
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseNumericLiteralSeparator.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseNumericLiteralSeparator.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (numericLiteral.Token.Text.IndexOf('_') < 0 &&
                         ShouldHaveSeparator(numericLiteral))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, numericLiteral.GetLocation()));
+                        c.ReportIssue(rule, numericLiteral);
                     }
                 },
                 SyntaxKind.NumericLiteralExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseParamsForVariableArguments.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseParamsForVariableArguments.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         && methodSymbol.IsPubliclyAccessible()
                         && methodSymbol.GetInterfaceMember() == null)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation()));
+                        c.ReportIssue(Rule, identifier);
                     }
                 },
                 SyntaxKind.MethodDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringCreate.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringCreate.cs
@@ -57,7 +57,7 @@ public sealed class UseStringCreate : SonarDiagnosticAnalyzer
                     && node.ArgumentList.Arguments[0].Expression is InterpolatedStringExpressionSyntax
                     && c.SemanticModel.GetTypeInfo(left).Type.Is(KnownType.System_FormattableString))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, node.GetIdentifier()?.GetLocation()));
+                    c.ReportIssue(Rule, node.GetIdentifier()?.GetLocation());
                 }
             },
             SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringIsNullOrEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringIsNullOrEmpty.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         if (IsStringIdentifier(firstArgument.Expression, c.SemanticModel)
                             && IsConstantEmptyString(memberAccessExpression.Expression, c.SemanticModel))
                         {
-                            c.ReportIssue(Diagnostic.Create(rule, invocationExpression.GetLocation(), MessageFormat));
+                            c.ReportIssue(rule, invocationExpression, MessageFormat);
                             return;
                         }
 
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         if (IsStringIdentifier(memberAccessExpression.Expression, c.SemanticModel)
                             && IsConstantEmptyString(firstArgument.Expression, c.SemanticModel))
                         {
-                            c.ReportIssue(Diagnostic.Create(rule, invocationExpression.GetLocation(), MessageFormat));
+                            c.ReportIssue(rule, invocationExpression.GetLocation(), MessageFormat);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringIsNullOrEmpty.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseStringIsNullOrEmpty.cs
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         if (IsStringIdentifier(memberAccessExpression.Expression, c.SemanticModel)
                             && IsConstantEmptyString(firstArgument.Expression, c.SemanticModel))
                         {
-                            c.ReportIssue(rule, invocationExpression.GetLocation(), MessageFormat);
+                            c.ReportIssue(rule, invocationExpression, MessageFormat);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseUriInsteadOfString.cs
@@ -83,14 +83,14 @@ namespace SonarAnalyzer.Rules.CSharp
                 if (!methodDeclaration.IsKind(SyntaxKind.ConstructorDeclaration)
                     && !methodDeclaration.ContainsMethodInvocation(context.SemanticModel, x => true, x => methodOverloads.Contains(x)))
                 {
-                    context.ReportIssue(Diagnostic.Create(RuleS3997, methodDeclaration.FindIdentifierLocation()));
+                    context.ReportIssue(RuleS3997, methodDeclaration.FindIdentifierLocation());
                 }
             }
             else
             {
                 foreach (var paramIdx in stringUrlParams)
                 {
-                    context.ReportIssue(Diagnostic.Create(RuleS3994, methodDeclaration.ParameterList.Parameters[paramIdx].Type.GetLocation()));
+                    context.ReportIssue(RuleS3994, methodDeclaration.ParameterList.Parameters[paramIdx].Type);
                 }
             }
         }
@@ -103,7 +103,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && !propertySymbol.IsOverride
                 && NameContainsUri(propertySymbol.Name))
             {
-                context.ReportIssue(Diagnostic.Create(RuleS3996, propertyDeclaration.Type.GetLocation()));
+                context.ReportIssue(RuleS3996, propertyDeclaration.Type);
             }
         }
 
@@ -112,7 +112,7 @@ namespace SonarAnalyzer.Rules.CSharp
             var declaration = (RecordDeclarationSyntaxWrapper)context.Node;
             if (!context.IsRedundantPositionalRecordContext() && HasStringUriParams(declaration.ParameterList, context.SemanticModel))
             {
-                context.ReportIssue(Diagnostic.Create(RuleS3996, declaration.SyntaxNode.GetLocation()));
+                context.ReportIssue(RuleS3996, declaration.SyntaxNode);
             }
         }
 
@@ -127,7 +127,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && StringUrlParamIndexes(invokedMethodSymbol) is { Count: not 0 } stringUrlParams
                 && FindOverloadsThatUseUriTypeInPlaceOfString(invokedMethodSymbol, stringUrlParams).Any())
             {
-                context.ReportIssue(Diagnostic.Create(RuleS4005, context.Node.GetLocation()));
+                context.ReportIssue(RuleS4005, context.Node);
             }
         }
 
@@ -137,7 +137,7 @@ namespace SonarAnalyzer.Rules.CSharp
                 && methodSymbol.ReturnType.Is(KnownType.System_String)
                 && NameContainsUri(methodSymbol.Name))
             {
-                context.ReportIssue(Diagnostic.Create(RuleS3995, returnTypeLocation));
+                context.ReportIssue(RuleS3995, returnTypeLocation);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseValueParameter.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseValueParameter.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(Rule, accessor.Keyword.GetLocation(), GetAccessorType(accessor)));
+                    c.ReportIssue(Rule, accessor.Keyword, GetAccessorType(accessor));
                 },
                 SyntaxKind.SetAccessorDeclaration,
                 SyntaxKindEx.InitAccessorDeclaration,

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UseWhileLoopInstead.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UseWhileLoopInstead.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     if (forStatement.Declaration == null &&
                         forStatement.Incrementors.Count == 0)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, forStatement.ForKeyword.GetLocation()));
+                        c.ReportIssue(rule, forStatement.ForKeyword);
                     }
                 },
                 SyntaxKind.ForStatement);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/ValuesUselesslyIncremented.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/ValuesUselesslyIncremented.cs
@@ -67,7 +67,7 @@ namespace SonarAnalyzer.Rules.CSharp
                         ? "increment"
                         : "decrement";
 
-                    context.ReportIssue(Diagnostic.Create(Rule, increment.GetLocation(), operatorText));
+                    context.ReportIssue(Rule, increment, operatorText);
                     return;
                 default:
                     return;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VariableShadowsField.cs
@@ -93,7 +93,7 @@ namespace SonarAnalyzer.Rules.CSharp
             if (members.FirstOrDefault(x => x.Name == identifier.ValueText
                 && (x.IsStatic || !identifier.Parent.EnclosingScope().GetModifiers().Any(x => x.Kind() == SyntaxKind.StaticKeyword))) is { } matchingMember)
             {
-                context.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.Text, GetSymbolName(matchingMember)));
+                context.ReportIssue(Rule, identifier, identifier.Text, GetSymbolName(matchingMember));
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/VirtualEventField.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/VirtualEventField.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.CSharp
                     {
                         var virt = eventField.Modifiers.First(modifier => modifier.IsKind(SyntaxKind.VirtualKeyword));
                         var names = string.Join(", ", eventField.Declaration.Variables.Select(syntax => $"'{syntax.Identifier.ValueText}'").OrderBy(s => s).JoinAnd());
-                        c.ReportIssue(Diagnostic.Create(Rule, virt.GetLocation(), names));
+                        c.ReportIssue(Rule, virt, names);
                     }
                 },
                 SyntaxKind.EventFieldDeclaration);

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/XmlExternalEntityShouldNotBeParsed.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.Rules.CSharp
                             if (trackers.XmlDocumentTracker.ShouldBeReported(objectCreation, c.SemanticModel, constructorIsSafe)
                                || trackers.XmlTextReaderTracker.ShouldBeReported(objectCreation, c.SemanticModel, constructorIsSafe))
                             {
-                                c.ReportIssue(Diagnostic.Create(Rule, objectCreation.Expression.GetLocation()));
+                                c.ReportIssue(Rule, objectCreation.Expression);
                             }
 
                             VerifyXPathDocumentConstructor(c, objectCreation);
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules.CSharp
                             if (trackers.XmlDocumentTracker.ShouldBeReported(assignment, c.SemanticModel)
                                || trackers.XmlTextReaderTracker.ShouldBeReported(assignment, c.SemanticModel))
                             {
-                                c.ReportIssue(Diagnostic.Create(Rule, assignment.GetLocation()));
+                                c.ReportIssue(Rule, assignment);
                             }
                         },
                         SyntaxKind.SimpleAssignmentExpression);
@@ -117,7 +117,7 @@ namespace SonarAnalyzer.Rules.CSharp
 
             if (!IsXPathDocumentSecureByDefault(versionProvider.GetDotNetFrameworkVersion(context.Compilation)))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, objectCreation.Expression.GetLocation()));
+                context.ReportIssue(Rule, objectCreation.Expression);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InvalidCastToInterfaceSymbolicExecution.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/SymbolicExecution/Sonar/Analyzers/InvalidCastToInterfaceSymbolicExecution.cs
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.SymbolicExecution.Sonar.Analyzers
 
                 if (context is not null)
                 {
-                    context.ReportIssue(Diagnostic.Create(InvalidCastToInterface.S1944, castExpression.GetLocation(), MessageDefinite));
+                    context.ReportIssue(InvalidCastToInterface.S1944, castExpression, MessageDefinite);
                 }
 
                 return null;

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
@@ -90,6 +90,10 @@ public abstract class SonarTreeReportingContextBase<TContext> : SonarReportingCo
 
     protected SonarTreeReportingContextBase(SonarAnalysisContext analysisContext, TContext context) : base(analysisContext, context) { }
 
+    [Obsolete("Use another overload of ReportIssue, without calling Diagnostic.Create")]
+    public void ReportIssue(Diagnostic diagnostic) =>
+        ReportIssueCore(diagnostic);
+
     public void ReportIssue(DiagnosticDescriptor rule, SyntaxNode locationSyntax, params string[] messageArgs) =>
         ReportIssue(rule, locationSyntax.GetLocation(), messageArgs);
 

--- a/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs
@@ -90,10 +90,6 @@ public abstract class SonarTreeReportingContextBase<TContext> : SonarReportingCo
 
     protected SonarTreeReportingContextBase(SonarAnalysisContext analysisContext, TContext context) : base(analysisContext, context) { }
 
-    [Obsolete("Use another overload of ReportIssue, without calling Diagnostic.Create")]
-    public void ReportIssue(Diagnostic diagnostic) =>
-        ReportIssueCore(diagnostic);
-
     public void ReportIssue(DiagnosticDescriptor rule, SyntaxNode locationSyntax, params string[] messageArgs) =>
         ReportIssue(rule, locationSyntax.GetLocation(), messageArgs);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AllBranchesShouldNotHaveSameImplementationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AllBranchesShouldNotHaveSameImplementationBase.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.Rules
 
                     if (ifBlocksStatements.All(ifStatements => AreEquivalent(ifStatements, elseStatements)))
                     {
-                        context.ReportIssue(Diagnostic.Create(rule, GetLocation(topLevelIf), StatementsMessage));
+                        context.ReportIssue(rule, topLevelIf, StatementsMessage);
                     }
                 };
 
@@ -87,7 +87,7 @@ namespace SonarAnalyzer.Rules
 
                     if (whenTrue.IsEquivalentTo(whenFalse, topLevel: false))
                     {
-                        context.ReportIssue(Diagnostic.Create(rule, GetLocation(ternaryStatement), TernaryMessage));
+                        context.ReportIssue(rule, GetLocation(ternaryStatement), TernaryMessage);
                     }
                 };
         }
@@ -115,7 +115,7 @@ namespace SonarAnalyzer.Rules
                         HasDefaultLabel(switchStatement) &&
                         sections.Skip(1).All(section => AreEquivalent(section, sections[0])))
                     {
-                        context.ReportIssue(Diagnostic.Create(rule, GetLocation(switchStatement), StatementsMessage));
+                        context.ReportIssue(rule, switchStatement, StatementsMessage);
                     }
                 };
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AllBranchesShouldNotHaveSameImplementationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AllBranchesShouldNotHaveSameImplementationBase.cs
@@ -60,7 +60,7 @@ namespace SonarAnalyzer.Rules
 
                     if (ifBlocksStatements.All(ifStatements => AreEquivalent(ifStatements, elseStatements)))
                     {
-                        context.ReportIssue(rule, topLevelIf, StatementsMessage);
+                        context.ReportIssue(rule, GetLocation(topLevelIf), StatementsMessage);
                     }
                 };
 
@@ -115,7 +115,7 @@ namespace SonarAnalyzer.Rules
                         HasDefaultLabel(switchStatement) &&
                         sections.Skip(1).All(section => AreEquivalent(section, sections[0])))
                     {
-                        context.ReportIssue(rule, switchStatement, StatementsMessage);
+                        context.ReportIssue(rule, GetLocation(switchStatement), StatementsMessage);
                     }
                 };
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AlwaysSetDateTimeKindBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AlwaysSetDateTimeKindBase.cs
@@ -39,7 +39,7 @@ public abstract class AlwaysSetDateTimeKindBase<TSyntaxKind> : SonarDiagnosticAn
                 && Array.Exists(ValidNames, x => x.Equals(identifier.ValueText, Language.NameComparison))
                 && IsDateTimeConstructorWithoutKindParameter(c.Node, c.SemanticModel))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                c.ReportIssue(Rule, c.Node);
             }
         },
         ObjectCreationExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AvoidDateTimeNowForBenchmarkingBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AvoidDateTimeNowForBenchmarkingBase.cs
@@ -45,7 +45,7 @@ public abstract class AvoidDateTimeNowForBenchmarkingBase<TMemberAccess, TInvoca
             && Language.Syntax.BinaryExpressionRight(context.Node) is var right
             && context.SemanticModel.GetTypeInfo(right).Type.Is(KnownType.System_DateTime))
         {
-            context.ReportIssue(Diagnostic.Create(Rule, context.Node.GetLocation()));
+            context.ReportIssue(Rule, context.Node);
         }
     }
 
@@ -60,7 +60,7 @@ public abstract class AvoidDateTimeNowForBenchmarkingBase<TMemberAccess, TInvoca
             && Language.Syntax.HasExactlyNArguments(invocation, 1)
             && ContainsDateTimeArgument(invocation, context.SemanticModel))
         {
-            context.ReportIssue(Diagnostic.Create(Rule, subtract.GetLocation()));
+            context.ReportIssue(Rule, subtract);
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/AvoidUnsealedAttributesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/AvoidUnsealedAttributesBase.cs
@@ -39,7 +39,7 @@ public abstract class AvoidUnsealedAttributesBase<TSyntaxKind> : SonarDiagnostic
                     && symbol.DerivesFrom(KnownType.System_Attribute)
                     && symbol.IsPubliclyAccessible())
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation()));
+                    c.ReportIssue(Rule, identifier);
                 }
             },
             Language.SyntaxKind.ClassDeclaration);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/BeginInvokePairedWithEndInvokeBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/BeginInvokePairedWithEndInvokeBase.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules
                     && IsInvalidCallback(callbackArg, c.SemanticModel)
                     && !ParentMethodContainsEndInvoke(invocation, c.SemanticModel))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, Language.Syntax.InvocationIdentifier(invocation).Value.GetLocation()));
+                    c.ReportIssue(Rule, Language.Syntax.InvocationIdentifier(invocation).Value);
                 }
             }, InvocationExpressionKind);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/BooleanCheckInvertedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/BooleanCheckInvertedBase.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules
 
                 if (IsLogicalNot(expression, out var logicalNot))
                 {
-                    c.ReportIssue(Diagnostic.Create(rule, logicalNot.GetLocation(), GetSuggestedReplacement(expression)));
+                    c.ReportIssue(rule, logicalNot, GetSuggestedReplacement(expression));
                 }
             };
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/BooleanLiteralUnnecessaryBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/BooleanLiteralUnnecessaryBase.cs
@@ -137,14 +137,14 @@ namespace SonarAnalyzer.Rules
 
             if (bothSideBool && !bothSideFalse && !bothSideTrue)
             {
-                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], thenBranch.CreateLocation(elseBranch)));
+                context.ReportIssue(SupportedDiagnostics[0], thenBranch.CreateLocation(elseBranch));
             }
             if (thenIsBooleanLiteral ^ elseIsBooleanLiteral)
             {
                 // one side is boolean literal, the other is NOT boolean literal
                 var booleanLiteralSide = thenIsBooleanLiteral ? thenBranch : elseBranch;
 
-                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], booleanLiteralSide.GetLocation()));
+                context.ReportIssue(SupportedDiagnostics[0], booleanLiteralSide);
             }
         }
 
@@ -172,7 +172,7 @@ namespace SonarAnalyzer.Rules
                     ? CalculateExtendedLocation(node, false)
                     : CalculateExtendedLocation(node, reportOnTrue == leftIsTrue);
 
-                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], errorLocation));
+                context.ReportIssue(SupportedDiagnostics[0], errorLocation);
                 return true;
             }
             return false;
@@ -186,7 +186,7 @@ namespace SonarAnalyzer.Rules
         {
             if (isBooleanLiteralKind(node) && GetLocation() is { } location)
             {
-                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], location));
+                context.ReportIssue(SupportedDiagnostics[0], location);
             }
 
             Location GetLocation() =>

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ClassNamedExceptionBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ClassNamedExceptionBase.cs
@@ -40,7 +40,7 @@ public abstract class ClassNamedExceptionBase<TSyntaxKind> : SonarDiagnosticAnal
                     && !classSymbol.DerivesFrom(KnownType.System_Exception)
                     && !classSymbol.Implements(KnownType.System_Runtime_InteropServices_Exception))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, classIdentifier.GetLocation()));
+                    c.ReportIssue(Rule, classIdentifier);
                 }
             },
             Language.SyntaxKind.ClassAndModuleDeclarations);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ClassShouldNotBeEmptyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ClassShouldNotBeEmptyBase.cs
@@ -58,7 +58,7 @@ public abstract class ClassShouldNotBeEmptyBase<TSyntaxKind, TDeclarationSyntax>
                     && !ShouldIgnoreBecauseOfName(identifier)
                     && !ShouldIgnoreBecauseOfBaseClassOrInterface(c.Node, c.SemanticModel))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), DeclarationTypeKeyword(c.Node)));
+                    c.ReportIssue(Rule, identifier, DeclarationTypeKeyword(c.Node));
                 }
             },
             Language.SyntaxKind.ClassAndRecordClassDeclarations);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CollectionEmptinessCheckingBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CollectionEmptinessCheckingBase.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules
             if (comparison.Compare(constant).IsEmptyOrNotEmpty()
                 && TryGetCountCall(expression, context.SemanticModel, out var location, out var typeArgument))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, location, typeArgument));
+                context.ReportIssue(Rule, location, typeArgument);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/CommentKeywordBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/CommentKeywordBase.cs
@@ -59,12 +59,12 @@ namespace SonarAnalyzer.Rules
                     {
                         foreach (var location in GetKeywordLocations(c.Tree, comment, ToDoKeyword))
                         {
-                            c.ReportIssue(Diagnostic.Create(toDoRule, location));
+                            c.ReportIssue(toDoRule, location);
                         }
 
                         foreach (var location in GetKeywordLocations(c.Tree, comment, FixMeKeyword))
                         {
-                            c.ReportIssue(Diagnostic.Create(fixMeRule, location));
+                            c.ReportIssue(fixMeRule, location);
                         }
                     }
                 });

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DateAndTimeShouldNotBeUsedasTypeForPrimaryKeyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DateAndTimeShouldNotBeUsedasTypeForPrimaryKeyBase.cs
@@ -50,7 +50,7 @@ public abstract class DateAndTimeShouldNotBeUsedasTypeForPrimaryKeyBase<TSyntaxK
                 {
                     foreach (var propertyType in TypeNodesOfTemporalKeyProperties(nodeContext))
                     {
-                        nodeContext.ReportIssue(Diagnostic.Create(Rule, propertyType.GetLocation(), Language.Syntax.NodeIdentifier(propertyType)));
+                        nodeContext.ReportIssue(Rule, propertyType, Language.Syntax.NodeIdentifier(propertyType)?.ValueText);
                     }
                 }, Language.SyntaxKind.ClassDeclaration);
             }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DateTimeFormatShouldNotBeHardcodedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DateTimeFormatShouldNotBeHardcodedBase.cs
@@ -54,7 +54,7 @@ public abstract class DateTimeFormatShouldNotBeHardcodedBase<TSyntaxKind, TInvoc
             && analysisContext.SemanticModel.GetSymbolInfo(identifier.Parent).Symbol is { } methodCallSymbol
             && CheckedTypes.Any(x => methodCallSymbol.ContainingType.ConstructedFrom.Is(x)))
         {
-            analysisContext.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], HardCodedArgumentLocation(invocation)));
+            analysisContext.ReportIssue(SupportedDiagnostics[0], HardCodedArgumentLocation(invocation));
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DebuggerDisplayUsesExistingMembersBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DebuggerDisplayUsesExistingMembersBase.cs
@@ -48,7 +48,7 @@ public abstract class DebuggerDisplayUsesExistingMembersBase<TAttributeSyntax, T
                     && Language.Syntax.StringValue(formatString, c.SemanticModel) is { } formatStringText
                     && FirstInvalidMemberName(c, formatStringText, attribute) is { } firstInvalidMember)
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, formatString.GetLocation(), firstInvalidMember));
+                    c.ReportIssue(Rule, formatString, firstInvalidMember);
                 }
             },
             Language.SyntaxKind.Attribute);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DeclareTypesInNamespacesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DeclareTypesInNamespacesBase.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules
                   }
 
                   var identifier = GetTypeIdentifier(declaration);
-                  c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.ValueText));
+                  c.ReportIssue(Rule, identifier.GetLocation(), identifier.ValueText);
               },
               SyntaxKinds);
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallInsecureSecurityAlgorithmBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallInsecureSecurityAlgorithmBase.cs
@@ -106,7 +106,7 @@ namespace SonarAnalyzer.Rules
         {
             foreach (var supportedDiagnostic in SupportedDiagnostics)
             {
-                context.ReportIssue(Diagnostic.Create(supportedDiagnostic, location));
+                context.ReportIssue(supportedDiagnostic, location);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallMethodsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCallMethodsBase.cs
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Rules
                 && IsInValidContext(invocation, analysisContext.SemanticModel)
                 && ShouldReportOnMethodCall(invocation, analysisContext.SemanticModel, disallowedMethodSignature))
             {
-                analysisContext.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], identifier.GetLocation(), disallowedMethodSignature.ToString()));
+                analysisContext.ReportIssue(SupportedDiagnostics[0], identifier.GetLocation(), disallowedMethodSignature.ToString());
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCheckZeroSizeCollectionBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotCheckZeroSizeCollectionBase.cs
@@ -62,7 +62,7 @@ namespace SonarAnalyzer.Rules
                 && context.SemanticModel.GetSymbolInfo(expression).Symbol is ISymbol symbol
                 && CollecionSizeTypeName(symbol) is { } symbolType)
             {
-                context.ReportIssue(Diagnostic.Create(Rule, issue.GetLocation(), symbol.Name, symbolType, result == CountComparisonResult.AlwaysTrue));
+                context.ReportIssue(Rule, issue, symbol.Name, symbolType, (result == CountComparisonResult.AlwaysTrue).ToString());
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotLockWeakIdentityObjectsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotLockWeakIdentityObjectsBase.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules
                 var lockExpression = Language.Syntax.NodeExpression(c.Node);
                 if (c.SemanticModel.GetSymbolInfo(lockExpression).Symbol?.GetSymbolType() is { } lockExpressionType && lockExpressionType.DerivesFromAny(weakIdentityTypes))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, lockExpression.GetLocation(), lockExpressionType.Name));
+                    c.ReportIssue(Rule, lockExpression, lockExpressionType.Name);
                 }
             }, SyntaxKind);
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/DoNotUseDateTimeNowBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/DoNotUseDateTimeNowBase.cs
@@ -43,7 +43,7 @@ public abstract class DoNotUseDateTimeNowBase<TSyntaxKind> : SonarDiagnosticAnal
             if ((IsDateTimeNowOrToday(c.Node, c.SemanticModel) || IsDateTimeOffsetNowDateTime(c.Node, c.SemanticModel))
                 && !IsInsideNameOf(c.Node))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                    c.ReportIssue(Rule, c.Node);
                 }
         }, Language.SyntaxKind.SimpleMemberAccessExpression);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/EmptyNestedBlockBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/EmptyNestedBlockBase.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules
                 {
                     foreach (var node in EmptyBlocks(c.Node))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
+                        c.ReportIssue(Rule, node);
                     }
                 },
                 SyntaxKinds);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/EnumNameHasEnumSuffixBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/EnumNameHasEnumSuffixBase.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules
                     if (Language.Syntax.NodeIdentifier(c.Node) is { } identifier
                         && nameEndings.FirstOrDefault(ending => identifier.ValueText.EndsWith(ending, System.StringComparison.OrdinalIgnoreCase)) is { } nameEnding)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.ValueText.Substring(identifier.ValueText.Length - nameEnding.Length)));
+                        c.ReportIssue(Rule, identifier, identifier.ValueText.Substring(identifier.ValueText.Length - nameEnding.Length));
                     }
                 },
                 Language.SyntaxKind.EnumDeclaration);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/EnumNameShouldFollowRegexBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/EnumNameShouldFollowRegexBase.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules
                     var pattern = c.Node.HasFlagsAttribute(c.SemanticModel) ? FlagsEnumNamePattern : EnumNamePattern;
                     if (Language.Syntax.NodeIdentifier(c.Node) is { } identifier && !NamingHelper.IsRegexMatch(identifier.ValueText, pattern))
                     {
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], identifier.GetLocation(), pattern));
+                        c.ReportIssue(SupportedDiagnostics[0], identifier, pattern);
                     }
                 },
                 Language.SyntaxKind.EnumDeclaration);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ExceptionsShouldBePublicBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ExceptionsShouldBePublicBase.cs
@@ -43,7 +43,7 @@ public abstract class ExceptionsShouldBePublicBase<TSyntaxKind> : SonarDiagnosti
                     && classSymbol.GetEffectiveAccessibility() != Accessibility.Public
                     && classSymbol.BaseType.IsAny(BaseTypes))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, Language.Syntax.NodeIdentifier(c.Node).Value.GetLocation()));
+                    c.ReportIssue(Rule, Language.Syntax.NodeIdentifier(c.Node).Value);
                 }
             },
             Language.SyntaxKind.ClassAndRecordClassDeclarations);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ExcludeFromCodeCoverageAttributesNeedJustificationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ExcludeFromCodeCoverageAttributesNeedJustificationBase.cs
@@ -43,7 +43,7 @@ public abstract class ExcludeFromCodeCoverageAttributesNeedJustificationBase<TSy
                     && attribute.IsInType(KnownType.System_Diagnostics_CodeAnalysis_ExcludeFromCodeCoverageAttribute)
                     && HasJustificationProperty(attribute.ContainingType))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                    c.ReportIssue(Rule, c.Node);
                 }
             },
             Language.SyntaxKind.Attribute);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ExpectedExceptionAttributeShouldNotBeUsedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ExpectedExceptionAttributeShouldNotBeUsedBase.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules
                     && c.SemanticModel.GetDeclaredSymbol(c.Node) is { } methodSymbol
                     && methodSymbol.GetAttributes(UnitTestHelper.KnownExpectedExceptionAttributes).FirstOrDefault() is { } attribute)
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, attribute.ApplicationSyntaxReference.GetSyntax().GetLocation()));
+                    c.ReportIssue(Rule, attribute.ApplicationSyntaxReference.GetSyntax());
                 }
             },
             Language.SyntaxKind.MethodDeclarations);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ExpressionComplexityBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ExpressionComplexityBase.cs
@@ -50,7 +50,7 @@ namespace SonarAnalyzer.Rules
                         var complexity = CalculateComplexity(c.Node);
                         if (complexity > Maximum)
                         {
-                            c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation(), Maximum, complexity));
+                            c.ReportIssue(rule, c.Node, Maximum.ToString(), complexity.ToString());
                         }
                     }
                 }, ComplexityIncreasingKinds.Concat(TransparentKinds).ToArray());

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ExtensionMethodShouldNotExtendObjectBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ExtensionMethodShouldNotExtendObjectBase.cs
@@ -43,7 +43,7 @@ public abstract class ExtensionMethodShouldNotExtendObjectBase<TSyntaxKind, TMet
                     && method.Parameters.Length > 0
                     && method.Parameters[0].Type.Is(KnownType.System_Object))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, Language.Syntax.NodeIdentifier(c.Node).Value.GetLocation()));
+                    c.ReportIssue(Rule, Language.Syntax.NodeIdentifier(c.Node).Value);
                 }
             },
             Language.SyntaxKind.MethodDeclarations);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FieldShouldNotBePublicBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FieldShouldNotBePublicBase.cs
@@ -49,7 +49,7 @@ namespace SonarAnalyzer.Rules
                     foreach (var variable in variables.Select(x => new Pair(x, c.SemanticModel.GetDeclaredSymbol(x) as IFieldSymbol)).Where(x => FieldIsRelevant(x.Symbol)))
                     {
                         var identifier = Language.Syntax.NodeIdentifier(variable.Node);
-                        c.ReportIssue(Diagnostic.Create(Rule, identifier.Value.GetLocation(), identifier.Value.ValueText));
+                        c.ReportIssue(Rule, identifier.Value, identifier.Value.ValueText);
                     }
                 },
                 Language.SyntaxKind.FieldDeclaration);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FileLinesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FileLinesBase.cs
@@ -50,8 +50,7 @@ namespace SonarAnalyzer.Rules
 
                     if (linesCount > Maximum)
                     {
-                        stac.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], Location.Create(stac.Tree,
-                            TextSpan.FromBounds(0, 0)), Maximum, linesCount));
+                        stac.ReportIssue(SupportedDiagnostics[0], Location.Create(stac.Tree, TextSpan.FromBounds(0, 0)), Maximum.ToString(), linesCount.ToString());
                     }
                 });
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FindInsteadOfFirstOrDefaultBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FindInsteadOfFirstOrDefaultBase.cs
@@ -49,7 +49,7 @@ public abstract class FindInsteadOfFirstOrDefaultBase<TSyntaxKind, TInvocationEx
                     && IsCorrectType(left, c.SemanticModel, out var isArray)
                     && !Language.Syntax.IsInExpressionTree(c.SemanticModel, invocation))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, Language.Syntax.NodeIdentifier(invocation)?.GetLocation(), isArray ? ArrayMessage : GenericMessage));
+                    c.ReportIssue(Rule, Language.Syntax.NodeIdentifier(invocation)?.GetLocation(), isArray ? ArrayMessage : GenericMessage);
                 }
             },
             Language.SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FlagsEnumWithoutInitializerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FlagsEnumWithoutInitializerBase.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules
                 {
                     if (c.Node.HasFlagsAttribute(c.SemanticModel) && !AreAllRequiredMembersInitialized(c.Node) && Language.Syntax.NodeIdentifier(c.Node) is { } identifier)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation()));
+                        c.ReportIssue(Rule, identifier);
                     }
                 },
                 Language.SyntaxKind.EnumDeclaration);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FlagsEnumZeroMemberBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FlagsEnumZeroMemberBase.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules
                         && Language.Syntax.NodeIdentifier(zeroMember) is { } identifier
                         && identifier.ValueText != "None")
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, zeroMember.GetLocation(), identifier.ValueText));
+                        c.ReportIssue(Rule, zeroMember, identifier.ValueText);
                     }
                 },
                 Language.SyntaxKind.EnumDeclaration);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/FunctionComplexityBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/FunctionComplexityBase.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules
             var complexity = GetComplexity(nodeToAnalyze, context.SemanticModel);
             if (complexity > Maximum)
             {
-                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], location(syntax), Maximum, complexity, declarationType));
+                context.ReportIssue(SupportedDiagnostics[0], location(syntax), Maximum.ToString(), complexity.ToString(), declarationType);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/GenericInheritanceShouldNotBeRecursiveBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/GenericInheritanceShouldNotBeRecursiveBase.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules
                     if (!c.IsRedundantPositionalRecordContext()
                         && IsRecursiveInheritance(GetNamedTypeSymbol(declaration, c.SemanticModel)))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, GetLocation(declaration), GetKeyword(declaration)));
+                        c.ReportIssue(Rule, GetLocation(declaration), GetKeyword(declaration).ValueText);
                     }
                 },
                 SyntaxKinds);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/GotoStatementBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/GotoStatementBase.cs
@@ -35,7 +35,7 @@ namespace SonarAnalyzer.Rules
         protected sealed override void Initialize(SonarAnalysisContext context) =>
             context.RegisterNodeAction(
                 Language.GeneratedCodeRecognizer,
-                c => c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetFirstToken().GetLocation())),
+                c => c.ReportIssue(Rule, c.Node.GetFirstToken()),
                 GotoSyntaxKinds);
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/DoNotHardcodeCredentialsBase.cs
@@ -255,7 +255,7 @@ namespace SonarAnalyzer.Rules
                         && GetAssignedValue(declarator, context.SemanticModel) is { } variableValue
                         && analyzer.IssueMessage(GetVariableName(declarator), variableValue) is { } message)
                     {
-                        context.ReportIssue(Diagnostic.Create(analyzer.rule, declarator.GetLocation(), message));
+                        context.ReportIssue(analyzer.rule, declarator, message);
                     }
                 };
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/HardcodedIpAddressBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/HardcodedIpAddressBase.cs
@@ -85,7 +85,7 @@ namespace SonarAnalyzer.Rules
                 && Language.Syntax.LiteralText(stringLiteral) is var literalValue
                 && IsHardcodedIp(literalValue, stringLiteral))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, stringLiteral.GetLocation(), literalValue));
+                context.ReportIssue(Rule, stringLiteral, literalValue);
             }
         }
 
@@ -95,7 +95,7 @@ namespace SonarAnalyzer.Rules
                 && Language.Syntax.TryGetInterpolatedTextValue(context.Node, context.SemanticModel, out var stringContent)
                 && IsHardcodedIp(stringContent, context.Node))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, context.Node.GetLocation(), stringContent));
+                context.ReportIssue(Rule, context.Node, stringContent);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/PubliclyWritableDirectoriesBase.cs
@@ -76,7 +76,7 @@ namespace SonarAnalyzer.Rules
                         && Language.Syntax.StringValue(c.Node, c.SemanticModel) is { } stringValue
                         && IsSensitiveDirectoryUsage(stringValue))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation()));
+                        c.ReportIssue(rule, c.Node);
                     }
                 },
                 kinds.ToArray());
@@ -90,7 +90,7 @@ namespace SonarAnalyzer.Rules
                         && (IsGetTempPathAssignment(invocation, KnownType.System_IO_Path, "GetTempPath", c.SemanticModel)
                             || IsInsecureEnvironmentVariableRetrieval(invocation, KnownType.System_Environment, "GetEnvironmentVariable", c.SemanticModel)))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation()));
+                        c.ReportIssue(rule, c.Node);
                     }
                 },
                 Language.SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/SpecifyTimeoutOnRegexBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/SpecifyTimeoutOnRegexBase.cs
@@ -64,7 +64,7 @@ public abstract class SpecifyTimeoutOnRegexBase<TSyntaxKind> : HotspotDiagnostic
                 if (IsCandidateCtor(c.Node)
                     && RegexMethodLacksTimeout(c.Node, c.SemanticModel))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                    c.ReportIssue(Rule, c.Node);
                 }
             },
             Language.SyntaxKind.ObjectCreationExpressions);
@@ -81,7 +81,7 @@ public abstract class SpecifyTimeoutOnRegexBase<TSyntaxKind> : HotspotDiagnostic
                 if (IsRegexMatchMethod(Language.Syntax.NodeIdentifier(c.Node).GetValueOrDefault().Text)
                     && RegexMethodLacksTimeout(c.Node, c.SemanticModel))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                    c.ReportIssue(Rule, c.Node.GetLocation());
                 }
             },
             Language.SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/SpecifyTimeoutOnRegexBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/SpecifyTimeoutOnRegexBase.cs
@@ -81,7 +81,7 @@ public abstract class SpecifyTimeoutOnRegexBase<TSyntaxKind> : HotspotDiagnostic
                 if (IsRegexMatchMethod(Language.Syntax.NodeIdentifier(c.Node).GetValueOrDefault().Text)
                     && RegexMethodLacksTimeout(c.Node, c.SemanticModel))
                 {
-                    c.ReportIssue(Rule, c.Node.GetLocation());
+                    c.ReportIssue(Rule, c.Node);
                 }
             },
             Language.SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/UsingNonstandardCryptographyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/Hotspots/UsingNonstandardCryptographyBase.cs
@@ -59,7 +59,7 @@ namespace SonarAnalyzer.Rules
                         && DerivesOrImplementsAny(declaration)
                         && DeclaredSymbol(declaration, c.SemanticModel).DerivesOrImplementsAny(nonInheritableClassesAndInterfaces))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, Location(declaration)));
+                        c.ReportIssue(rule, Location(declaration));
                     }
                 },
                 SyntaxKinds);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/IfChainWithoutElseBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/IfChainWithoutElseBase.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(Rule, IssueLocation(c, ifNode), ElseClause));
+                    c.ReportIssue(Rule, IssueLocation(c, ifNode), ElseClause);
                 },
                 SyntaxKind);
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/IndexOfCheckAgainstZeroBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/IndexOfCheckAgainstZeroBase.cs
@@ -61,7 +61,7 @@ namespace SonarAnalyzer.Rules
                     var lessThan = (TBinaryExpressionSyntax)c.Node;
                     if (IsInvalidComparison(Left(lessThan), Right(lessThan), c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, Left(lessThan).CreateLocation(OperatorToken(lessThan))));
+                        c.ReportIssue(Rule, Left(lessThan).CreateLocation(OperatorToken(lessThan)));
                     }
                 },
                 LessThanExpression);
@@ -73,7 +73,7 @@ namespace SonarAnalyzer.Rules
                     var greaterThan = (TBinaryExpressionSyntax)c.Node;
                     if (IsInvalidComparison(Right(greaterThan), Left(greaterThan), c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, OperatorToken(greaterThan).CreateLocation(Right(greaterThan))));
+                        c.ReportIssue(Rule, OperatorToken(greaterThan).CreateLocation(Right(greaterThan)));
                     }
                 },
                 GreaterThanExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/InsecureTemporaryFilesCreationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/InsecureTemporaryFilesCreationBase.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules
             var memberAccess = (TMemberAccessSyntax)context.Node;
             if (Language.Syntax.IsMemberAccessOnKnownType(memberAccess, VulnerableApiName, KnownType.System_IO_Path, context.SemanticModel))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, memberAccess.GetLocation()));
+                context.ReportIssue(Rule, memberAccess);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/InsteadOfAnyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/InsteadOfAnyBase.cs
@@ -124,5 +124,5 @@ public abstract class InsteadOfAnyBase<TSyntaxKind, TInvocationExpression> : Son
         && method.IsExtensionOn(KnownType.System_Collections_Generic_IEnumerable_T);
 
     private void RaiseIssue(SonarSyntaxNodeReportingContext c, SyntaxNode invocation, DiagnosticDescriptor rule, string methodName) =>
-        c.ReportIssue(Diagnostic.Create(rule, Language.Syntax.NodeIdentifier(invocation)?.GetLocation(), methodName));
+        c.ReportIssue(rule, Language.Syntax.NodeIdentifier(invocation)?.GetLocation(), methodName);
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/InvalidCastToInterfaceBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/InvalidCastToInterfaceBase.cs
@@ -51,7 +51,7 @@ public abstract class InvalidCastToInterfaceBase<TSyntaxKind> : SonarDiagnosticA
                             var interfaceTypeName = interfaceType.ToMinimalDisplayString(c.SemanticModel, location.SourceSpan.Start);
                             var expressionTypeName = expressionType.ToMinimalDisplayString(c.SemanticModel, location.SourceSpan.Start);
                             var message = expressionType.IsInterface() ? MessageInterface : MessageClass;
-                            c.ReportIssue(Diagnostic.Create(Rule, location, string.Format(message, expressionTypeName, interfaceTypeName)));
+                            c.ReportIssue(Rule, location, string.Format(message, expressionTypeName, interfaceTypeName));
                         }
                     },
                     Language.SyntaxKind.CastExpressions);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/LineLengthBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/LineLengthBase.cs
@@ -42,8 +42,7 @@ namespace SonarAnalyzer.Rules
                     foreach (var line in c.Tree.GetText().Lines
                         .Where(line => line.Span.Length > Maximum))
                     {
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], c.Tree.GetLocation(line.Span),
-                            Maximum, line.Span.Length));
+                        c.ReportIssue(SupportedDiagnostics[0], c.Tree.GetLocation(line.Span), Maximum.ToString(), line.Span.Length.ToString());
                     }
                 });
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/LinkedListPropertiesInsteadOfMethodsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/LinkedListPropertiesInsteadOfMethodsBase.cs
@@ -40,7 +40,7 @@ public abstract class LinkedListPropertiesInsteadOfMethodsBase<TSyntaxKind, TInv
 
             if (IsFirstOrLast(methodName) && IsRelevantCallAndType(invocation, c.SemanticModel))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, Language.Syntax.NodeIdentifier(invocation)?.GetLocation(), methodName));
+                c.ReportIssue(Rule, Language.Syntax.NodeIdentifier(invocation)?.GetLocation(), methodName);
             }
         }, Language.SyntaxKind.InvocationExpression);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MarkWindowsFormsMainWithStaThreadBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MarkWindowsFormsMainWithStaThreadBase.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules
                     ? ChangeMtaThreadToStaThreadMessage
                     : AddStaThreadMessage;
 
-                c.ReportIssue(Diagnostic.Create(Rule, GetLocation(methodDeclaration), message));
+                c.ReportIssue(Rule, GetLocation(methodDeclaration), message);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MethodsShouldNotHaveTooManyLinesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MethodsShouldNotHaveTooManyLinesBase.cs
@@ -61,13 +61,13 @@ namespace SonarAnalyzer.Rules
 
                         if (!string.IsNullOrEmpty(identifierToken?.ValueText))
                         {
-                            c.ReportIssue(Diagnostic.Create(
+                            c.ReportIssue(
                                 SupportedDiagnostics[0],
-                                identifierToken.Value.GetLocation(),
+                                identifierToken.Value,
                                 GetMethodKindAndName(identifierToken.Value),
-                                linesCount,
-                                Max,
-                                MethodKeyword));
+                                linesCount.ToString(),
+                                Max.ToString(),
+                                MethodKeyword);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.Common/Rules/MultipleVariableDeclarationBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/MultipleVariableDeclarationBase.cs
@@ -59,7 +59,7 @@ public abstract class MultipleVariableDeclarationBase<TSyntaxKind> : SonarDiagno
         }
         foreach (var variable in variables.Skip(1))
         {
-            context.ReportIssue(Diagnostic.Create(rule, variable.GetLocation(), variable.ValueText));
+            context.ReportIssue(rule, variable, variable.ValueText);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/NameOfShouldBeUsedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/NameOfShouldBeUsedBase.cs
@@ -88,7 +88,7 @@ namespace SonarAnalyzer.Rules
 
             foreach (var stringTokenAndParam in GetStringTokenAndParamNamePairs(stringTokensInsideThrowExpressions, parameterNames))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, stringTokenAndParam.Key.GetLocation(), stringTokenAndParam.Value, NameOf));
+                context.ReportIssue(Rule, stringTokenAndParam.Key.GetLocation(), stringTokenAndParam.Value, NameOf);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/NameOfShouldBeUsedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/NameOfShouldBeUsedBase.cs
@@ -88,7 +88,7 @@ namespace SonarAnalyzer.Rules
 
             foreach (var stringTokenAndParam in GetStringTokenAndParamNamePairs(stringTokensInsideThrowExpressions, parameterNames))
             {
-                context.ReportIssue(Rule, stringTokenAndParam.Key.GetLocation(), stringTokenAndParam.Value, NameOf);
+                context.ReportIssue(Rule, stringTokenAndParam.Key, stringTokenAndParam.Value, NameOf);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ObsoleteAttributesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ObsoleteAttributesBase.cs
@@ -54,11 +54,11 @@ public abstract class ObsoleteAttributesBase<TSyntaxKind> : SonarDiagnosticAnaly
                     && attribute.IsInType(KnownType.System_ObsoleteAttribute))
                 {
                     var location = c.Node.GetLocation();
-                    c.ReportIssue(Diagnostic.Create(RemoveRule, location));
+                    c.ReportIssue(RemoveRule, location);
 
                     if (NoExplanation(c.Node, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(ExplanationNeededRule, location));
+                        c.ReportIssue(ExplanationNeededRule, location);
                     }
                 }
             },

--- a/analyzers/src/SonarAnalyzer.Common/Rules/OptionalParameterBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/OptionalParameterBase.cs
@@ -55,7 +55,7 @@ namespace SonarAnalyzer.Rules
                     foreach (var parameter in parameters.Where(p => IsOptional(p) && !HasAllowedAttribute(p, c.SemanticModel)))
                     {
                         var location = GetReportLocation(parameter);
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], location));
+                        c.ReportIssue(SupportedDiagnostics[0], location);
                     }
                 },
                 SyntaxKindsOfInterest.ToArray());

--- a/analyzers/src/SonarAnalyzer.Common/Rules/OptionalParameterNotPassedToBaseCallBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/OptionalParameterNotPassedToBaseCallBase.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules
             var pluralize = difference > 1
                 ? "s"
                 : string.Empty;
-            c.ReportIssue(Diagnostic.Create(Rule, invocation.GetLocation(), pluralize));
+            c.ReportIssue(Rule, invocation, pluralize);
         }
 
         protected abstract int GetArgumentCount(TInvocationExpressionSyntax invocation);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParameterAssignedToBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParameterAssignedToBase.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules
                             && (symbol is IParameterSymbol { RefKind: RefKind.None } || IsAssignmentToCatchVariable(symbol, target))
                             && !IsReadBefore(c.SemanticModel, symbol, c.Node))
                         {
-                            c.ReportIssue(Diagnostic.Create(Rule, target.GetLocation(), target.ToString()));
+                            c.ReportIssue(Rule, target, target.ToString());
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParameterNameMatchesOriginalBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParameterNameMatchesOriginalBase.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules
                                     .Zip(expectedParameters, (actual, expected) => new { actual, expected })
                                     .Where(x => !x.actual.ValueText.Equals(x.expected.Name, Language.NameComparison)))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, item.actual.GetLocation(), item.actual.ValueText, item.expected.Name, expectedLocation));
+                context.ReportIssue(Rule, item.actual, item.actual.ValueText, item.expected.Name, expectedLocation);
             }
         }
 
@@ -84,7 +84,7 @@ namespace SonarAnalyzer.Rules
                     && (expectedParameter.Type.Kind != SymbolKind.TypeParameter
                         || actualParameters[i].Type.Kind == SymbolKind.TypeParameter))
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, parameter.GetLocation(), parameter.ValueText, expectedParameter.Name, expectedLocation));
+                    context.ReportIssue(Rule, parameter.GetLocation(), parameter.ValueText, expectedParameter.Name, expectedLocation);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ParameterNameMatchesOriginalBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ParameterNameMatchesOriginalBase.cs
@@ -84,7 +84,7 @@ namespace SonarAnalyzer.Rules
                     && (expectedParameter.Type.Kind != SymbolKind.TypeParameter
                         || actualParameters[i].Type.Kind == SymbolKind.TypeParameter))
                 {
-                    context.ReportIssue(Rule, parameter.GetLocation(), parameter.ValueText, expectedParameter.Name, expectedLocation);
+                    context.ReportIssue(Rule, parameter, parameter.ValueText, expectedParameter.Name, expectedLocation);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PartCreationPolicyShouldBeUsedWithExportAttributeBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PartCreationPolicyShouldBeUsedWithExportAttributeBase.cs
@@ -53,7 +53,7 @@ namespace SonarAnalyzer.Rules
                 return;
             }
 
-            c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], attribute.GetLocation()));
+            c.ReportIssue(SupportedDiagnostics[0], attribute);
 
             bool IsPartCreationPolicyAttribute(TAttributeSyntax attributeSyntax) =>
                 c.SemanticModel.GetSymbolInfo(attributeSyntax).Symbol is IMethodSymbol attributeSymbol

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PreferGuidEmptyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PreferGuidEmptyBase.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules
                         && c.SemanticModel.GetSymbolInfo(c.Node).Symbol is IMethodSymbol methodSymbol
                         && methodSymbol.ContainingType.Is(KnownType.System_Guid))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                        c.ReportIssue(Rule, c.Node);
                     }
                 },
                 Language.SyntaxKind.ObjectCreationExpressions);
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules
                     if (!IsInParameter(c.Node)
                         && c.SemanticModel.GetTypeInfo(c.Node).ConvertedType.Is(KnownType.System_Guid))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                        c.ReportIssue(Rule, c.Node);
                     }
                 },
                 Language.SyntaxKind.DefaultExpressions);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertyGetterWithThrowBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertyGetterWithThrowBase.cs
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.Rules
                                 return;
                             }
 
-                            c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], c.Node.GetLocation()));
+                            c.ReportIssue(SupportedDiagnostics[0], c.Node);
                         },
                         ThrowSyntaxKind);
                 });

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PropertyWriteOnlyBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PropertyWriteOnlyBase.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules
                     var prop = (TPropertyDeclaration)c.Node;
                     if (IsWriteOnlyProperty(prop) && Language.Syntax.NodeIdentifier(prop) is { }  identifier)
                     {
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], identifier.GetLocation(), identifier.ValueText));
+                        c.ReportIssue(SupportedDiagnostics[0], identifier, identifier.ValueText);
                     }
                 },
                 SyntaxKind);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PublicConstantFieldBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PublicConstantFieldBase.cs
@@ -58,8 +58,7 @@ namespace SonarAnalyzer.Rules
 
                     foreach (var variable in variables)
                     {
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], GetReportLocation(variable),
-                            MessageArgument));
+                        c.ReportIssue(SupportedDiagnostics[0], GetReportLocation(variable), MessageArgument);
                     }
                 },
                 FieldDeclarationKind);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/PublicMethodWithMultidimensionalArrayBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/PublicMethodWithMultidimensionalArrayBase.cs
@@ -42,7 +42,7 @@ public abstract class PublicMethodWithMultidimensionalArrayBase<TSyntaxKind> : S
                     && methodSymbol.IsPubliclyAccessible()
                     && MethodHasMultidimensionalArrayParameters(methodSymbol))
                 {
-                    c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], GetIssueLocation(c.Node), GetType(c.Node)));
+                    c.ReportIssue(SupportedDiagnostics[0], GetIssueLocation(c.Node), GetType(c.Node));
                 }
             },
             SyntaxKindsOfInterest.ToArray());

--- a/analyzers/src/SonarAnalyzer.Common/Rules/RedundantNullCheckBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/RedundantNullCheckBase.cs
@@ -50,13 +50,13 @@ namespace SonarAnalyzer.Rules
                 && GetIsOperatorCheckVariable(binaryExpressionRight) is  SyntaxNode isCheckVariable1
                 && AreEquivalent(nonNullCheckVariable1, isCheckVariable1))
             {
-                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], binaryExpressionLeft.GetLocation()));
+                context.ReportIssue(SupportedDiagnostics[0], binaryExpressionLeft);
             }
             if (GetNonNullCheckVariable(binaryExpressionRight) is SyntaxNode nonNullCheckVariable2
                 && GetIsOperatorCheckVariable(binaryExpressionLeft) is SyntaxNode isCheckVariable2
                 && AreEquivalent(nonNullCheckVariable2, isCheckVariable2))
             {
-                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], binaryExpressionRight.GetLocation()));
+                context.ReportIssue(SupportedDiagnostics[0], binaryExpressionRight);
             }
         }
 
@@ -71,13 +71,13 @@ namespace SonarAnalyzer.Rules
                 && GetInvertedIsOperatorCheckVariable(binaryExpressionRight) is SyntaxNode invertedIsCheckVariable1
                 && AreEquivalent(nullCheckVariable1, invertedIsCheckVariable1))
             {
-                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], binaryExpressionLeft.GetLocation()));
+                context.ReportIssue(SupportedDiagnostics[0], binaryExpressionLeft);
             }
             if (GetNullCheckVariable(binaryExpressionRight) is SyntaxNode nullCheckVariable2
                 && GetInvertedIsOperatorCheckVariable(binaryExpressionLeft) is SyntaxNode invertedIsCheckVariable2
                 && AreEquivalent(nullCheckVariable2, invertedIsCheckVariable2))
             {
-                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], binaryExpressionRight.GetLocation()));
+                context.ReportIssue(SupportedDiagnostics[0], binaryExpressionRight);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/RegularExpressions/RegexMustHaveValidSyntaxBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/RegularExpressions/RegexMustHaveValidSyntaxBase.cs
@@ -53,7 +53,7 @@ public abstract class RegexMustHaveValidSyntaxBase<TSyntaxKind> : SonarDiagnosti
     {
         if (context?.ParseError is { } error)
         {
-            c.ReportIssue(Diagnostic.Create(Rule, context.PatternNode.GetLocation(), error.Message));
+            c.ReportIssue(Rule, context.PatternNode, error.Message);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ReversedOperatorsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ReversedOperatorsBase.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules
                 if (TiedTogether(equalsSignSpan, operatorSpan) &&
                     !(IsMinusToken(operatorToken) && TiedTogether(operatorSpan, operandSpan)))
                 {
-                    c.ReportIssue(Diagnostic.Create(rule, operatorLocation, $"{operatorToken.Text}="));
+                    c.ReportIssue(rule, operatorLocation, $"{operatorToken.Text}=");
                 }
             };
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SecurityPInvokeMethodShouldNotBeCalledBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SecurityPInvokeMethodShouldNotBeCalledBase.cs
@@ -66,7 +66,7 @@ namespace SonarAnalyzer.Rules
                 && methodSymbol.IsStatic
                 && IsImportFromInteropDll(methodSymbol, analysisContext.SemanticModel))
             {
-                analysisContext.ReportIssue(Diagnostic.Create(Rule, Language.Syntax.NodeIdentifier(directMethodCall).Value.GetLocation(), GetMethodName(methodSymbol, analysisContext.SemanticModel)));
+                analysisContext.ReportIssue(Rule, Language.Syntax.NodeIdentifier(directMethodCall).Value, GetMethodName(methodSymbol, analysisContext.SemanticModel));
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SetPropertiesInsteadOfMethodsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SetPropertiesInsteadOfMethodsBase.cs
@@ -48,7 +48,7 @@ public abstract class SetPropertiesInsteadOfMethodsBase<TSyntaxKind, TInvocation
                 && IsCorrectType(typeNode, c.SemanticModel)
                 && IsCorrectCall(methodNode, c.SemanticModel))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, Language.Syntax.NodeIdentifier(invocation)?.GetLocation(), methodName));
+                c.ReportIssue(Rule, Language.Syntax.NodeIdentifier(invocation)?.GetLocation(), methodName);
             }
         }, Language.SyntaxKind.InvocationExpression);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ShiftDynamicNotIntegerBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ShiftDynamicNotIntegerBase.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules
                 && ShouldRaise(context.SemanticModel, left, right))
             {
                 var typeInMessage = GetTypeNameForMessage(right, typeOfRight, context.SemanticModel);
-                context.ReportIssue(Diagnostic.Create(Rule, right.GetLocation(), typeInMessage));
+                context.ReportIssue(Rule, right, typeInMessage);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ShouldImplementExportedInterfacesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ShouldImplementExportedInterfacesBase.cs
@@ -69,11 +69,12 @@ namespace SonarAnalyzer.Rules
                                      ? ActionForInterface
                                      : ActionForClass;
 
-                    c.ReportIssue(Rule,
-                                  attributeSyntax,
-                                  action,
-                                  exportedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                                  attributeTargetType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+                    c.ReportIssue(
+                        Rule,
+                        attributeSyntax,
+                        action,
+                        exportedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        attributeTargetType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
                 },
                 Language.SyntaxKind.Attribute);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ShouldImplementExportedInterfacesBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ShouldImplementExportedInterfacesBase.cs
@@ -69,12 +69,11 @@ namespace SonarAnalyzer.Rules
                                      ? ActionForInterface
                                      : ActionForClass;
 
-                    c.ReportIssue(
-                        Diagnostic.Create(Rule,
-                            attributeSyntax.GetLocation(),
-                            action,
-                            exportedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                            attributeTargetType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+                    c.ReportIssue(Rule,
+                                  attributeSyntax,
+                                  action,
+                                  exportedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                                  attributeTargetType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
                 },
                 Language.SyntaxKind.Attribute);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/SingleStatementPerLineBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/SingleStatementPerLineBase.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules
                     foreach (var statementsByLine in statementsByLines.Where(pair => pair.Value.Count > 1))
                     {
                         var location = CalculateLocationForLine(lines[statementsByLine.Key], c.Tree, statementsByLine.Value);
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], location));
+                        c.ReportIssue(SupportedDiagnostics[0], location);
                     }
                 });
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/StringConcatenationInLoopBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/StringConcatenationInLoopBase.cs
@@ -51,7 +51,7 @@ namespace SonarAnalyzer.Rules
                 && context.SemanticModel.GetSymbolInfo(assigned).Symbol is ILocalSymbol
                 && AreNotDefinedInTheSameLoop(assigned, assignment, context.SemanticModel))
             {
-                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], assignment.GetLocation()));
+                context.ReportIssue(SupportedDiagnostics[0], assignment);
             }
         }
 
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules
                 && context.SemanticModel.GetSymbolInfo(expression).Symbol is ILocalSymbol
                 && AreNotDefinedInTheSameLoop(expression, addAssignment, context.SemanticModel))
             {
-                context.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], addAssignment.GetLocation()));
+                context.ReportIssue(SupportedDiagnostics[0], addAssignment);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/TabCharacterBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/TabCharacterBase.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules
                     }
 
                     var location = c.Tree.GetLocation(TextSpan.FromBounds(offset, offset));
-                    c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], location));
+                    c.ReportIssue(SupportedDiagnostics[0], location);
                 });
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/TestsShouldNotUseThreadSleepBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/TestsShouldNotUseThreadSleepBase.cs
@@ -40,7 +40,7 @@ public abstract class TestsShouldNotUseThreadSleepBase<TMethodSyntax, TSyntaxKin
                 && method.Is(KnownType.System_Threading_Thread, nameof(Thread.Sleep))
                 && IsInTestMethod(c.Node, c.SemanticModel))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                c.ReportIssue(Rule, c.Node);
             }
         },
         Language.SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ThrowReservedExceptionsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ThrowReservedExceptionsBase.cs
@@ -45,7 +45,7 @@ public abstract class ThrowReservedExceptionsBase<TSyntaxKind> : SonarDiagnostic
             var expressionType = context.SemanticModel.GetTypeInfo(thrownExpression).Type;
             if (expressionType.IsAny(reservedExceptions))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, thrownExpression.GetLocation(), expressionType.ToDisplayString()));
+                context.ReportIssue(Rule, thrownExpression, expressionType.ToDisplayString());
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ToStringShouldNotReturnNullBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ToStringShouldNotReturnNullBase.cs
@@ -45,7 +45,7 @@ public abstract class ToStringShouldNotReturnNullBase<TSyntaxKind> : SonarDiagno
     {
         if (node is not null && ReturnsNull(Language.Syntax.NodeExpression(node)) && WithinToString(node))
         {
-            context.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
+            context.ReportIssue(Rule, node);
         }
     }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/TooManyLabelsInSwitchBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/TooManyLabelsInSwitchBase.cs
@@ -63,8 +63,7 @@ namespace SonarAnalyzer.Rules
                     var sectionsCount = GetSectionsCount(switchNode);
                     if (sectionsCount > Maximum)
                     {
-                        c.ReportIssue(
-                            Diagnostic.Create(Rule, GetKeywordLocation(switchNode), Maximum, sectionsCount));
+                        c.ReportIssue(Rule, GetKeywordLocation(switchNode), Maximum.ToString(), sectionsCount.ToString());
                     }
                 },
                 SyntaxKinds);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/TooManyParametersBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/TooManyParametersBase.cs
@@ -57,7 +57,7 @@ namespace SonarAnalyzer.Rules
                         && CanBeChanged(parent, c.SemanticModel))
                     {
                         var valueText = baseCount == 0 ? parametersCount.ToString() : $"{parametersCount - baseCount} new";
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], c.Node.GetLocation(), UserFriendlyNameForNode(c.Node.Parent), valueText, Maximum));
+                        c.ReportIssue(SupportedDiagnostics[0], c.Node, UserFriendlyNameForNode(c.Node.Parent), valueText, Maximum.ToString());
                     }
                 },
                 Language.SyntaxKind.ParameterList);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UnaryPrefixOperatorRepeatedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UnaryPrefixOperatorRepeatedBase.cs
@@ -64,8 +64,7 @@ namespace SonarAnalyzer.Rules
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(Rule, topLevelUnary.CreateLocation(GetOperatorToken(lastUnary)),
-                        GetOperatorToken(topLevelUnary).ToString()));
+                    c.ReportIssue(Rule, topLevelUnary.CreateLocation(GetOperatorToken(lastUnary)), GetOperatorToken(topLevelUnary).ValueText);
                 }, SyntaxKinds.ToArray());
         }
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UnconditionalJumpStatementBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UnconditionalJumpStatementBase.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules
                     walker.Visit();
                     foreach (var node in walker.GetRuleViolations())
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
+                        c.ReportIssue(Rule, node);
                     }
                 },
                 LoopStatements.ToArray());

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UnusedStringBuilderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UnusedStringBuilderBase.cs
@@ -48,7 +48,7 @@ public abstract class UnusedStringBuilderBase<TSyntaxKind, TVariableDeclarator, 
                 && GetScope(variableDeclarator) is { } scope
                 && !IsStringBuilderAccessed(c.SemanticModel, symbol, scope))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, variableDeclarator.GetLocation()));
+                c.ReportIssue(Rule, variableDeclarator);
             }
         }, Language.SyntaxKind.VariableDeclarator);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UriShouldNotBeHardcodedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UriShouldNotBeHardcodedBase.cs
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules
                 {
                     if (UriRegex.SafeIsMatch(Language.Syntax.LiteralText(c.Node)) && IsInCheckedContext(c.Node, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], c.Node.GetLocation(), AbsoluteUriMessage));
+                        c.ReportIssue(SupportedDiagnostics[0], c.Node, AbsoluteUriMessage);
                     }
                 },
                 Language.SyntaxKind.StringLiteralExpressions);
@@ -91,13 +91,13 @@ namespace SonarAnalyzer.Rules
                     var leftNode = Language.Syntax.BinaryExpressionLeft(c.Node);
                     if (IsPathDelimiter(leftNode) && isInCheckedContext.Value)
                     {
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], leftNode.GetLocation(), PathDelimiterMessage));
+                        c.ReportIssue(SupportedDiagnostics[0], leftNode, PathDelimiterMessage);
                     }
 
                     var rightNode = Language.Syntax.BinaryExpressionRight(c.Node);
                     if (IsPathDelimiter(rightNode) && isInCheckedContext.Value)
                     {
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], rightNode.GetLocation(), PathDelimiterMessage));
+                        c.ReportIssue(SupportedDiagnostics[0], rightNode, PathDelimiterMessage);
                     }
                 },
                 StringConcatenateExpressions);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseCharOverloadOfStringMethodsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseCharOverloadOfStringMethodsBase.cs
@@ -50,7 +50,7 @@ public abstract class UseCharOverloadOfStringMethodsBase<TSyntaxKind, TInvocatio
                     && Language.Syntax.TryGetOperands(invocation, out var left, out _)
                     && IsCorrectType(left, c.SemanticModel))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, Language.Syntax.NodeIdentifier(invocation)?.GetLocation(), methodName));
+                    c.ReportIssue(Rule, Language.Syntax.NodeIdentifier(invocation)?.GetLocation(), methodName);
                 }
             }, Language.SyntaxKind.InvocationExpression);
         });

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseDateTimeOffsetInsteadOfDateTimeBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseDateTimeOffsetInsteadOfDateTimeBase.cs
@@ -48,7 +48,7 @@ public abstract class UseDateTimeOffsetInsteadOfDateTimeBase<TSyntaxKind> : Sona
                 if ((c.Node.RawKind == (int)SyntaxKindEx.ImplicitObjectCreationExpression || IsNamedDateTime(GetTypeName(c.Node)))
                     && IsDateTimeType(c.Node, c.SemanticModel))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                    c.ReportIssue(Rule, c.Node);
                 }
             },
             Language.SyntaxKind.ObjectCreationExpressions);
@@ -62,7 +62,7 @@ public abstract class UseDateTimeOffsetInsteadOfDateTimeBase<TSyntaxKind> : Sona
                     && TargetMemberAccess.Contains(Language.GetName(c.Node))
                     && IsDateTimeType(expression, c.SemanticModel))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, Language.Syntax.NodeExpression(c.Node).GetLocation()));
+                    c.ReportIssue(Rule, Language.Syntax.NodeExpression(c.Node));
                 }
             },
             Language.SyntaxKind.SimpleMemberAccessExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseIFormatProviderForParsingDateAndTimeBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseIFormatProviderForParsingDateAndTimeBase.cs
@@ -54,7 +54,7 @@ public abstract class UseIFormatProviderForParsingDateAndTimeBase<TSyntaxKind> :
                 && TemporalTypes.Any(x => x.Matches(methodSymbol.ReceiverType))
                 && NotUsingFormatProvider(methodSymbol, c.Node))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                c.ReportIssue(Rule, c.Node);
             }
         }, Language.SyntaxKind.InvocationExpression);
 

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseIndexingInsteadOfLinqMethodsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseIndexingInsteadOfLinqMethodsBase.cs
@@ -46,12 +46,11 @@ public abstract class UseIndexingInsteadOfLinqMethodsBase<TSyntaxKind, TInvocati
                 && IsCorrectType(left, c.SemanticModel)
                 && IsCorrectCall(right, c.SemanticModel))
             {
-                var diagnostic = Diagnostic.Create(
+                c.ReportIssue(
                     Rule,
                     Language.Syntax.NodeIdentifier(invocation)?.GetLocation(),
-                    indexDescriptor == null ? "Indexing" : $"Indexing at {indexDescriptor}",
+                    indexDescriptor is null ? "Indexing" : $"Indexing at {indexDescriptor}",
                     methodName);
-                c.ReportIssue(diagnostic);
             }
         },
         Language.SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseLambdaParameterInConcurrentDictionaryBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseLambdaParameterInConcurrentDictionaryBase.cs
@@ -51,7 +51,7 @@ public abstract class UseLambdaParameterInConcurrentDictionaryBase<TSyntaxKind, 
                 {
                     if (IsLambdaAndContainsIdentifier(arguments[i], keyName))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, arguments[i].GetLocation(), keyName));
+                        c.ReportIssue(Rule, arguments[i], keyName);
                     }
                 }
             }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseShortCircuitingOperatorBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseShortCircuitingOperatorBase.cs
@@ -48,8 +48,7 @@ namespace SonarAnalyzer.Rules
                             || c.SemanticModel.GetSymbolInfo(right).Symbol is ILocalSymbol or IFieldSymbol or IPropertySymbol or IParameterSymbol
                                 ? string.Empty
                                 : " and extract the right operand to a variable if it should always be evaluated";
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], GetOperator(node).GetLocation(),
-                            GetCurrentOpName(node), GetSuggestedOpName(node), extractText));
+                        c.ReportIssue(SupportedDiagnostics[0], GetOperator(node), GetCurrentOpName(node), GetSuggestedOpName(node), extractText);
                     }
                 },
                 SyntaxKindsOfInterest.ToArray());

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseTestableTimeProviderBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseTestableTimeProviderBase.cs
@@ -40,7 +40,7 @@ public abstract class UseTestableTimeProviderBase<TSyntaxKind> : SonarDiagnostic
                 && property.IsInType(trackedTypes)
                 && !c.Node.Ancestors().Any(x => Ignore(x, c.SemanticModel)))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, c.Node.Parent.GetLocation()));
+                c.ReportIssue(Rule, c.Node.Parent);
             }
         },
         Language.SyntaxKind.IdentifierName);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseTrueForAllBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseTrueForAllBase.cs
@@ -41,7 +41,7 @@ public abstract class UseTrueForAllBase<TSyntaxKind> : SonarDiagnosticAnalyzer<T
                 && IsCorrectType(left, c.SemanticModel)
                 && IsCorrectCall(right, c.SemanticModel))
             {
-                c.ReportIssue(Diagnostic.Create(Rule, Language.Syntax.NodeIdentifier(c.Node)?.GetLocation()));
+                c.ReportIssue(Rule, Language.Syntax.NodeIdentifier(c.Node)?.GetLocation());
             }
         },
         Language.SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseUnixEpochBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseUnixEpochBase.cs
@@ -73,7 +73,7 @@ public abstract class UseUnixEpochBase<TSyntaxKind, TLiteralExpression, TMemberA
                             || (Language.FindConstantValue(cc.SemanticModel, arguments.First()) is long ticks && ticks == EpochTicks))
                         && CheckAndGetTypeName(cc.Node, cc.SemanticModel) is { } typeName)
                     {
-                        cc.ReportIssue(Rule, cc.Node.GetLocation(), typeName);
+                        cc.ReportIssue(Rule, cc.Node, typeName);
                     }
                 },
                 Language.SyntaxKind.ObjectCreationExpressions);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/UseUnixEpochBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/UseUnixEpochBase.cs
@@ -66,14 +66,14 @@ public abstract class UseUnixEpochBase<TSyntaxKind, TLiteralExpression, TMemberA
                         && CheckAndGetTypeName(cc.Node, cc.SemanticModel) is { } name
                         && IsEpochCtor(cc.Node, cc.SemanticModel))
                     {
-                        cc.ReportIssue(Diagnostic.Create(Rule, cc.Node.GetLocation(), name));
+                        cc.ReportIssue(Rule, cc.Node, name);
                     }
                     else if (arguments.Count() == 1
                         && ((literalsArguments.Count() == 1  && IsValueEqualTo(literalsArguments.First(), EpochTicks))
                             || (Language.FindConstantValue(cc.SemanticModel, arguments.First()) is long ticks && ticks == EpochTicks))
                         && CheckAndGetTypeName(cc.Node, cc.SemanticModel) is { } typeName)
                     {
-                        cc.ReportIssue(Diagnostic.Create(Rule, cc.Node.GetLocation(), typeName));
+                        cc.ReportIssue(Rule, cc.Node.GetLocation(), typeName);
                     }
                 },
                 Language.SyntaxKind.ObjectCreationExpressions);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/ValueTypeShouldImplementIEquatableBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/ValueTypeShouldImplementIEquatableBase.cs
@@ -40,7 +40,7 @@ public abstract class ValueTypeShouldImplementIEquatableBase<TSyntaxKind> : Sona
                     && !structSymbol.Implements(KnownType.System_IEquatable_T))
                 {
                     var identifier = Language.Syntax.NodeIdentifier(c.Node).Value;
-                    c.ReportIssue(Diagnostic.Create(Rule, identifier.GetLocation(), identifier.ValueText));
+                    c.ReportIssue(Rule, identifier, identifier.ValueText);
                 }
             },
             Language.SyntaxKind.StructDeclaration);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/VariableUnusedBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/VariableUnusedBase.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules
             {
                 foreach (var unused in declaredLocals.Except(usedLocals))
                 {
-                    c.ReportIssue(Diagnostic.Create(rule, unused.Locations.First(), unused.Name));
+                    c.ReportIssue(rule, unused.Locations.First(), unused.Name);
                 }
             }
         }

--- a/analyzers/src/SonarAnalyzer.Common/Rules/WcfNonVoidOneWayBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/WcfNonVoidOneWayBase.cs
@@ -64,7 +64,7 @@ namespace SonarAnalyzer.Rules
                     if (isOneWay.HasValue &&
                         isOneWay.Value)
                     {
-                        c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], GetReturnTypeLocation(methodDeclaration)));
+                        c.ReportIssue(SupportedDiagnostics[0], GetReturnTypeLocation(methodDeclaration));
                     }
                 },
                 MethodDeclarationKind);

--- a/analyzers/src/SonarAnalyzer.Common/Rules/WeakSslTlsProtocolsBase.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Rules/WeakSslTlsProtocolsBase.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules
                     var node = c.Node;
                     if (!IsPartOfBinaryNegationOrCondition(node) && IsWeakProtocol(node, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, node.GetLocation()));
+                        c.ReportIssue(Rule, node);
                     }
                 },
                 Language.SyntaxKind.IdentifierName);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayCreationLongSyntax.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayCreationLongSyntax.cs
@@ -46,14 +46,14 @@ namespace SonarAnalyzer.Rules.VisualBasic
                         if (AtLeastOneExactTypeMatch(c.SemanticModel, arrayCreation, arrayType)
                             && AllTypesAreConvertible(c.SemanticModel, arrayCreation, arrayType))
                         {
-                            c.ReportIssue(Diagnostic.Create(Rule, arrayCreation.GetLocation()));
+                            c.ReportIssue(Rule, arrayCreation);
                         }
                     }
                     else
                     {
                         if (arrayType.ElementType.Is(KnownType.System_Object))
                         {
-                            c.ReportIssue(Diagnostic.Create(Rule, arrayCreation.GetLocation()));
+                            c.ReportIssue(Rule, arrayCreation);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayDesignatorOnVariable.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayDesignatorOnVariable.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
                     foreach (var name in declarator.Names.Where(n => n.ArrayRankSpecifiers.Any()))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, name.GetLocation()));
+                        c.ReportIssue(rule, name);
                     }
                 },
                 SyntaxKind.VariableDeclarator);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayInitializationMultipleStatements.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ArrayInitializationMultipleStatements.cs
@@ -77,7 +77,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(rule, declaration.GetLocation()));
+                    c.ReportIssue(rule, declaration);
                 },
                 SyntaxKind.LocalDeclarationStatement);
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BinaryOperationWithIdenticalExpressions.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BinaryOperationWithIdenticalExpressions.cs
@@ -70,7 +70,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             if (VisualBasicEquivalenceChecker.AreEquivalent(left.RemoveParentheses(), right.RemoveParentheses()))
             {
                 var message = string.Format(OperatorMessageFormat, operatorToken);
-                context.ReportIssue(Diagnostic.Create(Rule, context.Node.GetLocation(), message));
+                context.ReportIssue(Rule, context.Node, message);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanLiteralUnnecessary.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/BooleanLiteralUnnecessary.cs
@@ -54,7 +54,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             var logicalNotOperand = logicalNot.Operand.RemoveParentheses();
             if (IsTrue(logicalNotOperand) || IsFalse(logicalNotOperand))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, logicalNot.Operand.GetLocation()));
+                context.ReportIssue(Rule, logicalNot.Operand);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameCondition.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameCondition.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             {
                 if (VisualBasicEquivalenceChecker.AreEquivalent(conditions[currentIndex], conditions[i]))
                 {
-                    context.ReportIssue(Diagnostic.Create(rule, conditions[currentIndex].GetLocation(), conditions[i].GetLineNumberToReport()));
+                    context.ReportIssue(rule, conditions[currentIndex], conditions[i].GetLineNumberToReport().ToString());
                     return;
                 }
             }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameImplementation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConditionalStructureSameImplementation.cs
@@ -108,8 +108,8 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
             var lastStatement = statementsToReport.Last();
 
-            context.ReportIssue(Diagnostic.Create(rule, firstStatement.CreateLocation(lastStatement),
-                locationProvider.First().GetLineNumberToReport(), constructType));
+            context.ReportIssue(rule, firstStatement.CreateLocation(lastStatement),
+                locationProvider.First().GetLineNumberToReport().ToString(), constructType);
         }
 
         private static bool IsApprovedStatement(StatementSyntax statement)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConstructorArgumentValueShouldExist.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ConstructorArgumentValueShouldExist.cs
@@ -53,8 +53,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         {
             var attributeSyntax =
                 (AttributeSyntax)constructorArgumentAttribute.ApplicationSyntaxReference.GetSyntax();
-            c.ReportIssue(Diagnostic.Create(rule,
-                attributeSyntax.ArgumentList.Arguments[0].GetLocation()));
+            c.ReportIssue(rule, attributeSyntax.ArgumentList.Arguments[0]);
         }
     }
 }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotInstantiateSharedClasses.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotInstantiateSharedClasses.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     if (createdType != null &&
                         createdType.GetAttributes(KnownType.System_ComponentModel_Composition_PartCreationPolicyAttribute).Any(IsShared))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, creationSyntax.GetLocation()));
+                        c.ReportIssue(rule, creationSyntax);
                     }
                 },
                 SyntaxKind.ObjectCreationExpression);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotLockOnSharedResource.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotLockOnSharedResource.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                         IsLockOnStringLiteral(lockStatement.Expression) ||
                         IsLockOnForbiddenKnownType(lockStatement.Expression, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, lockStatement.Expression.GetLocation()));
+                        c.ReportIssue(rule, lockStatement.Expression);
                     }
                 },
                 SyntaxKind.SyncLockStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotNestTernaryOperators.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotNestTernaryOperators.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                         .OfType<TernaryConditionalExpressionSyntax>()
                         .Any())
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                        c.ReportIssue(Rule, c.Node);
                     }
                 },
                 SyntaxKind.TernaryConditionalExpression);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotThrowFromDestructors.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotThrowFromDestructors.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 {
                     if (IsFinalizer(c.Node.FirstAncestorOrSelf<MethodBlockSyntax>()))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation()));
+                        c.ReportIssue(rule, c.Node);
                     }
                 },
                 SyntaxKind.ThrowStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotUseByVal.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotUseByVal.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 var parameter = (ParameterSyntax)c.Node;
                 foreach (var byVal in parameter.Modifiers.Where(IsByVal))
                 {
-                    c.ReportIssue(Diagnostic.Create(rule, byVal.GetLocation()));
+                    c.ReportIssue(rule, byVal);
                 }
             },
             SyntaxKind.Parameter);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotUseIIf.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/DoNotUseIIf.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
                 if (IsIIf(invokedMethod))
                 {
-                    c.ReportIssue(Diagnostic.Create(Rule, invocationExpression.GetLocation()));
+                    c.ReportIssue(Rule, invocationExpression);
                 }
             },
             SyntaxKind.InvocationExpression);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyMethod.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EmptyMethod.cs
@@ -38,7 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 && !ContainsComments(methodBlock.EndSubOrFunctionStatement.GetLeadingTrivia())
                 && !ShouldMethodBeExcluded(context, methodBlock.SubOrFunctionStatement))
             {
-                context.ReportIssue(Diagnostic.Create(Rule, methodBlock.SubOrFunctionStatement.Identifier.GetLocation()));
+                context.ReportIssue(Rule, methodBlock.SubOrFunctionStatement.Identifier);
             }
         }
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EndStatementUsage.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EndStatementUsage.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         protected override void Initialize(SonarAnalysisContext context)
         {
             context.RegisterNodeAction(
-                c => c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation())),
+                c => c.ReportIssue(rule, c.Node),
                 SyntaxKind.EndStatement);
         }
     }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EventNameContainsBeforeOrAfter.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/EventNameContainsBeforeOrAfter.cs
@@ -72,7 +72,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(rule, eventStatement.Identifier.GetLocation(), matched, part));
+                    c.ReportIssue(rule, eventStatement.Identifier, matched, part);
                 },
                 SyntaxKind.EventStatement);
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExitStatementUsage.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/ExitStatementUsage.cs
@@ -34,7 +34,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         protected override void Initialize(SonarAnalysisContext context)
         {
             context.RegisterNodeAction(
-                c => c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation())),
+                c => c.ReportIssue(rule, c.Node),
                 SyntaxKind.ExitForStatement,
                 SyntaxKind.ExitFunctionStatement,
                 SyntaxKind.ExitPropertyStatement,
@@ -58,7 +58,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                         return;
                     }
 
-                    c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation()));
+                    c.ReportIssue(rule, c.Node);
                 },
                 SyntaxKind.ExitDoStatement);
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FunctionNestingDepth.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/FunctionNestingDepth.cs
@@ -28,7 +28,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
         protected override void Initialize(SonarParametrizedAnalysisContext context) =>
             context.RegisterNodeAction(c =>
             {
-                var walker = new NestingDepthWalker(Maximum, token => c.ReportIssue(Diagnostic.Create(rule, token.GetLocation(), Maximum)));
+                var walker = new NestingDepthWalker(Maximum, token => c.ReportIssue(rule, token, Maximum.ToString()));
                 walker.SafeVisit(c.Node);
             },
             SyntaxKind.SubBlock,

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IndexedPropertyWithMultipleParameters.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/IndexedPropertyWithMultipleParameters.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     if (property.ParameterList != null &&
                         property.ParameterList.Parameters.Count > 1)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, property.Identifier.GetLocation(), property.ParameterList.Parameters.Count));
+                        c.ReportIssue(rule, property.Identifier, property.ParameterList.Parameters.Count.ToString());
                     }
                 },
                 SyntaxKind.PropertyStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LineContinuation.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/LineContinuation.cs
@@ -42,7 +42,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
                     foreach (var lineContinuation in lineContinuations)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, lineContinuation.GetLocation()));
+                        c.ReportIssue(rule, lineContinuation.GetLocation());
                     }
                 });
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodParameterUnused.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
                     foreach (var parameter in unusedParameters)
                     {
-                        c.ReportIssue(Rule, parameter, parameter.Identifier.Identifier.ValueText.ToString());
+                        c.ReportIssue(Rule, parameter, parameter.Identifier.Identifier.ValueText);
                     }
                 },
                 SyntaxKind.SubBlock,

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodParameterUnused.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/MethodParameterUnused.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
                     foreach (var parameter in unusedParameters)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, parameter.GetLocation(), parameter.Identifier.Identifier.ValueText));
+                        c.ReportIssue(Rule, parameter, parameter.Identifier.Identifier.ValueText.ToString());
                     }
                 },
                 SyntaxKind.SubBlock,

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ClassName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ClassName.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var declaration = (ClassStatementSyntax)c.Node;
                     if (!NamingHelper.IsRegexMatch(declaration.Identifier.ValueText, Pattern))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, declaration.Identifier.GetLocation(), Pattern));
+                        c.ReportIssue(rule, declaration.Identifier, Pattern.ToString());
                     }
                 },
                 SyntaxKind.ClassStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ClassName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ClassName.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var declaration = (ClassStatementSyntax)c.Node;
                     if (!NamingHelper.IsRegexMatch(declaration.Identifier.ValueText, Pattern))
                     {
-                        c.ReportIssue(rule, declaration.Identifier, Pattern.ToString());
+                        c.ReportIssue(rule, declaration.Identifier, Pattern);
                     }
                 },
                 SyntaxKind.ClassStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EnumerationValueName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EnumerationValueName.cs
@@ -43,8 +43,8 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var enumMemberDeclaration = (EnumMemberDeclarationSyntax)c.Node;
                     if (!NamingHelper.IsRegexMatch(enumMemberDeclaration.Identifier.ValueText, Pattern))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, enumMemberDeclaration.Identifier.GetLocation(),
-                            enumMemberDeclaration.Identifier.ValueText, Pattern));
+                        c.ReportIssue(rule, enumMemberDeclaration.Identifier,
+                            enumMemberDeclaration.Identifier.ValueText, Pattern);
                     }
                 },
                 SyntaxKind.EnumMemberDeclaration);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventHandlerName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventHandlerName.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     if (!NamingHelper.IsRegexMatch(methodDeclaration.Identifier.ValueText, Pattern)
                         && IsEventHandler(methodDeclaration, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation(), methodDeclaration.Identifier.ValueText, Pattern));
+                        c.ReportIssue(Rule, methodDeclaration.Identifier, methodDeclaration.Identifier.ValueText, Pattern);
                     }
                 },
                 SyntaxKind.SubStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventName.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var eventDeclaration = (EventStatementSyntax)c.Node;
                     if (!NamingHelper.IsRegexMatch(eventDeclaration.Identifier.ValueText, Pattern))
                     {
-                        c.ReportIssue(rule, eventDeclaration.Identifier, Pattern.ToString());
+                        c.ReportIssue(rule, eventDeclaration.Identifier, Pattern);
                     }
                 },
                 SyntaxKind.EventStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/EventName.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var eventDeclaration = (EventStatementSyntax)c.Node;
                     if (!NamingHelper.IsRegexMatch(eventDeclaration.Identifier.ValueText, Pattern))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, eventDeclaration.Identifier.GetLocation(), Pattern));
+                        c.ReportIssue(rule, eventDeclaration.Identifier, Pattern.ToString());
                     }
                 },
                 SyntaxKind.EventStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/FieldNameChecker.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/FieldNameChecker.cs
@@ -38,8 +38,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                             IsCandidateSymbol(symbol) &&
                             !NamingHelper.IsRegexMatch(symbol.Name, Pattern))
                         {
-                            c.ReportIssue(Diagnostic.Create(SupportedDiagnostics[0], name.GetLocation(),
-                                symbol.Name, Pattern));
+                            c.ReportIssue(SupportedDiagnostics[0], name, symbol.Name, Pattern);
                         }
                     }
                 },

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/FunctionName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/FunctionName.cs
@@ -43,7 +43,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     if (ShouldBeChecked(methodDeclaration, c.ContainingSymbol)
                         && !NamingHelper.IsRegexMatch(methodDeclaration.Identifier.ValueText, Pattern))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation(), "function", methodDeclaration.Identifier.ValueText, Pattern));
+                        c.ReportIssue(Rule, methodDeclaration.Identifier, "function", methodDeclaration.Identifier.ValueText, Pattern);
                     }
                 },
                 SyntaxKind.FunctionStatement);
@@ -56,7 +56,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                         && !NamingHelper.IsRegexMatch(methodDeclaration.Identifier.ValueText, Pattern)
                         && !EventHandlerName.IsEventHandler(methodDeclaration, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, methodDeclaration.Identifier.GetLocation(), "procedure", methodDeclaration.Identifier.ValueText, Pattern));
+                        c.ReportIssue(Rule, methodDeclaration.Identifier, "procedure", methodDeclaration.Identifier.ValueText, Pattern);
                     }
                 },
                 SyntaxKind.SubStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/InterfaceName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/InterfaceName.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var declaration = (InterfaceStatementSyntax)c.Node;
                     if (!NamingHelper.IsRegexMatch(declaration.Identifier.ValueText, Pattern))
                     {
-                        c.ReportIssue(rule, declaration.Identifier, Pattern.ToString());
+                        c.ReportIssue(rule, declaration.Identifier, Pattern);
                     }
                 },
                 SyntaxKind.InterfaceStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/InterfaceName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/InterfaceName.cs
@@ -46,7 +46,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var declaration = (InterfaceStatementSyntax)c.Node;
                     if (!NamingHelper.IsRegexMatch(declaration.Identifier.ValueText, Pattern))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, declaration.Identifier.GetLocation(), Pattern));
+                        c.ReportIssue(rule, declaration.Identifier, Pattern.ToString());
                     }
                 },
                 SyntaxKind.InterfaceStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 return;
             }
 
-            context.ReportIssue(rule, controlVar, Pattern.ToString());
+            context.ReportIssue(rule, controlVar, Pattern);
         }
 
         private void ProcessVariableDeclarator(SonarSyntaxNodeReportingContext context)

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/LocalVariableName.cs
@@ -65,7 +65,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 return;
             }
 
-            context.ReportIssue(Diagnostic.Create(rule, controlVar.GetLocation(), Pattern));
+            context.ReportIssue(rule, controlVar, Pattern.ToString());
         }
 
         private void ProcessVariableDeclarator(SonarSyntaxNodeReportingContext context)
@@ -86,7 +86,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     continue;
                 }
 
-                context.ReportIssue(Diagnostic.Create(rule, name.Identifier.GetLocation(), Pattern));
+                context.ReportIssue(rule, name.Identifier, Pattern);
             }
         }
     }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/NamespaceName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/NamespaceName.cs
@@ -48,7 +48,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     if (declarationName != null &&
                         !NamingHelper.IsRegexMatch(declarationName, Pattern))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, declaration.Name.GetLocation(), Pattern));
+                        c.ReportIssue(rule, declaration.Name, Pattern);
                     }
                 },
                 SyntaxKind.NamespaceStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/ParameterName.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     if (parameterDeclaration.Identifier != null &&
                         !NamingHelper.IsRegexMatch(parameterDeclaration.Identifier.Identifier.ValueText, Pattern))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, parameterDeclaration.Identifier.Identifier.GetLocation(), Pattern));
+                        c.ReportIssue(rule, parameterDeclaration.Identifier.Identifier, Pattern);
                     }
                 },
                 SyntaxKind.Parameter);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PropertyName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/PropertyName.cs
@@ -45,7 +45,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
                     if (!NamingHelper.IsRegexMatch(propertyDeclaration.Identifier.ValueText, Pattern))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, propertyDeclaration.Identifier.GetLocation(), Pattern));
+                        c.ReportIssue(rule, propertyDeclaration.Identifier, Pattern);
                     }
                 },
                 SyntaxKind.PropertyStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/TypeParameterName.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/Naming/TypeParameterName.cs
@@ -47,8 +47,8 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     if (!NamingHelper.IsRegexMatch(typeParameter.Identifier.ValueText, Pattern))
                     {
                         var location = typeParameter.Identifier.GetLocation();
-                        c.ReportIssue(Diagnostic.Create(S119, location, typeParameter.Identifier.ValueText, Pattern));
-                        c.ReportIssue(Diagnostic.Create(S2373, location, typeParameter.Identifier.ValueText, Pattern));
+                        c.ReportIssue(S119, location, typeParameter.Identifier.ValueText, Pattern);
+                        c.ReportIssue(S2373, location, typeParameter.Identifier.ValueText, Pattern);
                     }
                 },
                 SyntaxKind.TypeParameter);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NegatedIsExpression.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NegatedIsExpression.cs
@@ -39,7 +39,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var unary = (UnaryExpressionSyntax)c.Node;
                     if (unary.Operand.IsKind(SyntaxKind.IsExpression))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, unary.GetLocation()));
+                        c.ReportIssue(rule, unary);
                     }
                 },
                 SyntaxKind.NotExpression);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NoExceptionsInFinally.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NoExceptionsInFinally.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             }
 
             public override void VisitThrowStatement(ThrowStatementSyntax node) =>
-                context.ReportIssue(Diagnostic.Create(rule, node.GetLocation()));
+                context.ReportIssue(rule, node);
 
             public override void VisitFinallyBlock(FinallyBlockSyntax node)
             {

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NonAsyncTaskShouldNotReturnNull.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/NonAsyncTaskShouldNotReturnNull.cs
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                         !enclosingMember.IsKind(SyntaxKind.VariableDeclarator) &&
                         IsInvalidEnclosingSymbolContext(enclosingMember, c.SemanticModel))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, nullLiteral.GetLocation()));
+                        c.ReportIssue(rule, nullLiteral);
                     }
                 },
                 SyntaxKind.NothingLiteralExpression);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OnErrorStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/OnErrorStatement.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 c =>
                 {
                     var node = (OnErrorGoToStatementSyntax)c.Node;
-                    c.ReportIssue(Diagnostic.Create(rule, node.OnKeyword.CreateLocation(node.ErrorKeyword)));
+                    c.ReportIssue(rule, node.OnKeyword.CreateLocation(node.ErrorKeyword));
                 },
                 SyntaxKind.OnErrorGoToLabelStatement,
                 SyntaxKind.OnErrorGoToZeroStatement,
@@ -47,7 +47,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 c =>
                 {
                     var node = (OnErrorResumeNextStatementSyntax)c.Node;
-                    c.ReportIssue(Diagnostic.Create(rule, node.OnKeyword.CreateLocation(node.ErrorKeyword)));
+                    c.ReportIssue(rule, node.OnKeyword.CreateLocation(node.ErrorKeyword));
                 },
                 SyntaxKind.OnErrorResumeNextStatement);
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyWithArrayType.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/PropertyWithArrayType.cs
@@ -41,7 +41,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                         && !symbol.IsAutoProperty()
                         && symbol.Type is IArrayTypeSymbol)
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, property.Identifier.GetLocation(), symbol.Name));
+                        c.ReportIssue(Rule, property.Identifier, symbol.Name);
                     }
                 },
                 SyntaxKind.PropertyStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantExitSelect.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/RedundantExitSelect.cs
@@ -44,7 +44,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
 
                     if (caseBlock.Statements.Last() == exit)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, exit.GetLocation()));
+                        c.ReportIssue(rule, exit);
                     }
                 },
                 SyntaxKind.ExitSelectStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SelfAssignment.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SelfAssignment.cs
@@ -33,7 +33,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var expression = (AssignmentStatementSyntax) c.Node;
                     if (VisualBasicEquivalenceChecker.AreEquivalent(expression.Left, expression.Right))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, c.Node.GetLocation()));
+                        c.ReportIssue(Rule, c.Node);
                     }
                 },
                 SyntaxKind.SimpleAssignmentStatement);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SimpleDoLoop.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SimpleDoLoop.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                 c =>
                 {
                     var doBlock = (DoLoopBlockSyntax)c.Node;
-                    c.ReportIssue(Diagnostic.Create(rule, doBlock.DoStatement.DoKeyword.GetLocation()));
+                    c.ReportIssue(rule, doBlock.DoStatement.DoKeyword);
                 },
                 SyntaxKind.SimpleDoLoopBlock);
         }

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringConcatenationWithPlus.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/StringConcatenationWithPlus.cs
@@ -40,7 +40,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                         // If op_Addition exist, there's areason for it => don't raise. We don't care about type of op_Addition arguments, they match because it compiles.
                         || (leftType.GetMembers("op_Addition").IsEmpty && c.SemanticModel.GetTypeInfo(binary.Right).Type.Is(KnownType.System_String)))
                     {
-                        c.ReportIssue(Diagnostic.Create(Rule, binary.OperatorToken.GetLocation()));
+                        c.ReportIssue(Rule, binary.OperatorToken);
                     }
                 },
                 SyntaxKind.AddExpression);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchCasesMinimumThree.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchCasesMinimumThree.cs
@@ -36,7 +36,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var selectNode = (SelectBlockSyntax)c.Node;
                     if (!HasAtLeastThreeLabels(selectNode))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, selectNode.SelectStatement.SelectKeyword.GetLocation()));
+                        c.ReportIssue(rule, selectNode.SelectStatement.SelectKeyword);
                     }
                 },
                 SyntaxKind.SelectBlock);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchSectionShouldNotHaveTooManyStatements.cs
@@ -43,8 +43,8 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var statementsCount = caseBlock.Statements.SelectMany(GetInnerStatements).Count();
                     if (statementsCount > Threshold)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, caseBlock.CaseStatement.GetLocation(),
-                            "'Case' block", statementsCount, Threshold, "procedure"));
+                        c.ReportIssue(rule, caseBlock.CaseStatement,
+                            "'Case' block", statementsCount.ToString(), Threshold.ToString(), "procedure");
                     }
                 },
                 SyntaxKind.CaseBlock,

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchShouldNotBeNested.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/SwitchShouldNotBeNested.cs
@@ -37,7 +37,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var selectBlock = (SelectBlockSyntax)c.Node;
                     if (selectBlock.Parent?.FirstAncestorOrSelf<SelectBlockSyntax>() != null)
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, selectBlock.SelectStatement.GetLocation()));
+                        c.ReportIssue(rule, selectBlock.SelectStatement);
                     }
                 },
                 SyntaxKind.SelectBlock);

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnsignedTypesUsage.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UnsignedTypesUsage.cs
@@ -45,8 +45,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
                     var typeSymbol = c.SemanticModel.GetSymbolInfo(typeSyntax).Symbol as ITypeSymbol;
                     if (typeSymbol.IsAny(KnownType.UnsignedIntegers))
                     {
-                        c.ReportIssue(Diagnostic.Create(rule, typeSyntax.GetLocation(),
-                            SignedPairs[typeSymbol.SpecialType]));
+                        c.ReportIssue(rule, typeSyntax, SignedPairs[typeSymbol.SpecialType]);
                     }
                 },
                 SyntaxKind.PredefinedType,

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseReturnStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseReturnStatement.cs
@@ -54,10 +54,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             {
                 if (IsImplicitReturnValue(node))
                 {
-                    context.ReportIssue(Rule, node,
-                        IsAssignmentStatement(node)
-                        ? UseReturnStatementMessage
-                        : DontUseImplicitMessage);
+                    context.ReportIssue(Rule, node, IsAssignmentStatement(node) ? UseReturnStatementMessage : DontUseImplicitMessage);
                 }
             }
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseReturnStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseReturnStatement.cs
@@ -54,10 +54,10 @@ namespace SonarAnalyzer.Rules.VisualBasic
             {
                 if (IsImplicitReturnValue(node))
                 {
-                    context.ReportIssue(Diagnostic.Create(Rule, node.GetLocation(),
+                    context.ReportIssue(Rule, node,
                         IsAssignmentStatement(node)
                         ? UseReturnStatementMessage
-                        : DontUseImplicitMessage));
+                        : DontUseImplicitMessage);
                 }
             }
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
@@ -107,8 +107,8 @@ namespace SonarAnalyzer.Rules.VisualBasic
             if (matchCount >= MinimumSeriesLength)
             {
                 var nextStatementCount = matchCount - 1;
-                context.ReportIssue(Diagnostic.Create(rule, executableStatement.GetLocation(),
-                    nextStatementCount, expression.ToString(), nextStatementCount == 1 ? string.Empty : "s"));
+                context.ReportIssue(rule, executableStatement,
+                    nextStatementCount.ToString(), expression.ToString(), nextStatementCount == 1 ? string.Empty : "s");
                 return true;
             }
 

--- a/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
+++ b/analyzers/src/SonarAnalyzer.VisualBasic/Rules/UseWithStatement.cs
@@ -107,8 +107,7 @@ namespace SonarAnalyzer.Rules.VisualBasic
             if (matchCount >= MinimumSeriesLength)
             {
                 var nextStatementCount = matchCount - 1;
-                context.ReportIssue(rule, executableStatement,
-                    nextStatementCount.ToString(), expression.ToString(), nextStatementCount == 1 ? string.Empty : "s");
+                context.ReportIssue(rule, executableStatement, nextStatementCount.ToString(), expression.ToString(), nextStatementCount == 1 ? string.Empty : "s");
                 return true;
             }
 


### PR DESCRIPTION
Follow up on #9298 and others

The PR replaces all simple cases of calls to
https://github.com/SonarSource/sonar-dotnet/blob/4ffbdc6d996feaa9448e053e9983641fde2e90c7/analyzers/src/SonarAnalyzer.Common/AnalysisContext/SonarReportingContextBase.cs#L93-L95