### PR TITLE
Streamline packaging/binaries folder

### DIFF
--- a/analyzers/its/Directory.Build.targets
+++ b/analyzers/its/Directory.Build.targets
@@ -20,7 +20,8 @@
       <SonarProjectType Condition="$(SonarUnknownProjectType) == 'true'">Unknown</SonarProjectType>
     </PropertyGroup>
 
-    <Error Text="Could not find '$(BinariesFolder)\SonarAnalyzer.CSharp\SonarAnalyzer.dll'" Condition="!Exists('$(BinariesFolder)\SonarAnalyzer.CSharp\SonarAnalyzer.dll')" />
+    <Error Text="Could not find '$(BinariesFolder)\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.dll'" Condition="!Exists('$(BinariesFolder)\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.dll')" />
+    <Error Text="Could not find '$(BinariesFolder)\SonarAnalyzer.VisualBasic\SonarAnalyzer.VisualBasic.dll'" Condition="!Exists('$(BinariesFolder)\SonarAnalyzer.VisualBasic\SonarAnalyzer.VisualBasic.dll')" />
 
     <!-- This section builds content of SonarProjectConfig.xml additional file. We need to simulate S4MSB behavior to configure the analyzer. -->
     <ItemGroup>
@@ -52,8 +53,8 @@
       <!-- Remove all previously added analyzers, except built-in SourceGenerators -->
       <Analyzer Remove="@(Analyzer)" Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)', '(Generator|Generators|SourceGeneration|SourceGenerators)$'))"/>
       <!-- Add the SonarAnalyzer analyzer DLLs -->
-      <Analyzer Include="$(BinariesFolder)\SonarAnalyzer.*\SonarAnalyzer*.dll" />
-      <Analyzer Include="$(BinariesFolder)\SonarAnalyzer.*\Google.Protobuf.dll" />
+      <Analyzer Include="$(BinariesFolder)\SonarAnalyzer.CSharp\*.dll" />
+      <Analyzer Include="$(BinariesFolder)\SonarAnalyzer.VisualBasic\*.dll" />
       <AdditionalFiles Include="$(MSBuildStartupDirectory)\output\$(PROJECT)\SonarLint.xml" />
       <AdditionalFiles Include="$(SonarProjectConfigFilePath)" />
     </ItemGroup>

--- a/analyzers/its/Directory.Build.targets
+++ b/analyzers/its/Directory.Build.targets
@@ -20,7 +20,7 @@
       <SonarProjectType Condition="$(SonarUnknownProjectType) == 'true'">Unknown</SonarProjectType>
     </PropertyGroup>
 
-    <Error Text="Could not find '$(BinariesFolder)\SonarAnalyzer.dll'" Condition="!Exists('$(BinariesFolder)\SonarAnalyzer.dll')" />
+    <Error Text="Could not find '$(BinariesFolder)\SonarAnalyzer.CSharp\SonarAnalyzer.dll'" Condition="!Exists('$(BinariesFolder)\SonarAnalyzer.CSharp\SonarAnalyzer.dll')" />
 
     <!-- This section builds content of SonarProjectConfig.xml additional file. We need to simulate S4MSB behavior to configure the analyzer. -->
     <ItemGroup>
@@ -52,8 +52,8 @@
       <!-- Remove all previously added analyzers, except built-in SourceGenerators -->
       <Analyzer Remove="@(Analyzer)" Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)', '(Generator|Generators|SourceGeneration|SourceGenerators)$'))"/>
       <!-- Add the SonarAnalyzer analyzer DLLs -->
-      <Analyzer Include="$(BinariesFolder)\SonarAnalyzer*.dll" />
-      <Analyzer Include="$(BinariesFolder)\Google.Protobuf.dll" />
+      <Analyzer Include="$(BinariesFolder)\SonarAnalyzer.*\SonarAnalyzer*.dll" />
+      <Analyzer Include="$(BinariesFolder)\SonarAnalyzer.*\Google.Protobuf.dll" />
       <AdditionalFiles Include="$(MSBuildStartupDirectory)\output\$(PROJECT)\SonarLint.xml" />
       <AdditionalFiles Include="$(SonarProjectConfigFilePath)" />
     </ItemGroup>

