### PR TITLE
Update Syntax.xml from Roslyn release/dev17.12 branch

### DIFF
--- a/analyzers/src/SonarAnalyzer.ShimLayer/Syntax.xml
+++ b/analyzers/src/SonarAnalyzer.ShimLayer/Syntax.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 
-<!--
+<!-- 
  To re-generate source from this file, run eng/generate-compiler-code.cmd
 -->
 
@@ -1987,9 +1987,7 @@
             <Kind Name="InterpolatedSingleLineRawStringStartToken"/>
             <Kind Name="InterpolatedMultiLineRawStringStartToken"/>
             <PropertyComment>
-                <summary>
-                    The first part of an interpolated string, <c>$"</c> or <c>$@"</c> or <c>$"""</c>
-                </summary>
+                <summary>The first part of an interpolated string, <c>$"</c> or <c>$@"</c> or <c>$"""</c></summary>
             </PropertyComment>
         </Field>
         <Field Name="Contents" Type="SyntaxList&lt;InterpolatedStringContentSyntax&gt;" >
@@ -2197,9 +2195,7 @@
         <Field Name="OpenBraceToken" Type="SyntaxToken">
             <Kind Name="OpenBraceToken"/>
             <PropertyComment>
-                <summary>
-                    This could be a single <c>{</c> or multiple in a row (in the case of an interpolation in a raw interpolated string).
-                </summary>
+                <summary>This could be a single <c>{</c> or multiple in a row (in the case of an interpolation in a raw interpolated string).</summary>
             </PropertyComment>
         </Field>
         <Field Name="Expression" Type="ExpressionSyntax"/>
@@ -3742,6 +3738,47 @@
             <Kind Name="DefaultKeyword"/>
         </Field>
     </Node>
+
+    <Node Name="AllowsConstraintClauseSyntax" Base="TypeParameterConstraintSyntax">
+        <TypeComment>
+            <summary>The allows type parameter constraint clause.</summary>
+        </TypeComment>
+        <Kind Name="AllowsConstraintClause"/>
+        <Field Name="AllowsKeyword" Type="SyntaxToken">
+            <Kind Name="AllowsKeyword"/>
+        </Field>
+        <Field Name="Constraints" Type="SeparatedSyntaxList&lt;AllowsConstraintSyntax&gt;" MinCount="1">
+            <PropertyComment>
+                <summary>Gets the constraints list.</summary>
+            </PropertyComment>
+        </Field>
+    </Node>
+
+    <AbstractNode Name="AllowsConstraintSyntax" Base="CSharpSyntaxNode">
+        <TypeComment>
+            <summary>Base type for allow constraint syntax.</summary>
+        </TypeComment>
+    </AbstractNode>
+
+    <Node Name="RefStructConstraintSyntax" Base="AllowsConstraintSyntax">
+        <TypeComment>
+            <summary>Ref struct constraint syntax.</summary>
+        </TypeComment>
+        <Kind Name="RefStructConstraint"/>
+        <Field Name="RefKeyword" Type="SyntaxToken">
+            <PropertyComment>
+                <summary>Gets the "ref" keyword.</summary>
+            </PropertyComment>
+            <Kind Name="RefKeyword"/>
+        </Field>
+        <Field Name="StructKeyword" Type="SyntaxToken">
+            <PropertyComment>
+                <summary>Gets the "struct" keyword.</summary>
+            </PropertyComment>
+            <Kind Name="StructKeyword"/>
+        </Field>
+    </Node>
+
     <AbstractNode Name="BaseFieldDeclarationSyntax" Base="MemberDeclarationSyntax">
         <Field Name="Declaration" Type="VariableDeclarationSyntax"/>
         <Field Name="SemicolonToken" Type="SyntaxToken">
@@ -4523,7 +4560,8 @@
         <TypeComment>
             <summary>
                 An element of a BaseCrefParameterListSyntax.
-                Unlike a regular parameter, a cref parameter has only an optional ref or out keyword and a type -
+                Unlike a regular parameter, a cref parameter has only an optional ref, in, out keyword,
+                an optional readonly keyword, and a type -
                 there is no name and there are no attributes or other modifiers.
             </summary>
         </TypeComment>
@@ -4532,6 +4570,9 @@
             <Kind Name="RefKeyword"/>
             <Kind Name="OutKeyword"/>
             <Kind Name="InKeyword"/>
+        </Field>
+        <Field Name="ReadOnlyKeyword" Type="SyntaxToken" Optional="true">
+            <Kind Name="ReadOnlyKeyword"/>
         </Field>
         <Field Name="Type" Type="TypeSyntax"/>
     </Node>


### PR DESCRIPTION
Part of the fix for #9600

Roslyn [Syntax.xml](https://github.com/dotnet/roslyn/blob/release/dev17.12/src/Compilers/CSharp/Portable/Syntax/Syntax.xml)