### PR TITLE
Fix S1172: code fix does not delete unused parameter in function call

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Extensions/ParameterSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Extensions/ParameterSyntaxExtensions.cs
@@ -18,19 +18,21 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-namespace SonarAnalyzer.Extensions
-{
-    internal static class ParameterSyntaxExtensions
-    {
-        /// <summary>
-        /// Returns true if the parameter is of type string. For performance reasons the check is done at the syntax level.
-        /// </summary>
-        internal static bool IsString(this ParameterSyntax parameterSyntax) =>
-            IsString(parameterSyntax.Type.ToString());
+namespace SonarAnalyzer.Extensions;
 
-        private static bool IsString(string parameterTypeName) =>
-            parameterTypeName == "string" ||
-            parameterTypeName == "String" ||
-            parameterTypeName == "System.String";
-    }
+internal static class ParameterSyntaxExtensions
+{
+    /// <summary>
+    /// Returns true if the parameter is of type string. For performance reasons the check is done at the syntax level.
+    /// </summary>
+    internal static bool IsString(this ParameterSyntax parameterSyntax) =>
+        IsString(parameterSyntax.Type.ToString());
+
+    internal static int? GetParameterIndex(this ParameterSyntax parameter) =>
+        (parameter.Parent as ParameterListSyntax)?.Parameters.IndexOf(parameter);
+
+    private static bool IsString(string parameterTypeName) =>
+        parameterTypeName == "string" ||
+        parameterTypeName == "String" ||
+        parameterTypeName == "System.String";
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnusedCodeFix.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/MethodParameterUnusedCodeFix.cs
@@ -60,7 +60,6 @@ public sealed class MethodParameterUnusedCodeFix : SonarCodeFix
         var diagnosticSpan = diagnostic.Location.SourceSpan;
         var parameter = root.FindNode(diagnosticSpan, getInnermostNodeForTie: true) as ParameterSyntax;
 
-
         if (!bool.Parse(diagnostic.Properties[MethodParameterUnused.IsRemovableKey]))
         {
             return Task.CompletedTask;
@@ -71,7 +70,7 @@ public sealed class MethodParameterUnusedCodeFix : SonarCodeFix
             async x =>
             {
                 var newRoot = root.RemoveNodes(
-                    [parameter, ..(await ArgumentsToRemoveAsync(context, parameter, x))],
+                    [parameter, ..await ArgumentsToRemoveAsync(context, parameter, x)],
                     SyntaxRemoveOptions.KeepLeadingTrivia | SyntaxRemoveOptions.AddElasticMarker);
 
                 return context.Document.WithSyntaxRoot(newRoot);

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/MethodParameterUnusedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/MethodParameterUnusedTest.cs
@@ -86,9 +86,9 @@ public class Sample
 
 #if NET
 
-        [TestMethod]
-        public void MethodParameterUnused_CSharp10_RoslynCfg() =>
-            roslynCS.AddPaths("MethodParameterUnused.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
+    [TestMethod]
+    public void MethodParameterUnused_CSharp10_RoslynCfg() =>
+        roslynCS.AddPaths("MethodParameterUnused.CSharp10.cs").WithOptions(ParseOptionsHelper.FromCSharp10).Verify();
 
 #endif
 

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/MethodParameterUnusedTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/MethodParameterUnusedTest.cs
@@ -21,68 +21,68 @@
 using CS = SonarAnalyzer.Rules.CSharp;
 using VB = SonarAnalyzer.Rules.VisualBasic;
 
-namespace SonarAnalyzer.Test.Rules
+namespace SonarAnalyzer.Test.Rules;
+
+[TestClass]
+public class MethodParameterUnusedTest
 {
-    [TestClass]
-    public class MethodParameterUnusedTest
-    {
-        private readonly VerifierBuilder sonarCS = new VerifierBuilder().AddAnalyzer(() => new CS.MethodParameterUnused(AnalyzerConfiguration.AlwaysEnabledWithSonarCfg));
-        private readonly VerifierBuilder roslynCS = new VerifierBuilder<CS.MethodParameterUnused>();   // Default constructor uses Roslyn CFG
+    private readonly VerifierBuilder sonarCS = new VerifierBuilder().AddAnalyzer(() => new CS.MethodParameterUnused(AnalyzerConfiguration.AlwaysEnabledWithSonarCfg));
+    private readonly VerifierBuilder roslynCS = new VerifierBuilder<CS.MethodParameterUnused>();   // Default constructor uses Roslyn CFG
 
-        [TestMethod]
-        public void MethodParameterUnused_CS_SonarCfg() =>
-            sonarCS.AddPaths("MethodParameterUnused.SonarCfg.cs").Verify();
+    [TestMethod]
+    public void MethodParameterUnused_CS_SonarCfg() =>
+        sonarCS.AddPaths("MethodParameterUnused.SonarCfg.cs").Verify();
 
-        [TestMethod]
-        public void MethodParameterUnused_CS_RoslynCfg() =>
-            roslynCS.AddPaths("MethodParameterUnused.RoslynCfg.cs").Verify();
+    [TestMethod]
+    public void MethodParameterUnused_CS_RoslynCfg() =>
+        roslynCS.AddPaths("MethodParameterUnused.RoslynCfg.cs").Verify();
 
 #if NETFRAMEWORK
 
-        [TestMethod]
-        public void MethodParameterUnused_CS_RoslynCfg_NetFx() =>
-            roslynCS.AddPaths("MethodParameterUnused.RoslynCfg.NetFx.cs").Verify();
+    [TestMethod]
+    public void MethodParameterUnused_CS_RoslynCfg_NetFx() =>
+        roslynCS.AddPaths("MethodParameterUnused.RoslynCfg.NetFx.cs").Verify();
 
 #endif
 
-        [TestMethod]
-        public void MethodParameterUnused_CodeFix_CS() =>
-            roslynCS.AddPaths("MethodParameterUnused.RoslynCfg.cs")
-                .WithCodeFix<CS.MethodParameterUnusedCodeFix>()
-                .WithCodeFixedPaths("MethodParameterUnused.RoslynCfg.Fixed.cs")
-                .VerifyCodeFix();
+    [TestMethod]
+    public void MethodParameterUnused_CodeFix_CS() =>
+        roslynCS.AddPaths("MethodParameterUnused.RoslynCfg.cs")
+            .WithCodeFix<CS.MethodParameterUnusedCodeFix>()
+            .WithCodeFixedPaths("MethodParameterUnused.RoslynCfg.Fixed.cs")
+            .VerifyCodeFix();
 
-        [TestMethod]
-        public void MethodParameterUnused_CSharp7_CS() =>
-            roslynCS.AddPaths("MethodParameterUnused.CSharp7.cs").WithOptions(ParseOptionsHelper.FromCSharp7).AddReferences(NuGetMetadataReference.SystemValueTuple("4.5.0")).VerifyNoIssues();
+    [TestMethod]
+    public void MethodParameterUnused_CSharp7_CS() =>
+        roslynCS.AddPaths("MethodParameterUnused.CSharp7.cs").WithOptions(ParseOptionsHelper.FromCSharp7).AddReferences(NuGetMetadataReference.SystemValueTuple("4.5.0")).VerifyNoIssues();
 
-        [TestMethod]
-        public void MethodParameterUnused_CSharp8_CS() =>
-            roslynCS.AddPaths("MethodParameterUnused.CSharp8.cs").WithOptions(ParseOptionsHelper.FromCSharp8).AddReferences(MetadataReferenceFacade.NetStandard21).Verify();
+    [TestMethod]
+    public void MethodParameterUnused_CSharp8_CS() =>
+        roslynCS.AddPaths("MethodParameterUnused.CSharp8.cs").WithOptions(ParseOptionsHelper.FromCSharp8).AddReferences(MetadataReferenceFacade.NetStandard21).Verify();
 
-        [TestMethod]
-        public void MethodParameterUnused_DoubleCompilation_CS()
-        {
-            // https://github.com/SonarSource/sonar-dotnet/issues/5491
-            const string code = @"
+    [TestMethod]
+    public void MethodParameterUnused_DoubleCompilation_CS()
+    {
+        // https://github.com/SonarSource/sonar-dotnet/issues/5491
+        const string code = @"
 public class Sample
 {
     private void Method(int arg) =>
         arg.ToString();
 }";
-            var compilation1 = roslynCS.AddSnippet(code).WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7).Compile().Single();
-            var compilation2 = compilation1.WithAssemblyName("Different-Compilation-Reusing-Same-Nodes");
-            // Modified compilation should not reuse cached CFG, because symbols from method would not be equal to symbols from the other CFG.
-            Analyze(compilation1).Should().BeEmpty();
-            Analyze(compilation2).Should().BeEmpty();
+        var compilation1 = roslynCS.AddSnippet(code).WithLanguageVersion(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7).Compile().Single();
+        var compilation2 = compilation1.WithAssemblyName("Different-Compilation-Reusing-Same-Nodes");
+        // Modified compilation should not reuse cached CFG, because symbols from method would not be equal to symbols from the other CFG.
+        Analyze(compilation1).Should().BeEmpty();
+        Analyze(compilation2).Should().BeEmpty();
 
-            ImmutableArray<Diagnostic> Analyze(Compilation compilation) =>
-                compilation.WithAnalyzers(roslynCS.Analyzers.Select(x => x()).ToImmutableArray()).GetAllDiagnosticsAsync(default).Result;
-        }
+        ImmutableArray<Diagnostic> Analyze(Compilation compilation) =>
+            compilation.WithAnalyzers(roslynCS.Analyzers.Select(x => x()).ToImmutableArray()).GetAllDiagnosticsAsync(default).Result;
+    }
 
-        [TestMethod]
-        public void MethodParameterUnused_VB() =>
-            new VerifierBuilder<VB.MethodParameterUnused>().AddPaths("MethodParameterUnused.vb").WithOptions(ParseOptionsHelper.FromVisualBasic14).Verify();
+    [TestMethod]
+    public void MethodParameterUnused_VB() =>
+        new VerifierBuilder<VB.MethodParameterUnused>().AddPaths("MethodParameterUnused.vb").WithOptions(ParseOptionsHelper.FromVisualBasic14).Verify();
 
 #if NET
 
@@ -92,37 +92,36 @@ public class Sample
 
 #endif
 
-        [TestMethod]
-        public void MethodParameterUnused_CSharp11_CS() =>
-            roslynCS.AddPaths("MethodParameterUnused.CSharp11.cs")
-                .WithOptions(ParseOptionsHelper.FromCSharp11)
-                .Verify();
+    [TestMethod]
+    public void MethodParameterUnused_CSharp11_CS() =>
+        roslynCS.AddPaths("MethodParameterUnused.CSharp11.cs")
+            .WithOptions(ParseOptionsHelper.FromCSharp11)
+            .Verify();
 
-        [TestMethod]
-        // https://github.com/SonarSource/sonar-dotnet/issues/8988
-        public void MethodParameterUnused_GeneratedCode_CS() =>
-            roslynCS
-                .AddSnippet("""
-                    using System.CodeDom.Compiler;
+    [TestMethod]
+    // https://github.com/SonarSource/sonar-dotnet/issues/8988
+    public void MethodParameterUnused_GeneratedCode_CS() =>
+        roslynCS
+            .AddSnippet("""
+                        using System.CodeDom.Compiler;
 
-                    [GeneratedCode("TestTool", "Version")]
-                    public partial class Generated
-                    {
-                        private partial void M(int a, int unused);
-                    }             
-                    """)
-                .AddSnippet("""
-                    using System;
-
-                    public partial class Generated
-                    {
-                        private partial void M(int a, int unused) // Noncompliant FP
+                        [GeneratedCode("TestTool", "Version")]
+                        public partial class Generated
                         {
-                            Console.WriteLine(a);
+                            private partial void M(int a, int unused);
                         }
-                    }
-                    """)
-                .WithOptions(ParseOptionsHelper.FromCSharp9)
-                .Verify();
-    }
+                        """)
+            .AddSnippet("""
+                        using System;
+
+                        public partial class Generated
+                        {
+                            private partial void M(int a, int unused) // Noncompliant FP
+                            {
+                                Console.WriteLine(a);
+                            }
+                        }
+                        """)
+            .WithOptions(ParseOptionsHelper.FromCSharp9)
+            .Verify();
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/MethodParameterUnused.RoslynCfg.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/MethodParameterUnused.RoslynCfg.Fixed.cs
@@ -649,14 +649,45 @@ namespace Tests.TestCases
     // https://github.com/SonarSource/sonar-dotnet/issues/8187
     public class Repro_8187_CodeFix
     {
-        void Method()
+        private int a = 21;
+        private int? obj = null;
+
+        async Task Method()
         {
             DoSomething(21);
+            DoSomething(a: 42);
+            DoSomething(21, a++);
+            DoSomething(21, a % 2 == 0 ? a++ : a);
+            DoSomething(21);
+            DoSomething(21, obj ?? (a % 2 == 0 ? a++ : SomeMethod()));
+            DoSomething(21, SomeMethod());
+            DoSomething(21, await SomeMethodAsync());
+
+            DoSomething2();
         }
 
         void DoSomething(int a) // Fixed
         {
             Console.WriteLine(a);
+        }
+
+        // Fixed
+        // Fixed
+        void DoSomething2() // Fixed
+        {
+            Console.WriteLine("DoSomething2");
+        }
+
+        int SomeMethod()
+        {
+            a++;
+            return a;
+        }
+
+        Task<int> SomeMethodAsync()
+        {
+            a++;
+            return Task.FromResult(a);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/MethodParameterUnused.RoslynCfg.Fixed.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/MethodParameterUnused.RoslynCfg.Fixed.cs
@@ -16,7 +16,7 @@ namespace Tests.TestCases
 
     public class BasicTests : MyPrivateInterface
     {
-        private BasicTests(int a) : this(a, 42) // Compliant
+        private BasicTests(int a) : this(a) // Compliant
         { }
 
         private BasicTests(
@@ -643,6 +643,20 @@ namespace Tests.TestCases
                 ReferenceEquals(1, 2);
                 return null;
             }
+        }
+    }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/8187
+    public class Repro_8187_CodeFix
+    {
+        void Method()
+        {
+            DoSomething(21);
+        }
+
+        void DoSomething(int a) // Fixed
+        {
+            Console.WriteLine(a);
         }
     }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/MethodParameterUnused.RoslynCfg.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/MethodParameterUnused.RoslynCfg.cs
@@ -647,4 +647,18 @@ namespace Tests.TestCases
             }
         }
     }
+
+    // https://github.com/SonarSource/sonar-dotnet/issues/8187
+    public class Repro_8187_CodeFix
+    {
+        void Method()
+        {
+            DoSomething(21, 42);
+        }
+
+        void DoSomething(int a, int b) // Noncompliant
+        {
+            Console.WriteLine(a);
+        }
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/MethodParameterUnused.RoslynCfg.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/MethodParameterUnused.RoslynCfg.cs
@@ -651,14 +651,45 @@ namespace Tests.TestCases
     // https://github.com/SonarSource/sonar-dotnet/issues/8187
     public class Repro_8187_CodeFix
     {
-        void Method()
+        private int a = 21;
+        private int? obj = null;
+
+        async Task Method()
         {
             DoSomething(21, 42);
+            DoSomething(b: 21, a: 42);
+            DoSomething(21, a++);
+            DoSomething(21, a % 2 == 0 ? a++ : a);
+            DoSomething(21, a % 2 == 0 ? 21 : a);
+            DoSomething(21, obj ?? (a % 2 == 0 ? a++ : SomeMethod()));
+            DoSomething(21, SomeMethod());
+            DoSomething(21, await SomeMethodAsync());
+
+            DoSomething2(21, c: 32);
         }
 
         void DoSomething(int a, int b) // Noncompliant
         {
             Console.WriteLine(a);
+        }
+
+        // Noncompliant@+2
+        // Noncompliant@+1
+        void DoSomething2(int a, int b = 21, int c = 42) // Noncompliant
+        {
+            Console.WriteLine("DoSomething2");
+        }
+
+        int SomeMethod()
+        {
+            a++;
+            return a;
+        }
+
+        Task<int> SomeMethodAsync()
+        {
+            a++;
+            return Task.FromResult(a);
         }
     }
 }


### PR DESCRIPTION
Fixes #8187

It does not support changing usage outside of the current SyntaxTree (e.g.: in case of usage in partial class).