### PR TITLE
NET-4419 S2737: Preserve temporary-context rethrows

### DIFF
--- a/analyzers/src/SonarAnalyzer.CSharp/Rules/CatchRethrow.cs
+++ b/analyzers/src/SonarAnalyzer.CSharp/Rules/CatchRethrow.cs
@@ -36,6 +36,106 @@ public sealed class CatchRethrow : CatchRethrowBase<SyntaxKind, CatchClauseSynta
     protected override bool HasFilter(CatchClauseSyntax catchClause) =>
         catchClause.Filter is not null;
 
+    /// <summary>Determines whether a bare rethrow restores a recognized temporary context.</summary>
+    /// <param name="catchClause">The catch clause being analyzed.</param>
+    /// <param name="semanticModel">The semantic model for the analyzed file.</param>
+    /// <returns><see langword="true" /> when the catch clause forms a required unwind boundary.</returns>
+    protected override bool IsTemporaryContextBoundary(CatchClauseSyntax catchClause, SemanticModel semanticModel) =>
+        catchClause.Parent is TryStatementSyntax tryStatement
+        && (HasTemporaryContextInvocation(tryStatement, semanticModel)
+            || HasWindowsImpersonationUsing(tryStatement, semanticModel)
+            || HasCodeAccessPermissionBoundary(tryStatement, semanticModel));
+
+    /// <summary>Determines whether a try block invokes a temporary-context API.</summary>
+    /// <param name="tryStatement">The try statement associated with the catch clause.</param>
+    /// <param name="semanticModel">The semantic model for the analyzed file.</param>
+    /// <returns><see langword="true" /> when the try block invokes a recognized API.</returns>
+    private static bool HasTemporaryContextInvocation(TryStatementSyntax tryStatement, SemanticModel semanticModel) =>
+        tryStatement.Block.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Any(invocation => IsInLocalTryScope(invocation, tryStatement)
+                               && (IsMethod(semanticModel, invocation, KnownType.System_Threading_ExecutionContext, "Run")
+                                   || IsMethod(semanticModel, invocation, KnownType.System_Security_Principal_WindowsIdentity, "RunImpersonated")));
+
+    /// <summary>Determines whether a try block uses a legacy Windows impersonation scope.</summary>
+    /// <param name="tryStatement">The try statement associated with the catch clause.</param>
+    /// <param name="semanticModel">The semantic model for the analyzed file.</param>
+    /// <returns><see langword="true" /> when the try block uses a recognized impersonation scope.</returns>
+    private static bool HasWindowsImpersonationUsing(TryStatementSyntax tryStatement, SemanticModel semanticModel) =>
+        tryStatement.Block.DescendantNodes().OfType<UsingStatementSyntax>()
+            .Any(usingStatement => IsInLocalTryScope(usingStatement, tryStatement) && IsWindowsImpersonationUsing(usingStatement, semanticModel));
+
+    /// <summary>Determines whether a using statement owns a Windows impersonation context.</summary>
+    /// <param name="usingStatement">The using statement to inspect.</param>
+    /// <param name="semanticModel">The semantic model for the analyzed file.</param>
+    /// <returns><see langword="true" /> when the statement owns the recognized context.</returns>
+    private static bool IsWindowsImpersonationUsing(UsingStatementSyntax usingStatement, SemanticModel semanticModel) =>
+        usingStatement.Expression is { } expression
+            ? IsWindowsImpersonationContext(expression, semanticModel)
+            : usingStatement.Declaration is { } declaration && IsWindowsImpersonationUsing(declaration, semanticModel);
+
+    /// <summary>Determines whether a using declaration owns a Windows impersonation context.</summary>
+    /// <param name="declaration">The declaration to inspect.</param>
+    /// <param name="semanticModel">The semantic model for the analyzed file.</param>
+    /// <returns><see langword="true" /> when the declaration owns the recognized context.</returns>
+    private static bool IsWindowsImpersonationUsing(VariableDeclarationSyntax declaration, SemanticModel semanticModel) =>
+        declaration.Variables.Any(variable => variable.Initializer?.Value is { } expression && IsWindowsImpersonationContext(expression, semanticModel));
+
+    /// <summary>Determines whether an expression creates a Windows impersonation context.</summary>
+    /// <param name="expression">The expression to inspect.</param>
+    /// <param name="semanticModel">The semantic model for the analyzed file.</param>
+    /// <returns><see langword="true" /> when the expression invokes the recognized API.</returns>
+    private static bool IsWindowsImpersonationContext(ExpressionSyntax expression, SemanticModel semanticModel) =>
+        expression is InvocationExpressionSyntax invocation
+        && IsMethod(semanticModel, invocation, KnownType.System_Security_Principal_WindowsIdentity, "Impersonate")
+        && semanticModel.GetTypeInfo(expression).Type.Is(KnownType.System_Security_Principal_WindowsImpersonationContext);
+
+    /// <summary>Determines whether an inner finally restores a code-access assertion.</summary>
+    /// <param name="tryStatement">The try statement associated with the catch clause.</param>
+    /// <param name="semanticModel">The semantic model for the analyzed file.</param>
+    /// <returns><see langword="true" /> when the try block has a recognized assertion boundary.</returns>
+    private static bool HasCodeAccessPermissionBoundary(TryStatementSyntax tryStatement, SemanticModel semanticModel) =>
+        tryStatement.Block.DescendantNodes().OfType<TryStatementSyntax>()
+            .Where(innerTry => innerTry.Finally is not null && IsInLocalTryScope(innerTry, tryStatement))
+            .Any(innerTry => ContainsRevertAssert(innerTry.Finally.Block, semanticModel)
+                             && ContainsAssertBefore(tryStatement, innerTry, semanticModel));
+
+    /// <summary>Determines whether a block invokes CodeAccessPermission.RevertAssert.</summary>
+    /// <param name="block">The finally block to inspect.</param>
+    /// <param name="semanticModel">The semantic model for the analyzed file.</param>
+    /// <returns><see langword="true" /> when the block restores an assertion.</returns>
+    private static bool ContainsRevertAssert(BlockSyntax block, SemanticModel semanticModel) =>
+        block.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Any(invocation => IsMethod(semanticModel, invocation, KnownType.System_Security_CodeAccessPermission, "RevertAssert"));
+
+    /// <summary>Determines whether an assertion precedes an inner try statement.</summary>
+    /// <param name="outerTry">The try statement associated with the catch clause.</param>
+    /// <param name="innerTry">The inner try statement that restores the assertion.</param>
+    /// <param name="semanticModel">The semantic model for the analyzed file.</param>
+    /// <returns><see langword="true" /> when an assertion is established before the inner try.</returns>
+    private static bool ContainsAssertBefore(TryStatementSyntax outerTry, TryStatementSyntax innerTry, SemanticModel semanticModel) =>
+        outerTry.Block.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Any(invocation => invocation.SpanStart < innerTry.SpanStart
+                               && IsInLocalTryScope(invocation, outerTry)
+                               && IsMethod(semanticModel, invocation, KnownType.System_Security_CodeAccessPermission, "Assert"));
+
+    /// <summary>Determines whether a node is not protected by an intervening catch clause.</summary>
+    /// <param name="node">The node inside the try statement.</param>
+    /// <param name="tryStatement">The try statement associated with the catch clause.</param>
+    /// <returns><see langword="true" /> when the associated catch is the local unwind boundary.</returns>
+    private static bool IsInLocalTryScope(SyntaxNode node, TryStatementSyntax tryStatement) =>
+        node.AncestorsAndSelf().TakeWhile(x => x != tryStatement).OfType<TryStatementSyntax>().All(x => x.Catches.Count == 0);
+
+    /// <summary>Determines whether an invocation resolves to a known framework method.</summary>
+    /// <param name="semanticModel">The semantic model for the analyzed file.</param>
+    /// <param name="invocation">The invocation to inspect.</param>
+    /// <param name="containingType">The expected containing type.</param>
+    /// <param name="methodName">The expected method name.</param>
+    /// <returns><see langword="true" /> when the invocation resolves to the expected method.</returns>
+    private static bool IsMethod(SemanticModel semanticModel, InvocationExpressionSyntax invocation, KnownType containingType, string methodName) =>
+        semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol method
+        && method.Name == methodName
+        && method.ContainingType.Is(containingType);
+
     protected override void Initialize(SonarAnalysisContext context) =>
         context.RegisterNodeAction(RaiseOnInvalidCatch, SyntaxKind.TryStatement);
 }

