### PR TITLE
Fix S1854 FP: Value used in `catch` or `when` should LiveIn for all try blocks

### DIFF
--- a/analyzers/its/expected/Ember-MM/S2259-EmberAPI.json
+++ b/analyzers/its/expected/Ember-MM/S2259-EmberAPI.json
@@ -38,6 +38,24 @@
     },
     {
       "Id": "S2259",
+      "Message": "\u0027inList\u0027 is Nothing on at least one execution path.",
+      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Ember-MM/EmberAPI/clsAPIScanner.vb#L1022",
+      "Location": "Line 1022 Position 60-66"
+    },
+    {
+      "Id": "S2259",
+      "Message": "\u0027dList\u0027 is Nothing on at least one execution path.",
+      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Ember-MM/EmberAPI/clsAPIScanner.vb#L926",
+      "Location": "Line 926 Position 52-57"
+    },
+    {
+      "Id": "S2259",
+      "Message": "\u0027inList\u0027 is Nothing on at least one execution path.",
+      "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Ember-MM/EmberAPI/clsAPIScanner.vb#L995",
+      "Location": "Line 995 Position 56-62"
+    },
+    {
+      "Id": "S2259",
       "Message": "\u0027movieName\u0027 is Nothing on at least one execution path.",
       "Uri": "https://github.com/SonarSource/sonar-dotnet/blob/master/analyzers/its/Projects/Ember-MM/EmberAPI/clsAPIStringUtils.vb#L161",
       "Location": "Line 161 Position 55-64"

--- a/analyzers/src/SonarAnalyzer.CFG/LiveVariableAnalysis/RoslynLiveVariableAnalysis.cs
+++ b/analyzers/src/SonarAnalyzer.CFG/LiveVariableAnalysis/RoslynLiveVariableAnalysis.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Runtime.CompilerServices;
 using SonarAnalyzer.CFG.Roslyn;
 
 namespace SonarAnalyzer.CFG.LiveVariableAnalysis;

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/DeadStores.RoslynCfg.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/DeadStores.RoslynCfg.cs
@@ -1436,7 +1436,7 @@ namespace Tests.Diagnostics
             {
             }
         }
-        
+
         public void UsedInFinally_Throw()
         {
             var value = 42; // Compliant 

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/SymbolicExecution/Roslyn/ConditionEvaluatesToConstant.cs
@@ -4166,9 +4166,9 @@ class Repro_8719
                 exception = e;
             }
         }
-        if (exception != null)  // FN!
+        if (exception != null)              // Noncompliant
         {
-            Console.WriteLine(exception);
+            Console.WriteLine(exception);   // Secondary
         }
         Console.WriteLine(success);
     }


### PR DESCRIPTION
Fixes #9447
Fixes #8719

The FP is not visible in this PR, because it's muted by the rule, see #4940