### PR TITLE
Increase threshold of flaky UT

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Extensions/SyntaxNodeExtensionsTest.cs
@@ -473,7 +473,7 @@ public class SyntaxNodeExtensionsTest
                     SyntaxNodeExtensionsCSharp.CreateCfg(lambda, model, default);
                 }
             };
-        a.ExecutionTime().Should().BeLessThan(1.Seconds());     // Takes roughly 0.2 sec on CI
+        a.ExecutionTime().Should().BeLessThan(1500.Milliseconds());     // Takes roughly 0.2 sec on CI
     }
 
     [TestMethod]


### PR DESCRIPTION
Increasing the threshold to 1,5s for a flaky UT (CreateCfg_Performance_UsesCache_CS)