### PR TITLE
Fix S3241 FP: Exclude fluent extension methods from unused return value rule

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
@@ -136,7 +136,6 @@ public sealed class UnusedReturnValue : SonarDiagnosticAnalyzer
         invocation.OriginalDefinition.Equals(declaration)
         || (declaration.AssociatedExtensionImplementation is { } implementation && invocation.OriginalDefinition.Equals(implementation));
 
-    // Extension-block members have two equivalent symbols; use the implementation to find the hidden this parameter.
     private static bool IsFluentExtensionMethod(IMethodSymbol method, MethodDeclarationSyntax syntax, SemanticModel model)
     {
         if (!method.IsExtension)
@@ -148,8 +147,13 @@ public sealed class UnusedReturnValue : SonarDiagnosticAnalyzer
         {
             return false;
         }
-        return method.AssociatedExtensionImplementation is not null
-            || ReturnsThisParameter(syntax, model, actualMethod.Parameters[0]);
+        // Extension-block members need to use the containing type's ExtensionParameter
+        // as the comparison symbol, since the implementation's hidden parameter has a
+        // different identity than what the body references.
+        var thisParameter = method.AssociatedExtensionImplementation is not null
+            ? (method.ContainingType.ExtensionParameter ?? actualMethod.Parameters[0])
+            : actualMethod.Parameters[0];
+        return ReturnsThisParameter(syntax, model, thisParameter);
     }
 
     private static bool ReturnsThisParameter(MethodDeclarationSyntax syntax, SemanticModel model, IParameterSymbol thisParameter)
@@ -160,7 +164,11 @@ public sealed class UnusedReturnValue : SonarDiagnosticAnalyzer
         }
         if (syntax.Body is { } body)
         {
-            var returnStatements = body.DescendantNodes().OfType<ReturnStatementSyntax>();
+            var returnStatements = body.DescendantNodes(n =>
+                !n.IsKind(SyntaxKind.SimpleLambdaExpression)
+                && !n.IsKind(SyntaxKind.ParenthesizedLambdaExpression)
+                && !n.IsKind(SyntaxKindEx.LocalFunctionStatement))
+                .OfType<ReturnStatementSyntax>();
             return returnStatements.Any() && returnStatements.All(r => r.Expression is not null && ReturnsSymbol(r.Expression, model, thisParameter));
         }
         return false;

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
@@ -139,9 +139,8 @@ public sealed class UnusedReturnValue : SonarDiagnosticAnalyzer
     // Extension methods that return their own this parameter type follow the fluent builder pattern and should not be flagged.
     private static bool IsFluentExtensionMethod(IMethodSymbol method)
     {
-        // Extension block members do not have IsExtensionMethod set; they are identified via AssociatedExtensionImplementation.
         var actualMethod = method.AssociatedExtensionImplementation ?? method;
-        return actualMethod.IsExtensionMethod
+        return method.IsExtension
             && actualMethod.Parameters.Length > 0
             && method.ReturnType.Equals(actualMethod.Parameters[0].Type);
     }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
@@ -61,7 +61,7 @@ public sealed class UnusedReturnValue : SonarDiagnosticAnalyzer
 
             // Method invocation is noncompliant when there is at least 1 invocation of the method, and no invocation is using the return value. The case of 0 invocation is handled by S1144.
             // Extension methods that return their this parameter type (fluent pattern) are excluded.
-            if (matchingInvocations.Any() && !matchingInvocations.Any(IsReturnValueUsed) && !IsFluentExtensionMethod(declaredPrivateMethodWithReturn.Symbol))
+            if (matchingInvocations.Any() && !matchingInvocations.Any(IsReturnValueUsed) && !IsFluentExtensionMethod(declaredPrivateMethodWithReturn.Symbol, declaredPrivateMethodWithReturn.Node, declaredPrivateMethodWithReturn.Model))
             {
                 context.ReportIssue(Rule, declaredPrivateMethodWithReturn.Node.ReturnType);
             }
