### PR TITLE
Fix S1104 FP: Do not report in Unity serializable classes

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldsShouldBeEncapsulatedInProperties.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/FieldsShouldBeEncapsulatedInProperties.cs
@@ -37,6 +37,10 @@ public sealed class FieldsShouldBeEncapsulatedInProperties : SonarDiagnosticAnal
         SyntaxKind.ConstKeyword
     };
 
+    private static readonly ImmutableArray<KnownType> IgnoredTypes = ImmutableArray.Create(
+        KnownType.UnityEngine_MonoBehaviour,
+        KnownType.UnityEngine_ScriptableObject);
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
     protected override void Initialize(SonarAnalysisContext context) =>
@@ -52,7 +56,9 @@ public sealed class FieldsShouldBeEncapsulatedInProperties : SonarDiagnosticAnal
                 var firstVariable = fieldDeclaration.Declaration.Variables[0];
                 var symbol = c.SemanticModel.GetDeclaredSymbol(firstVariable);
                 var parentSymbol = c.SemanticModel.GetDeclaredSymbol(fieldDeclaration.Parent);
-                if (parentSymbol.HasAttribute(KnownType.System_Runtime_InteropServices_StructLayoutAttribute) || Serializable(symbol, parentSymbol))
+                if (symbol.ContainingType.DerivesFromAny(IgnoredTypes)
+                    || parentSymbol.HasAttribute(KnownType.System_Runtime_InteropServices_StructLayoutAttribute)
+                    || Serializable(symbol, parentSymbol))
                 {
                     return;
                 }

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/FieldsShouldBeEncapsulatedInPropertiesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/FieldsShouldBeEncapsulatedInPropertiesTest.cs
@@ -31,6 +31,13 @@ public class FieldsShouldBeEncapsulatedInPropertiesTest
     public void FieldsShouldBeEncapsulatedInProperties() =>
         builder.AddPaths("FieldsShouldBeEncapsulatedInProperties.cs").Verify();
 
+    [TestMethod]
+    public void FieldsShouldBeEncapsulatedInProperties_Unity3D_Ignored() =>
+        builder.AddPaths("FieldsShouldBeEncapsulatedInProperties.Unity3D.cs")
+            // Concurrent analysis puts fake Unity3D class into the Concurrent namespace
+            .WithConcurrentAnalysis(false)
+            .VerifyNoIssues();
+
 #if NET
 
     [TestMethod]

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/FieldsShouldBeEncapsulatedInPropertiesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/FieldsShouldBeEncapsulatedInPropertiesTest.cs
@@ -36,7 +36,7 @@ public class FieldsShouldBeEncapsulatedInPropertiesTest
         builder.AddPaths("FieldsShouldBeEncapsulatedInProperties.Unity3D.cs")
             // Concurrent analysis puts fake Unity3D class into the Concurrent namespace
             .WithConcurrentAnalysis(false)
-            .VerifyNoIssues();
+            .Verify();
 
 #if NET
 

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/FieldsShouldBeEncapsulatedInProperties.Unity3D.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/FieldsShouldBeEncapsulatedInProperties.Unity3D.cs
@@ -1,0 +1,18 @@
+﻿// https://github.com/SonarSource/sonar-dotnet/issues/7522
+public class UnityMonoBehaviour : UnityEngine.MonoBehaviour
+{
+    public int Field1; // Compliant
+}
+
+public class UnityScriptableObject : UnityEngine.ScriptableObject
+{
+    public int Field1; // Compliant
+}
+
+// Unity3D does not seem to be available as a nuget package and we cannot use the original classes
+// Cannot run this test case in Concurrent mode because of the Concurrent namespace
+namespace UnityEngine
+{
+    public class MonoBehaviour { }
+    public class ScriptableObject { }
+}

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/FieldsShouldBeEncapsulatedInProperties.Unity3D.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/FieldsShouldBeEncapsulatedInProperties.Unity3D.cs
@@ -1,4 +1,6 @@
-﻿// https://github.com/SonarSource/sonar-dotnet/issues/7522
+﻿using System;
+
+// https://github.com/SonarSource/sonar-dotnet/issues/7522
 public class UnityMonoBehaviour : UnityEngine.MonoBehaviour
 {
     public int Field1; // Compliant
@@ -9,10 +11,22 @@ public class UnityScriptableObject : UnityEngine.ScriptableObject
     public int Field1; // Compliant
 }
 
+public class InvalidCustomSerializableClass1 : UnityEngine.Object
+{
+    public int Field1; // Noncompliant
+}
+
+[Serializable]
+public class ValidCustomSerializableClass : UnityEngine.Object
+{
+    public int Field1; // Compliant
+}
+
 // Unity3D does not seem to be available as a nuget package and we cannot use the original classes
 // Cannot run this test case in Concurrent mode because of the Concurrent namespace
 namespace UnityEngine
 {
     public class MonoBehaviour { }
     public class ScriptableObject { }
+    public class Object { }
 }


### PR DESCRIPTION
Fixes #7522 

Ignore fields in the following Unity classes:
- [ScriptableObject](https://docs.unity3d.com/ScriptReference/ScriptableObject.html)
- [MonoBehaviour](https://docs.unity3d.com/ScriptReference/MonoBehaviour.html)