### PR TITLE
Update file path for global.json in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,6 +83,11 @@ stages:
           sonar.cpd.exclusions=$(CpdExclusionsPattern)
 
     - powershell: |
+        dotnet --version
+        cd analyzers
+        dotnet --version
+        cd analyzers\src\SonarAnalyzer.ShimLayer.Generator\
+        dotnet --version
         $ProjectNameToken = '$(ProjectName)'  # Workaround for escaping difficulties: Azure DevOps doesn't have ProjectName, so it will not replace it. We need to pass it like that into AltCover via powershell.
         dotnet build --no-restore analyzers\src\SonarAnalyzer.ShimLayer.Generator\SonarAnalyzer.ShimLayer.Generator.csproj -c $(BuildConfiguration) # Needs a pre-build to prevent file locking issue in SonarAnalyzer.ShimLayer.Generator.Test
         dotnet test --no-restore $(Solution) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) --filter "FullyQualifiedName!~CreateCfg_Performance_UsesCache" /p:RunAnalyzers=true /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter="testhost|Moq|Humanizer|AltCover|Microsoft|\.Test^",AltCoverPathFilter="SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration",AltCoverAttributeFilter="ExcludeFromCodeCoverage",AltCoverReport="$(CoveragePath)/coverage.$ProjectNameToken.xml"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ stages:
             "rollForward": "disable"
           }
         }
-        "@ | Out-File -FilePath global.json -Encoding utf8
+        "@ | Out-File -FilePath $(solution)/global.json -Encoding utf8
         dotnet --version
       displayName: "Pin .NET SDK version"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,7 @@ stages:
           }
         }
         "@ | Out-File -FilePath analyzers//global.json -Encoding utf8
+        cd analyzers
         dotnet --version
       displayName: "Pin .NET SDK version"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ stages:
             "rollForward": "disable"
           }
         }
-        "@ | Out-File -FilePath $(solution)/global.json -Encoding utf8
+        "@ | Out-File -FilePath analyzers//global.json -Encoding utf8
         dotnet --version
       displayName: "Pin .NET SDK version"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ stages:
             "rollForward": "disable"
           }
         }
-        "@ | Out-File -FilePath analyzers//global.json -Encoding utf8
+        "@ | Out-File -FilePath analyzers/global.json -Encoding utf8
         cd analyzers
         dotnet --version
       displayName: "Pin .NET SDK version"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,14 +83,9 @@ stages:
           sonar.cpd.exclusions=$(CpdExclusionsPattern)
 
     - powershell: |
-        dotnet --version
-        cd analyzers
-        dotnet --version
-        cd analyzers\src\SonarAnalyzer.ShimLayer.Generator\
-        dotnet --version
         $ProjectNameToken = '$(ProjectName)'  # Workaround for escaping difficulties: Azure DevOps doesn't have ProjectName, so it will not replace it. We need to pass it like that into AltCover via powershell.
-        dotnet build --no-restore analyzers\src\SonarAnalyzer.ShimLayer.Generator\SonarAnalyzer.ShimLayer.Generator.csproj -c $(BuildConfiguration) # Needs a pre-build to prevent file locking issue in SonarAnalyzer.ShimLayer.Generator.Test
-        dotnet test --no-restore $(Solution) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) --filter "FullyQualifiedName!~CreateCfg_Performance_UsesCache" /p:RunAnalyzers=true /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter="testhost|Moq|Humanizer|AltCover|Microsoft|\.Test^",AltCoverPathFilter="SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration",AltCoverAttributeFilter="ExcludeFromCodeCoverage",AltCoverReport="$(CoveragePath)/coverage.$ProjectNameToken.xml"
+        dotnet build -v diag --no-restore analyzers\src\SonarAnalyzer.ShimLayer.Generator\SonarAnalyzer.ShimLayer.Generator.csproj -c $(BuildConfiguration) # Needs a pre-build to prevent file locking issue in SonarAnalyzer.ShimLayer.Generator.Test
+        dotnet test -v diag --no-restore $(Solution) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) --filter "FullyQualifiedName!~CreateCfg_Performance_UsesCache" /p:RunAnalyzers=true /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter="testhost|Moq|Humanizer|AltCover|Microsoft|\.Test^",AltCoverPathFilter="SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration",AltCoverAttributeFilter="ExcludeFromCodeCoverage",AltCoverReport="$(CoveragePath)/coverage.$ProjectNameToken.xml"
       displayName: '.NET UTs'
 
     - powershell: |


### PR DESCRIPTION
----
## Summary by Gitar

- **Pipeline configuration:**
  - Updated `Out-File` path to point to `analyzers/global.json` within `azure-pipelines.yml`.
  - Added `cd analyzers` command to set the working directory before executing `dotnet --version`.
  - Added `-v diag` verbosity flag to `dotnet build` and `dotnet test` commands for improved troubleshooting.

<sub>This will update automatically on new commits.</sub>