### PR TITLE
Fix S2259 FP: Engine does not learn `NotNull` from LINQ methods

### DIFF
--- a/analyzers/its/expected/CSharpLatest/S6966-NetCore31.MVC.ConfigurableRules-netcoreapp3.1.Views.json
+++ b/analyzers/its/expected/CSharpLatest/S6966-NetCore31.MVC.ConfigurableRules-netcoreapp3.1.Views.json
@@ -4,7 +4,7 @@
       "Id": "S6966",
       "Message": "Await RenderSectionAsync instead.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/CSharpLatest/NetCore31WithConfigurableRules/Views/Shared/_Layout.cshtml#L46",
-      "Location": "Line 46 Position 7-48"
+      "Location": "Line 46 Position 6-47"
     }
   ]
 }

--- a/analyzers/its/expected/CSharpLatest/S6966-NetCore31.MVC.ConfigurableRules-netcoreapp3.1.Views.json
+++ b/analyzers/its/expected/CSharpLatest/S6966-NetCore31.MVC.ConfigurableRules-netcoreapp3.1.Views.json
@@ -4,7 +4,7 @@
       "Id": "S6966",
       "Message": "Await RenderSectionAsync instead.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/CSharpLatest/NetCore31WithConfigurableRules/Views/Shared/_Layout.cshtml#L46",
-      "Location": "Line 46 Position 6-47"
+      "Location": "Line 46 Position 7-48"
     }
   ]
 }