--- a/analyzers/its/regression-test.ps1
+++ b/analyzers/its/regression-test.ps1
@@ -230,10 +230,8 @@ function Invoke-JsonParser()
 try {
     . (Join-Path $PSScriptRoot "..\..\scripts\build\build-utils.ps1")
     Push-Location $PSScriptRoot
-    Test-FileExists "..\packaging\binaries\SonarAnalyzer.CSharp\SonarAnalyzer.dll"
-    Test-FileExists "..\packaging\binaries\SonarAnalyzer.CSharp\SonarAnalyzer.CFG.dll"
-    Test-FileExists "..\packaging\binaries\SonarAnalyzer.VisualBasic\SonarAnalyzer.dll"
-    Test-FileExists "..\packaging\binaries\SonarAnalyzer.VisualBasic\SonarAnalyzer.CFG.dll"
+    Test-FileExists "..\packaging\binaries\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.dll"
+    Test-FileExists "..\packaging\binaries\SonarAnalyzer.VisualBasic\SonarAnalyzer.VisualBasic.dll"
     Test-FileExists "..\packaging\binaries\ITs.JsonParser\ITs.JsonParser.exe"
 
     Write-Header "Initializing the environment"

--- a/analyzers/its/regression-test.ps1
+++ b/analyzers/its/regression-test.ps1
@@ -230,8 +230,10 @@ function Invoke-JsonParser()
 try {
     . (Join-Path $PSScriptRoot "..\..\scripts\build\build-utils.ps1")
     Push-Location $PSScriptRoot
-    Test-FileExists "..\packaging\binaries\SonarAnalyzer.dll"
-    Test-FileExists "..\packaging\binaries\SonarAnalyzer.CFG.dll"
+    Test-FileExists "..\packaging\binaries\SonarAnalyzer.CSharp\SonarAnalyzer.dll"
+    Test-FileExists "..\packaging\binaries\SonarAnalyzer.CSharp\SonarAnalyzer.CFG.dll"
+    Test-FileExists "..\packaging\binaries\SonarAnalyzer.VisualBasic\SonarAnalyzer.dll"
+    Test-FileExists "..\packaging\binaries\SonarAnalyzer.VisualBasic\SonarAnalyzer.CFG.dll"
     Test-FileExists "..\packaging\binaries\ITs.JsonParser\ITs.JsonParser.exe"
 
     Write-Header "Initializing the environment"

--- a/analyzers/packaging/SonarAnalyzer.CSharp.Styling.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.CSharp.Styling.nuspec
@@ -22,7 +22,7 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="binaries\internal\Internal.SonarAnalyzer.CSharp.Styling.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.CSharp.Styling\Internal.SonarAnalyzer.CSharp.Styling.dll" target="analyzers" />
     <file src="logos\sonarsource_64.png" target="images\" />
     <file src="..\..\THIRD-PARTY-NOTICES.txt" target="license\" />
   </files>

--- a/analyzers/packaging/SonarAnalyzer.CSharp.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.CSharp.nuspec
@@ -23,10 +23,10 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="binaries\Google.Protobuf.dll" target="analyzers" />
-    <file src="binaries\SonarAnalyzer.dll" target="analyzers" />
-    <file src="binaries\SonarAnalyzer.CFG.dll" target="analyzers" />
-    <file src="binaries\SonarAnalyzer.CSharp.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.CSharp\Google.Protobuf.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.CSharp\SonarAnalyzer.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.CSharp\SonarAnalyzer.CFG.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.CSharp\SonarAnalyzer.CSharp.dll" target="analyzers" />
     <file src="tools-cs\*.ps1" target="tools\" />
     <file src="logos\sonarsource_64.png" target="images\" />
     <file src="..\..\THIRD-PARTY-NOTICES.txt" target="license\" />

--- a/analyzers/packaging/SonarAnalyzer.VisualBasic.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.VisualBasic.nuspec
@@ -23,10 +23,10 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="binaries\Google.Protobuf.dll" target="analyzers" />
-    <file src="binaries\SonarAnalyzer.dll" target="analyzers" />
-    <file src="binaries\SonarAnalyzer.CFG.dll" target="analyzers" />
-    <file src="binaries\SonarAnalyzer.VisualBasic.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.VisualBasic\Google.Protobuf.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.VisualBasic\SonarAnalyzer.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.VisualBasic\SonarAnalyzer.CFG.dll" target="analyzers" />
+    <file src="binaries\SonarAnalyzer.VisualBasic\SonarAnalyzer.VisualBasic.dll" target="analyzers" />
     <file src="tools-vbnet\*.ps1" target="tools\" />
     <file src="logos\sonarsource_64.png" target="images\" />
     <file src="..\..\THIRD-PARTY-NOTICES.txt" target="license\" />

--- a/analyzers/src/Directory.Build.targets
+++ b/analyzers/src/Directory.Build.targets
@@ -3,12 +3,10 @@
   <Import Project="$(MSBuildThisFileDirectory)\..\Analyzers.targets" />
 
   <PropertyGroup>
-    <!-- `BinariesFolder` - binary files folder used by ITs and java packaging -->
+    <!-- `BinariesFolder` - binary files folder used by ITs, NuGet and java packaging -->
     <BinariesFolder>$(MSBuildThisFileDirectory)..\packaging\binaries\$(ProjectName)</BinariesFolder>
   </PropertyGroup>
 
-  <!-- The condition causes the target to only be executed once during the outer build step.
-       Without it, it will be executed multiple times, which can introduce race conditions. -->
   <Target Name="CleanBinaries" AfterTargets="Clean" Condition="Exists('$(BinariesFolder)')">
     <RemoveDir Directories="$(BinariesFolder)" />
   </Target>

--- a/analyzers/src/Directory.Build.targets
+++ b/analyzers/src/Directory.Build.targets
@@ -4,14 +4,12 @@
 
   <PropertyGroup>
     <!-- `BinariesFolder` - binary files folder used by ITs and java packaging -->
-    <BinariesFolder>$(MSBuildThisFileDirectory)..\packaging\binaries\</BinariesFolder>
-    <!-- Avoid SonarAnalyzer.CSharp.Styling to be picked up by Java ITs -->
-    <BinariesFolderInternal>$(BinariesFolder)internal\</BinariesFolderInternal>
+    <BinariesFolder>$(MSBuildThisFileDirectory)..\packaging\binaries\$(ProjectName)</BinariesFolder>
   </PropertyGroup>
 
   <!-- The condition causes the target to only be executed once during the outer build step.
        Without it, it will be executed multiple times, which can introduce race conditions. -->
-  <Target Name="CleanBinaries" AfterTargets="Clean" Condition="'$(IsCrossTargetingBuild)' == 'true' And Exists('$(BinariesFolder)')">
+  <Target Name="CleanBinaries" AfterTargets="Clean" Condition="Exists('$(BinariesFolder)')">
     <RemoveDir Directories="$(BinariesFolder)" />
   </Target>
 </Project>

--- a/analyzers/src/ITs.JsonParser/ITs.JsonParser.csproj
+++ b/analyzers/src/ITs.JsonParser/ITs.JsonParser.csproj
@@ -20,7 +20,7 @@
       <BinariesToCopy Include="$(OutputPath)\*.dll" />
       <BinariesToCopy Include="$(OutputPath)\*.json" />
     </ItemGroup>
-    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(BinariesFolder)\ITs.JsonParser" />
+    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(BinariesFolder)" />
   </Target>
 
 </Project>

--- a/analyzers/src/RuleDescriptorGenerator/RuleDescriptorGenerator.csproj
+++ b/analyzers/src/RuleDescriptorGenerator/RuleDescriptorGenerator.csproj
@@ -27,7 +27,7 @@
       <BinariesToCopy Include="$(OutputPath)\*.dll" />
       <BinariesToCopy Include="$(OutputPath)\*.json" />
     </ItemGroup>
-    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(BinariesFolder)\RuleDescriptorGenerator" />
+    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(BinariesFolder)" />
   </Target>
 
 </Project>

--- a/analyzers/src/SonarAnalyzer.CSharp.Styling/SonarAnalyzer.CSharp.Styling.csproj
+++ b/analyzers/src/SonarAnalyzer.CSharp.Styling/SonarAnalyzer.CSharp.Styling.csproj
@@ -49,6 +49,6 @@
   </Target>
 
   <Target Name="CopyBinaries" AfterTargets="Build" DependsOnTargets="SignDlls">
-    <Copy SourceFiles="$(OutputPath)$(TargetFileName)" DestinationFolder="$(BinariesFolderInternal)" />
+    <Copy SourceFiles="$(OutputPath)$(TargetFileName)" DestinationFolder="$(BinariesFolder)" />
   </Target>
 </Project>

--- a/docs/contributing-analyzer.md
+++ b/docs/contributing-analyzer.md
@@ -133,7 +133,7 @@ You can visualize the differences using:
 If you want to debug the analysis of a project, you can add a [`Debugger.Launch()`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.debugger.launch) breakpoint in the class you want to debug. Rebuild `SonarAnalyzer.sln` and link the analyzer debug binaries to the project you want to debug the analysis for.
 
 - If you are analyzing the project with the Scanner for .NET, after the begin step you can replace the binaries in the local cache (`%TEMP%\.sonarqube\resources\` - the `0` folder for the C# Analyzer, the `1` folder for the VB .NET analyzer), and then run the build.
-- If you don't want to use the Scanner for .NET, you can manually reference the binaries in `analyzers/packaging/binaries/` in the {cs,vb}proj file with `<Analyzer Include=... />` items (see [Directory.Build.targets](../analyzers/its/Directory.Build.targets#L46) as an example)
+- If you don't want to use the Scanner for .NET, you can manually reference the binaries in `analyzers/packaging/binaries/` in the {cs,vb}proj file with `<Analyzer Include=... />` items (see [Directory.Build.targets](../analyzers/its/Directory.Build.targets#L55) as an example)
 
 Please note that if the rule is not in SonarWay, you will also need to enable it in a RuleSet file and link it in the {cs,vb}proj file with the `<CodeAnalysisRuleSet>` property (see [example](../analyzers/src/Directory.Build.targets#L8)).
 

--- a/its/src/test/java/com/sonar/it/shared/StylingTest.java
+++ b/its/src/test/java/com/sonar/it/shared/StylingTest.java
@@ -44,7 +44,7 @@ public class StylingTest {
   @Test
   public void hasIssues() throws IOException {
     Path projectFullPath = TestUtils.projectDir(temp, PROJECT);
-    FileUtils.copyFile(new File("..\\analyzers\\packaging\\binaries\\internal\\" + STYLING_DLL),
+    FileUtils.copyFile(new File("..\\analyzers\\packaging\\binaries\\SonarAnalyzer.CSharp.Styling\\" + STYLING_DLL),
       projectFullPath.resolve(STYLING_DLL).toFile());
     Tests.ORCHESTRATOR.executeBuild(TestUtils.createBeginStep(PROJECT, projectFullPath));
     TestUtils.runBuild(projectFullPath);

--- a/sonar-csharp-plugin/pom.xml
+++ b/sonar-csharp-plugin/pom.xml
@@ -225,7 +225,7 @@
               <target>
                 <!-- ITs requires the SonarAnalyzer-VERSION.zip to be present so don't remove these lines -->
                 <copy todir="${sonarAnalyzer.workDirectory}/SonarAnalyzer.CSharp">
-                  <fileset dir="${analyzers.directory}/packaging/binaries/">
+                  <fileset dir="${analyzers.directory}/packaging/binaries/SonarAnalyzer.CSharp/">
                     <include name="Google.Protobuf.dll"/>
                     <include name="SonarAnalyzer.dll"/>
                     <include name="SonarAnalyzer.CFG.dll"/>
@@ -247,7 +247,7 @@
                       failonerror="true"
                       dir="${analyzers.directory}/packaging/binaries/RuleDescriptorGenerator">
                   <arg value="RuleDescriptorGenerator.dll"/>
-                  <arg value="${analyzers.directory}/packaging/binaries/SonarAnalyzer.CSharp.dll"/>
+                  <arg value="${analyzers.directory}/packaging/binaries/SonarAnalyzer.CSharp/SonarAnalyzer.CSharp.dll"/>
                   <arg value="${sonarAnalyzer.workDirectory}/org/sonar/plugins/csharp/Rules.json"/>
                 </exec>
                 <copy todir="${sonarAnalyzer.workDirectory}/static">

--- a/sonar-vbnet-plugin/pom.xml
+++ b/sonar-vbnet-plugin/pom.xml
@@ -225,7 +225,7 @@
               <target>
                 <!-- ITs requires the SonarAnalyzer-VERSION.zip to be present so don't remove these lines -->
                 <copy todir="${sonarAnalyzer.workDirectory}/SonarAnalyzer.VisualBasic">
-                  <fileset dir="${analyzers.directory}/packaging/binaries/">
+                  <fileset dir="${analyzers.directory}/packaging/binaries/SonarAnalyzer.VisualBasic/">
                     <include name="Google.Protobuf.dll"/>
                     <include name="SonarAnalyzer.dll"/>
                     <include name="SonarAnalyzer.CFG.dll"/>
@@ -247,7 +247,7 @@
                       failonerror="true"
                       dir="${analyzers.directory}/packaging/binaries/RuleDescriptorGenerator">
                   <arg value="RuleDescriptorGenerator.dll"/>
-                  <arg value="${analyzers.directory}/packaging/binaries/SonarAnalyzer.VisualBasic.dll"/>
+                  <arg value="${analyzers.directory}/packaging/binaries/SonarAnalyzer.VisualBasic/SonarAnalyzer.VisualBasic.dll"/>
                   <arg value="${sonarAnalyzer.workDirectory}/org/sonar/plugins/vbnet/Rules.json"/>
                 </exec>
                 <copy todir="${sonarAnalyzer.workDirectory}/static">


### PR DESCRIPTION
Change the structure of `analyzers/packaging/binaries` to have one folder per project.
This simplifies the clean-up process.
[Background Task](https://trello.com/c/0QOHiwL1/1360-future-proof-cleanbinaries-target)