### PR TITLE
Shimlayer: Fix TypeDeclarationSyntax ParameterList for RecordDeclarationSyntax

### DIFF
--- a/analyzers/src/SonarAnalyzer.ShimLayer/Sonar/TypeDeclarationSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.ShimLayer/Sonar/TypeDeclarationSyntaxExtensions.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * SonarAnalyzer for .NET
+ * Copyright (C) 2015-2024 SonarSource SA
+ * mailto: contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace StyleCop.Analyzers.Lightup;
+
+internal static partial class TypeDeclarationSyntaxExtensions
+{
+    private static readonly Func<TypeDeclarationSyntax, ParameterListSyntax> RecordDeclarationParameterListAccessor;
+
+    // In earlier versions, the ParameterList was only available on the derived RecordDeclarationSyntax (starting from version 3.7)
+    // To work with version 3.7 to version 4.6 we need to special case the record declaration and access
+    // the parameter list from the derived RecordDeclarationSyntax.
+    public static ParameterListSyntax ParameterList(this TypeDeclarationSyntax syntax) =>
+        syntax.Kind() is SyntaxKindEx.RecordDeclaration or SyntaxKindEx.RecordStructDeclaration
+            ? RecordDeclarationParameterListAccessor(syntax)
+            : ParameterListAccessor(syntax);
+}

--- a/analyzers/src/SonarAnalyzer.ShimLayer/TypeDeclarationSyntaxExtensions.cs
+++ b/analyzers/src/SonarAnalyzer.ShimLayer/TypeDeclarationSyntaxExtensions.cs
@@ -6,7 +6,7 @@ namespace StyleCop.Analyzers.Lightup;
 using System;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-internal static class TypeDeclarationSyntaxExtensions
+internal static partial class TypeDeclarationSyntaxExtensions
 {
     private static readonly Func<TypeDeclarationSyntax, ParameterListSyntax?> ParameterListAccessor;
     private static readonly Func<TypeDeclarationSyntax, ParameterListSyntax?, TypeDeclarationSyntax> WithParameterListAccessor;
@@ -15,25 +15,9 @@ internal static class TypeDeclarationSyntaxExtensions
     {
         ParameterListAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<TypeDeclarationSyntax, ParameterListSyntax>(typeof(TypeDeclarationSyntax), nameof(ParameterList));
         WithParameterListAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<TypeDeclarationSyntax, ParameterListSyntax?>(typeof(TypeDeclarationSyntax), nameof(ParameterList));
-    }
 
-    public static ParameterListSyntax? ParameterList(this TypeDeclarationSyntax syntax)
-    {
-        if (!LightupHelpers.SupportsCSharp12)
-        {
-            // Prior to C# 12, the ParameterList property in RecordDeclarationSyntax did not override a base method.
-            switch (syntax.Kind())
-            {
-            case SyntaxKindEx.RecordDeclaration:
-            case SyntaxKindEx.RecordStructDeclaration:
-                return ((RecordDeclarationSyntaxWrapper)syntax).ParameterList;
-
-            default:
-                return null;
-            }
-        }
-
-        return ParameterListAccessor(syntax);
+        var recordDeclaration = SyntaxWrapperHelper.GetWrappedType(typeof(RecordDeclarationSyntaxWrapper)); // Sonar
+        RecordDeclarationParameterListAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<TypeDeclarationSyntax, ParameterListSyntax>(recordDeclaration, nameof(ParameterList)); // Sonar
     }
 
     public static TypeDeclarationSyntax WithParameterList(this TypeDeclarationSyntax syntax, ParameterListSyntax? parameterList)


### PR DESCRIPTION
Fix Shimlayer after peach validation

dotnet runtime
`C:\nuget\microsoft.net.compilers.toolset\4.0.0-4.21427.11\tasks\netcoreapp3.1\Microsoft.CSharp.Core.targets(75,5): error :    at StyleCop.Analyzers.Lightup.RecordDeclarationSyntaxWrapper.get_ParameterList() [C:\sonar-ci\Project\src\tasks\WorkloadBuildTasks\WorkloadBuildTasks.csproj]`

lethetus-ide
`C:\Program Files\dotnet\sdk\7.0.410\Roslyn\Microsoft.CSharp.Core.targets(80,5): error :    at StyleCop.Analyzers.Lightup.TypeDeclarationSyntaxExtensions.ParameterList(Microsoft.CodeAnalysis.CSharp.Syntax.TypeDeclarationSyntax) [C:\sonar-ci\Project\Luthetus.Common\Source\Lib\Luthetus.Common.RazorLib\Luthetus.Common.RazorLib.csproj]`