### PR TITLE
NET-2922 Normalize NuSpec paths to Unix forward slash

### DIFF
--- a/analyzers/packaging/SonarAnalyzer.CFG.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.CFG.nuspec
@@ -18,8 +18,8 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="binaries\SonarAnalyzer.CFG\*.dll" target="lib\netstandard2.0" />
-    <file src="licenses\THIRD_PARTY_LICENSES\StyleCop.Analyzers-LICENSE.txt" target="licenses\THIRD_PARTY_LICENSES\" />
-    <file src="..\..\LICENSE.txt" target="licenses\" />
+    <file src="binaries/SonarAnalyzer.CFG/*.dll" target="lib/netstandard2.0" />
+    <file src="licenses/THIRD_PARTY_LICENSES/StyleCop.Analyzers-LICENSE.txt" target="licenses/THIRD_PARTY_LICENSES/" />
+    <file src="../../LICENSE.txt" target="licenses/" />
   </files>
 </package>

--- a/analyzers/packaging/SonarAnalyzer.CFG.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.CFG.nuspec
@@ -6,7 +6,7 @@
     <title>CFG library for SonarAnalyzer</title>
     <authors>SonarSource</authors>
     <owners>SonarSource</owners>
-    <license type="file">licenses\LICENSE.txt</license>
+    <license type="file">licenses/LICENSE.txt</license>
     <repository type="git" url="https://github.com/SonarSource/sonar-dotnet" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>SonarSource CFG library</description>

--- a/analyzers/packaging/SonarAnalyzer.CSharp.Styling.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.CSharp.Styling.nuspec
@@ -9,7 +9,7 @@
     <license type="file">licenses/LICENSE.txt</license>
     <projectUrl>https://redirect.sonarsource.com/doc/sonar-visualstudio.html</projectUrl>
     <repository type="git" url="https://github.com/SonarSource/sonar-dotnet" />
-    <icon>images\sonarsource_64.png</icon>
+    <icon>images/sonarsource_64.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Internal Sonar styling analyzer for C#</summary>
     <description>This package contains a set of coding style rules to follow in Sonar code base. Coding style changes as well as breaking changes will appear between minor versions without prior notice. We do not provide support for this package.</description>
@@ -22,9 +22,9 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="binaries\SonarAnalyzer.CSharp.Styling\Internal.SonarAnalyzer.CSharp.Styling.dll" target="analyzers" />
-    <file src="logos\sonarsource_64.png" target="images\" />
-    <file src="licenses\THIRD_PARTY_LICENSES\*" target="licenses\THIRD_PARTY_LICENSES\" />
-    <file src="..\..\LICENSE.txt" target="licenses\" />
+    <file src="binaries/SonarAnalyzer.CSharp.Styling/Internal.SonarAnalyzer.CSharp.Styling.dll" target="analyzers" />
+    <file src="logos/sonarsource_64.png" target="images/" />
+    <file src="licenses/THIRD_PARTY_LICENSES/*" target="licenses/THIRD_PARTY_LICENSES/" />
+    <file src="../../LICENSE.txt" target="licenses/" />
   </files>
 </package>

--- a/analyzers/packaging/SonarAnalyzer.CSharp.Styling.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.CSharp.Styling.nuspec
@@ -6,7 +6,7 @@
     <title>Internal Sonar styling analyzer for C#</title>
     <authors>SonarSource</authors>
     <owners>SonarSource</owners>
-    <license type="file">licenses\LICENSE.txt</license>
+    <license type="file">licenses/LICENSE.txt</license>
     <projectUrl>https://redirect.sonarsource.com/doc/sonar-visualstudio.html</projectUrl>
     <repository type="git" url="https://github.com/SonarSource/sonar-dotnet" />
     <icon>images\sonarsource_64.png</icon>

--- a/analyzers/packaging/SonarAnalyzer.CSharp.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.CSharp.nuspec
@@ -6,7 +6,7 @@
     <title>SonarAnalyzer for C#</title>
     <authors>SonarSource</authors>
     <owners>SonarSource</owners>
-    <license type="file">licenses\LICENSE.txt</license>
+    <license type="file">licenses/LICENSE.txt</license>
     <projectUrl>https://redirect.sonarsource.com/doc/sonar-visualstudio.html</projectUrl>
     <repository type="git" url="https://github.com/SonarSource/sonar-dotnet" />
     <icon>images\sonarsource_64.png</icon>

--- a/analyzers/packaging/SonarAnalyzer.CSharp.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.CSharp.nuspec
@@ -9,7 +9,7 @@
     <license type="file">licenses/LICENSE.txt</license>
     <projectUrl>https://redirect.sonarsource.com/doc/sonar-visualstudio.html</projectUrl>
     <repository type="git" url="https://github.com/SonarSource/sonar-dotnet" />
