### PR TITLE
Replace deprecated ReportIssue calls in UTs

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextTest.Register.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextTest.Register.cs
@@ -352,7 +352,7 @@ public partial class SonarAnalysisContextTest
                         nodeContext.ReportIssue(diagnosticDescriptor, location, "Node"), SyntaxKind.InvocationExpression);
                 },
             SymbolKind.NamedType)));
-        var compilation = snippet.Compilation.WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+        var compilation = snippet.Compilation.WithAnalyzers([analyzer]);
         var diagnostics = await compilation.GetAllDiagnosticsAsync();
         diagnostics.Should().HaveCount(expectedDiagnostics.Length);
         // Ordering is only partially guaranteed and therefore we use BeEquivalentTo https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Analyzer%20Actions%20Semantics.md

--- a/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextTest.Register.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarAnalysisContextTest.Register.cs
@@ -337,18 +337,18 @@ public partial class SonarAnalysisContextTest
                 compilationStartContext.RegisterSymbolStartAction(symbolStartContext =>
                 {
                     symbolStartContext.RegisterCodeBlockAction(codeBlockContext =>
-                        codeBlockContext.ReportIssue(CreateDiagnostic("CodeBlock")));
+                        codeBlockContext.ReportIssue(diagnosticDescriptor, LocationInTree(), "CodeBlock"));
                     symbolStartContext.RegisterCodeBlockStartAction<SyntaxKind>(codeBlockStartContext =>
                     {
                         codeBlockStartContext.RegisterNodeAction(nodeContext =>
-                            nodeContext.ReportIssue(CreateDiagnostic("CodeBlockStart_Node")), SyntaxKind.InvocationExpression);
+                            nodeContext.ReportIssue(diagnosticDescriptor, LocationInTree(), "CodeBlockStart_Node"), SyntaxKind.InvocationExpression);
                         codeBlockStartContext.RegisterCodeBlockEndAction(codeBlockEndContext =>
-                            codeBlockEndContext.ReportIssue(CreateDiagnostic("CodeBlockStart_End")));
+                            codeBlockEndContext.ReportIssue(diagnosticDescriptor, LocationInTree(), "CodeBlockStart_End"));
                     });
                     symbolStartContext.RegisterSymbolEndAction(symbolEndContext =>
-                        symbolEndContext.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, CreateDiagnostic("SymbolEnd")));
+                        symbolEndContext.ReportIssue(CSharpGeneratedCodeRecognizer.Instance, diagnosticDescriptor, LocationInTree(), "SymbolEnd"));
                     symbolStartContext.RegisterSyntaxNodeAction(nodeContext =>
-                        nodeContext.ReportIssue(CreateDiagnostic("Node")), SyntaxKind.InvocationExpression);
+                        nodeContext.ReportIssue(diagnosticDescriptor, LocationInTree(), "Node"), SyntaxKind.InvocationExpression);
                 },
             SymbolKind.NamedType)));
         var compilation = snippet.Compilation.WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
@@ -357,7 +357,7 @@ public partial class SonarAnalysisContextTest
         // Ordering is only partially guaranteed and therefore we use BeEquivalentTo https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Analyzer%20Actions%20Semantics.md
         diagnostics.Select(x => x.GetMessage()).Should().BeEquivalentTo(expectedDiagnostics);
 
-        Diagnostic CreateDiagnostic(string message) => Diagnostic.Create(diagnosticDescriptor, Location.Create(snippet.SyntaxTree, TextSpan.FromBounds(0, 0)), message);
+        Location LocationInTree() => Location.Create(snippet.SyntaxTree, TextSpan.FromBounds(0, 0));
     }
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarSemanticModelReportingContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarSemanticModelReportingContextTest.cs
@@ -48,7 +48,7 @@ public class SonarSemanticModelReportingContextTest
     public void RegistrationIsExecuted_SonarAnalysisContext_CS() =>
         new VerifierBuilder().AddAnalyzer(() => new TestAnalyzerCS((context, g) =>
             context.RegisterSemanticModelAction(g, c =>
-                c.ReportIssue(Diagnostic.Create(TestAnalyzer.Rule, c.Tree.GetRoot().GetFirstToken().GetLocation())))))
+                c.ReportIssue(TestAnalyzer.Rule, c.Tree.GetRoot().GetFirstToken()))))
         .AddSnippet("""
         using System; // Noncompliant
         """)
