### PR TITLE
Update RuleDescriptor.cs TO USE UNDERSCORES

### DIFF
--- a/analyzers/src/SonarAnalyzer.Core/Common/RuleDescriptor.cs
+++ b/analyzers/src/SonarAnalyzer.Core/Common/RuleDescriptor.cs
@@ -19,15 +19,15 @@ namespace SonarAnalyzer.Common
     public record RuleDescriptor(string Id, string Title, string Type, string DefaultSeverity, string Status, SourceScope Scope, bool SonarWay, string Description)
     {
         public string Category =>
-            $"{DefaultSeverity} {ReadableType}";
+            $"{DefaultSeverity}_{ReadableType}";
 
         private string ReadableType =>
             Type switch
             {
                 "BUG" => "Bug",
-                "CODE_SMELL" => "Code Smell",
+                "CODE_SMELL" => "Code_Smell",
                 "VULNERABILITY" => "Vulnerability",
-                "SECURITY_HOTSPOT" => "Security Hotspot",
+                "SECURITY_HOTSPOT" => "Security_Hotspot",
                 _ => throw new UnexpectedValueException(nameof(Type), Type)
             };
 


### PR DESCRIPTION
Whitespaces break analyser key parsing in Roslyn, they should not be allowed here. Use underscore instead. Or PascalCase. Or anything compliant.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
