### PR TITLE
Fix the "valid.xml" OpenCover test case

### DIFF
--- a/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/OpenCoverReportParserTest.java
+++ b/sonar-dotnet-shared-library/src/test/java/org/sonar/plugins/dotnet/tests/OpenCoverReportParserTest.java
@@ -121,10 +121,7 @@ public class OpenCoverReportParserTest {
     List<String> debugLogs = logTester.logs(Level.DEBUG);
     assertThat(debugLogs.get(0)).startsWith("The current user dir is '");
 
-    // FIXME the test case may be wrong https://github.com/SonarSource/sonar-dotnet/issues/4038
-    assertThat(logTester.logs(Level.WARN)).hasSize(6);
-    assertThat(logTester.logs(Level.WARN).get(0))
-      .startsWith("OpenCover parser: invalid start line for file (ID '3', path 'MyLibrary\\Adder.cs', indexed as");
+    assertThat(logTester.logs(Level.WARN)).isEmpty();
   }
 
   @Test
@@ -139,10 +136,7 @@ public class OpenCoverReportParserTest {
     assertThat(logTester.logs(Level.INFO).get(0)).startsWith("Parsing the OpenCover report ");
     assertThat(logTester.logs(Level.DEBUG).get(0)).startsWith("The current user dir is ");
 
-    // FIXME the test case may be wrong https://github.com/SonarSource/sonar-dotnet/issues/4038
-    assertThat(logTester.logs(Level.WARN))
-      .hasSize(6)
-      .contains("OpenCover parser: invalid start line for file (ID '3', path 'MyLibrary\\Adder.cs', NO INDEXED PATH).");
+    assertThat(logTester.logs(Level.WARN)).isEmpty();
   }
 
   @Test
@@ -184,8 +178,7 @@ public class OpenCoverReportParserTest {
         "CoveredFile created: (ID '4', path 'MyLibrary\\Multiplier.cs', NO INDEXED PATH)."
       );
 
-    // FIXME the test case may be wrong https://github.com/SonarSource/sonar-dotnet/issues/4038
-    assertThat(logTester.logs(Level.WARN)).hasSize(6);
+    assertThat(logTester.logs(Level.WARN)).isEmpty();
   }
 
   @Test

--- a/sonar-dotnet-shared-library/src/test/resources/opencover/valid.xml
+++ b/sonar-dotnet-shared-library/src/test/resources/opencover/valid.xml
@@ -254,12 +254,12 @@
                 -->
               </SequencePoints>
               <BranchPoints>
-                <BranchPoint vc="2" uspid="21" ordinal="0" offset="6" path="0" />
-                <BranchPoint vc="0" uspid="22" ordinal="1" offset="6" path="1" />
-                <BranchPoint vc="0" uspid="23" ordinal="2" offset="21" path="0" />
-                <BranchPoint vc="2" uspid="24" ordinal="3" offset="21" path="1" />
-                <BranchPoint vc="2" uspid="25" ordinal="4" offset="81" path="0" />
-                <BranchPoint vc="0" uspid="26" ordinal="5" offset="81" path="1" />
+                <BranchPoint vc="2" uspid="21" ordinal="0" offset="6" sl="12" path="0" offsetend="10" />
+                <BranchPoint vc="0" uspid="22" ordinal="1" offset="6" sl="12" path="1" offsetend="10" />
+                <BranchPoint vc="0" uspid="23" ordinal="2" offset="21" sl="12" path="0" offsetend="22" />
+                <BranchPoint vc="2" uspid="24" ordinal="3" offset="21" sl="12" path="1" offsetend="22" />
+                <BranchPoint vc="2" uspid="25" ordinal="4" offset="81" sl="22" path="0" offsetend="82" />
+                <BranchPoint vc="0" uspid="26" ordinal="5" offset="81" sl="22" path="1" offsetend="82" />
               </BranchPoints>
               <MethodPoint xsi:type="SequencePoint" vc="2" uspid="8" ordinal="0" offset="0" sl="11" sc="9" el="11" ec="10" />
             </Method>


### PR DESCRIPTION
Fixes #4038

Additional context:
From my understanding, the problem is that `valid.xml` was created with a very old version of OpenCover, which did not have `sl` and `offsetend` attributes in `Branchpoint`s. I did not go through the trouble of fully recreating the file; instead, I just added the missing attributes with arbitrary values.