### PR TITLE
Shimlayer: Light up TypeArgumentNullableAnnotations

### DIFF
--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.Sonar.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.Sonar.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Reflection;
+using static System.Linq.Expressions.Expression;
+
+namespace StyleCop.Analyzers.Lightup;
+
+public static class INamedTypeSymbolExtensionsSonar
+{
+    private static readonly Func<INamedTypeSymbol, ImmutableArray<NullableAnnotation>> TypeArgumentNullableAnnotationsAccessor;
+
+    static INamedTypeSymbolExtensionsSonar()
+    {
+        TypeArgumentNullableAnnotationsAccessor = CreateTypeArgumentNullableAnnotationsAccessor();
+    }
+
+    public static ImmutableArray<NullableAnnotation> TypeArgumentNullableAnnotations(this INamedTypeSymbol symbol) => TypeArgumentNullableAnnotationsAccessor(symbol);
+
+    private static Func<INamedTypeSymbol, ImmutableArray<NullableAnnotation>> CreateTypeArgumentNullableAnnotationsAccessor()
+    {
+        // INamedTypeSymbol.TypeArgumentNullableAnnotations is ImmutableArray<Roslyn.NullableAnnotation>
+        // The generated code is symbol => ImmutableArray.CreateRange(symbol.TypeArgumentNullableAnnotations, x => (Sonar.NullableAnnotationType)x);
+
+        // Callers may rely on the fact that symbol.TypeArgumentNullableAnnotations is supposed to have the same length as symbol.TypeArguments
+        var fallback = static (INamedTypeSymbol x) => Enumerable.Repeat(NullableAnnotation.None, x.TypeArguments.Length).ToImmutableArray();
+        if (OriginalNullableAnnotationType() is not { } originalNullableAnnotationType)
+        {
+            return fallback;
+        }
+
+        if (typeof(ImmutableArray).GetMethods(BindingFlags.Public | BindingFlags.Static).FirstOrDefault(x =>
+            x.Name == nameof(ImmutableArray.CreateRange)     // https://learn.microsoft.com/en-us/dotnet/api/system.collections.immutable.immutablearray.createrange
+            && x.GetParameters() is { Length: 2 } parameters // CreateRange<TSource,TResult>(ImmutableArray<TSource> items, Func<TSource,TResult> selector)
+            && parameters[0].Name == "items"                 // see also https://stackoverflow.com/a/4036187
+            && parameters[1].Name == "selector"
+            && x.GetGenericArguments() is { Length: 2 } typeArguments
+            && typeArguments[0].Name == "TSource"
+            && typeArguments[1].Name == "TResult") is not { } createRange)
+        {
+            return fallback;
+        }
+        var sonarNullableAnnotationType = typeof(NullableAnnotation);
+        var createRangeT = createRange.MakeGenericMethod(originalNullableAnnotationType, sonarNullableAnnotationType);
+        var delegateType = typeof(Func<,>).MakeGenericType(originalNullableAnnotationType, sonarNullableAnnotationType);
+
+        var originalNullableAnnotationParameter = Parameter(originalNullableAnnotationType, "x");
+        var conversion = Lambda(delegateType, Convert(originalNullableAnnotationParameter, sonarNullableAnnotationType), originalNullableAnnotationParameter); // (originalNullableAnnotationType x) => (sonarNullableAnnotationType)x;
+
+        var symbolParameter = Parameter(typeof(INamedTypeSymbol), "symbol");
+        return Lambda<Func<INamedTypeSymbol, ImmutableArray<NullableAnnotation>>>(
+            Call(createRangeT, Property(symbolParameter, nameof(TypeArgumentNullableAnnotations)), conversion), // ImmutableArray.CreateRange(symbol.TypeArgumentNullableAnnotations, conversion)
+            symbolParameter).Compile();
+    }
+
+    private static Type OriginalNullableAnnotationType()
+    {
+        try
+        {
+            return Type.GetType("Microsoft.CodeAnalysis.NullableAnnotation, Microsoft.CodeAnalysis");
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+}

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
@@ -1,25 +1,20 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+
 namespace StyleCop.Analyzers.Lightup
 {
-    using System.Reflection;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
-    using static System.Linq.Expressions.Expression;
-
     public static class INamedTypeSymbolExtensions
     {
         private static readonly Func<INamedTypeSymbol, INamedTypeSymbol> TupleUnderlyingTypeAccessor;
         private static readonly Func<INamedTypeSymbol, ImmutableArray<IFieldSymbol>> TupleElementsAccessor;
         private static readonly Func<INamedTypeSymbol, bool> IsSerializableAccessor;
-        private static readonly Func<INamedTypeSymbol, ImmutableArray<NullableAnnotation>> TypeArgumentNullableAnnotationsAccessor;
 
         static INamedTypeSymbolExtensions()
         {
             TupleUnderlyingTypeAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<INamedTypeSymbol, INamedTypeSymbol>(typeof(INamedTypeSymbol), nameof(TupleUnderlyingType));
             TupleElementsAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<INamedTypeSymbol, ImmutableArray<IFieldSymbol>>(typeof(INamedTypeSymbol), nameof(TupleElements));
             IsSerializableAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<INamedTypeSymbol, bool>(typeof(INamedTypeSymbol), nameof(IsSerializable));
-            TypeArgumentNullableAnnotationsAccessor = CreateTypeArgumentNullableAnnotationsAccessor();
         }
 
         public static INamedTypeSymbol TupleUnderlyingType(this INamedTypeSymbol symbol) => TupleUnderlyingTypeAccessor(symbol);
@@ -27,55 +22,5 @@ namespace StyleCop.Analyzers.Lightup
         public static ImmutableArray<IFieldSymbol> TupleElements(this INamedTypeSymbol symbol) => TupleElementsAccessor(symbol);
 
         public static bool IsSerializable(this INamedTypeSymbol symbol) => IsSerializableAccessor(symbol);
-
-        public static ImmutableArray<NullableAnnotation> TypeArgumentNullableAnnotations(this INamedTypeSymbol symbol) => TypeArgumentNullableAnnotationsAccessor(symbol);
-
-        private static Func<INamedTypeSymbol, ImmutableArray<NullableAnnotation>> CreateTypeArgumentNullableAnnotationsAccessor()
-        {
-            // INamedTypeSymbol.TypeArgumentNullableAnnotations is ImmutableArray<Roslyn.NullableAnnotation>
-            // The generated code is symbol => ImmutableArray.CreateRange(symbol.TypeArgumentNullableAnnotations, x => (Sonar.NullableAnnotationType)x);
-
-            // Callers may rely on the fact that symbol.TypeArgumentNullableAnnotations is supposed to have the same length as symbol.TypeArguments
-            var fallback = static (INamedTypeSymbol x) => Enumerable.Repeat(NullableAnnotation.None, x.TypeArguments.Length).ToImmutableArray();
-            if (OriginalNullableAnnotationType() is not { } originalNullableAnnotationType)
-            {
-                return fallback;
-            }
-
-            if (typeof(ImmutableArray).GetMethods(BindingFlags.Public | BindingFlags.Static).FirstOrDefault(x =>
-                x.Name == nameof(ImmutableArray.CreateRange)     // https://learn.microsoft.com/en-us/dotnet/api/system.collections.immutable.immutablearray.createrange
-                && x.GetParameters() is { Length: 2 } parameters // CreateRange<TSource,TResult>(ImmutableArray<TSource> items, Func<TSource,TResult> selector)
-                && parameters[0].Name == "items"                 // see also https://stackoverflow.com/a/4036187
-                && parameters[1].Name == "selector"
-                && x.GetGenericArguments() is { Length: 2 } typeArguments
-                && typeArguments[0].Name == "TSource"
-                && typeArguments[1].Name == "TResult") is not { } createRange)
-            {
-                return fallback;
-            }
-            var sonarNullableAnnotationType = typeof(NullableAnnotation);
-            var createRangeT = createRange.MakeGenericMethod(originalNullableAnnotationType, sonarNullableAnnotationType);
-            var delegateType = typeof(Func<,>).MakeGenericType(originalNullableAnnotationType, sonarNullableAnnotationType);
-
-            var originalNullableAnnotationParameter = Parameter(originalNullableAnnotationType, "x");
-            var conversion = Lambda(delegateType, Convert(originalNullableAnnotationParameter, sonarNullableAnnotationType), originalNullableAnnotationParameter); // (originalNullableAnnotationType x) => (sonarNullableAnnotationType)x;
-
-            var symbolParameter = Parameter(typeof(INamedTypeSymbol), "symbol");
-            return Lambda<Func<INamedTypeSymbol, ImmutableArray<NullableAnnotation>>>(
-                Call(createRangeT, Property(symbolParameter, nameof(TypeArgumentNullableAnnotations)), conversion), // ImmutableArray.CreateRange(symbol.TypeArgumentNullableAnnotations, conversion)
-                symbolParameter).Compile();
-        }
-
-        private static Type OriginalNullableAnnotationType()
-        {
-            try
-            {
-                return Type.GetType("Microsoft.CodeAnalysis.NullableAnnotation, Microsoft.CodeAnalysis");
-            }
-            catch
-            {
-                return null;
-            }
-        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
@@ -32,6 +32,12 @@ namespace StyleCop.Analyzers.Lightup
 
         private static Func<INamedTypeSymbol, ImmutableArray<NullableAnnotation>> CreateTypeArgumentNullableAnnotationsAccessor()
         {
+            // INamedTypeSymbol.TypeArgumentNullableAnnotations is ImmutableArray<Roslyn.NullableAnnotation>
+            // The generated code
+            // * retrieves the original ImmutableArray
+            // * create a new ImmutableArrayBuilder for the Sonar.NullableAnnotation with the capacity of original
+            // * Copies over the converted NullableAnnotation into the builder in a loop
+            // * Skips the builder creation and the loop if the original is empty
             var originalNullableAnnotationType = Type.GetType("Microsoft.CodeAnalysis.NullableAnnotation, Microsoft.CodeAnalysis, Version=4.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35");
             if (originalNullableAnnotationType is null)
             {
@@ -57,7 +63,7 @@ namespace StyleCop.Analyzers.Lightup
             var empty = Field(null, immutableArrayTypeT, nameof(ImmutableArray<int>.Empty));
             var body = Block([builder, original, i],
                 Assign(original, Property(symbol, nameof(TypeArgumentNullableAnnotations))),                               // original = symbol.TypeArgumentNullableAnnotations;
-                IfThen(Equal(Property(original, nameof(ImmutableArray<int>.Length)), Constant(0)), Goto(exit, empty)),     // if (original.Length == 0) goto exit(empty)
+                IfThen(Equal(Property(original, nameof(ImmutableArray<int>.Length)), Constant(0)), Goto(exit, empty)),     // if (original.Length == 0) goto exit(ImmutableArray<Sonar.NullableAnnotation>.Empty)
                 Assign(builder, Call(builderCreate, Property(original, nameof(ImmutableArray<int>.Length)))),              // builder = ImmutableArray.CreateBuilder<NullableAnnotation>(original.Length);
                 Assign(i, Constant(0)),                                                                                    // i = 0;
                                                                                                                            // Endless loop:

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
@@ -38,8 +38,7 @@ namespace StyleCop.Analyzers.Lightup
             // * Creates a new ImmutableArrayBuilder of Sonar.NullableAnnotation with the capacity of original
             // * Copies over the converted NullableAnnotation into the builder in a loop
             // * Skips the builder creation and the loop if the original is empty
-            var originalNullableAnnotationType = OriginalNullableAnnotationType();
-            if (originalNullableAnnotationType is null)
+            if (OriginalNullableAnnotationType() is not { } originalNullableAnnotationType)
             {
                 // Callers may rely on the fact that symbol.TypeArgumentNullableAnnotations is supposed to have the same length as symbol.TypeArguments
                 return static x => Enumerable.Repeat(NullableAnnotation.None, x.TypeArguments.Length).ToImmutableArray();

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
@@ -67,7 +67,6 @@ namespace StyleCop.Analyzers.Lightup
                 IfThen(Equal(Property(original, nameof(ImmutableArray<int>.Length)), Constant(0)), Goto(exit, empty)),     // if (original.Length == 0) goto exit(ImmutableArray<Sonar.NullableAnnotation>.Empty)
                 Assign(builder, Call(builderCreate, Property(original, nameof(ImmutableArray<int>.Length)))),              // builder = ImmutableArray.CreateBuilder<NullableAnnotation>(original.Length);
                 Assign(i, Constant(0)),                                                                                    // i = 0;
-                                                                                                                           // Endless loop:
                 Loop(
                     IfThenElse(
                         LessThan(i, Property(original, nameof(ImmutableArray<int>.Length))),                               // if (i < original.Length)

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
@@ -4,17 +4,22 @@
 
 namespace StyleCop.Analyzers.Lightup
 {
+    using System.Reflection;
+    using static System.Linq.Expressions.Expression;
+
     public static class INamedTypeSymbolExtensions
     {
         private static readonly Func<INamedTypeSymbol, INamedTypeSymbol> TupleUnderlyingTypeAccessor;
         private static readonly Func<INamedTypeSymbol, ImmutableArray<IFieldSymbol>> TupleElementsAccessor;
         private static readonly Func<INamedTypeSymbol, bool> IsSerializableAccessor;
+        private static readonly Func<INamedTypeSymbol, ImmutableArray<NullableAnnotation>> TypeArgumentNullableAnnotationsAccessor;
 
         static INamedTypeSymbolExtensions()
         {
             TupleUnderlyingTypeAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<INamedTypeSymbol, INamedTypeSymbol>(typeof(INamedTypeSymbol), nameof(TupleUnderlyingType));
             TupleElementsAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<INamedTypeSymbol, ImmutableArray<IFieldSymbol>>(typeof(INamedTypeSymbol), nameof(TupleElements));
             IsSerializableAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<INamedTypeSymbol, bool>(typeof(INamedTypeSymbol), nameof(IsSerializable));
+            TypeArgumentNullableAnnotationsAccessor = CreateTypeArgumentNullableAnnotationsAccessor();
         }
 
         public static INamedTypeSymbol TupleUnderlyingType(this INamedTypeSymbol symbol) => TupleUnderlyingTypeAccessor(symbol);
@@ -23,6 +28,39 @@ namespace StyleCop.Analyzers.Lightup
 
         public static bool IsSerializable(this INamedTypeSymbol symbol) => IsSerializableAccessor(symbol);
 
-        public static ImmutableArray<NullableAnnotation> TypeArgumentNullableAnnotations(this INamedTypeSymbol symbol) => ImmutableArray<NullableAnnotation>.Empty;
+        public static ImmutableArray<NullableAnnotation> TypeArgumentNullableAnnotations(this INamedTypeSymbol symbol) => TypeArgumentNullableAnnotationsAccessor(symbol);
+
+        private static Func<INamedTypeSymbol, ImmutableArray<NullableAnnotation>> CreateTypeArgumentNullableAnnotationsAccessor()
+        {
+            var originalNullableAnnotationType = Type.GetType("Microsoft.CodeAnalysis.NullableAnnotation, Microsoft.CodeAnalysis, Version=4.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35");
+            var immutableArrayType = typeof(ImmutableArray);
+            var immutableArrayTpe = typeof(ImmutableArray<NullableAnnotation>);
+            var builderType = typeof(ImmutableArray<NullableAnnotation>.Builder);
+            var originalType = typeof(ImmutableArray<>).MakeGenericType(originalNullableAnnotationType);
+
+            var builderCreateT = immutableArrayType.GetMethod(nameof(ImmutableArray.CreateBuilder), BindingFlags.Static | BindingFlags.Public, null, [typeof(int)], null); // Ctor with capacity
+            var builderCreate = builderCreateT.MakeGenericMethod(typeof(NullableAnnotation));
+            var builderAdd = builderType.GetMethod(nameof(ImmutableArray<int>.Builder.Add));
+            var builderToImmutable = builderType.GetMethod(nameof(ImmutableArray<int>.Builder.ToImmutable));
+
+            var symbol = Parameter(typeof(INamedTypeSymbol), "symbol");
+            var original = Parameter(originalType, "original");
+            var builder = Parameter(builderType, "builder");
+            var i = Parameter(typeof(int), "i");
+
+            var exit = Label(immutableArrayTpe);
+            var body = Block([builder, original, i],
+                Assign(original, Property(symbol, nameof(TypeArgumentNullableAnnotations))), // original = symbol.TypeArgumentNullableAnnotations;
+                Assign(builder, Call(builderCreate, Property(original, nameof(ImmutableArray<int>.Length)))), // builder = ImmutableArray.CreateBuilder<NullableAnnotation>(original.Length);
+                Assign(i, Constant(0)), // i = 0;
+                Loop(
+                    IfThenElse(LessThan(i, Property(original, "Length")), // if (i < original.Length)
+                    ifTrue: Block(
+                        Call(builder, builderAdd, Convert(Property(original, "Item", i), typeof(NullableAnnotation))), // builder.Add((NullableAnnotation)original[i]);
+                        AddAssign(i, Constant(1))), // i += 1;
+                    ifFalse: Return(exit, Call(builder, builderToImmutable))), // return builder.ToImmutable();
+                    exit));
+            return Lambda<Func<INamedTypeSymbol, ImmutableArray<NullableAnnotation>>>(body, symbol).Compile();
+        }
     }
 }

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-
 namespace StyleCop.Analyzers.Lightup
 {
     using System.Reflection;

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
@@ -22,5 +22,7 @@ namespace StyleCop.Analyzers.Lightup
         public static ImmutableArray<IFieldSymbol> TupleElements(this INamedTypeSymbol symbol) => TupleElementsAccessor(symbol);
 
         public static bool IsSerializable(this INamedTypeSymbol symbol) => IsSerializableAccessor(symbol);
+
+        public static ImmutableArray<NullableAnnotation> TypeArgumentNullableAnnotations(this INamedTypeSymbol symbol) => ImmutableArray<NullableAnnotation>.Empty;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
@@ -61,7 +61,7 @@ namespace StyleCop.Analyzers.Lightup
                                                                                                                            // Endless loop:
                 Loop(
                     IfThenElse(
-                        LessThan(i, Property(original, "Length")),                                                         // if (i < original.Length)
+                        LessThan(i, Property(original, nameof(ImmutableArray<int>.Length))),                               // if (i < original.Length)
                         ifTrue: Block(
                             Call(builder, builderAdd, Convert(Property(original, "Item", i), typeof(NullableAnnotation))), // builder.Add((NullableAnnotation)original[i]);
                             AddAssign(i, Constant(1))),                                                                    // i += 1;

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
@@ -35,10 +35,11 @@ namespace StyleCop.Analyzers.Lightup
         {
             // INamedTypeSymbol.TypeArgumentNullableAnnotations is ImmutableArray<Roslyn.NullableAnnotation>
             // The generated code is symbol => ImmutableArray.CreateRange(symbol.TypeArgumentNullableAnnotations, x => (Sonar.NullableAnnotationType)x);
+
+            // Callers may rely on the fact that symbol.TypeArgumentNullableAnnotations is supposed to have the same length as symbol.TypeArguments
             var fallback = static (INamedTypeSymbol x) => Enumerable.Repeat(NullableAnnotation.None, x.TypeArguments.Length).ToImmutableArray();
             if (OriginalNullableAnnotationType() is not { } originalNullableAnnotationType)
             {
-                // Callers may rely on the fact that symbol.TypeArgumentNullableAnnotations is supposed to have the same length as symbol.TypeArguments
                 return fallback;
             }
 

--- a/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/ShimLayer/INamedTypeSymbolExtensions.cs
@@ -55,16 +55,17 @@ namespace StyleCop.Analyzers.Lightup
 
             var exit = Label(immutableArrayTypeT);
             var body = Block([builder, original, i],
-                Assign(original, Property(symbol, nameof(TypeArgumentNullableAnnotations))), // original = symbol.TypeArgumentNullableAnnotations;
-                Assign(builder, Call(builderCreate, Property(original, nameof(ImmutableArray<int>.Length)))), // builder = ImmutableArray.CreateBuilder<NullableAnnotation>(original.Length);
-                Assign(i, Constant(0)), // i = 0;
+                Assign(original, Property(symbol, nameof(TypeArgumentNullableAnnotations))),                               // original = symbol.TypeArgumentNullableAnnotations;
+                Assign(builder, Call(builderCreate, Property(original, nameof(ImmutableArray<int>.Length)))),              // builder = ImmutableArray.CreateBuilder<NullableAnnotation>(original.Length);
+                Assign(i, Constant(0)),                                                                                    // i = 0;
+                                                                                                                           // Endless loop:
                 Loop(
                     IfThenElse(
-                        LessThan(i, Property(original, "Length")), // if (i < original.Length)
+                        LessThan(i, Property(original, "Length")),                                                         // if (i < original.Length)
                         ifTrue: Block(
                             Call(builder, builderAdd, Convert(Property(original, "Item", i), typeof(NullableAnnotation))), // builder.Add((NullableAnnotation)original[i]);
-                            AddAssign(i, Constant(1))), // i += 1;
-                        ifFalse: Return(exit, Call(builder, builderToImmutable))), // return builder.ToImmutable();
+                            AddAssign(i, Constant(1))),                                                                    // i += 1;
+                        ifFalse: Return(exit, Call(builder, builderToImmutable))),                                         // return builder.ToImmutable();
                     exit));
             return Lambda<Func<INamedTypeSymbol, ImmutableArray<NullableAnnotation>>>(body, symbol).Compile();
         }

--- a/analyzers/tests/SonarAnalyzer.Test/Wrappers/INamedTypeSymbolExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Wrappers/INamedTypeSymbolExtensionsTests.cs
@@ -46,12 +46,7 @@ public class INamedTypeSymbolExtensionsTests
                 }
             }
             """;
-        var (tree, semanticModel) = TestHelper.CompileCS(code);
-        var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Last(x => x.NameIs("o")); // o in o.ToString()
-        var namedType = semanticModel.GetTypeInfo(identifier).Type.Should().BeAssignableTo<INamedTypeSymbol>().Which;
-        var typeArgumentNullabilityShim = namedType.TypeArgumentNullableAnnotations();
-        var typeArgumentNullability = namedType.TypeArgumentNullableAnnotations;
-        typeArgumentNullabilityShim.Should().BeEquivalentTo([expected]).And.BeEquivalentTo(typeArgumentNullability.Select(x => (NullableAnnotation)x));
+        ValidateTypeArgumentNullableAnnotations(code, expected);
     }
 
     [TestMethod]
@@ -69,14 +64,8 @@ public class INamedTypeSymbolExtensionsTests
                 }
             }
             """;
-        var (tree, semanticModel) = TestHelper.CompileCS(code);
-        var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Last(x => x.NameIs("o")); // o in o.ToString()
-        var namedType = semanticModel.GetTypeInfo(identifier).Type.Should().BeAssignableTo<INamedTypeSymbol>().Which;
-        var typeArgumentNullabilityShim = namedType.TypeArgumentNullableAnnotations();
-        var typeArgumentNullability = namedType.TypeArgumentNullableAnnotations;
-        typeArgumentNullabilityShim.Should().BeEquivalentTo(
-            [NullableAnnotation.NotAnnotated, NullableAnnotation.Annotated, NullableAnnotation.Annotated, NullableAnnotation.NotAnnotated, NullableAnnotation.Annotated])
-            .And.BeEquivalentTo(typeArgumentNullability.Select(x => (NullableAnnotation)x));
+        ValidateTypeArgumentNullableAnnotations(code,
+            NullableAnnotation.NotAnnotated, NullableAnnotation.Annotated, NullableAnnotation.Annotated, NullableAnnotation.NotAnnotated, NullableAnnotation.Annotated);
     }
 
     [TestMethod]
@@ -94,12 +83,16 @@ public class INamedTypeSymbolExtensionsTests
                 }
             }
             """;
+        ValidateTypeArgumentNullableAnnotations(code);
+    }
+
+    private static void ValidateTypeArgumentNullableAnnotations(string code, params NullableAnnotation[] expected)
+    {
         var (tree, semanticModel) = TestHelper.CompileCS(code);
         var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Last(x => x.NameIs("o")); // o in o.ToString()
         var namedType = semanticModel.GetTypeInfo(identifier).Type.Should().BeAssignableTo<INamedTypeSymbol>().Which;
         var typeArgumentNullabilityShim = namedType.TypeArgumentNullableAnnotations();
         var typeArgumentNullability = namedType.TypeArgumentNullableAnnotations;
-        typeArgumentNullabilityShim.Should().BeEmpty()
-            .And.BeEquivalentTo(typeArgumentNullability.Select(x => (NullableAnnotation)x));
+        typeArgumentNullabilityShim.Should().BeEquivalentTo(expected).And.BeEquivalentTo(typeArgumentNullability.Select(x => (NullableAnnotation)x));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/Wrappers/INamedTypeSymbolExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Wrappers/INamedTypeSymbolExtensionsTests.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using StyleCop.Analyzers.Lightup;
+using NullableAnnotation = StyleCop.Analyzers.Lightup.NullableAnnotation;
+
+namespace SonarAnalyzer.Test.Wrappers;
+
+[TestClass]
+public class INamedTypeSymbolExtensionsTests
+{
+    [TestMethod]
+    public void NullabilityInfoFromShimEqualsOriginal()
+    {
+        var code = """
+            #nullable enable
+            using System.Collections.Generic;
+            public class C
+            {
+                public void M()
+                {
+                    IEnumerable<object?> o = new object[0];
+                    o.ToString();
+                }
+            }
+
+            """;
+        var (tree, semanticModel) = TestHelper.CompileCS(code);
+        var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Last(x => x.NameIs("o")); // o in o.ToString()
+        var typeInfo = semanticModel.GetTypeInfo(identifier);
+        var namedType = typeInfo.Type.Should().BeAssignableTo<INamedTypeSymbol>().Which;
+        var typeArgumentNullabilityShim = namedType.TypeArgumentNullableAnnotations();
+        var typeArgumentNullability = namedType.TypeArgumentNullableAnnotations;
+        typeArgumentNullabilityShim.Should().BeEquivalentTo(typeArgumentNullability.Select(x => (NullableAnnotation)x));
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.Test/Wrappers/INamedTypeSymbolExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Wrappers/INamedTypeSymbolExtensionsTests.cs
@@ -48,8 +48,7 @@ public class INamedTypeSymbolExtensionsTests
             """;
         var (tree, semanticModel) = TestHelper.CompileCS(code);
         var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Last(x => x.NameIs("o")); // o in o.ToString()
-        var typeInfo = semanticModel.GetTypeInfo(identifier);
-        var namedType = typeInfo.Type.Should().BeAssignableTo<INamedTypeSymbol>().Which;
+        var namedType = semanticModel.GetTypeInfo(identifier).Type.Should().BeAssignableTo<INamedTypeSymbol>().Which;
         var typeArgumentNullabilityShim = namedType.TypeArgumentNullableAnnotations();
         var typeArgumentNullability = namedType.TypeArgumentNullableAnnotations;
         typeArgumentNullabilityShim.Should().BeEquivalentTo([expected]).And.BeEquivalentTo(typeArgumentNullability.Select(x => (NullableAnnotation)x));
@@ -72,12 +71,35 @@ public class INamedTypeSymbolExtensionsTests
             """;
         var (tree, semanticModel) = TestHelper.CompileCS(code);
         var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Last(x => x.NameIs("o")); // o in o.ToString()
-        var typeInfo = semanticModel.GetTypeInfo(identifier);
-        var namedType = typeInfo.Type.Should().BeAssignableTo<INamedTypeSymbol>().Which;
+        var namedType = semanticModel.GetTypeInfo(identifier).Type.Should().BeAssignableTo<INamedTypeSymbol>().Which;
         var typeArgumentNullabilityShim = namedType.TypeArgumentNullableAnnotations();
         var typeArgumentNullability = namedType.TypeArgumentNullableAnnotations;
         typeArgumentNullabilityShim.Should().BeEquivalentTo(
             [NullableAnnotation.NotAnnotated, NullableAnnotation.Annotated, NullableAnnotation.Annotated, NullableAnnotation.NotAnnotated, NullableAnnotation.Annotated])
+            .And.BeEquivalentTo(typeArgumentNullability.Select(x => (NullableAnnotation)x));
+    }
+
+    [TestMethod]
+    public void TypeArgumentNullableAnnotationsFromShimEqualsOriginal_NoTypeArguments()
+    {
+        var code = """
+            #nullable enable
+            using System;
+            public class C
+            {
+                public void M()
+                {
+                    object? o = null;
+                    o.ToString();
+                }
+            }
+            """;
+        var (tree, semanticModel) = TestHelper.CompileCS(code);
+        var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Last(x => x.NameIs("o")); // o in o.ToString()
+        var namedType = semanticModel.GetTypeInfo(identifier).Type.Should().BeAssignableTo<INamedTypeSymbol>().Which;
+        var typeArgumentNullabilityShim = namedType.TypeArgumentNullableAnnotations();
+        var typeArgumentNullability = namedType.TypeArgumentNullableAnnotations;
+        typeArgumentNullabilityShim.Should().BeEmpty()
             .And.BeEquivalentTo(typeArgumentNullability.Select(x => (NullableAnnotation)x));
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/Wrappers/INamedTypeSymbolExtensionsTests.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Wrappers/INamedTypeSymbolExtensionsTests.cs
@@ -45,7 +45,6 @@ public class INamedTypeSymbolExtensionsTests
                     o.ToString();
                 }
             }
-
             """;
         var (tree, semanticModel) = TestHelper.CompileCS(code);
         var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Last(x => x.NameIs("o")); // o in o.ToString()
@@ -70,7 +69,6 @@ public class INamedTypeSymbolExtensionsTests
                     o.ToString();
                 }
             }
-
             """;
         var (tree, semanticModel) = TestHelper.CompileCS(code);
         var identifier = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Last(x => x.NameIs("o")); // o in o.ToString()


### PR DESCRIPTION
Precondition for #8413

Exposes [INamedTypeSymbol.TypeArgumentNullableAnnotations](https://learn.microsoft.com/zh-tw/dotnet/api/microsoft.codeanalysis.inamedtypesymbol.typeargumentnullableannotations?view=roslyn-dotnet-4.7.0) (but not [IMethodSymbol.TypeArgumentNullableAnnotations](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.imethodsymbol.typeargumentnullableannotations?view=roslyn-dotnet-4.7.0)) 