-    <icon>images\sonarsource_64.png</icon>
+    <icon>images/sonarsource_64.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Roslyn analyzers that spot Bugs, Vulnerabilities and Code Smells in your code. For an even better overall experience, you can use SonarQube for IDE (Visual Studio, Rider), which is a free extension that can be used standalone or with SonarQube (Server, Cloud).</summary>
     <description>Roslyn analyzers that spot Bugs, Vulnerabilities and Code Smells in your code. For an even better overall experience, you can use SonarQube for IDE (Visual Studio, Rider, see https://www.sonarsource.com/products/sonarlint), which is a free extension that can be used standalone or with SonarQube (Server, Cloud, see: https://www.sonarsource.com/products/sonarqube/ and https://www.sonarsource.com/products/sonarcloud/).</description>
@@ -23,10 +23,10 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="binaries\SonarAnalyzer.CSharp\*.dll" target="analyzers" />
-    <file src="tools-cs\*.ps1" target="tools\" />
-    <file src="logos\sonarsource_64.png" target="images\" />
-    <file src="licenses\THIRD_PARTY_LICENSES\*" target="licenses\THIRD_PARTY_LICENSES\" />
-    <file src="..\..\LICENSE.txt" target="licenses\" />
+    <file src="binaries/SonarAnalyzer.CSharp/*.dll" target="analyzers" />
+    <file src="tools-cs/*.ps1" target="tools/" />
+    <file src="logos/sonarsource_64.png" target="images/" />
+    <file src="licenses/THIRD_PARTY_LICENSES/*" target="licenses/THIRD_PARTY_LICENSES/" />
+    <file src="../../LICENSE.txt" target="licenses/" />
   </files>
 </package>

--- a/analyzers/packaging/SonarAnalyzer.VisualBasic.nuspec
+++ b/analyzers/packaging/SonarAnalyzer.VisualBasic.nuspec
@@ -6,10 +6,10 @@
     <title>SonarAnalyzer for Visual Basic</title>
     <authors>SonarSource</authors>
     <owners>SonarSource</owners>
-    <license type="file">licenses\LICENSE.txt</license>
+    <license type="file">licenses/LICENSE.txt</license>
     <projectUrl>https://redirect.sonarsource.com/doc/sonar-visualstudio.html</projectUrl>
     <repository type="git" url="https://github.com/SonarSource/sonar-dotnet" />
-    <icon>images\sonarsource_64.png</icon>
+    <icon>images/sonarsource_64.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Roslyn analyzers that spot Bugs, Vulnerabilities and Code Smells in your code. For an even better overall experience, you can use SonarQube for IDE (Visual Studio, Rider), which is a free extension that can be used standalone or with SonarQube (Server, Cloud).</summary>
     <description>Roslyn analyzers that spot Bugs, Vulnerabilities and Code Smells in your code. For an even better overall experience, you can use SonarQube for IDE (Visual Studio, Rider, see https://www.sonarsource.com/products/sonarlint), which is a free extension that can be used standalone or with SonarQube (Server, Cloud, see: https://www.sonarsource.com/products/sonarqube/ and https://www.sonarsource.com/products/sonarcloud/).</description>
@@ -23,10 +23,10 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="binaries\SonarAnalyzer.VisualBasic\*.dll" target="analyzers" />
-    <file src="tools-vbnet\*.ps1" target="tools\" />
-    <file src="logos\sonarsource_64.png" target="images\" />
-    <file src="licenses\THIRD_PARTY_LICENSES\*" target="licenses\THIRD_PARTY_LICENSES\" />
-    <file src="..\..\LICENSE.txt" target="licenses\" />
+    <file src="binaries/SonarAnalyzer.VisualBasic/*.dll" target="analyzers" />
+    <file src="tools-vbnet/*.ps1" target="tools/" />
+    <file src="logos/sonarsource_64.png" target="images/" />
+    <file src="licenses/THIRD_PARTY_LICENSES/*" target="licenses/THIRD_PARTY_LICENSES/" />
+    <file src="../../LICENSE.txt" target="licenses/" />
   </files>
 </package>


### PR DESCRIPTION
In this commit <https://github.com/SonarSource/sonar-dotnet/commit/5a23948061117a93e8fe59c9c49a17a0c4f156e8#diff-f8f453a6bb79d1bba0a5f48cfd1d9a73373d4e68008591548d15bb0ef30abaa4R9> I see that the path has been changed, but it has been changed to a Windows path and not a normalized one that any OS can interpret.

This is starting to cause problems when you try to read the package metadata (license in this case) through dotnet tooling or NuGet packages with their API when doing so from a Linux machine.