### PR TITLE
feat(S6960): excluded custom services

### DIFF
--- a/analyzers/rspec/cs/S6960.html
+++ b/analyzers/rspec/cs/S6960.html
@@ -3,7 +3,7 @@ Following the <a href="https://en.wikipedia.org/wiki/Single_responsibility_princ
 lean and <a href="https://learn.microsoft.com/en-us/dotnet/architecture/modern-web-apps-azure/architectural-principles#separation-of-concerns">focused
 on a single, separate concern</a>. In short, they should have a <em>single reason to change</em>.</p>
 <p>The rule identifies different responsibilities by looking at groups of actions that use different sets of services defined in the controller.</p>
-<p>Basic services that are typically required by most controllers are not considered:</p>
+<p>Basic services that are typically required by most controllers are not considered by default:</p>
 <ul>
   <li><a href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/"><code>ILogger</code></a></li>
   <li><a href="https://en.wikipedia.org/wiki/Mediator_pattern"><code>IMediator</code></a></li>
@@ -11,7 +11,9 @@ on a single, separate concern</a>. In short, they should have a <em>single reaso
   <li><a href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/"><code>IConfiguration</code></a></li>
   <li><a href="https://masstransit.io/documentation/configuration#configuration"><code>IBus</code></a></li>
   <li><a href="https://wolverinefx.io/guide/messaging/message-bus.html"><code>IMessageBus</code></a></li>
+  <li><a href="https://learn.microsoft.com/en-us/dotnet/api/system.net.http.ihttpclientfactory"><code>IHttpClientFactory</code></a></li>
 </ul>
+<p>This list can be configured via the <code>excludedServices</code> rule parameter (comma-separated type names).</p>
 <p>The rule currently applies to ASP.NET Core only, and doesn’t cover <a
 href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/choose-aspnet-framework">ASP.NET MVC 4.x</a>.</p>
 <p>It also only takes into account web APIs controllers, i.e. the ones marked with the <a

--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/ControllersHaveMixedResponsibilities.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/AspNet/ControllersHaveMixedResponsibilities.cs
@@ -20,11 +20,12 @@ using System.Collections.Concurrent;
 namespace SonarAnalyzer.CSharp.Rules;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class ControllersHaveMixedResponsibilities : SonarDiagnosticAnalyzer
+public sealed class ControllersHaveMixedResponsibilities : ParametrizedDiagnosticAnalyzer
 {
     private const string DiagnosticId = "S6960";
     private const string MessageFormat = "This controller has multiple responsibilities and could be split into {0} smaller controllers.";
     private const string UnspeakableIndexerName = "<indexer>I"; // All indexers are considered part of the same group
+    private const string ExcludedServicesDefaultValue = "ILogger, IMediator, IMapper, IConfiguration, IBus, IMessageBus, IHttpClientFactory";
 
     public enum MemberType
     {
@@ -32,47 +33,46 @@ public sealed class ControllersHaveMixedResponsibilities : SonarDiagnosticAnalyz
         Action,
     }
 
-    private static readonly HashSet<string> ExcludedWellKnownServices =
-    [
-        "ILogger",
-        "IMediator",
-        "IMapper",
-        "IConfiguration",
-        "IBus",
-        "IMessageBus",
-        "IHttpClientFactory"
-    ];
-
     private static readonly DiagnosticDescriptor Rule = DescriptorFactory.Create(DiagnosticId, MessageFormat);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-    protected override void Initialize(SonarAnalysisContext context) =>
-        context.RegisterCompilationStartAction(compilationStartContext =>
-        {
-            if (!compilationStartContext.Compilation.ReferencesNetCoreControllers())
-            {
-                return;
-            }
+    [RuleParameter(
+        "excludedServices",
+        PropertyType.String,
+        "Comma-separated list of service type names that are ignored when detecting mixed responsibilities (e.g. ILogger, IMediator).",
+        ExcludedServicesDefaultValue)]
+    public string ExcludedServices { get; set; } = ExcludedServicesDefaultValue;
 
-            compilationStartContext.RegisterSymbolStartAction(symbolStartContext =>
+    protected override void Initialize(SonarParametrizedAnalysisContext context) =>
+        context.RegisterCompilationStartAction(
+            compilationStartContext =>
             {
-                if (symbolStartContext.Symbol is INamedTypeSymbol { IsCoreApiController: true, IsAbstract: false } symbol
-                    && symbol.BaseType.Is(KnownType.Microsoft_AspNetCore_Mvc_ControllerBase))
+                if (!compilationStartContext.Compilation.ReferencesNetCoreControllers())
                 {
-                    var relevantMembers = RelevantMembers(symbol);
-
-                    if (relevantMembers.Count < 2)
-                    {
-                        return;
-                    }
-
-                    var dependencies = new ConcurrentStack<Dependency>();
-                    symbolStartContext.RegisterCodeBlockStartAction(PopulateDependencies(relevantMembers, dependencies));
-                    symbolStartContext.RegisterSymbolEndAction(CalculateAndReportOnResponsibilities(symbol, relevantMembers, dependencies));
+                    return;
                 }
-                }, SymbolKind.NamedType);
-        });
+
+                compilationStartContext.RegisterSymbolStartAction(
+                    symbolStartContext =>
+                    {
+                        if (symbolStartContext.Symbol is INamedTypeSymbol { IsCoreApiController: true, IsAbstract: false } symbol
+                            && symbol.BaseType.Is(KnownType.Microsoft_AspNetCore_Mvc_ControllerBase))
+                        {
+                            var relevantMembers = RelevantMembers(symbol);
+
+                            if (relevantMembers.Count < 2)
+                            {
+                                return;
+                            }
+
+                            var dependencies = new ConcurrentStack<Dependency>();
+                            symbolStartContext.RegisterCodeBlockStartAction(PopulateDependencies(relevantMembers, dependencies));
+                            symbolStartContext.RegisterSymbolEndAction(CalculateAndReportOnResponsibilities(symbol, relevantMembers, dependencies));
+                        }
+                    },
+                    SymbolKind.NamedType);
+            });
 
     private static Action<SonarCodeBlockStartAnalysisContext<SyntaxKind>> PopulateDependencies(
         ImmutableDictionary<string, MemberType> relevantMembers,
@@ -81,13 +81,15 @@ public sealed class ControllersHaveMixedResponsibilities : SonarDiagnosticAnalyz
         {
             if (BlockName(codeBlockStartContext.CodeBlock) is { } blockName)
             {
-                codeBlockStartContext.RegisterNodeAction(c =>
-                {
-                    if (c.Node.GetName() is { } dependencyName && relevantMembers.ContainsKey(blockName) && relevantMembers.ContainsKey(dependencyName))
+                codeBlockStartContext.RegisterNodeAction(
+                    c =>
                     {
-                        dependencies.Push(new(blockName, dependencyName));
-                    }
-                }, SyntaxKind.IdentifierName);
+                        if (c.Node.GetName() is { } dependencyName && relevantMembers.ContainsKey(blockName) && relevantMembers.ContainsKey(dependencyName))
+                        {
+                            dependencies.Push(new(blockName, dependencyName));
+                        }
+                    },
+                    SyntaxKind.IdentifierName);
             }
         };
 
