### PR TITLE
Pin dotnet sdk via sdk provider

### DIFF
--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Common/SdkPathProviderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Common/SdkPathProviderTest.cs
@@ -49,7 +49,8 @@ public class SdkPathProviderTest
     [TestMethod]
     public void LatestSdkVersion_PathDoesNotExists() =>
         ((Func<string>)(() => SdkPathProvider.LatestFolder("C:\\NonExistingPath", "dotnet.dll", ""))).Should().Throw<NotSupportedException>();
-
+   
+    [Ignore("FixMe: SDK pinned to 10.0.204 until https://sonarsource.atlassian.net/browse/NET-3786 is fixed. Until then this test has to be skipped.")]
     [TestMethod]
     public void LatestSdkFolder_ReturnLatest()
     {

--- a/analyzers/tests/SonarAnalyzer.TestFramework.Test/Common/SdkPathProviderTest.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework.Test/Common/SdkPathProviderTest.cs
@@ -48,7 +48,7 @@ public class SdkPathProviderTest
 
     [TestMethod]
     public void LatestSdkVersion_PathDoesNotExists() =>
-        ((Func<string>)(() => SdkPathProvider.LatestFolder("C:\\NonExistingPath", "dotnet.dll"))).Should().Throw<NotSupportedException>();
+        ((Func<string>)(() => SdkPathProvider.LatestFolder("C:\\NonExistingPath", "dotnet.dll", ""))).Should().Throw<NotSupportedException>();
 
     [TestMethod]
     public void LatestSdkFolder_ReturnLatest()

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/SdkPathProvider.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/SdkPathProvider.cs
@@ -23,8 +23,10 @@ public static class SdkPathProvider
 {
     // Due to the preview versions naming convention, we cannot use the folder names as version numbers so we need to look at the file versions of the assemblies from the folder.
     // When reading the dll versions, the File version (e.g. 9.1.24.40712) is considered instead of the Product version (e.g. 9.1.100-preview.7.24407.12+hash).
-    // FixMe: Pinned to 10.0.204 until https://sonarsource.atlassian.net/browse/NET-3786 is fixed
-    private const string DotnetVersion = "10.0.204";
+    // FixMe: SDK pinned to 10.0.204 until https://sonarsource.atlassian.net/browse/NET-3786 is fixed.
+    // Runtime folders (AspNetCore, WindowsDesktop) use a different version (e.g. 10.0.4) so they keep the wildcard pattern.
+    private const string SdkVersion = "10.0.204";
+    private const string RuntimeVersionPattern = "10.*";
 
     private static readonly string RazorSourceGeneratorPath = Path.Combine(LatestSdkFolder(), "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.CodeAnalysis.Razor.Compiler.dll");
 
@@ -34,22 +36,22 @@ public static class SdkPathProvider
     ];
 
     public static string LatestSdkFolder() =>
-        LatestFolder(TestConstants.SdkPath, "dotnet.dll");
+        LatestFolder(TestConstants.SdkPath, "dotnet.dll", SdkVersion);
 
     public static string LatestAspNetCoreSdkFolder() =>
-        LatestFolder(TestConstants.AspNetCorePath, "Microsoft.AspNetCore.dll");
+        LatestFolder(TestConstants.AspNetCorePath, "Microsoft.AspNetCore.dll", RuntimeVersionPattern);
 
     public static string LatestWindowsDesktopSdkFolder() =>
-        LatestFolder(TestConstants.WindowsDesktopPath, "PresentationCore.dll");
+        LatestFolder(TestConstants.WindowsDesktopPath, "PresentationCore.dll", RuntimeVersionPattern);
 
-    public static string LatestFolder(string path, string assemblyName)
+    public static string LatestFolder(string path, string assemblyName, string versionPattern)
     {
         if (!Directory.Exists(path))
         {
             throw new NotSupportedException(
                 $"The directory '{path}' does not exist. This may be because you are not using .NET Core. Please note that Razor analysis is only supported when using .NET Core.");
         }
-        return Directory.GetDirectories(path, DotnetVersion).OrderBy(x => FromFolderName(x, assemblyName)).Last();
+        return Directory.GetDirectories(path, versionPattern).OrderBy(x => FromFolderName(x, assemblyName)).Last();
 
         static Version FromFolderName(string folderName, string assemblyName)
         {

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/SdkPathProvider.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/SdkPathProvider.cs
@@ -25,7 +25,7 @@ public static class SdkPathProvider
     // When reading the dll versions, the File version (e.g. 9.1.24.40712) is considered instead of the Product version (e.g. 9.1.100-preview.7.24407.12+hash).
     // FixMe: SDK pinned to 10.0.204 until https://sonarsource.atlassian.net/browse/NET-3786 is fixed.
     // Runtime folders (AspNetCore, WindowsDesktop) use a different version (e.g. 10.0.4) so they keep the wildcard pattern.
-    private const string SdkVersion = "10.0.20*";
+    private const string SdkVersion = "10.0.204";
     private const string RuntimeVersionPattern = "10.*";
 
     private static readonly string RazorSourceGeneratorPath = Path.Combine(LatestSdkFolder(), "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.CodeAnalysis.Razor.Compiler.dll");

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/SdkPathProvider.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/SdkPathProvider.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SonarAnalyzer for .NET
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
@@ -23,8 +23,7 @@ public static class SdkPathProvider
 {
     private const int DotnetVersion = 10;
 
-    private static readonly string RazorSourceGeneratorPath =
-        Path.Combine(LatestSdkFolder(), "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.CodeAnalysis.Razor.Compiler.dll");
+    private static readonly string RazorSourceGeneratorPath = Path.Combine(LatestSdkFolder(), "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.CodeAnalysis.Razor.Compiler.dll");
 
     public static AnalyzerFileReference[] SourceGenerators { get; } =
     [
@@ -32,7 +31,7 @@ public static class SdkPathProvider
     ];
 
     public static string LatestSdkFolder() =>
-        LatestFolder(TestConstants.SdkPath, "dotnet.dll");
+        LatestFolder(TestConstants.SdkPath, "dotnet.dll", "204");
 
     public static string LatestAspNetCoreSdkFolder() =>
         LatestFolder(TestConstants.AspNetCorePath, "Microsoft.AspNetCore.dll");
@@ -40,7 +39,7 @@ public static class SdkPathProvider
     public static string LatestWindowsDesktopSdkFolder() =>
         LatestFolder(TestConstants.WindowsDesktopPath, "PresentationCore.dll");
 
-    public static string LatestFolder(string path, string assemblyName)
+    public static string LatestFolder(string path, string assemblyName, string dotnetVersionMinor = null) // FixMe: Remove dotnetVersionMinor paramemeter once https://sonarsource.atlassian.net/browse/NET-3786 is fixed
     {
         if (!Directory.Exists(path))
         {
@@ -50,7 +49,7 @@ public static class SdkPathProvider
 
         // Due to the preview versions naming convention, we cannot use the folder names as version numbers so we need to look at the file versions of the assemblies from the folder.
         // When reading the dll versions, the File version (e.g. 9.1.24.40712) is considered instead of the Product version (e.g. 9.1.100-preview.7.24407.12+hash).
-        return Directory.GetDirectories(path, $"{DotnetVersion}.*")
+        return Directory.GetDirectories(path, $"{DotnetVersion}.{dotnetVersionMinor ?? "*"}")
             .OrderBy(x => FromFolderName(x, assemblyName))
             .Last();
 

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/SdkPathProvider.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/SdkPathProvider.cs
@@ -25,7 +25,7 @@ public static class SdkPathProvider
     // When reading the dll versions, the File version (e.g. 9.1.24.40712) is considered instead of the Product version (e.g. 9.1.100-preview.7.24407.12+hash).
     // FixMe: SDK pinned to 10.0.204 until https://sonarsource.atlassian.net/browse/NET-3786 is fixed.
     // Runtime folders (AspNetCore, WindowsDesktop) use a different version (e.g. 10.0.4) so they keep the wildcard pattern.
-    private const string SdkVersion = "10.0.204";
+    private const string SdkVersion = "10.0.20*";
     private const string RuntimeVersionPattern = "10.*";
 
     private static readonly string RazorSourceGeneratorPath = Path.Combine(LatestSdkFolder(), "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.CodeAnalysis.Razor.Compiler.dll");

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/SdkPathProvider.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/SdkPathProvider.cs
@@ -24,7 +24,7 @@ public static class SdkPathProvider
     // Due to the preview versions naming convention, we cannot use the folder names as version numbers so we need to look at the file versions of the assemblies from the folder.
     // When reading the dll versions, the File version (e.g. 9.1.24.40712) is considered instead of the Product version (e.g. 9.1.100-preview.7.24407.12+hash).
     // FixMe: Pinned to 10.0.204 until https://sonarsource.atlassian.net/browse/NET-3786 is fixed
-    private const string DotnetVersion = "10.0.204*";
+    private const string DotnetVersion = "10.0.204";
 
     private static readonly string RazorSourceGeneratorPath = Path.Combine(LatestSdkFolder(), "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.CodeAnalysis.Razor.Compiler.dll");
 
@@ -63,6 +63,6 @@ public static class SdkPathProvider
         public void AddDependencyLocation(string fullPath) { }
 
         public Assembly LoadFromPath(string fullPath) =>
-            Assembly.Load(fullPath);
+            Assembly.LoadFrom(fullPath);
     }
 }

--- a/analyzers/tests/SonarAnalyzer.TestFramework/Common/SdkPathProvider.cs
+++ b/analyzers/tests/SonarAnalyzer.TestFramework/Common/SdkPathProvider.cs
@@ -21,7 +21,10 @@ namespace SonarAnalyzer.TestFramework.Common;
 
 public static class SdkPathProvider
 {
-    private const int DotnetVersion = 10;
+    // Due to the preview versions naming convention, we cannot use the folder names as version numbers so we need to look at the file versions of the assemblies from the folder.
+    // When reading the dll versions, the File version (e.g. 9.1.24.40712) is considered instead of the Product version (e.g. 9.1.100-preview.7.24407.12+hash).
+    // FixMe: Pinned to 10.0.204 until https://sonarsource.atlassian.net/browse/NET-3786 is fixed
+    private const string DotnetVersion = "10.0.204*";
 
     private static readonly string RazorSourceGeneratorPath = Path.Combine(LatestSdkFolder(), "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.CodeAnalysis.Razor.Compiler.dll");
 
@@ -31,7 +34,7 @@ public static class SdkPathProvider
     ];
 
     public static string LatestSdkFolder() =>
-        LatestFolder(TestConstants.SdkPath, "dotnet.dll", "204");
+        LatestFolder(TestConstants.SdkPath, "dotnet.dll");
 
     public static string LatestAspNetCoreSdkFolder() =>
         LatestFolder(TestConstants.AspNetCorePath, "Microsoft.AspNetCore.dll");
@@ -39,19 +42,14 @@ public static class SdkPathProvider
     public static string LatestWindowsDesktopSdkFolder() =>
         LatestFolder(TestConstants.WindowsDesktopPath, "PresentationCore.dll");
 
-    public static string LatestFolder(string path, string assemblyName, string dotnetVersionMinor = null) // FixMe: Remove dotnetVersionMinor paramemeter once https://sonarsource.atlassian.net/browse/NET-3786 is fixed
+    public static string LatestFolder(string path, string assemblyName)
     {
         if (!Directory.Exists(path))
         {
             throw new NotSupportedException(
                 $"The directory '{path}' does not exist. This may be because you are not using .NET Core. Please note that Razor analysis is only supported when using .NET Core.");
         }
-
-        // Due to the preview versions naming convention, we cannot use the folder names as version numbers so we need to look at the file versions of the assemblies from the folder.
-        // When reading the dll versions, the File version (e.g. 9.1.24.40712) is considered instead of the Product version (e.g. 9.1.100-preview.7.24407.12+hash).
-        return Directory.GetDirectories(path, $"{DotnetVersion}.{dotnetVersionMinor ?? "*"}")
-            .OrderBy(x => FromFolderName(x, assemblyName))
-            .Last();
+        return Directory.GetDirectories(path, DotnetVersion).OrderBy(x => FromFolderName(x, assemblyName)).Last();
 
         static Version FromFolderName(string folderName, string assemblyName)
         {
@@ -64,6 +62,7 @@ public static class SdkPathProvider
     {
         public void AddDependencyLocation(string fullPath) { }
 
-        public Assembly LoadFromPath(string fullPath) => Assembly.LoadFrom(fullPath);
+        public Assembly LoadFromPath(string fullPath) =>
+            Assembly.Load(fullPath);
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ stages:
     - powershell: |
         $ProjectNameToken = '$(ProjectName)'  # Workaround for escaping difficulties: Azure DevOps doesn't have ProjectName, so it will not replace it. We need to pass it like that into AltCover via powershell.
         dotnet build --no-restore analyzers\src\SonarAnalyzer.ShimLayer.Generator\SonarAnalyzer.ShimLayer.Generator.csproj -c $(BuildConfiguration) # Needs a pre-build to prevent file locking issue in SonarAnalyzer.ShimLayer.Generator.Test
-        dotnet test --no-restore $(Solution) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) --filter "FullyQualifiedName!~CreateCfg_Performance_UsesCache" /p:RunAnalyzers=true /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter="testhost|Moq|Humanizer|AltCover|Microsoft|\.Test^",AltCoverPathFilter="SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration",AltCoverAttributeFilter="ExcludeFromCodeCoverage",AltCoverReport="$(CoveragePath)/coverage.$ProjectNameToken.xml"
+        dotnet test -v diag --no-restore $(Solution) -c $(BuildConfiguration) -l trx --results-directory $(UnitTestResultsPath) --filter "FullyQualifiedName!~CreateCfg_Performance_UsesCache" /p:RunAnalyzers=true /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter="testhost|Moq|Humanizer|AltCover|Microsoft|\.Test^",AltCoverPathFilter="SonarAnalyzer\.CFG\\ShimLayer|SonarAnalyzer\.ShimLayer\.CodeGeneration",AltCoverAttributeFilter="ExcludeFromCodeCoverage",AltCoverReport="$(CoveragePath)/coverage.$ProjectNameToken.xml"
       displayName: '.NET UTs'
 
     - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,21 +32,6 @@ stages:
       clean: all
 
     steps:
-    - powershell: |
-        # Pin the .NET SDK to 10.0.204 because tests fail with the latest SDK.
-        # Revert once https://sonarsource.atlassian.net/browse/NET-3786 is implemented.
-        # Must run before "dotnet restore" so the lock file is produced with the same SDK that later builds/tests use.
-        @"
-        {
-          "sdk": {
-            "version": "10.0.204",
-            "rollForward": "disable"
-          }
-        }
-        "@ | Out-File -FilePath global.json -Encoding utf8
-        dotnet --version
-      displayName: "Pin .NET SDK version"
-
     - task: CmdLine@2
       displayName: "NuGet Restore"
       inputs:


### PR DESCRIPTION
----
## Summary by Gitar

- **SDK resolution:**
  - Pinned `SdkVersion` to `10.0.204` in `SdkPathProvider` as a temporary workaround for versioning issues.
  - Updated `LatestFolder` signature to require a `versionPattern` for SDK and runtime directory discovery.
- **CI configuration:**
  - Enabled verbose diagnostic logging (`-v diag`) for the `.NET UTs` task in `azure-pipelines.yml`.
- **Test suite:**
  - Ignored `LatestSdkFolder_ReturnLatest` pending resolution of the underlying SDK versioning issue.

<sub>This will update automatically on new commits.</sub>