### PR TITLE
Bump vault-action-wrapper to v3

### DIFF
--- a/.github/workflows/LabelIssue.yml
+++ b/.github/workflows/LabelIssue.yml
@@ -17,7 +17,7 @@ jobs:
         && startsWith(github.event.label.name, 'Type:')
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@2.5.0-4
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-kanban token | kanban_token;

--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -11,7 +11,7 @@ jobs:
       id-token: write
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@2.4.3-1
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-lock token | lock_token;


### PR DESCRIPTION
Recreation of #9431 based on https://github.com/sonarsource/vault-action-wrapper?tab=readme-ov-file#vault-action-wrapper

Also related to https://github.com/SonarSource/gh-action-lt-backlog/pull/76 in the samples of the original actions