### PR TITLE
Fix S6966 FP: EntityFrameworks IDbContextFactory CreateDbContext method is preferred over its Async counterpart

### DIFF
--- a/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Common/Helpers/KnownType.cs
@@ -136,6 +136,7 @@ namespace SonarAnalyzer.Helpers
         public static readonly KnownType Microsoft_EntityFrameworkCore_DbContextOptionsBuilder = new("Microsoft.EntityFrameworkCore.DbContextOptionsBuilder");
         public static readonly KnownType Microsoft_EntityFrameworkCore_DbSet_TEntity = new("Microsoft.EntityFrameworkCore.DbSet", "TEntity");
         public static readonly KnownType Microsoft_EntityFrameworkCore_EntityFrameworkQueryableExtensions = new("Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions");
+        public static readonly KnownType Microsoft_EntityFrameworkCore_IDbContextFactory_TContext = new("Microsoft.EntityFrameworkCore.IDbContextFactory", "TContext");
         public static readonly KnownType Microsoft_EntityFrameworkCore_Migrations_Migration = new("Microsoft.EntityFrameworkCore.Migrations.Migration");
         public static readonly KnownType Microsoft_EntityFrameworkCore_MySQLDbContextOptionsExtensions = new("Microsoft.EntityFrameworkCore.MySQLDbContextOptionsExtensions");
         public static readonly KnownType Microsoft_EntityFrameworkCore_NpgsqlDbContextOptionsExtensions = new("Microsoft.EntityFrameworkCore.NpgsqlDbContextOptionsExtensions");

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UseAwaitableMethod_EF.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UseAwaitableMethod_EF.cs
@@ -79,3 +79,32 @@ public class EntityFramework
         databaseFacade.UseTransaction(null);                                                         // Noncompliant
     }
 }
+
+// https://github.com/SonarSource/sonar-dotnet/issues/9590
+public class Repro_9590
+{
+    public async Task DoSomeWork(IDbContextFactory<AppDbContext> factory, MyDbContextFactory factory2, NotADbContextFactory factory3)
+    {
+        using AppDbContext dbContext = factory.CreateDbContext(); // Compliant - CreateDbContextAsync is excluded
+        using AppDbContext dbContext2 = factory2.CreateDbContext(); // Compliant - CreateDbContextAsync is excluded
+        using AppDbContext dbContext3 = factory3.CreateDbContext(); // Noncompliant
+    }
+
+    public class MyDbContextFactory : IDbContextFactory<AppDbContext>
+    {
+        public AppDbContext CreateDbContext() => throw new NotImplementedException();
+
+        public Task<AppDbContext> CreateDbContextAsync() => throw new NotImplementedException();
+    }
+
+    public class NotADbContextFactory
+    {
+        public AppDbContext CreateDbContext() => throw new NotImplementedException();
+
+        public Task<AppDbContext> CreateDbContextAsync() => throw new NotImplementedException();
+    }
+
+    public class AppDbContext : DbContext
+    {
+    }
+}


### PR DESCRIPTION
Fixes #9590 