--- a/analyzers/src/SonarAnalyzer.Core/Rules/CatchRethrowBase.cs
+++ b/analyzers/src/SonarAnalyzer.Core/Rules/CatchRethrowBase.cs
@@ -28,6 +28,12 @@ public abstract class CatchRethrowBase<TSyntaxKind, TCatchClause> : SonarDiagnos
     protected abstract bool HasFilter(TCatchClause catchClause);
     protected abstract bool ContainsOnlyThrow(TCatchClause currentCatch);
 
+    /// <summary>Determines whether a catch clause preserves a temporary context boundary.</summary>
+    /// <param name="catchClause">The catch clause being analyzed.</param>
+    /// <param name="semanticModel">The semantic model for the analyzed file.</param>
+    /// <returns><see langword="true" /> when the catch clause must not be reported.</returns>
+    protected virtual bool IsTemporaryContextBoundary(TCatchClause catchClause, SemanticModel semanticModel) => false;
+
     protected override string MessageFormat => "Add logic to this catch clause or eliminate it and rethrow the exception automatically.";
 
     protected CatchRethrowBase() : base(DiagnosticId) { }
@@ -46,6 +52,7 @@ public abstract class CatchRethrowBase<TSyntaxKind, TCatchClause> : SonarDiagnos
             if (ContainsOnlyThrow(currentCatch))
             {
                 if (!HasFilter(currentCatch)
+                    && !IsTemporaryContextBoundary(currentCatch, context.Model)
                     // Make sure we report only catch clauses that will not change the method behavior if removed.
                     && (followingCatchesOnlyThrow || IsRedundantToFollowingCatches(i, catches, caughtExceptionTypes.Value, redundantCatches)))
                 {

--- a/analyzers/src/SonarAnalyzer.Core/Semantics/KnownType.cs
+++ b/analyzers/src/SonarAnalyzer.Core/Semantics/KnownType.cs
@@ -617,6 +617,7 @@ public sealed partial class KnownType
     public static readonly KnownType System_Security_Cryptography_X509Certificates_X509Certificate2 = new("System.Security.Cryptography.X509Certificates.X509Certificate2");
     public static readonly KnownType System_Security_Cryptography_X509Certificates_X509Chain = new("System.Security.Cryptography.X509Certificates.X509Chain");
     public static readonly KnownType System_Security_Cryptography_Xml_SignedXml = new("System.Security.Cryptography.Xml.SignedXml");
+    public static readonly KnownType System_Security_CodeAccessPermission = new("System.Security.CodeAccessPermission");
     public static readonly KnownType System_Security_Permissions_CodeAccessSecurityAttribute = new("System.Security.Permissions.CodeAccessSecurityAttribute");
     public static readonly KnownType System_Security_Permissions_PrincipalPermission = new("System.Security.Permissions.PrincipalPermission");
     public static readonly KnownType System_Security_Permissions_PrincipalPermissionAttribute = new("System.Security.Permissions.PrincipalPermissionAttribute");
@@ -626,6 +627,7 @@ public sealed partial class KnownType
     public static readonly KnownType System_Security_Principal_NTAccount = new("System.Security.Principal.NTAccount");
     public static readonly KnownType System_Security_Principal_SecurityIdentifier = new("System.Security.Principal.SecurityIdentifier");
     public static readonly KnownType System_Security_Principal_WindowsIdentity = new("System.Security.Principal.WindowsIdentity");
+    public static readonly KnownType System_Security_Principal_WindowsImpersonationContext = new("System.Security.Principal.WindowsImpersonationContext");
     public static readonly KnownType System_Security_SecureString = new("System.Security.SecureString");
     public static readonly KnownType System_Security_SecurityCriticalAttribute = new("System.Security.SecurityCriticalAttribute");
     public static readonly KnownType System_Security_SecuritySafeCriticalAttribute = new("System.Security.SecuritySafeCriticalAttribute");
@@ -649,6 +651,7 @@ public sealed partial class KnownType
     public static readonly KnownType System_Threading_AsyncLocal_T = new("System.Threading.AsyncLocal", "T");
     public static readonly KnownType System_Threading_CancellationToken = new("System.Threading.CancellationToken");
     public static readonly KnownType System_Threading_CancellationTokenSource = new("System.Threading.CancellationTokenSource");
+    public static readonly KnownType System_Threading_ExecutionContext = new("System.Threading.ExecutionContext");
     public static readonly KnownType System_Threading_Lock = new("System.Threading.Lock");
     public static readonly KnownType System_Threading_Lock_Scope = new("System.Threading.Lock+Scope");
     public static readonly KnownType System_Threading_Monitor = new("System.Threading.Monitor");

--- a/analyzers/tests/SonarAnalyzer.Test/Rules/CatchRethrowTest.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/Rules/CatchRethrowTest.cs
@@ -36,6 +36,34 @@ public class CatchRethrowTest
             .WithCodeFixedPaths("CatchRethrow.Fixed.cs")
             .VerifyCodeFix();
 
+    /// <summary>Verifies the execution-context temporary boundary.</summary>
+    [TestMethod]
+    public void CatchRethrow_ExecutionContext() =>
+        builderCS.AddPaths("CatchRethrow.ExecutionContext.cs").Verify();
+
+    /// <summary>Verifies that unrecognized temporary-context shapes are reported.</summary>
+    [TestMethod]
+    public void CatchRethrow_TemporaryContextControls() =>
+        builderCS.AddPaths("CatchRethrow.TemporaryContextControls.cs").Verify();
+
+    /// <summary>Verifies the Windows identity temporary boundary.</summary>
+    [TestMethod]
+    public void CatchRethrow_WindowsIdentity()
+    {
+        var verifier = builderCS.AddPaths("CatchRethrow.WindowsIdentity.cs").WithNetOnly();
+#if NET
+        verifier = verifier.AddReferences([CoreMetadataReference.SystemSecurityClaims]);
+#endif
+        verifier.Verify();
+    }
+
+    /// <summary>Verifies legacy temporary-context boundaries.</summary>
+    [TestMethod]
+    public void CatchRethrow_LegacyContexts() =>
+        builderCS.AddPaths("CatchRethrow.LegacyContexts.cs")
+            .WithNetFrameworkOnly()
+            .Verify();
+
     [TestMethod]
     public void CatchRethrow_VB() =>
         new VerifierBuilder<VB.CatchRethrow>().AddPaths("CatchRethrow.vb").Verify();

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/CatchRethrow.ExecutionContext.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/CatchRethrow.ExecutionContext.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading;
+
+namespace Tests.TestCases
+{
+    public class CatchRethrowExecutionContext
+    {
+        /// <summary>Verifies that ExecutionContext.Run establishes an unwind boundary.</summary>
+        public void ExecutionContextRun()
+        {
+            try
+            {
+                ExecutionContext.Run(ExecutionContext.Capture(), _ => throw new InvalidOperationException(), null);
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
+        /// <summary>Verifies that an unrelated rethrow is still reported.</summary>
+        public void UnrelatedRethrow()
+        {
+            try
+            {
+                throw new InvalidOperationException();
+            }
+            catch // Noncompliant
+            {
+                throw;
+            }
+        }
+
+        /// <summary>Verifies that only the local temporary-context boundary is exempted.</summary>
+        public void NestedTemporaryContext()
+        {
+            try
+            {
+                try
+                {
+                    ExecutionContext.Run(ExecutionContext.Capture(), _ => throw new InvalidOperationException(), null);
+                }
+                catch
+                {
+                    throw;
+                }
+            }
+            catch // Noncompliant
+            {
+                throw;
+            }
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/CatchRethrow.LegacyContexts.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/CatchRethrow.LegacyContexts.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Security;
+using System.Security.Permissions;
+using System.Security.Principal;
+
+namespace Tests.TestCases
+{
+    public class CatchRethrowLegacyContexts
+    {
+        /// <summary>Verifies that an impersonation using scope establishes an unwind boundary.</summary>
+        public void LegacyImpersonation()
+        {
+            try
+            {
+                using (WindowsIdentity.GetCurrent().Impersonate())
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
+        /// <summary>Verifies that an assertion restored in an inner finally establishes an unwind boundary.</summary>
+        public void CodeAccessPermissionAssertion()
+        {
+            try
+            {
+                new SecurityPermission(SecurityPermissionFlag.Execution).Assert();
+                try
+                {
+                    throw new InvalidOperationException();
+                }
+                finally
+                {
+                    CodeAccessPermission.RevertAssert();
+                }
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
+        /// <summary>Verifies that an unrelated rethrow is still reported.</summary>
+        public void UnrelatedRethrow()
+        {
+            try
+            {
+                throw new InvalidOperationException();
+            }
+            catch // Noncompliant
+            {
+                throw;
+            }
+        }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/CatchRethrow.TemporaryContextControls.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/CatchRethrow.TemporaryContextControls.cs
@@ -1,0 +1,75 @@
+﻿using System;
+
+namespace Tests.TestCases
+{
+    public class TemporaryContextControls
+    {
+        /// <summary>Verifies that an ordinary disposable scope does not suppress the rule.</summary>
+        public void OrdinaryUsing()
+        {
+            try
+            {
+                using (System.IO.File.OpenRead("temporary-file"))
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+            catch // Noncompliant
+            {
+                throw;
+            }
+        }
+
+        /// <summary>Verifies that lookalike user methods do not suppress the rule.</summary>
+        public void UserDefinedLookalikes()
+        {
+            try
+            {
+                var context = new UserDefinedContext();
+                context.Impersonate();
+                context.Run();
+                try
+                {
+                    throw new InvalidOperationException();
+                }
+                finally
+                {
+                    context.Revert();
+                }
+            }
+            catch // Noncompliant
+            {
+                throw;
+            }
+        }
+
+        /// <summary>Verifies that a rethrow after a handling catch remains reported.</summary>
+        public void RethrowAfterHandlingCatch()
+        {
+            try
+            {
+                throw new InvalidOperationException();
+            }
+            catch (ArgumentException)
+            {
+                Console.WriteLine("handled");
+            }
+            catch // Noncompliant
+            {
+                throw;
+            }
+        }
+    }
+
+    public sealed class UserDefinedContext
+    {
+        /// <summary>Imitates an impersonation method.</summary>
+        public void Impersonate() { }
+
+        /// <summary>Imitates a context-running method.</summary>
+        public void Run() { }
+
+        /// <summary>Imitates a context-restoration method.</summary>
+        public void Revert() { }
+    }
+}

--- a/analyzers/tests/SonarAnalyzer.Test/TestCases/CatchRethrow.WindowsIdentity.cs
+++ b/analyzers/tests/SonarAnalyzer.Test/TestCases/CatchRethrow.WindowsIdentity.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Security.Principal;
+using Microsoft.Win32.SafeHandles;
+
+namespace Tests.TestCases
+{
+    public class CatchRethrowWindowsIdentity
+    {
+        /// <summary>Verifies that RunImpersonated establishes an unwind boundary.</summary>
+        public void RunImpersonated()
+        {
+            try
+            {
+                WindowsIdentity.RunImpersonated(SafeAccessTokenHandle.InvalidHandle, () => throw new InvalidOperationException());
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
+        /// <summary>Verifies that an unrelated rethrow is still reported.</summary>
+        public void UnrelatedRethrow()
+        {
+            try
+            {
+                throw new InvalidOperationException();
+            }
+            catch // Noncompliant
+            {
+                throw;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Avoid reporting S2737 when a bare C# rethrow deliberately unwinds a recognized temporary execution or security context before an upstream exception filter runs.

## Changes
- Recognize temporary-context APIs and legacy impersonation scopes through Roslyn symbols.
- Recognize CodeAccessPermission assertions restored by an inner finally block.
- Add positive and negative regression cases, including catch-boundary controls.
