### PR TITLE
Add GH action slack notification

### DIFF
--- a/.github/workflows/SlackNotification.yml
+++ b/.github/workflows/SlackNotification.yml
@@ -1,0 +1,15 @@
+# .github/workflows/slack_notify.yml
+---
+name: Slack Notifications
+on:
+ check_run:
+  types: [rerequested, completed]
+
+jobs:
+ slack-notifications:
+  permissions:
+   id-token: write  # to authenticate via OIDC
+  uses: SonarSource/gh-action_build-notify/.github/workflows/main.yaml@v1
+  if: github.event.check_run.name == 'Sonar.Net'
+  with:
+    slackChannel: squad-dotnet


### PR DESCRIPTION
The workflow needs to be on the master branch to be triggered.
See the [documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#check_run):
```
Note: This event will only trigger a workflow run if the workflow file is on the default branch.
```

Until then, no tests can be done.

Based on https://github.com/SonarSource/sonar-scanner-msbuild/blob/master/.github/workflows/SlackNotification.yml