@@ -136,12 +136,52 @@ public sealed class UnusedReturnValue : SonarDiagnosticAnalyzer
         invocation.OriginalDefinition.Equals(declaration)
         || (declaration.AssociatedExtensionImplementation is { } implementation && invocation.OriginalDefinition.Equals(implementation));
 
-    // Extension methods that return their own this parameter type follow the fluent builder pattern and should not be flagged.
-    private static bool IsFluentExtensionMethod(IMethodSymbol method)
+    // Extension-block members have two equivalent symbols; use the implementation to find the hidden this parameter.
+    private static bool IsFluentExtensionMethod(IMethodSymbol method, MethodDeclarationSyntax syntax, SemanticModel model)
     {
+        if (!method.IsExtension)
+        {
+            return false;
+        }
         var actualMethod = method.AssociatedExtensionImplementation ?? method;
-        return method.IsExtension
-            && actualMethod.Parameters.Length > 0
-            && method.ReturnType.Equals(actualMethod.Parameters[0].Type);
+        if (actualMethod.Parameters.Length == 0 || !method.ReturnType.Equals(actualMethod.Parameters[0].Type))
+        {
+            return false;
+        }
+        return method.AssociatedExtensionImplementation is not null
+            || ReturnsThisParameter(syntax, model, actualMethod.Parameters[0]);
+    }
+
+    private static bool ReturnsThisParameter(MethodDeclarationSyntax syntax, SemanticModel model, IParameterSymbol thisParameter)
+    {
+        if (syntax.ExpressionBody is { } expressionBody)
+        {
+            return ReturnsSymbol(expressionBody.Expression, model, thisParameter);
+        }
+        if (syntax.Body is { } body)
+        {
+            var returnStatements = body.DescendantNodes().OfType<ReturnStatementSyntax>();
+            return returnStatements.Any() && returnStatements.All(r => r.Expression is not null && ReturnsSymbol(r.Expression, model, thisParameter));
+        }
+        return false;
+    }
+
+    private static bool ReturnsSymbol(ExpressionSyntax expression, SemanticModel model, IParameterSymbol thisParameter)
+    {
+        var symbol = model.GetSymbolInfo(expression).Symbol;
+        if (symbol is not null && symbol.Equals(thisParameter))
+        {
+            return true;
+        }
+        if (expression is InvocationExpressionSyntax invocation
+            && invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            var target = model.GetSymbolInfo(memberAccess.Expression).Symbol;
+            if (target is not null && target.Equals(thisParameter))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/UnusedReturnValue.cs
@@ -60,7 +60,8 @@ public sealed class UnusedReturnValue : SonarDiagnosticAnalyzer
                 .ToList();
 
             // Method invocation is noncompliant when there is at least 1 invocation of the method, and no invocation is using the return value. The case of 0 invocation is handled by S1144.
-            if (matchingInvocations.Any() && !matchingInvocations.Any(IsReturnValueUsed))
+            // Extension methods that return their this parameter type (fluent pattern) are excluded.
+            if (matchingInvocations.Any() && !matchingInvocations.Any(IsReturnValueUsed) && !IsFluentExtensionMethod(declaredPrivateMethodWithReturn.Symbol))
             {
                 context.ReportIssue(Rule, declaredPrivateMethodWithReturn.Node.ReturnType);
             }
@@ -134,4 +135,14 @@ public sealed class UnusedReturnValue : SonarDiagnosticAnalyzer
     private static bool MatchesDeclaration(IMethodSymbol invocation, IMethodSymbol declaration) =>
         invocation.OriginalDefinition.Equals(declaration)
         || (declaration.AssociatedExtensionImplementation is { } implementation && invocation.OriginalDefinition.Equals(implementation));
+
+    // Extension methods that return their own this parameter type follow the fluent builder pattern and should not be flagged.
+    private static bool IsFluentExtensionMethod(IMethodSymbol method)
+    {
+        // Extension block members do not have IsExtensionMethod set; they are identified via AssociatedExtensionImplementation.
+        var actualMethod = method.AssociatedExtensionImplementation ?? method;
+        return actualMethod.IsExtensionMethod
+            && actualMethod.Parameters.Length > 0
+            && method.ReturnType.Equals(actualMethod.Parameters[0].Type);
+    }
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedReturnValue.Latest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedReturnValue.Latest.cs
@@ -90,6 +90,9 @@ public static class Extensions
 
             Extensions.NonCompliantStatic(this);        // Return value discarded.
             var y = Extensions.CompliantStatic(this);   // Return value used.
+
+            this.FluentExtension();     // Fluent extension, return value discarded.
+            this.NonFluentExtension();  // Non-fluent extension, return value discarded.
         }
     }
 