--- a/analyzers/its/expected/Ember-MM/S2259-scraper.EmberCore.json
+++ b/analyzers/its/expected/Ember-MM/S2259-scraper.EmberCore.json
@@ -182,21 +182,9 @@
     },
     {
       "Id": "S2259",
-      "Message": "\u0027sResults\u0027 is Nothing on at least one execution path.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Ember-MM/Addons/scraper.EmberCore/TVScraper/dlgTVDBSearchResults.vb#L347",
-      "Location": "Line 347 Position 28-36"
-    },
-    {
-      "Id": "S2259",
       "Message": "\u0027sResults.OrderBy(Function(s) s.Lev).FirstOrDefault(Function(s) s.Language.ShortLang = \u0022en\u0022)\u0027 is Nothing on at least one execution path.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Ember-MM/Addons/scraper.EmberCore/TVScraper/dlgTVDBSearchResults.vb#L358",
       "Location": "Line 358 Position 54-145"
-    },
-    {
-      "Id": "S2259",
-      "Message": "\u0027sResults\u0027 is Nothing on at least one execution path.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Ember-MM/Addons/scraper.EmberCore/TVScraper/dlgTVDBSearchResults.vb#L358",
-      "Location": "Line 358 Position 54-62"
     },
     {
       "Id": "S2259",

--- a/analyzers/its/expected/Nancy/S3900-Nancy-net452.json
+++ b/analyzers/its/expected/Nancy/S3900-Nancy-net452.json
@@ -1382,18 +1382,6 @@
     },
     {
       "Id": "S3900",
-      "Message": "Refactor this method to add validation of parameter \u0027localCaptures\u0027 before using it.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy/Routing/Trie/Nodes/TrieNode.cs#L224",
-      "Location": "Line 224 Position 46-59"
-    },
-    {
-      "Id": "S3900",
-      "Message": "Refactor this method to add validation of parameter \u0027localCaptures\u0027 before using it.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy/Routing/Trie/Nodes/TrieNode.cs#L249",
-      "Location": "Line 249 Position 48-61"
-    },
-    {
-      "Id": "S3900",
       "Message": "Refactor this method to add validation of parameter \u0027segments\u0027 before using it.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy/Routing/Trie/Nodes/TrieNode.cs#L96",
       "Location": "Line 96 Position 44-52"

--- a/analyzers/its/expected/Nancy/S3900-Nancy-net452.json
+++ b/analyzers/its/expected/Nancy/S3900-Nancy-net452.json
@@ -1263,12 +1263,6 @@
     {
       "Id": "S3900",
       "Message": "Refactor this method to add validation of parameter \u0027constraint\u0027 before using it.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy/Routing/Constraints/ParameterizedRouteSegmentConstraintBase.cs#L21",
-      "Location": "Line 21 Position 113-123"
-    },
-    {
-      "Id": "S3900",
-      "Message": "Refactor this method to add validation of parameter \u0027constraint\u0027 before using it.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy/Routing/Constraints/ParameterizedRouteSegmentConstraintBase.cs#L35",
       "Location": "Line 35 Position 51-61"
     },

--- a/analyzers/its/expected/Nancy/S3900-Nancy-netstandard2.0.json
+++ b/analyzers/its/expected/Nancy/S3900-Nancy-netstandard2.0.json
@@ -1382,18 +1382,6 @@
     },
     {
       "Id": "S3900",
-      "Message": "Refactor this method to add validation of parameter \u0027localCaptures\u0027 before using it.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy/Routing/Trie/Nodes/TrieNode.cs#L224",
-      "Location": "Line 224 Position 46-59"
-    },
-    {
-      "Id": "S3900",
-      "Message": "Refactor this method to add validation of parameter \u0027localCaptures\u0027 before using it.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy/Routing/Trie/Nodes/TrieNode.cs#L249",
-      "Location": "Line 249 Position 48-61"
-    },
-    {
-      "Id": "S3900",
       "Message": "Refactor this method to add validation of parameter \u0027segments\u0027 before using it.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy/Routing/Trie/Nodes/TrieNode.cs#L96",
       "Location": "Line 96 Position 44-52"

--- a/analyzers/its/expected/Nancy/S3900-Nancy-netstandard2.0.json
+++ b/analyzers/its/expected/Nancy/S3900-Nancy-netstandard2.0.json
@@ -1263,12 +1263,6 @@
     {
       "Id": "S3900",
       "Message": "Refactor this method to add validation of parameter \u0027constraint\u0027 before using it.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy/Routing/Constraints/ParameterizedRouteSegmentConstraintBase.cs#L21",
-      "Location": "Line 21 Position 113-123"
-    },
-    {
-      "Id": "S3900",
-      "Message": "Refactor this method to add validation of parameter \u0027constraint\u0027 before using it.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy/Routing/Constraints/ParameterizedRouteSegmentConstraintBase.cs#L35",
       "Location": "Line 35 Position 51-61"
     },

--- a/analyzers/its/expected/Nancy/S3900-Nancy.Testing-net452.json
+++ b/analyzers/its/expected/Nancy/S3900-Nancy.Testing-net452.json
@@ -62,12 +62,6 @@
     },
     {
       "Id": "S3900",
-      "Message": "Refactor this method to add validation of parameter \u0027cookies\u0027 before using it.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy.Testing/BrowserContextExtensions.cs#L119",
-      "Location": "Line 119 Position 36-43"
-    },
-    {
-      "Id": "S3900",
       "Message": "Refactor this method to add validation of parameter \u0027browserContext\u0027 before using it.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy.Testing/BrowserContextExtensions.cs#L152",
       "Location": "Line 152 Position 13-27"

--- a/analyzers/its/expected/Nancy/S3900-Nancy.Testing-netstandard2.0.json
+++ b/analyzers/its/expected/Nancy/S3900-Nancy.Testing-netstandard2.0.json
@@ -62,12 +62,6 @@
     },
     {
       "Id": "S3900",
-      "Message": "Refactor this method to add validation of parameter \u0027cookies\u0027 before using it.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy.Testing/BrowserContextExtensions.cs#L119",
-      "Location": "Line 119 Position 36-43"
-    },
-    {
-      "Id": "S3900",
       "Message": "Refactor this method to add validation of parameter \u0027browserContext\u0027 before using it.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Nancy/src/Nancy.Testing/BrowserContextExtensions.cs#L152",
       "Location": "Line 152 Position 13-27"

--- a/analyzers/its/expected/akka.net/S3900-Akka-netstandard2.0.json
+++ b/analyzers/its/expected/akka.net/S3900-Akka-netstandard2.0.json
@@ -188,12 +188,6 @@
     },
     {
       "Id": "S3900",
-      "Message": "Refactor this method to add validation of parameter \u0027elements\u0027 before using it.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/akka.net/src/core/Akka/Actor/ActorSelection.cs#L82",
-      "Location": "Line 82 Position 31-39"
-    },
-    {
-      "Id": "S3900",
       "Message": "Refactor this method to add validation of parameter \u0027setup\u0027 before using it.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/akka.net/src/core/Akka/Actor/ActorSystem.cs#L261",
       "Location": "Line 261 Position 34-39"

--- a/analyzers/its/expected/akka.net/S3900-Akka.Cluster.TestKit-netstandard2.0.json
+++ b/analyzers/its/expected/akka.net/S3900-Akka.Cluster.TestKit-netstandard2.0.json
@@ -2,12 +2,6 @@
   "Issues": [
     {
       "Id": "S3900",
-      "Message": "Refactor this method to add validation of parameter \u0027roles\u0027 before using it.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/akka.net/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs#L269",
-      "Location": "Line 269 Position 32-37"
-    },
-    {
-      "Id": "S3900",
       "Message": "Refactor this method to add validation of parameter \u0027expectedAddresses\u0027 before using it.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/akka.net/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs#L306",
       "Location": "Line 306 Position 37-54"

--- a/analyzers/its/expected/akka.net/S3900-Akka.Remote.TestKit-netstandard2.0.json
+++ b/analyzers/its/expected/akka.net/S3900-Akka.Remote.TestKit-netstandard2.0.json
@@ -44,21 +44,9 @@
     },
     {
       "Id": "S3900",
-      "Message": "Refactor this method to add validation of parameter \u0027messageClasses\u0027 before using it.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/akka.net/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs#L552",
-      "Location": "Line 552 Position 44-58"
-    },
-    {
-      "Id": "S3900",
       "Message": "Refactor this method to add validation of parameter \u0027tc\u0027 before using it.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/akka.net/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs#L565",
       "Location": "Line 565 Position 27-29"
-    },
-    {
-      "Id": "S3900",
-      "Message": "Refactor this method to add validation of parameter \u0027names\u0027 before using it.",
-      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/akka.net/src/core/Akka.Remote.TestKit/Player.cs#L127",
-      "Location": "Line 127 Position 34-39"
     }
   ]
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/SymbolicExecution/Roslyn/NullPointerDereference.cs
@@ -2140,7 +2140,7 @@ class Repro_8907_8908
         }
         if (5 < values.Count())         // FN, will throw when values is null
         {
-            _ = values[5].ToString();   // Noncompliant FP, we do not learn NotNull from LINQ methods
+            _ = values[5].ToString();   // Compliant, we learn NotNull from LINQ methods
         }
     }
 }