@@ -136,8 +138,9 @@ public sealed class ControllersHaveMixedResponsibilities : SonarDiagnosticAnalyz
             _ => null
         };
 
-    private static ImmutableDictionary<string, MemberType> RelevantMembers(INamedTypeSymbol symbol)
+    private ImmutableDictionary<string, MemberType> RelevantMembers(INamedTypeSymbol symbol)
     {
+        var excludedServices = ParseExcludedServices(ExcludedServices);
         var builder = ImmutableDictionary.CreateBuilder<string, MemberType>();
         foreach (var member in symbol.GetMembers().Where(x => !x.IsStatic))
         {
@@ -167,10 +170,16 @@ public sealed class ControllersHaveMixedResponsibilities : SonarDiagnosticAnalyz
         }
 
         return builder.ToImmutable();
+
+        bool IsService(ISymbol member) =>
+            !excludedServices.Contains(member.SymbolType.Name);
     }
 
-    private static bool IsService(ISymbol symbol) =>
-        !ExcludedWellKnownServices.Contains(symbol.SymbolType.Name);
+    private static HashSet<string> ParseExcludedServices(string value) =>
+        value.Split([','], StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => x.Trim())
+            .Where(x => x.Length != 0)
+            .ToHashSet(StringComparer.Ordinal);
 
     private static IEnumerable<SecondaryLocation> SecondaryLocations(INamedTypeSymbol controllerSymbol, List<List<string>> sets)
     {

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/AspNet/ControllersHaveMixedResponsibilitiesTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/AspNet/ControllersHaveMixedResponsibilitiesTest.cs
@@ -43,6 +43,53 @@ public class ControllersHaveMixedResponsibilitiesTest
             .AddPaths("ControllersHaveMixedResponsibilities.Latest.cs", "ControllersHaveMixedResponsibilities.Latest.Partial.cs")
             .WithLanguageVersion(LanguageVersion.Latest)
             .Verify();
+
+    [TestMethod]
+    public void ControllersHaveMixedResponsibilities_CustomExcludedServices() =>
+        new VerifierBuilder()
+            .AddAnalyzer(() => new ControllersHaveMixedResponsibilities { ExcludedServices = "IS1, IS2" })
+            .AddReferences(References)
+            .AddSnippet("""
+                using Microsoft.AspNetCore.Mvc;
+
+                public interface IS1 { void Use(); }
+                public interface IS2 { void Use(); }
+                public interface IS3 { void Use(); }
+                public interface IS4 { void Use(); }
+                public interface ILogger<T> { void Use(); }
+
+                // Compliant: IS1 and IS2 are excluded via rule parameter; remaining services form one responsibility
+                [ApiController]
+                public class OnlyExcludedAndSharedService(IS1 s1, IS2 s2, IS3 s3) : ControllerBase
+                {
+                    public IActionResult A1() { s1.Use(); s3.Use(); return Ok(); }
+                    public IActionResult A2() { s2.Use(); s3.Use(); return Ok(); }
+                }
+
+                // Noncompliant@+2 {{This controller has multiple responsibilities and could be split into 2 smaller controllers.}}
+                [ApiController]
+                public class CustomExclusionStillFlagsOtherServices(IS3 s3, IS4 s4) : ControllerBase
+                {
+                    public IActionResult A1() { s3.Use(); return Ok(); } // Secondary {{May belong to responsibility #1.}}
+                    public IActionResult A2() { s4.Use(); return Ok(); } // Secondary {{May belong to responsibility #2.}}
+                }
+
+                // Noncompliant@+2: default well-known ILogger is not excluded when the parameter overrides the default list
+                [ApiController]
+                public class LoggerIsNotExcludedWhenOverridden(ILogger<LoggerIsNotExcludedWhenOverridden> logger, IS3 s3) : ControllerBase
+                {
+                    public IActionResult A1() { logger.Use(); return Ok(); } // Secondary {{May belong to responsibility #1.}}
+                    public IActionResult A2() { s3.Use(); return Ok(); }     // Secondary {{May belong to responsibility #2.}}
+                }
+                """)
+            .WithLanguageVersion(LanguageVersion.Latest)
+            .WithAutogenerateConcurrentFiles(false)
+            .Verify();
+
+    [TestMethod]
+    public void ExcludedServices_ByDefault_ContainsWellKnownServices() =>
+        new ControllersHaveMixedResponsibilities().ExcludedServices.Should().Be(
+            "ILogger, IMediator, IMapper, IConfiguration, IBus, IMessageBus, IHttpClientFactory");
 }
 
 #endif


