### PR TITLE
Find rules with limited code size to implement in VB

### DIFF
--- a/analyzers/tests/SonarAnalyzer.Test/Analysis/Queries.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Analysis/Queries.cs
@@ -1,0 +1,57 @@
+﻿using System.IO;
+using System.Reflection;
+
+namespace SonarAnalyzer.UnitTest.Analysis;
+
+[TestClass]
+public class Queries
+{
+    [TestMethod]
+    public void Find_rules_with_limited_code_size_to_implement_to_VB()
+    {
+        var csharps = typeof(SonarAnalyzer.CSharp.Rules.AbstractClassToInterface).Assembly
+            .GetExportedTypes()
+            .Where(x => !x.IsAbstract && x.GetCustomAttributes<DiagnosticAnalyzerAttribute>().Any())
+            .Select(AnalyzerInfo.FromType)
+            .Where(x => x.Size.HasValue && x.Base == typeof(SonarDiagnosticAnalyzer))
+            .OrderBy(x => x.Size)
+            .ToArray();
+
+        foreach (var csharp in csharps)
+        {
+            Console.WriteLine(csharp);
+        }
+    }
+}
+
+internal class AnalyzerInfo
+{
+    private DiagnosticAnalyzer analyzer;
+
+    public string Name => Type.Name;
+    public Type Type { get; init; }
+    public Type Base => Type.BaseType;
+
+    public IReadOnlyCollection<string> DiagnosticIds => [.. analyzer.SupportedDiagnostics.Select(x => x.Id)];
+
+    public FileInfo File { get; init; }
+
+    public long? Size => File.Exists ? File.Length : null;
+
+    public override string ToString() =>
+        $"{string.Join(",", DiagnosticIds)} {Name}, Size: {Size / 1000.0:0.0}kb";
+
+    public static AnalyzerInfo FromType(Type type)
+    {
+        var name = $"SonarAnalyzer.CSharp/Rules/{type.Name}.cs";
+        var file = new FileInfo(Path.Combine(type.Assembly.Location, "../../../../../../src", name));
+        var instance = (DiagnosticAnalyzer)Activator.CreateInstance(type);
+
+        return new AnalyzerInfo
+        {
+            Type = type,
+            File = file,
+            analyzer = instance,
+        };
+    }
+}


### PR DESCRIPTION
In the past I've put in some effort to implement existing rules for VB.NET too. I'm not sure if you still put any effort in doing that, but while cleaning up me repo, I thought I might be nice to share it.

All rules under the (arbitrary) size of 2kb are:

| ID | Rule | Size |
|:--:|------|-----:|
| S1116 | EmptyStatement | 1.4kb
| S1848 | ObjectCreatedDropped | 1.7kb
| S1264 | UseWhileLoopInstead | 1.7kb
| S1199 | NestedCodeBlock | 1.7kb
| S4016 | EnumsShouldNotBeNamedReserved | 1.8kb
| S3261 | EmptyNamespace | 1.8kb
| S3880 | FinalizerShouldNotBeEmpty | 1.8kb
| S6377 | XmlSignatureCheck | 1.9kb
| S3244 | AnonymousDelegateEventUnsubscribe | 1.9kb