### PR DESCRIPTION
Fixes #8907

For this PR, I had to build two lists of methods: 
* one that does early null-checking
* and one that doesn't, or does lazily when the enumerable is used somehow.

These lists may have changed over time, in different versions of .NET Framework and Core.

So I decided to be conservative and only include the (public) LINQ methods that do null-checking as precondition, i.e. right at the beginning of the call, and typically with code like `if (source == null) throw Error.ArgumentNull("source")`. The assumption is that null-checks are most likely going to be added, not removed.

I used `Enumerable.cs` from .NET Framework 4.0 for that, went through the merged class, and checked if the precondition is asserted right after the signature. That means that my list was not complete, and intentionally so. Every new .NET version may come with new LINQ methods (e.g. `Order`), that will need to be checked and added to this list.

Moreover, I haven't run all the methods: there were too many of them, and I should have then checked the stack trace to understand if the exception was truly intentionally produced by an explicit null-check or not. That would have been a lot of marginal work for the same marginal return.

I have now added the methods `Count`, `OrderBy`, and `GroupBy` to the list because, even though, unlike all other LINQ methods, don't explicitly have preconditions on, where manually tested and also quite common. For the future, when LINQ methods will be added to this list, we should make sure that, or at least assess whether, the early null-check has changed across .NET versions.