@@ -58,7 +58,7 @@ public class SonarSemanticModelReportingContextTest
     public void RegistrationIsExecuted_SonarAnalysisContext_VB() =>
         new VerifierBuilder().AddAnalyzer(() => new TestAnalyzerVB((context, g) =>
             context.RegisterSemanticModelAction(g, c =>
-                c.ReportIssue(Diagnostic.Create(TestAnalyzer.Rule, c.Tree.GetRoot().GetFirstToken().GetLocation())))))
+                c.ReportIssue(TestAnalyzer.Rule, c.Tree.GetRoot().GetFirstToken()))))
         .AddSnippet("""
         Imports System ' Noncompliant
         """)
@@ -72,7 +72,7 @@ public class SonarSemanticModelReportingContextTest
                 {
                     if (c.Tree.GetRoot().GetFirstToken() is { RawKind: not (int)CS.SyntaxKind.None } token)
                     {
-                        c.ReportIssue(Diagnostic.Create(TestAnalyzer.Rule, token.GetLocation()));
+                        c.ReportIssue(TestAnalyzer.Rule, token);
                     }
                 }))))
             .AddSnippet("""
@@ -88,7 +88,7 @@ public class SonarSemanticModelReportingContextTest
                 {
                     if (c.Tree.GetRoot().GetFirstToken() is { RawKind: not (int)VB.SyntaxKind.None } token)
                     {
-                        c.ReportIssue(Diagnostic.Create(TestAnalyzer.Rule, token.GetLocation()));
+                        c.ReportIssue(TestAnalyzer.Rule, token);
                     }
                 }))))
             .AddSnippet("""

--- a/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarSyntaxNodeReportingContextTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/AnalysisContext/SonarSyntaxNodeReportingContextTest.cs
@@ -66,7 +66,7 @@ public class SonarSyntaxNodeReportingContextTest
         var sut = new SonarSyntaxNodeReportingContext(analysisContext, context);
         try
         {
-            sut.ReportIssue(Diagnostic.Create(rule, (reportOnCorrectTree ? nodeFromCorrectCompilation : nodeFromAnotherCompilation).GetLocation()));
+            sut.ReportIssue(rule, reportOnCorrectTree ? nodeFromCorrectCompilation : nodeFromAnotherCompilation);
         }
         catch (Exception ex)    // Can't catch internal DebugAssertException
         {

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/CodeFixProviderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Verification/CodeFixProviderTest.cs
@@ -54,8 +54,8 @@ public class CodeFixProviderTest
             context.RegisterNodeAction(TestGeneratedCodeRecognizer.Instance, c =>
             {
                 // Duplicate issues from different analyzer versions, see https://github.com/SonarSource/sonar-dotnet/issues/1109
-                c.ReportIssue(Diagnostic.Create(rule, c.Context.Node.GetLocation()));
-                c.ReportIssue(Diagnostic.Create(rule, c.Context.Node.GetLocation()));
+                c.ReportIssue(rule, c.Context.Node);
+                c.ReportIssue(rule, c.Context.Node);
             }, SyntaxKind.NamespaceDeclaration);
     }
 

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Analyzers/DummyAnalyzer.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Analyzers/DummyAnalyzer.cs
@@ -46,5 +46,5 @@ public abstract class DummyAnalyzer<TSyntaxKind> : SonarDiagnosticAnalyzer where
     protected abstract TSyntaxKind NumericLiteralExpression { get; }
 
     protected sealed override void Initialize(SonarAnalysisContext context) =>
-        context.RegisterNodeAction(TestGeneratedCodeRecognizer.Instance, c => c.ReportIssue(Diagnostic.Create(rule, c.Node.GetLocation())), NumericLiteralExpression);
+        context.RegisterNodeAction(TestGeneratedCodeRecognizer.Instance, c => c.ReportIssue(rule, c.Node), NumericLiteralExpression);
 }


### PR DESCRIPTION
Follow up on #9377

After this PR, there are still 12 `ReportIssue(diagnostic)` calls left. These require a bit more work to resolve, as they use a "collect and report later" approach.