### PR DESCRIPTION
## Title

S6960: Make excluded services configurable via rule parameter

## Summary

Makes the list of ignored infrastructure services in **S6960** (*Controllers should not have mixed responsibilities*) configurable through a new rule parameter `excludedServices`, so projects can treat additional shared services (or a custom subset) the same way as the built-in well-known ones.

## Motivation

S6960 ignores a hardcoded set of common services (`ILogger`, `IMediator`, `IMapper`, `IConfiguration`, `IBus`, `IMessageBus`, `IHttpClientFactory`). Many codebases have other cross-cutting dependencies that should not count as separate responsibilities. Today the only options are to suppress the rule or accept false positives.

## Changes

### Rule (`ControllersHaveMixedResponsibilities`)

- Inherit from `ParametrizedDiagnosticAnalyzer`
- Add `[RuleParameter("excludedServices", PropertyType.String, ...)]`
- Default value (unchanged behavior):

  `ILogger, IMediator, IMapper, IConfiguration, IBus, IMessageBus, IHttpClientFactory`

- Matching stays name-based (e.g. `ILogger` matches `ILogger<T>`), same as before
- Setting the parameter **replaces** the default list entirely

### Docs

- Update `S6960.html`: note that the list is the default and is configurable

### Tests

- Existing default test cases still pass (no behavior change with defaults)
- Custom parameter coverage via snippet:
  - excluded services are ignored
  - non-excluded services still raise
  - overriding the list drops previous defaults (e.g. `ILogger` is no longer ignored unless listed)
- Default parameter value assertion

## Configuration

### SonarQube / SonarQube Cloud

Set `excludedServices` on the quality profile for S6960 (Connected Mode picks it up in SonarQube for IDE).

### Standalone / `SonarLint.xml`

```xml
<?xml version="1.0" encoding="utf-8"?>
<AnalysisInput xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <Rules>
    <Rule>
      <Key>S6960</Key>
      <Parameters>
        <Parameter>
          <Key>excludedServices</Key>
          <Value>ILogger, IMediator, IMapper, IConfiguration, IBus, IMessageBus, IHttpClientFactory, IMyTelemetry</Value>
        </Parameter>
      </Parameters>
    </Rule>
  </Rules>
</AnalysisInput>
```

```xml
<ItemGroup>
  <AdditionalFiles Include="SonarLint.xml" />
</ItemGroup>
```

## Checklist

- [x] Follows existing parametrized-rule pattern (`ParametrizedDiagnosticAnalyzer` + `[RuleParameter]`)
- [x] Default behavior preserved when the parameter is not set
- [x] Unit tests added/updated
- [x] RSPEC description updated
- [x] Coding style / analyzer warnings clean on touched files

## Test plan

```bash
dotnet test analyzers/tests/SonarAnalyzer.Test/SonarAnalyzer.Test.csproj -f net10.0 \
  --filter "FullyQualifiedName~ControllersHaveMixedResponsibilities"
```

**Result:** Passed (3/3)

- `ControllersHaveMixedResponsibilities_CS` — default cases  
- `ControllersHaveMixedResponsibilities_CustomExcludedServices` — custom parameter  
- `ExcludedServices_ByDefault_ContainsWellKnownServices` — default value  

Also verified `SonarAnalyzer.CSharp` builds with analyzers enabled (no diagnostics on the changed rule file).

Closed: https://github.com/SonarSource/sonar-dotnet/issues/9826