@@ -103,6 +106,11 @@ public static class Extensions
 //              ^^^
 
         private int CompliantStatic() => 42;
+
+        private Sample FluentExtension() => s; // Compliant, fluent pattern (returns this type)
+
+        private int NonFluentExtension() => 42; // Noncompliant {{Change return type to 'void'; not a single caller uses the returned value.}}
+//              ^^^
     }
 }
 

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedReturnValue.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedReturnValue.cs
@@ -154,6 +154,8 @@ public static class PrivateStaticAndExtensions
             PrivateStaticAndExtensions.StaticNonCompliant(this);      // Return value discarded via static-call syntax.
             var x = this.ExtensionCompliant();                        // Return value used via extension-call syntax.
             var y = PrivateStaticAndExtensions.StaticCompliant(this); // Return value used via static-call syntax.
+            this.FluentExtension();                                   // Fluent extension, return value discarded.
+            this.NonFluentExtension();                                // Non-fluent extension, return value discarded.
         }
     }
 
@@ -164,4 +166,9 @@ public static class PrivateStaticAndExtensions
     private static int StaticNonCompliant(Sample sample) => 42; // Noncompliant{{Change return type to 'void'; not a single caller uses the returned value.}}
 //                 ^^^
     private static int StaticCompliant(Sample sample) => 42;
+
+    private static Sample FluentExtension(this Sample sample) => sample; // Compliant, fluent pattern (returns this type)
+
+    private static int NonFluentExtension(this Sample sample) => 42; // Noncompliant {{Change return type to 'void'; not a single caller uses the returned value.}}
+//                 ^^^
 }

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedReturnValue.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/UnusedReturnValue.cs
@@ -172,3 +172,33 @@ public static class PrivateStaticAndExtensions
     private static int NonFluentExtension(this Sample sample) => 42; // Noncompliant {{Change return type to 'void'; not a single caller uses the returned value.}}
 //                 ^^^
 }
+
+// https://github.com/SonarSource/sonar-dotnet/issues/9813 - fluent extension chains where only the last method is flagged
+public static class FluentChain
+{
+    public class Container
+    {
+        public void Test()
+        {
+            var builder = new List<int>();
+            builder
+                .AddFoo()
+                .AddBar();               // Last in chain, return value discarded.
+            Use(builder);                // Original variable still used after the chain.
+            NonFluent(builder);          // Non-fluent, return value discarded.
+        }
+
+        private static void Use(List<int> list) { }
+    }
+
+    private static List<int> AddFoo(this List<int> list)  // Compliant, return value used by AddBar
+    {
+        list.Add(1);
+        return list;
+    }
+
+    private static List<int> AddBar(this List<int> list) => list; // Compliant, fluent pattern (returns this type)
+
+    private static int NonFluent(this List<int> list) => 42; // Noncompliant {{Change return type to 'void'; not a single caller uses the returned value.}}
+//                 ^^^
+}


### PR DESCRIPTION
Extension methods that return their own this-parameter type follow the fluent builder pattern (e.g. IServiceCollection extensions in ASP.NET Core). These should not be flagged even when no caller currently uses the return value, since changing to void would break the chaining contract.

Applies to both old-style this-parameter extensions and C# 13 extension blocks.

Fixes #9813
Regression from NET-2829