### PR TITLE
Fix S1144 FP: Ignore unused `Deconstruct` methods

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -190,9 +190,14 @@ public sealed class UnusedPrivateMember : SonarDiagnosticAnalyzer
             .Except(usageCollector.UsedSymbols)
             .Where(x => !IsMentionedInDebuggerDisplay(x, usageCollector)
                 && !IsAccessorUsed(x, usageCollector)
+                && !IsDeconstructMethod(x)
                 && !usageCollector.PrivateAttributes.Contains(x)
                 && !IsUsedWithReflection(x, usageCollector.TypesUsedWithReflection))
             .ToHashSet();
+
+    private static bool IsDeconstructMethod(ISymbol symbol) =>
+        symbol is IMethodSymbol { Name: "Deconstruct", Parameters.Length: > 0 } method
+        && method.Parameters.All(x => x.RefKind == RefKind.Out);
 
     private static bool IsAccessorUsed(ISymbol symbol, CSharpSymbolUsageCollector usageCollector) =>
         symbol is IMethodSymbol { AssociatedSymbol: IPropertySymbol property } accessor

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedPrivateMember.cs
@@ -197,6 +197,7 @@ public sealed class UnusedPrivateMember : SonarDiagnosticAnalyzer
 
     private static bool IsDeconstructMethod(ISymbol symbol) =>
         symbol is IMethodSymbol { Name: "Deconstruct", Parameters.Length: > 0 } method
+        && method.ReturnType.Is(KnownType.Void)
         && method.Parameters.All(x => x.RefKind == RefKind.Out);
 
     private static bool IsAccessorUsed(ISymbol symbol, CSharpSymbolUsageCollector usageCollector) =>

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.CSharp7.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.CSharp7.cs
@@ -113,6 +113,18 @@ public class ReproIssue2478
         private void Deconstruct(out string a, out string b) { a = b = null; } // Compliant, Deconstruct methods are ignored
     }
 
+    public class InvalidDeconstruct
+    {
+        private void Deconstruct(object a, out object b, out object c) { b = c = a; } // Noncompliant
+        private void Deconstruct() { } // Noncompliant
+
+        private int Deconstruct(out object a, out object b, out object c) // Noncompliant
+        {
+            a = b = c = null;
+            return 42;
+        }
+    }
+
     private ForMethod ReturnFromMethod() => null;
     private sealed class ForMethod
     {

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.CSharp7.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.CSharp7.cs
@@ -98,7 +98,7 @@ public class ReproIssue2478
     private class Ambiguous
     {
         public void Deconstruct(out string a, out string b, out string c) { a = b = c = null; }
-        public void Deconstruct(out object a, out object b, out object c) { a = b = c = null; } // Compliant, Deconstruct methods are ignored FP, actually the one above is not used
+        public void Deconstruct(out object a, out object b, out object c) { a = b = c = null; } // Compliant, Deconstruct methods are ignored
     }
 
     private class NotUsedDifferentArgumentCount

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.CSharp7.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.CSharp7.cs
@@ -60,32 +60,29 @@ public class ReproIssue2478
     {
         public void Deconstruct(out object a, out InternalDeconstruct b) { a = b = null; }
 
-        // deconstructors must be public, internal or protected internal
-        private void Deconstruct(out object a, out object b) { a = b = null; } // Noncompliant
+        private void Deconstruct(out object a, out object b) { a = b = null; } // Compliant, Deconstruct methods are ignored
     }
 
     internal sealed class InternalDeconstruct
     {
         internal void Deconstruct(out object a, out object b) { a = b = null; }
 
-        // deconstructors must be public, internal or protected internal
-        private void Deconstruct(out object a, out string b, out string c) { a = b = c = null; } // Noncompliant
+        private void Deconstruct(out object a, out string b, out string c) { a = b = c = null; } // Compliant, Deconstruct methods are ignored
     }
 
     private class PublicDeconstruct
     {
         public void Deconstruct(out object a, out object b, out object c) { a = b = c = null; }
 
-        // deconstructors must be public, internal or protected internal
-        protected void Deconstruct(out string a, out string b, out string c) { a = b = c = null; } // Noncompliant
-        private void Deconstruct(out object a, out string b, out string c) { a = b = c = null; } // Noncompliant
+        protected void Deconstruct(out string a, out string b, out string c) { a = b = c = null; } // Compliant, Deconstruct methods are ignored
+        private void Deconstruct(out object a, out string b, out string c) { a = b = c = null; } // Compliant, Deconstruct methods are ignored
     }
 
     private sealed class MultipleDeconstructors
     {
         public void Deconstruct(out object a, out object b, out object c) { a = b = c = null; }
 
-        public void Deconstruct(out object a, out object b) // Noncompliant
+        public void Deconstruct(out object a, out object b) // Compliant, Deconstruct methods are ignored
         {
             a = b = null;
         }
@@ -95,25 +92,25 @@ public class ReproIssue2478
     {
         protected internal void Deconstruct(out object a, out object b) { a = b = null; }
 
-        protected internal void Deconstruct(out object a, out object b, out object c) { a = b = c = null; } // Noncompliant
+        protected internal void Deconstruct(out object a, out object b, out object c) { a = b = c = null; } // Compliant, Deconstruct methods are ignored
     }
 
     private class Ambiguous
     {
         public void Deconstruct(out string a, out string b, out string c) { a = b = c = null; }
-        public void Deconstruct(out object a, out object b, out object c) { a = b = c = null; } // Noncompliant FP, actually the one above is not used
+        public void Deconstruct(out object a, out object b, out object c) { a = b = c = null; } // Compliant, Deconstruct methods are ignored FP, actually the one above is not used
     }
 
     private class NotUsedDifferentArgumentCount
     {
-        public void Deconstruct(out string a, out string b, out string c) { a = b = c = null; } // Noncompliant
-        public void Deconstruct(out string a, out string b, out string c, out string d) { a = b = c = d = null; } // Noncompliant
+        public void Deconstruct(out string a, out string b, out string c) { a = b = c = null; } // Compliant, Deconstruct methods are ignored
+        public void Deconstruct(out string a, out string b, out string c, out string d) { a = b = c = d = null; } // Compliant, Deconstruct methods are ignored
     }
 
     private class NotUsedNotVisible
     {
-        protected void Deconstruct(out object a, out object b) { a = b = null; } // Noncompliant
-        private void Deconstruct(out string a, out string b) { a = b = null; } // Noncompliant
+        protected void Deconstruct(out object a, out object b) { a = b = null; } // Compliant, Deconstruct methods are ignored
+        private void Deconstruct(out string a, out string b) { a = b = null; } // Compliant, Deconstruct methods are ignored
     }
 
     private ForMethod ReturnFromMethod() => null;

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.CSharp8.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedPrivateMember.CSharp8.cs
@@ -33,12 +33,12 @@ namespace Tests.Diagnostics
 
         private sealed class ForSwitchArm
         {
-            public void Deconstruct(out object a, out object b) { a = b = null; } // Noncompliant FP
+            public void Deconstruct(out object a, out object b) { a = b = null; } // Compliant, Deconstruct methods are ignored
         }
 
         private sealed class ForIsPattern
         {
-            public void Deconstruct(out string a, out string b) { a = b = null; } // Noncompliant FP
+            public void Deconstruct(out string a, out string b) { a = b = null; } // Compliant
         }
     }
 }


### PR DESCRIPTION
Fixes #3842

To merge after #9459

S1144 will now ignore unused `Deconstruct` methods.
It ignores methods named `Deconstruct` with at least 1 parameter and when all parameters have the `out` reference keyword.  