### PR TITLE
Demote warning with false-positives to info

### DIFF
--- a/sonar-dotnet-core/src/main/java/org/sonarsource/dotnet/shared/plugins/protobuf/ProtobufImporter.java
+++ b/sonar-dotnet-core/src/main/java/org/sonarsource/dotnet/shared/plugins/protobuf/ProtobufImporter.java
@@ -56,7 +56,7 @@ public abstract class ProtobufImporter<T> extends RawProtobufImporter<T> {
 
     // file may be null because it's not within the project base dir
     if (inputFile == null) {
-      LOG.warn("File '{}' referenced by the protobuf '{}' does not exist in the analysis context", filePath,
+      LOG.info("File '{}' referenced by the protobuf '{}' does not exist in the analysis context", filePath,
         message.getClass().getSimpleName());
       return;
     }


### PR DESCRIPTION
Our build gets flooded with these warnings:

```
'sources\Project\obj\<platform>\<configuration>\<framework>\MyGeneratedFile.cs' referenced by the protobuf 'MetricsInfo' does not exist in the analysis context
```

This is a VERY long-standing issue

https://community.sonarsource.com/t/ignore-specific-warnings-in-sonarqube-analysis/133070/6

https://community.sonarsource.com/t/improvement-dont-log-does-not-exist-in-the-analysis-context-warnings-for-excluded-files/73799

There is no way to supress this from the user-side, so this must not be a warning.